### PR TITLE
Fix #10: Fix docstring in execution.py

### DIFF
--- a/robo_trader/execution.py
+++ b/robo_trader/execution.py
@@ -28,8 +28,17 @@ class AbstractExecutor:
 class PaperExecutor(AbstractExecutor):
     """Simple in-memory simulator for order placement.
 
-    This does not model slippage or partial fills; it's intended as a safe default
+    Models symmetric slippage (in basis points) around the limit price for both
+    buy and sell orders. Does not model partial fills. Intended as a safe default
     to test logic without touching live accounts.
+    
+    Args:
+        slippage_bps: Slippage in basis points to apply symmetrically to fills.
+                      Defaults to 0.0 (no slippage).
+    
+    Attributes:
+        fills: Dictionary tracking all executed orders with timestamps and fill prices.
+        slippage_bps: Configured slippage in basis points.
     """
 
     def __init__(self, slippage_bps: float = 0.0) -> None:


### PR DESCRIPTION
## Summary
Fixes incorrect docstring in PaperExecutor class that contradicted the actual implementation.

## Changes
- Updated PaperExecutor docstring to accurately state that slippage IS modeled
- Added proper parameter and attribute documentation
- Clarified symmetric slippage behavior for buy/sell orders

## Testing
- Verified PaperExecutor functionality with manual tests
- Confirmed slippage calculations work correctly (10 bps test)
- No code logic changed, only documentation updated

## Notes
The existing test suite has import errors due to missing pandas dependency, but these are unrelated to this documentation fix. The core functionality remains intact and working.

Closes #10