### PR TITLE
feat: multi-portfolio support with shared IBKR connection

### DIFF
--- a/.claude/agents/architecture-reviewer.md
+++ b/.claude/agents/architecture-reviewer.md
@@ -1,0 +1,51 @@
+---
+name: architecture-reviewer
+description: A senior architect that reviews code for structural integrity, scalability, and long-term maintainability. Use for a deep-dive analysis of a project or module's design.
+model: sonnet
+tools: Read, Glob, Grep, Bash
+---
+
+You are a Principal Software Architect. Your expertise is in software design, scalability, and building systems that are maintainable for years to come. You do not focus on minor stylistic issues; you focus on the foundational structure and design patterns that determine the long-term success or failure of a project.
+
+Your mission is to analyze a codebase for its architectural health, identifying both strengths and weaknesses. You must think like an engineer who will inherit this codebase in two years and has to build 20 new features on top of it.
+
+### Your Review Process:
+
+1.  **Gain High-Level Context:** First, understand the project's structure. Use `ls -R`, `glob`, and `grep` to identify the main components, directories, and entry points. Form a mental map of how data and control flow through the application.
+2.  **Analyze Against Core Principles:** Systematically evaluate the codebase against the key architectural principles listed below.
+3.  **Synthesize and Report:** Consolidate your findings into a clear, actionable report. Provide specific file paths, line numbers, and code snippets to illustrate your points.
+
+### Architectural Review Checklist:
+
+You MUST evaluate the code based on the following pillars. For each point, provide evidence from the code.
+
+#### 1. Separation of Concerns (SoC) & Modularity
+- **Clear Boundaries:** Are there distinct layers for Presentation (APIs/UI), Business Logic (Domain), and Data Access? Or is logic from these different domains mixed together?
+- **Leaking Abstractions:** Does the business logic layer have direct knowledge of the database schema or HTTP request/response objects? (e.g., a service function that takes `(req, res)` as arguments).
+- **Module Cohesion:** Do modules have a single, well-defined purpose? Look for "utility" or "helper" modules that have become a dumping ground for unrelated functions.
+- **Coupling:** How tightly coupled are the modules? If you change one module, how many other modules are likely to break? Look for excessive direct imports between major components.
+
+#### 2. SOLID Principles
+- **Single Responsibility:** Identify classes or modules that are doing too many things (e.g., a `UserService` that also handles authentication tokens, profile pictures, and password hashing).
+- **Open/Closed:** Is the system designed for extension? If a new feature is added (e.g., a new payment provider), can it be done by adding new code rather than modifying a dozen existing files?
+- **Dependency Inversion:** Do high-level business logic modules depend on concrete low-level implementations (like a specific database driver or ORM), or do they depend on abstractions (interfaces/ports)? Grep for direct imports of database clients inside core business logic files.
+
+#### 3. Scalability and Resilience
+- **Asynchronous Operations:** For long-running tasks (e.g., sending emails, report generation), are they handled asynchronously (e.g., via a message queue) or do they block the main execution thread?
+- **Database Interaction:** Are there obvious performance bottlenecks, like making N+1 queries inside a loop?
+- **State Management:** Are services stateless? A scalable application should be able to run multiple instances behind a load balancer without relying on local memory or file system state.
+- **Error Handling:** Is error handling robust and consistent? Does the application handle failures (e.g., database connection lost, external API timeout) gracefully, or does it crash?
+
+#### 4. Maintainability and Testability
+- **Don't Repeat Yourself (DRY):** Look for duplicated blocks of code or logic that could be abstracted into a single, reusable function or component.
+- **Dependency Injection:** Is it possible to test business logic in isolation? Are dependencies (like database connections or external API clients) injected, or are they hardcoded and created directly within the code? Hardcoded dependencies make unit testing nearly impossible.
+- **Configuration Management:** Are configuration values (API keys, database URLs, feature flags) hardcoded in the source? They should be loaded from environment variables or a configuration file.
+
+### Final Report Format:
+
+Present your findings in a structured Markdown report with the following sections:
+
+-   **Executive Summary:** A brief, high-level overview of the architecture's current state.
+-   **✅ Architectural Strengths:** What the project is doing well.
+-   **⚠️ Critical Architectural Risks:** Major issues that will severely impact scalability or maintainability in the future. These are MUST-FIX items.
+-   **💡 Areas for Improvement:** Important but less critical issues or suggestions for refactoring that would improve the long-term health of the codebase.

--- a/.claude/agents/bug-finder.md
+++ b/.claude/agents/bug-finder.md
@@ -1,3 +1,9 @@
+---
+name: bug-finder
+description: Identifies bugs, edge cases, and potential issues in Python trading systems.
+model: sonnet
+---
+
 # Bug Finder Agent
 
 Specialized in identifying bugs, edge cases, and potential issues in Python trading systems.

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,3 +1,9 @@
+---
+name: code-reviewer
+description: Reviews code for quality, security, performance, and maintainability in Python trading systems.
+model: sonnet
+---
+
 # Code Reviewer Agent
 
 Expert code review specialist for Python trading systems. Focuses on quality, security, performance, and maintainability.

--- a/.claude/agents/doc-implementer.md
+++ b/.claude/agents/doc-implementer.md
@@ -1,0 +1,69 @@
+---
+name: doc-implementer
+description: Use this agent to implement documentation changes based on review findings. This agent takes review recommendations and systematically implements the required updates, fixes, and new documentation.
+tools: Read, Write, Edit, MultiEdit, Grep, Glob, Bash
+model: haiku
+---
+
+You are a specialized Documentation Implementation Agent focused on executing documentation changes based on review findings from the doc-reviewer agent.
+
+Your core responsibilities include:
+
+1. **Execute Review Recommendations**: Implement the specific changes identified by the doc-reviewer
+2. **Update Existing Documentation**: Modify files to fix outdated content and improve quality
+3. **Create New Documentation**: Write new documentation files where gaps were identified
+4. **Fix Technical Issues**: Resolve broken links, update code examples, fix formatting
+5. **Maintain Consistency**: Ensure all changes follow project documentation standards
+
+**Your Implementation Process:**
+
+1. **Parse Review Findings**:
+   - Understand the prioritized list of issues from doc-reviewer
+   - Identify which changes are critical vs enhancement
+   - Plan the implementation order for maximum impact
+
+2. **Systematic Implementation**:
+   - Start with critical issues that could confuse users
+   - Update existing documentation files with corrections
+   - Create new documentation files where needed
+   - Fix broken references and links
+
+3. **Quality Assurance**:
+   - Ensure all changes are accurate and helpful
+   - Maintain consistent formatting and style
+   - Verify code examples work correctly
+   - Check that new content integrates well with existing docs
+
+4. **Documentation Standards**:
+   - Follow established formatting conventions
+   - Use appropriate markdown syntax
+   - Include proper code blocks and examples
+   - Maintain clear section hierarchy
+
+**Your Output Format:**
+
+Provide a comprehensive implementation report:
+
+🔧 **Implementation Summary**:
+- Files updated: [count]
+- New files created: [count]
+- Issues resolved: [count]
+
+📝 **Changes Made**:
+- **Updated Files**: [List files modified with brief description of changes]
+- **New Files**: [List new documentation created]
+- **Fixed Issues**: [List specific problems resolved]
+
+✅ **Quality Checks**:
+- All links verified and working
+- Code examples tested
+- Formatting consistent
+- Content accurate and helpful
+
+**Remaining Items** (if any):
+- [List any issues that couldn't be resolved and why]
+
+**Next Steps**:
+- [Suggest any follow-up actions or future improvements]
+
+You are the executor of documentation improvements, turning review findings into concrete, high-quality documentation that serves users and developers effectively.

--- a/.claude/agents/doc-reviewer.md
+++ b/.claude/agents/doc-reviewer.md
@@ -1,0 +1,63 @@
+---
+name: doc-reviewer
+description: Use this agent to analyze and review documentation state, identifying gaps, outdated content, and quality issues. This agent only reviews and reports - it does not make changes.
+model: sonnet
+---
+
+You are a specialized Documentation Review Agent focused on analyzing documentation state and identifying issues. You DO NOT make any changes - you only review and report findings.
+
+Your core responsibilities include:
+
+1. **Documentation Gap Analysis**: Identify code that lacks proper documentation
+2. **Sync Detection**: Find documentation that has become outdated due to code changes
+3. **Documentation Quality**: Ensure existing documentation is accurate, clear, and helpful
+4. **Coverage Assessment**: Identify areas where documentation should be added or expanded
+
+**Your Review Methodology:**
+
+1. **Code-Documentation Mapping**: 
+   - Scan recent code changes and identify what documentation should be updated
+   - Check for new functions, classes, or APIs that need documentation
+   - Identify deprecated or removed code with documentation that needs cleanup
+
+2. **Documentation Freshness Audit**:
+   - Compare documentation against actual code implementation
+   - Flag documentation that references old APIs or outdated workflows
+   - Identify broken links or references in documentation
+
+3. **Content Quality Review**:
+   - Assess if documentation accurately reflects current functionality
+   - Check for clarity, completeness, and usefulness
+   - Identify documentation that could be improved or restructured
+
+4. **Documentation Standards**:
+   - Ensure consistent formatting and style across documentation
+   - Verify proper use of code examples and API references
+   - Check that documentation follows established conventions
+
+**Your Output Format:**
+
+Structure your analysis as a clear action plan:
+
+📊 **Documentation Status**:
+- Files analyzed: [count]
+- Documentation gaps found: [count]
+- Outdated sections: [count]
+
+🔍 **Findings**:
+- **Missing Documentation**: [List code elements that need documentation]
+- **Outdated Content**: [List documentation that needs updates]
+- **Quality Issues**: [List documentation with clarity or accuracy problems]
+
+📝 **Recommended Actions**:
+1. [Prioritized list of documentation tasks]
+2. [Specific files/sections to update]
+3. [New documentation to create]
+
+**Critical Issues** (if any):
+- [List any documentation problems that could confuse users or cause errors]
+
+**Enhancement Opportunities**:
+- [List ways to improve documentation quality or coverage]
+
+You are the guardian of documentation quality assessment, providing thorough analysis and clear recommendations for the doc-implementer agent to execute.

--- a/.claude/agents/parallel-coordinator.md
+++ b/.claude/agents/parallel-coordinator.md
@@ -1,3 +1,9 @@
+---
+name: parallel-coordinator
+description: Orchestrates multiple agents working simultaneously for maximum review efficiency.
+model: sonnet
+---
+
 # Parallel Coordinator Agent
 
 Orchestrates multiple agents working simultaneously for maximum efficiency.

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -1,3 +1,9 @@
+---
+name: planner
+description: Creates detailed implementation plans before coding with risk analysis and rollback strategies.
+model: sonnet
+---
+
 # Planner Agent
 
 Creates detailed implementation plans before coding.

--- a/.claude/agents/structural-completeness-reviewer.md
+++ b/.claude/agents/structural-completeness-reviewer.md
@@ -1,0 +1,71 @@
+---
+name: structural-completeness-reviewer
+description: Use this agent any time you make a code change that is sufficiently complex to warrant a review, particularly after implementing features, refactoring code, or making significant modifications. This agent focuses exclusively on ensuring changes are fully integrated, old code is properly removed, and no technical debt is introduced. It does NOT review functional correctness, test quality, or documentation - only structural integrity and codebase hygiene.\n\nExamples:\n- <example>\n  Context: You have just refactored a module to use a new API pattern.\n  assistant: "I've finished refactoring the authentication module to use the new token service"\n  assistant: "Let me review the structural completeness of the refactoring"\n  <commentary>\n  Since refactoring was completed, use the structural-completeness-reviewer agent to ensure old code was removed and the change is fully integrated.\n  </commentary>\n  </example>\n- <example>\n  Context: The user has implemented a new feature that touches multiple parts of the codebase.\n  user: "I've added the new dashboard widget feature across the API and UI layers"\n  assistant: "I'll use the structural-completeness-reviewer agent to verify the change is complete across all layers"\n  <commentary>\n  Multi-layer changes need structural review to ensure all parts are present and properly integrated.\n  </commentary>\n  </example>\n- <example>\n  Context: The user has removed a deprecated feature from the codebase.\n  user: "I've removed the legacy export functionality as planned"\n  assistant: "Let me check the structural completeness of this removal"\n  <commentary>\n  Feature removal requires careful review to ensure all related code, dependencies, and configurations are cleaned up.\n  </commentary>\n  </example>
+model: sonnet
+---
+
+You are a meticulous Technical Lead specializing in structural code review and codebase hygiene. Your expertise lies in identifying incomplete changes, dead code, and potential sources of technical debt. You approach every review with the mindset of a custodian protecting the long-term health of the codebase.
+
+Your review scope is strictly limited to structural completeness and cleanliness. You explicitly DO NOT review:
+- Functional correctness (assumed verified by author and tests)
+- Test quality or coverage
+- Documentation quality
+- Code style or formatting (assumed handled by linters)
+
+**Your Review Methodology:**
+
+1. **Dead Code Detection**: You systematically identify any code that has been replaced or refactored and verify its complete removal. You check for:
+   - Unused functions, classes, or modules that should have been deleted
+   - Old implementations left alongside new ones
+   - Orphaned imports or dependencies
+   - Obsolete configuration entries
+
+2. **Change Completeness Audit**: You verify that all components of a change are present:
+   - If a feature touches multiple layers (API, UI, database), confirm all are included
+   - Check that related configuration files are updated (build scripts, deployment configs, environment variables)
+   - Verify that dependency lists reflect additions and removals
+   - Ensure database migrations or schema changes are included if needed
+
+3. **Development Artifact Scan**: You identify and flag any temporary development artifacts:
+   - Commented-out code blocks (unless with clear justification)
+   - TODO, FIXME, or HACK comments without tickets/tracking
+   - Debug logging or test data left in production code
+   - Temporary workarounds that should be proper implementations
+   - Console.log statements or debug breakpoints
+
+4. **Dependency Hygiene**: You verify dependency changes are clean:
+   - New dependencies are actually used and necessary
+   - Removed features have their dependencies removed from package.json/requirements/etc.
+   - No duplicate or conflicting dependencies introduced
+   - Lock files are updated consistently
+
+5. **Configuration Consistency**: You ensure all configuration updates are complete:
+   - Build configurations reflect any new compilation requirements
+   - CI/CD pipelines are updated for new dependencies or build steps
+   - Environment-specific configs are updated consistently across all environments
+   - Feature flags or toggles are properly configured if used
+
+**Your Review Output Format:**
+
+Structure your review as a checklist with clear pass/fail indicators:
+
+✅ **Clean Removals**: [State if old code is completely removed or list what remains]
+✅ **Complete Changes**: [Confirm all required parts are present or list what's missing]
+✅ **No Dev Artifacts**: [Confirm clean or list artifacts found]
+✅ **Dependencies Clean**: [Confirm or list issues]
+✅ **Configs Updated**: [Confirm or list missing updates]
+
+**Critical Issues** (if any):
+- [List any findings that will cause immediate problems]
+
+**Technical Debt Risks** (if any):
+- [List any findings that will cause future maintenance issues]
+
+**Decision Frameworks:**
+
+- When you find incomplete changes, categorize them as either "blocking" (will break builds/deployments) or "debt-inducing" (will cause future confusion/maintenance issues)
+- If you're unsure whether old code should be removed, flag it for author clarification rather than assuming
+- For configuration changes, verify both addition AND removal scenarios
+- When reviewing refactoring, trace all call sites of modified code to ensure completeness
+
+You are the final guardian against the accumulation of technical debt through incomplete changes. Your thoroughness prevents the "death by a thousand cuts" that degrades codebases over time. Every review you perform is an investment in the codebase's future maintainability.

--- a/.claude/agents/style-checker.md
+++ b/.claude/agents/style-checker.md
@@ -1,3 +1,9 @@
+---
+name: style-checker
+description: Ensures code follows Python PEP 8 and project-specific style guidelines.
+model: haiku
+---
+
 # Style Checker Agent
 
 Ensures code follows Python and project-specific style guidelines.

--- a/.claude/agents/trading-validator.md
+++ b/.claude/agents/trading-validator.md
@@ -1,3 +1,9 @@
+---
+name: trading-validator
+description: Validates trading logic, risk management, and order execution flow.
+model: sonnet
+---
+
 # Trading Validator Agent
 
 Specialized agent for validating trading logic and risk management.
@@ -43,7 +49,7 @@ Files: `robo_trader/risk/advanced_risk.py`, `robo_trader/risk/kelly_sizing.py`
 ### Before Trade
 - [ ] Symbol is valid
 - [ ] No existing position (for BUY)
-- [ ] No recent BUY in last 120 seconds
+- [ ] No recent BUY in last 600 seconds (10 min cooldown)
 - [ ] Position size within limits
 - [ ] Sufficient buying power
 

--- a/.claude/agents/verification-challenger.md
+++ b/.claude/agents/verification-challenger.md
@@ -1,3 +1,9 @@
+---
+name: verification-challenger
+description: Second-phase agent that filters false positives from other reviewers.
+model: sonnet
+---
+
 # Verification Challenger Agent
 
 Second-phase agent that filters false positives from other reviewers.

--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -1,3 +1,9 @@
+---
+name: verifier
+description: End-to-end verification and testing specialist for trading systems.
+model: sonnet
+---
+
 # Verifier Agent
 
 End-to-end verification and testing specialist for trading systems.

--- a/.claude/commands/arewedone.md
+++ b/.claude/commands/arewedone.md
@@ -1,0 +1,21 @@
+---
+description: Run structural completeness review
+---
+
+# 1. Structural Completeness Review
+
+Use the structural-completeness-reviewer agent to check if recent changes are fully integrated and no technical debt was introduced.
+
+Launch the structural-completeness-reviewer agent to verify:
+- Changes are fully integrated
+- Old code is properly removed  
+- No technical debt introduced
+- Structural integrity maintained
+
+# 2. Address Review Comments
+
+After the agent returns its review results, you should immediately make the recommended updates. 
+
+# 3. Commit the changes
+
+Create a conventional commit for all the completed changes.

--- a/.claude/commands/code-simplifier.md
+++ b/.claude/commands/code-simplifier.md
@@ -1,3 +1,7 @@
+---
+description: Simplify recently written code while preserving functionality
+---
+
 # Code Simplifier
 
 Review recently written code and simplify it while maintaining functionality.

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,61 +1,22 @@
-# Quick Commit Workflow
+---
+description: Quick conventional commit of staged changes
+---
 
-Fast commit with proper message format.
+# Quick Commit
 
-## Steps
-
-1. Check current changes:
+1. Check changes:
 ```bash
 git status
 git diff --stat
 ```
 
-2. Stage changes:
+2. Stage specific files (never `git add -A`):
 ```bash
-git add -A
+git add <relevant files>
 ```
 
-3. Generate commit message based on:
-- What files changed
-- What the changes accomplish
-- Why the changes were made
+3. Generate commit message:
+   - Summarize the "why" not the "what"
+   - Use conventional format: `<type>: <short description>`
 
-4. Commit with proper format:
-```bash
-git commit -m "$(cat <<'EOF'
-<type>: <short description>
-
-<optional longer description>
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
-EOF
-)"
-```
-
-## Commit Types
-
-| Type | When to Use |
-|------|-------------|
-| `feat` | New feature or functionality |
-| `fix` | Bug fix |
-| `refactor` | Code restructuring, no behavior change |
-| `test` | Adding or updating tests |
-| `docs` | Documentation changes |
-| `chore` | Maintenance, dependencies, configs |
-| `perf` | Performance improvements |
-| `style` | Formatting, no code change |
-
-## Examples
-
-```bash
-# Feature
-git commit -m "feat: add multi-subagent code review command"
-
-# Bug fix
-git commit -m "fix: correct market close time to 4:00 PM"
-
-# Refactor
-git commit -m "refactor: simplify position sizing calculation"
-```
+Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `perf`, `style`

--- a/.claude/commands/docs.md
+++ b/.claude/commands/docs.md
@@ -1,0 +1,41 @@
+---
+description: Complete documentation workflow: review, implement fixes, and commit changes
+argument-hint: [optional: specific file or directory to focus on]
+---
+
+# Documentation Workflow Command
+
+## Context
+
+Current working directory: !`pwd`
+
+Recent changes: !`git log --oneline -5`
+
+Documentation files: !`ls *.md 2>/dev/null`
+
+## Your task
+
+$ARGUMENTS
+
+Execute a complete documentation workflow in three phases:
+
+## Phase 1: Documentation Review
+Use the doc-reviewer agent to analyze the current state of documentation:
+- Identify code changes that need corresponding documentation updates
+- Find documentation that has become outdated
+- Suggest areas where new documentation should be added
+- Review documentation quality and consistency
+
+## Phase 2: Implement Changes
+Use the doc-implementer agent to execute the review recommendations:
+- Update existing documentation files
+- Create new documentation where needed
+- Fix broken links and references
+- Ensure consistent formatting and quality
+
+## Phase 3: Commit Changes
+Create a conventional commit for all documentation improvements.
+
+If arguments are provided, focus the entire workflow on the specified files or directories. Otherwise, perform a comprehensive documentation review and update of the entire project.
+
+Execute each phase sequentially, ensuring each agent completes its work before proceeding to the next phase.

--- a/.claude/commands/oncall-debug.md
+++ b/.claude/commands/oncall-debug.md
@@ -1,3 +1,7 @@
+---
+description: Systematic production debugging workflow
+---
+
 # On-Call Debug Workflow
 
 Systematic debugging for production issues in the trading system.

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,92 +1,40 @@
-# Create Pull Request Workflow
+---
+description: Full PR workflow: test, lint, push, create PR
+---
 
-Full PR workflow with tests, linting, and review.
+# Create Pull Request
 
-## Pre-PR Checklist
-
-### Step 1: Run Full Test Suite
+## Step 1: Verify Clean
 
 ```bash
 python3 -m pytest tests/ --tb=short
-```
-
-All tests must pass.
-
-### Step 2: Run Linting
-
-```bash
 python3 -m black --check .
-python3 -m isort --check-only .
 python3 -m flake8 .
 ```
 
 Fix any issues before proceeding.
 
-### Step 3: Run BugBot
-
-```bash
-./scripts/run_bugbot.sh
-```
-
-- No CRITICAL bugs allowed
-- HIGH priority bugs should be addressed
-
-### Step 4: Check for Uncommitted Changes
+## Step 2: Check State
 
 ```bash
 git status
-git diff --stat
+git log main..HEAD --oneline
 ```
 
-Ensure all changes are committed.
-
-### Step 5: Create PR
+## Step 3: Create PR
 
 ```bash
-# Get current branch
-BRANCH=$(git branch --show-current)
-
-# Get commits since main
-git log main..HEAD --oneline
-
-# Create PR
 gh pr create --title "<type>: <description>" --body "$(cat <<'EOF'
 ## Summary
 - Brief description of changes
-- Key files modified
-- Why these changes were made
-
-## Changes
-- [ ] Change 1
-- [ ] Change 2
 
 ## Test Plan
-- [ ] All tests pass (`pytest tests/`)
-- [ ] Linting passes (`black`, `isort`, `flake8`)
-- [ ] BugBot finds no critical issues
-- [ ] Manual verification of key functionality
-
-## Related Issues
-Closes #XXX (if applicable)
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
+- [ ] All tests pass
+- [ ] Linting passes
 EOF
 )"
 ```
 
-## PR Title Format
+Use conventional commit types for the PR title.
 
-Use conventional commits:
-- `feat: Add new feature`
-- `fix: Fix bug in X`
-- `refactor: Restructure Y`
-- `test: Add tests for Z`
-- `docs: Update documentation`
-- `chore: Maintenance task`
-
-## After PR Created
-
-1. Note the PR URL
-2. Run `/review` command on the PR if needed
-3. Address any CI failures
-4. Request review if required
+If `gh pr create` fails, provide a clickable compare URL with pre-filled title and body per `.claude/CLAUDE.md` instructions.

--- a/.claude/commands/rebase.md
+++ b/.claude/commands/rebase.md
@@ -1,0 +1,28 @@
+---
+allowed-tools: Bash(git:*)
+description: Rebase current branch onto remote upstream branch with smart stash handling
+argument-hint: [optional: target-branch-name]
+---
+
+# Git Rebase Command
+
+## Context
+
+Current git status: !`git status --porcelain`
+
+Current branch: !`git branch --show-current`
+
+Remote tracking branch: !`git rev-parse --abbrev-ref @{upstream} 2>/dev/null || echo "No upstream branch"`
+
+## Your task
+
+Arguments: $ARGUMENTS
+
+Rebase current branch onto the remote upstream branch.
+
+1. Stash uncommitted changes if working directory is dirty
+2. `git fetch origin`
+3. Determine target: use argument if provided, otherwise use upstream tracking branch
+4. `git rebase origin/<target-branch>`
+5. Pop stash if one was created
+6. If conflicts occur at any step, provide clear guidance to the user

--- a/.claude/commands/retrospective.md
+++ b/.claude/commands/retrospective.md
@@ -1,8 +1,10 @@
+---
+description: Extract session learnings and update CLAUDE.md
+---
+
 # Retrospective - Extract Learnings
 
 Review the current session and extract learnings to update CLAUDE.md.
-
-> "When Claude makes a mistake: Fix the immediate issue, add a rule to CLAUDE.md, commit it. This makes all future sessions smarter." — Boris Cherny
 
 ## Process
 
@@ -13,24 +15,10 @@ Review the conversation for:
 - Patterns that worked well
 - Anti-patterns that caused problems
 - New domain knowledge discovered
-- Type mismatches or API surprises
 
-### Step 2: Categorize Learnings
+### Step 2: Update CLAUDE.md
 
-For each learning, categorize:
-
-| Category | Example |
-|----------|---------|
-| **Type Errors** | Decimal vs float in financial calculations |
-| **Connection/Socket** | Using lsof instead of socket.connect_ex() |
-| **Async/Await** | Proper executor usage for stdin |
-| **Database** | Column name mismatches (action vs side) |
-| **Trading Logic** | Market close is 4:00 PM not 4:30 PM |
-| **Config** | Attribute paths that don't exist |
-
-### Step 3: Update CLAUDE.md
-
-Add new entries to the "Common Mistakes" table in `/Users/oliver/robo_trader/CLAUDE.md`:
+Add new entries to the "Common Mistakes" table in CLAUDE.md:
 
 ```markdown
 | Mistake | Correct Approach | Date |
@@ -38,51 +26,13 @@ Add new entries to the "Common Mistakes" table in `/Users/oliver/robo_trader/CLA
 | [What went wrong] | [How to do it right] | [YYYY-MM-DD] |
 ```
 
-### Step 4: Verify Entry Quality
+Good entries are specific, actionable, and include the "why". Skip one-time issues unlikely to recur.
 
-Good entries:
-- Specific and actionable
-- Include the "why" not just "what"
-- Reference actual code patterns if helpful
-
-Bad entries:
-- Too vague ("be careful with types")
-- One-time issues unlikely to recur
-- Personal preferences not project rules
-
-## Output Format
-
-```markdown
-## Session Retrospective
-
-### Learnings Identified
-
-1. **[Category]:** [Brief description]
-   - What happened: ...
-   - Root cause: ...
-   - Prevention: ...
-
-2. ...
-
-### CLAUDE.md Updates
-
-Added to Common Mistakes table:
-| Mistake | Correct Approach | Date |
-|---------|-----------------|------|
-| ... | ... | ... |
-
-### No Updates Needed (if applicable)
-
-Reason: Session went smoothly / Issues were one-time / Already documented
-```
-
-## Commit Message
+### Step 3: Commit
 
 If updates were made:
 ```
 docs: add [topic] to CLAUDE.md common mistakes
-
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 ```
 
 ## When NOT to Update

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,3 +1,7 @@
+---
+description: Multi-agent parallel code review
+---
+
 # Multi-Subagent Code Review
 
 Review the current changes using multiple parallel perspectives, then verify findings.

--- a/.claude/commands/shared-knowledge.md
+++ b/.claude/commands/shared-knowledge.md
@@ -1,3 +1,7 @@
+---
+description: Capture patterns and bugs as CLAUDE.md rules
+---
+
 # Update Shared Knowledge
 
 When Claude makes a mistake or discovers an important pattern, update CLAUDE.md so all future sessions learn from it.

--- a/.claude/commands/test-and-commit.md
+++ b/.claude/commands/test-and-commit.md
@@ -1,6 +1,8 @@
-# Test and Commit Workflow
+---
+description: Run tests, fix failures, then commit
+---
 
-Run tests, then commit if passing. Fix issues if failing.
+# Test and Commit
 
 ## Step 1: Run Tests
 
@@ -8,53 +10,17 @@ Run tests, then commit if passing. Fix issues if failing.
 python3 -m pytest tests/ -x --tb=short -q
 ```
 
-## Step 2: Evaluate Results
+If tests fail: analyze, fix, and re-run until passing.
 
-### If ALL tests pass:
-1. Run linting checks:
-   ```bash
-   python3 -m black --check .
-   python3 -m isort --check-only .
-   python3 -m flake8 .
-   ```
+## Step 2: Lint Check
 
-2. If linting passes, proceed to commit:
-   ```bash
-   git add -A
-   git status
-   ```
-
-3. Generate commit message based on changes:
-   - Look at staged files
-   - Summarize the "why" not the "what"
-   - Use conventional commit format (feat:, fix:, refactor:, etc.)
-
-4. Create commit with generated message
-
-### If tests FAIL:
-1. Analyze the failure output
-2. Identify root cause
-3. Fix the issue
-4. Re-run tests
-5. Repeat until passing
-6. Then proceed to commit
-
-## Commit Message Format
-
-```
-<type>: <short description>
-
-<longer description if needed>
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+```bash
+python3 -m black --check .
+python3 -m flake8 .
 ```
 
-## Types
-- `feat`: New feature
-- `fix`: Bug fix
-- `refactor`: Code restructuring
-- `test`: Adding/updating tests
-- `docs`: Documentation only
-- `chore`: Maintenance tasks
+## Step 3: Commit
+
+Stage specific files (never `git add -A`) and commit with conventional format.
+
+Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`

--- a/.claude/commands/two-phase-review.md
+++ b/.claude/commands/two-phase-review.md
@@ -1,3 +1,7 @@
+---
+description: Parallel review with false-positive challenger phase
+---
+
 # Two-Phase Review (Boris Cherny Method)
 
 Run a parallel code review with challenger phase to filter false positives.

--- a/.claude/commands/verify-trading.md
+++ b/.claude/commands/verify-trading.md
@@ -1,3 +1,7 @@
+---
+description: Check trading system health: Gateway, zombies, risk params
+---
+
 # Verify Trading System
 
 Comprehensive verification of the trading system health and readiness.
@@ -14,11 +18,6 @@ ps aux | grep -E "(runner_async|app.py|websocket_server)" | grep -v grep
 - `app.py` - Dashboard
 
 If `runner_async` is NOT running, start it:
-```bash
-nohup python3 -m robo_trader.runner_async > robo_trader.log 2>&1 &
-```
-
-Or use the full startup script:
 ```bash
 ./START_TRADER.sh
 ```
@@ -53,11 +52,14 @@ Check `.env` for required safety configs:
 - `STOP_LOSS_PERCENT` - Should be set (default: 2.0)
 - `MAX_POSITION_SIZE` - Should be set
 - `EXECUTION_MODE` - Should be `paper` for testing
+- `USE_TRAILING_STOP` - Should be `true` (locks in profits)
+- `TRAILING_STOP_PERCENT` - Should be set (default: 5.0)
+- `ENABLE_EXTENDED_HOURS` - Set to `true` for pre/after market
 
 ## Step 5: Safety Feature Tests
 
 ```bash
-/Users/oliver/robo_trader/venv/bin/python3 -m pytest tests/test_safety_features.py -v
+.venv/bin/python3 -m pytest tests/test_safety_features.py -v
 ```
 
 All tests should pass.

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -1,3 +1,7 @@
+---
+description: Run full verification loop: tests, lint, types, trading checks
+---
+
 # Verification Loop
 
 Run a complete verification loop on recent changes. This is the single most important practice for quality.

--- a/.claude/commands/worktree.md
+++ b/.claude/commands/worktree.md
@@ -1,0 +1,29 @@
+---
+allowed-tools: Bash(git:*)
+description: Create a new git worktree that tracks the remote default branch
+argument-hint: (no arguments needed)
+---
+
+# Git Worktree Command
+
+## Context
+
+Current repository info: !`git remote get-url origin 2>/dev/null || echo "No remote origin found"`
+
+Current branch: !`git branch --show-current`
+
+Existing worktrees: !`git worktree list`
+
+Existing branches: !`git branch --list 'worktree*'`
+
+Default remote branch: !`git remote show origin 2>/dev/null | grep "HEAD branch" | cut -d: -f2 | xargs || git branch -r | grep -E 'origin/(main|master)' | head -1 | sed 's/.*origin\///'`
+
+## Your task
+
+Create a new git worktree with an auto-generated branch name tracking the remote default branch.
+
+1. `git fetch origin`
+2. Determine default remote branch (origin/main or origin/master)
+3. Find next available `worktreeN` number from existing branches
+4. Create worktree: `git worktree add --track -b worktreeN /worktreeN origin/<default-branch>`
+5. Display: new branch name, worktree path, upstream branch

--- a/.claude/hooks/clean_commit_guard.py
+++ b/.claude/hooks/clean_commit_guard.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+Hook to prevent commits containing "Claude" or "Anthropic" in any form, and emojis.
+Blocks commits with these terms in:
+- Commit messages
+- Author fields
+- Co-author fields
+- Emojis in commit messages
+"""
+
+import json
+import sys
+import re
+
+
+def contains_emoji(text):
+    """Check if text contains any emoji characters."""
+    # Unicode ranges for emoji characters
+    emoji_pattern = re.compile(
+        "["
+        "\U0001f600-\U0001f64f"  # emoticons
+        "\U0001f300-\U0001f5ff"  # symbols & pictographs
+        "\U0001f680-\U0001f6ff"  # transport & map symbols
+        "\U0001f1e0-\U0001f1ff"  # flags (iOS)
+        "\U00002702-\U000027b0"  # dingbats
+        "\U000024c2-\U0001f251"  # enclosed characters
+        "\U0001f900-\U0001f9ff"  # supplemental symbols
+        "\U0001fa70-\U0001faff"  # symbols and pictographs extended-a
+        "]+",
+        flags=re.UNICODE,
+    )
+    return bool(emoji_pattern.search(text))
+
+
+def check_git_commit_command(command):
+    """Check if a git commit command contains prohibited terms."""
+    prohibited_terms = ["claude", "anthropic"]
+    command_lower = command.lower()
+
+    # Check for emojis in the command
+    if contains_emoji(command):
+        return True, "Command contains emojis - removing emojis from commit"
+
+    # Check for prohibited terms in the entire command
+    for term in prohibited_terms:
+        if term in command_lower:
+            return (
+                True,
+                f"Command contains '{term}' - removing all Claude/Anthropic references",
+            )
+
+    # Specific checks for git commit patterns
+    if "git commit" in command:
+        # Check for co-author patterns
+        if re.search(r"co-authored-by:.*claude", command_lower):
+            return True, "Removing Claude as co-author from commit"
+
+        # Check for author override attempts
+        if "--author" in command and any(
+            term in command_lower for term in prohibited_terms
+        ):
+            return True, "Cannot set Claude/Anthropic as commit author"
+
+    return False, None
+
+
+def suggest_cleaned_command(command):
+    """Suggest a cleaned version of the command."""
+    # Remove all emojis
+    emoji_pattern = re.compile(
+        "["
+        "\U0001f600-\U0001f64f"  # emoticons
+        "\U0001f300-\U0001f5ff"  # symbols & pictographs
+        "\U0001f680-\U0001f6ff"  # transport & map symbols
+        "\U0001f1e0-\U0001f1ff"  # flags (iOS)
+        "\U00002702-\U000027b0"  # dingbats
+        "\U000024c2-\U0001f251"  # enclosed characters
+        "\U0001f900-\U0001f9ff"  # supplemental symbols
+        "\U0001fa70-\U0001faff"  # symbols and pictographs extended-a
+        "]+",
+        flags=re.UNICODE,
+    )
+    cleaned = emoji_pattern.sub("", command)
+
+    # Remove co-author lines with Claude/Anthropic
+    cleaned = re.sub(r"(?i)co-authored-by:.*(?:claude|anthropic).*\n?", "", cleaned)
+
+    # Remove any lines mentioning generated with Claude
+    cleaned = re.sub(r"(?i).*generated with.*claude.*\n?", "", cleaned)
+
+    # Clean up author fields
+    if "--author" in cleaned:
+        cleaned = re.sub(
+            r'--author[= ]["\']?[^"\']*(?:claude|anthropic)[^"\']*["\']?',
+            "",
+            cleaned,
+            flags=re.IGNORECASE,
+        )
+
+    # Remove extra whitespace and newlines
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    cleaned = cleaned.strip()
+
+    return cleaned
+
+
+def main():
+    try:
+        input_data = json.load(sys.stdin)
+        tool_name = input_data.get("tool_name", "")
+        tool_input = input_data.get("tool_input", {})
+        cwd = input_data.get("cwd", "")
+
+        # Exception: Skip checks if we're in the ~/.claude/ directory
+        # This is the only directory where "claude" is allowed in paths
+        import os
+
+        claude_dir = os.path.expanduser("~/.claude").replace("\\", "/")
+        current_dir = cwd.replace("\\", "/")
+        if current_dir.startswith(claude_dir):
+            sys.exit(0)  # Allow all commands in ~/.claude/
+
+        # Handle both Bash commands and MCP git tools
+        if tool_name == "Bash":
+            command = tool_input.get("command", "")
+        elif tool_name == "git_commit":
+            # For MCP git_commit tool, check the message parameter
+            message = tool_input.get("message", "")
+            if message:
+                # Check the commit message for prohibited content
+                has_issue, issue_message = check_git_commit_command(
+                    f'git commit -m "{message}"'
+                )
+                if has_issue:
+                    print(f"BLOCKED: {issue_message}", file=sys.stderr)
+                    print("\nYour CLAUDE.md configuration specifies:", file=sys.stderr)
+                    print("- Never add Claude as a commit author", file=sys.stderr)
+                    print(
+                        "- Always commit using the default git settings",
+                        file=sys.stderr,
+                    )
+                    sys.exit(2)  # Exit code 2 blocks the command
+            sys.exit(0)
+        else:
+            sys.exit(0)
+
+        command = tool_input.get("command", "")
+
+        # Check if this is a git commit command
+        if "git commit" not in command and "git config" not in command:
+            sys.exit(0)
+
+        # Block git config commands that try to set Claude as author
+        if "git config" in command:
+            command_lower = command.lower()
+            if "user.name" in command and (
+                "claude" in command_lower or "anthropic" in command_lower
+            ):
+                print(
+                    "BLOCKED: Cannot set git user.name to Claude or Anthropic",
+                    file=sys.stderr,
+                )
+                print("Use the default git settings for commits", file=sys.stderr)
+                sys.exit(2)  # Exit code 2 blocks the command
+            if "user.email" in command and (
+                "claude" in command_lower or "anthropic" in command_lower
+            ):
+                print(
+                    "BLOCKED: Cannot set git user.email with Claude/Anthropic",
+                    file=sys.stderr,
+                )
+                print("Use the default git settings for commits", file=sys.stderr)
+                sys.exit(2)
+
+        # Check git commit commands
+        has_issue, message = check_git_commit_command(command)
+
+        if has_issue:
+            print(f"BLOCKED: {message}", file=sys.stderr)
+            print("\nYour CLAUDE.md configuration specifies:", file=sys.stderr)
+            print("- Never add Claude as a commit author", file=sys.stderr)
+            print("- Always commit using the default git settings", file=sys.stderr)
+
+            # Suggest cleaned command if it's a commit
+            if "git commit" in command:
+                cleaned = suggest_cleaned_command(command)
+                if cleaned and "git commit" in cleaned:
+                    print("\nSuggested cleaned command:", file=sys.stderr)
+                    print(cleaned, file=sys.stderr)
+                    print(
+                        "\nThe commit will use your default git author settings.",
+                        file=sys.stderr,
+                    )
+
+            sys.exit(2)  # Exit code 2 blocks the command
+
+    except Exception as e:
+        # Silent fail - don't break Claude's workflow
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/emoji_remover.py
+++ b/.claude/hooks/emoji_remover.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""
+Emoji checker hook for Claude Code.
+Detects emojis in edited files and asks Claude to remove them.
+"""
+
+import json
+import sys
+import os
+import re
+
+# Emoji pattern to detect any emoji
+EMOJI_PATTERN = re.compile(
+    "["
+    "\U0001f600-\U0001f64f"  # emoticons
+    "\U0001f300-\U0001f5ff"  # symbols & pictographs
+    "\U0001f680-\U0001f6ff"  # transport & map symbols
+    "\U0001f1e0-\U0001f1ff"  # flags
+    "\U00002700-\U000027bf"  # dingbats
+    "\U0001f900-\U0001f9ff"  # supplemental symbols
+    "\U00002600-\U000026ff"  # misc symbols
+    "\U0001fa70-\U0001faff"  # symbols and pictographs extended-A
+    "\U00002300-\U000023ff"  # misc technical
+    "]+",
+    flags=re.UNICODE,
+)
+
+try:
+    input_data = json.load(sys.stdin)
+    tool_input = input_data.get("tool_input", {})
+    file_path = tool_input.get("file_path", "")
+
+    if not file_path or not os.path.exists(file_path):
+        sys.exit(0)
+
+    with open(file_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    # Check for emojis
+    emojis_found = EMOJI_PATTERN.findall(content)
+
+    if emojis_found:
+        # Exit with code 2 to block and provide feedback to Claude
+        print(
+            f"Emojis are not allowed in files. Please remove or replace the emojis in {file_path} with text equivalents like [X], [OK], [WARNING], etc.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    sys.exit(0)
+
+except:
+    sys.exit(0)

--- a/.claude/hooks/github_issue_guard.py
+++ b/.claude/hooks/github_issue_guard.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+GitHub Issue Content Guard Hook
+
+WHAT THIS SCRIPT DOES:
+- Prevents GitHub issues created through Claude Code from containing "Claude" or "Anthropic" references
+- Blocks both MCP GitHub tools (mcp__github__create_issue, etc.) and gh CLI commands
+- Allows emojis in GitHub issues (unlike the commit guard hook)
+- Provides helpful error messages and suggests cleaned commands when blocking
+
+SPECIFIC BEHAVIORS:
+1. For MCP GitHub tools: Scans title, body, comment, and content fields for prohibited terms
+2. For gh CLI commands: Scans the entire command line for prohibited terms
+3. Case-insensitive matching for "claude" and "anthropic"
+4. Suggests cleaned versions of gh commands when possible
+5. Exits with code 2 to block the operation when prohibited content is found
+
+TRIGGERED BY:
+- MCP tools: mcp__github__create_issue, mcp__github__add_issue_comment, mcp__github__update_issue
+- Bash commands: gh issue create, gh issue edit, gh issue comment
+
+This prevents issues like "Generated with Claude Code" from appearing in GitHub issues.
+"""
+
+import json
+import sys
+import re
+
+
+def check_github_issue_content(text):
+    """Check if text contains prohibited terms for GitHub issues."""
+    if not text:
+        return False, None
+
+    prohibited_terms = ["claude", "anthropic"]
+    text_lower = text.lower()
+
+    # Check for prohibited terms
+    for term in prohibited_terms:
+        if term in text_lower:
+            return (
+                True,
+                f"Content contains '{term}' - removing all Claude/Anthropic references",
+            )
+
+    return False, None
+
+
+def check_mcp_github_tool(tool_name, tool_input):
+    """Check MCP GitHub tools for prohibited content."""
+    github_tools = [
+        "mcp__github__create_issue",
+        "mcp__github__add_issue_comment",
+        "mcp__github__update_issue",
+    ]
+
+    if tool_name not in github_tools:
+        return False, None
+
+    # Check various content fields
+    fields_to_check = ["title", "body", "comment", "content"]
+
+    for field in fields_to_check:
+        if field in tool_input:
+            has_issue, message = check_github_issue_content(tool_input[field])
+            if has_issue:
+                return True, f"Issue {field} {message}"
+
+    return False, None
+
+
+def check_gh_command(command):
+    """Check gh CLI commands for prohibited content."""
+    if not any(
+        gh_cmd in command
+        for gh_cmd in ["gh issue create", "gh issue edit", "gh issue comment"]
+    ):
+        return False, None
+
+    command_lower = command.lower()
+    prohibited_terms = ["claude", "anthropic"]
+
+    # Check for prohibited terms in the entire command
+    for term in prohibited_terms:
+        if term in command_lower:
+            return (
+                True,
+                f"GitHub issue command contains '{term}' - removing all Claude/Anthropic references",
+            )
+
+    return False, None
+
+
+def suggest_cleaned_gh_command(command):
+    """Suggest a cleaned version of the gh command."""
+    # Remove any references to Claude or Anthropic
+    cleaned = re.sub(r"(?i)\b(?:claude|anthropic)\b[^\s]*\s*", "", command)
+
+    # Remove lines mentioning "Generated with Claude"
+    cleaned = re.sub(r"(?i).*generated with.*claude.*", "", cleaned)
+
+    # Remove "Co-Authored-By" lines with Claude/Anthropic
+    cleaned = re.sub(r"(?i)co-authored-by:.*(?:claude|anthropic).*", "", cleaned)
+
+    # Clean up extra whitespace
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    cleaned = cleaned.strip()
+
+    return cleaned
+
+
+def main():
+    try:
+        input_data = json.load(sys.stdin)
+        tool_name = input_data.get("tool_name", "")
+        tool_input = input_data.get("tool_input", {})
+
+        # Check MCP GitHub tools
+        if tool_name.startswith("mcp__github__"):
+            has_issue, message = check_mcp_github_tool(tool_name, tool_input)
+            if has_issue:
+                print(f"BLOCKED: {message}", file=sys.stderr)
+                print(
+                    "GitHub issues cannot contain Claude or Anthropic references",
+                    file=sys.stderr,
+                )
+                sys.exit(2)  # Exit code 2 blocks the command
+
+        # Check Bash commands (for gh CLI)
+        elif tool_name == "Bash":
+            command = tool_input.get("command", "")
+            has_issue, message = check_gh_command(command)
+            if has_issue:
+                print(f"BLOCKED: {message}", file=sys.stderr)
+                print(
+                    "GitHub issues cannot contain Claude or Anthropic references",
+                    file=sys.stderr,
+                )
+
+                # Suggest cleaned command
+                cleaned = suggest_cleaned_gh_command(command)
+                if cleaned and cleaned != command:
+                    print("\nSuggested cleaned command:", file=sys.stderr)
+                    print(cleaned, file=sys.stderr)
+
+                sys.exit(2)  # Exit code 2 blocks the command
+
+    except Exception as e:
+        # Silent fail - don't break Claude's workflow
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/protect_claude_md.py
+++ b/.claude/hooks/protect_claude_md.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""
+Hook to prevent any modifications to files named CLAUDE.md
+Protects both user-level and project-level CLAUDE.md files from being edited.
+"""
+
+import json
+import sys
+import os
+
+
+def main():
+    try:
+        input_data = json.load(sys.stdin)
+        tool_name = input_data.get("tool_name", "")
+
+        # Check only file modification tools
+        if tool_name not in ["Edit", "MultiEdit", "Write", "NotebookEdit"]:
+            sys.exit(0)
+
+        file_path = input_data.get("tool_input", {}).get("file_path", "")
+
+        # Check if the file being modified is named CLAUDE.md
+        if os.path.basename(file_path).upper() == "CLAUDE.MD":
+            print("❌ BLOCKED: Cannot modify CLAUDE.md files")
+            print(
+                "\nCLAUDE.md files contain user instructions that should only be modified by the user directly."
+            )
+            print("These files are protected from automated modifications.")
+
+            # Provide context about which CLAUDE.md was attempted
+            if ".claude" in file_path:
+                if os.path.expanduser("~") in file_path:
+                    print(
+                        "\nAttempted to modify: User-level CLAUDE.md (~/.claude/CLAUDE.md)"
+                    )
+                else:
+                    print(
+                        "\nAttempted to modify: Project-level CLAUDE.md (.claude/CLAUDE.md)"
+                    )
+
+            print(
+                "\nIf you need to update your instructions, please edit CLAUDE.md manually."
+            )
+
+            sys.exit(2)  # Exit code 2 blocks the command
+
+    except Exception as e:
+        # Silent fail - don't break Claude's workflow
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/sync_docs_on_start.py
+++ b/.claude/hooks/sync_docs_on_start.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""
+Session start hook to sync Claude Code documentation
+Runs the documentation sync script when a new Claude Code session starts
+"""
+
+import subprocess
+import sys
+import os
+from pathlib import Path
+
+
+def main():
+    """Run the documentation sync script"""
+    try:
+        # Get the directory containing this hook
+        hook_dir = Path(__file__).parent
+        claude_dir = hook_dir.parent
+
+        # Path to the sync script
+        sync_script = claude_dir / "sync-docs.py"
+
+        if not sync_script.exists():
+            print("Documentation sync script not found, skipping sync")
+            return 0
+
+        print("Syncing Claude Code documentation...")
+
+        # Run the sync script
+        result = subprocess.run(
+            [sys.executable, str(sync_script)],
+            capture_output=True,
+            text=True,
+            cwd=str(claude_dir),
+        )
+
+        if result.returncode == 0:
+            print("+ Documentation sync completed successfully")
+        else:
+            print("! Documentation sync completed with warnings")
+            if result.stderr:
+                print(f"Errors: {result.stderr.strip()}")
+
+        return 0
+
+    except Exception as e:
+        print(f"- Documentation sync failed: {e}")
+        return 0  # Don't block the session if sync fails
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/skill-creator/scripts/init_skill.py
+++ b/.claude/skills/skill-creator/scripts/init_skill.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""
+Skill Initializer - Creates a new skill from template
+
+Usage:
+    init_skill.py <skill-name> --path <path>
+
+Examples:
+    init_skill.py my-new-skill --path skills/public
+    init_skill.py my-api-helper --path skills/private
+    init_skill.py custom-skill --path /custom/location
+"""
+
+import sys
+from pathlib import Path
+
+SKILL_TEMPLATE = """---
+name: {skill_name}
+description: [TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]
+---
+
+# {skill_title}
+
+## Overview
+
+[TODO: 1-2 sentences explaining what this skill enables]
+
+## Structuring This Skill
+
+[TODO: Choose the structure that best fits this skill's purpose. Common patterns:
+
+**1. Workflow-Based** (best for sequential processes)
+- Works well when there are clear step-by-step procedures
+- Example: DOCX skill with "Workflow Decision Tree" → "Reading" → "Creating" → "Editing"
+- Structure: ## Overview → ## Workflow Decision Tree → ## Step 1 → ## Step 2...
+
+**2. Task-Based** (best for tool collections)
+- Works well when the skill offers different operations/capabilities
+- Example: PDF skill with "Quick Start" → "Merge PDFs" → "Split PDFs" → "Extract Text"
+- Structure: ## Overview → ## Quick Start → ## Task Category 1 → ## Task Category 2...
+
+**3. Reference/Guidelines** (best for standards or specifications)
+- Works well for brand guidelines, coding standards, or requirements
+- Example: Brand styling with "Brand Guidelines" → "Colors" → "Typography" → "Features"
+- Structure: ## Overview → ## Guidelines → ## Specifications → ## Usage...
+
+**4. Capabilities-Based** (best for integrated systems)
+- Works well when the skill provides multiple interrelated features
+- Example: Product Management with "Core Capabilities" → numbered capability list
+- Structure: ## Overview → ## Core Capabilities → ### 1. Feature → ### 2. Feature...
+
+Patterns can be mixed and matched as needed. Most skills combine patterns (e.g., start with task-based, add workflow for complex operations).
+
+Delete this entire "Structuring This Skill" section when done - it's just guidance.]
+
+## [TODO: Replace with the first main section based on chosen structure]
+
+[TODO: Add content here. See examples in existing skills:
+- Code samples for technical skills
+- Decision trees for complex workflows
+- Concrete examples with realistic user requests
+- References to scripts/templates/references as needed]
+
+## Resources
+
+This skill includes example resource directories that demonstrate how to organize different types of bundled resources:
+
+### scripts/
+Executable code (Python/Bash/etc.) that can be run directly to perform specific operations.
+
+**Examples from other skills:**
+- PDF skill: `fill_fillable_fields.py`, `extract_form_field_info.py` - utilities for PDF manipulation
+- DOCX skill: `document.py`, `utilities.py` - Python modules for document processing
+
+**Appropriate for:** Python scripts, shell scripts, or any executable code that performs automation, data processing, or specific operations.
+
+**Note:** Scripts may be executed without loading into context, but can still be read by Claude for patching or environment adjustments.
+
+### references/
+Documentation and reference material intended to be loaded into context to inform Claude's process and thinking.
+
+**Examples from other skills:**
+- Product management: `communication.md`, `context_building.md` - detailed workflow guides
+- BigQuery: API reference documentation and query examples
+- Finance: Schema documentation, company policies
+
+**Appropriate for:** In-depth documentation, API references, database schemas, comprehensive guides, or any detailed information that Claude should reference while working.
+
+### assets/
+Files not intended to be loaded into context, but rather used within the output Claude produces.
+
+**Examples from other skills:**
+- Brand styling: PowerPoint template files (.pptx), logo files
+- Frontend builder: HTML/React boilerplate project directories
+- Typography: Font files (.ttf, .woff2)
+
+**Appropriate for:** Templates, boilerplate code, document templates, images, icons, fonts, or any files meant to be copied or used in the final output.
+
+---
+
+**Any unneeded directories can be deleted.** Not every skill requires all three types of resources.
+"""
+
+EXAMPLE_SCRIPT = '''#!/usr/bin/env python3
+"""
+Example helper script for {skill_name}
+
+This is a placeholder script that can be executed directly.
+Replace with actual implementation or delete if not needed.
+
+Example real scripts from other skills:
+- pdf/scripts/fill_fillable_fields.py - Fills PDF form fields
+- pdf/scripts/convert_pdf_to_images.py - Converts PDF pages to images
+"""
+
+def main():
+    print("This is an example script for {skill_name}")
+    # TODO: Add actual script logic here
+    # This could be data processing, file conversion, API calls, etc.
+
+if __name__ == "__main__":
+    main()
+'''
+
+EXAMPLE_REFERENCE = """# Reference Documentation for {skill_title}
+
+This is a placeholder for detailed reference documentation.
+Replace with actual reference content or delete if not needed.
+
+Example real reference docs from other skills:
+- product-management/references/communication.md - Comprehensive guide for status updates
+- product-management/references/context_building.md - Deep-dive on gathering context
+- bigquery/references/ - API references and query examples
+
+## When Reference Docs Are Useful
+
+Reference docs are ideal for:
+- Comprehensive API documentation
+- Detailed workflow guides
+- Complex multi-step processes
+- Information too lengthy for main SKILL.md
+- Content that's only needed for specific use cases
+
+## Structure Suggestions
+
+### API Reference Example
+- Overview
+- Authentication
+- Endpoints with examples
+- Error codes
+- Rate limits
+
+### Workflow Guide Example
+- Prerequisites
+- Step-by-step instructions
+- Common patterns
+- Troubleshooting
+- Best practices
+"""
+
+EXAMPLE_ASSET = """# Example Asset File
+
+This placeholder represents where asset files would be stored.
+Replace with actual asset files (templates, images, fonts, etc.) or delete if not needed.
+
+Asset files are NOT intended to be loaded into context, but rather used within
+the output Claude produces.
+
+Example asset files from other skills:
+- Brand guidelines: logo.png, slides_template.pptx
+- Frontend builder: hello-world/ directory with HTML/React boilerplate
+- Typography: custom-font.ttf, font-family.woff2
+- Data: sample_data.csv, test_dataset.json
+
+## Common Asset Types
+
+- Templates: .pptx, .docx, boilerplate directories
+- Images: .png, .jpg, .svg, .gif
+- Fonts: .ttf, .otf, .woff, .woff2
+- Boilerplate code: Project directories, starter files
+- Icons: .ico, .svg
+- Data files: .csv, .json, .xml, .yaml
+
+Note: This is a text placeholder. Actual assets can be any file type.
+"""
+
+
+def title_case_skill_name(skill_name):
+    """Convert hyphenated skill name to Title Case for display."""
+    return " ".join(word.capitalize() for word in skill_name.split("-"))
+
+
+def init_skill(skill_name, path):
+    """
+    Initialize a new skill directory with template SKILL.md.
+
+    Args:
+        skill_name: Name of the skill
+        path: Path where the skill directory should be created
+
+    Returns:
+        Path to created skill directory, or None if error
+    """
+    # Determine skill directory path
+    skill_dir = Path(path).resolve() / skill_name
+
+    # Check if directory already exists
+    if skill_dir.exists():
+        print(f"❌ Error: Skill directory already exists: {skill_dir}")
+        return None
+
+    # Create skill directory
+    try:
+        skill_dir.mkdir(parents=True, exist_ok=False)
+        print(f"✅ Created skill directory: {skill_dir}")
+    except Exception as e:
+        print(f"❌ Error creating directory: {e}")
+        return None
+
+    # Create SKILL.md from template
+    skill_title = title_case_skill_name(skill_name)
+    skill_content = SKILL_TEMPLATE.format(
+        skill_name=skill_name, skill_title=skill_title
+    )
+
+    skill_md_path = skill_dir / "SKILL.md"
+    try:
+        skill_md_path.write_text(skill_content)
+        print("✅ Created SKILL.md")
+    except Exception as e:
+        print(f"❌ Error creating SKILL.md: {e}")
+        return None
+
+    # Create resource directories with example files
+    try:
+        # Create scripts/ directory with example script
+        scripts_dir = skill_dir / "scripts"
+        scripts_dir.mkdir(exist_ok=True)
+        example_script = scripts_dir / "example.py"
+        example_script.write_text(EXAMPLE_SCRIPT.format(skill_name=skill_name))
+        example_script.chmod(0o755)
+        print("✅ Created scripts/example.py")
+
+        # Create references/ directory with example reference doc
+        references_dir = skill_dir / "references"
+        references_dir.mkdir(exist_ok=True)
+        example_reference = references_dir / "api_reference.md"
+        example_reference.write_text(EXAMPLE_REFERENCE.format(skill_title=skill_title))
+        print("✅ Created references/api_reference.md")
+
+        # Create assets/ directory with example asset placeholder
+        assets_dir = skill_dir / "assets"
+        assets_dir.mkdir(exist_ok=True)
+        example_asset = assets_dir / "example_asset.txt"
+        example_asset.write_text(EXAMPLE_ASSET)
+        print("✅ Created assets/example_asset.txt")
+    except Exception as e:
+        print(f"❌ Error creating resource directories: {e}")
+        return None
+
+    # Print next steps
+    print(f"\n✅ Skill '{skill_name}' initialized successfully at {skill_dir}")
+    print("\nNext steps:")
+    print("1. Edit SKILL.md to complete the TODO items and update the description")
+    print(
+        "2. Customize or delete the example files in scripts/, references/, and assets/"
+    )
+    print("3. Run the validator when ready to check the skill structure")
+
+    return skill_dir
+
+
+def main():
+    if len(sys.argv) < 4 or sys.argv[2] != "--path":
+        print("Usage: init_skill.py <skill-name> --path <path>")
+        print("\nSkill name requirements:")
+        print("  - Hyphen-case identifier (e.g., 'data-analyzer')")
+        print("  - Lowercase letters, digits, and hyphens only")
+        print("  - Max 40 characters")
+        print("  - Must match directory name exactly")
+        print("\nExamples:")
+        print("  init_skill.py my-new-skill --path skills/public")
+        print("  init_skill.py my-api-helper --path skills/private")
+        print("  init_skill.py custom-skill --path /custom/location")
+        sys.exit(1)
+
+    skill_name = sys.argv[1]
+    path = sys.argv[3]
+
+    print(f"🚀 Initializing skill: {skill_name}")
+    print(f"   Location: {path}")
+    print()
+
+    result = init_skill(skill_name, path)
+
+    if result:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/skill-creator/scripts/package_skill.py
+++ b/.claude/skills/skill-creator/scripts/package_skill.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Skill Packager - Creates a distributable .skill file of a skill folder
+
+Usage:
+    python utils/package_skill.py <path/to/skill-folder> [output-directory]
+
+Example:
+    python utils/package_skill.py skills/public/my-skill
+    python utils/package_skill.py skills/public/my-skill ./dist
+"""
+
+import sys
+import zipfile
+from pathlib import Path
+from quick_validate import validate_skill
+
+
+def package_skill(skill_path, output_dir=None):
+    """
+    Package a skill folder into a .skill file.
+
+    Args:
+        skill_path: Path to the skill folder
+        output_dir: Optional output directory for the .skill file (defaults to current directory)
+
+    Returns:
+        Path to the created .skill file, or None if error
+    """
+    skill_path = Path(skill_path).resolve()
+
+    # Validate skill folder exists
+    if not skill_path.exists():
+        print(f"❌ Error: Skill folder not found: {skill_path}")
+        return None
+
+    if not skill_path.is_dir():
+        print(f"❌ Error: Path is not a directory: {skill_path}")
+        return None
+
+    # Validate SKILL.md exists
+    skill_md = skill_path / "SKILL.md"
+    if not skill_md.exists():
+        print(f"❌ Error: SKILL.md not found in {skill_path}")
+        return None
+
+    # Run validation before packaging
+    print("🔍 Validating skill...")
+    valid, message = validate_skill(skill_path)
+    if not valid:
+        print(f"❌ Validation failed: {message}")
+        print("   Please fix the validation errors before packaging.")
+        return None
+    print(f"✅ {message}\n")
+
+    # Determine output location
+    skill_name = skill_path.name
+    if output_dir:
+        output_path = Path(output_dir).resolve()
+        output_path.mkdir(parents=True, exist_ok=True)
+    else:
+        output_path = Path.cwd()
+
+    skill_filename = output_path / f"{skill_name}.skill"
+
+    # Create the .skill file (zip format)
+    try:
+        with zipfile.ZipFile(skill_filename, "w", zipfile.ZIP_DEFLATED) as zipf:
+            # Walk through the skill directory
+            for file_path in skill_path.rglob("*"):
+                if file_path.is_file():
+                    # Calculate the relative path within the zip
+                    arcname = file_path.relative_to(skill_path.parent)
+                    zipf.write(file_path, arcname)
+                    print(f"  Added: {arcname}")
+
+        print(f"\n✅ Successfully packaged skill to: {skill_filename}")
+        return skill_filename
+
+    except Exception as e:
+        print(f"❌ Error creating .skill file: {e}")
+        return None
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(
+            "Usage: python utils/package_skill.py <path/to/skill-folder> [output-directory]"
+        )
+        print("\nExample:")
+        print("  python utils/package_skill.py skills/public/my-skill")
+        print("  python utils/package_skill.py skills/public/my-skill ./dist")
+        sys.exit(1)
+
+    skill_path = sys.argv[1]
+    output_dir = sys.argv[2] if len(sys.argv) > 2 else None
+
+    print(f"📦 Packaging skill: {skill_path}")
+    if output_dir:
+        print(f"   Output directory: {output_dir}")
+    print()
+
+    result = package_skill(skill_path, output_dir)
+
+    if result:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/skill-creator/scripts/quick_validate.py
+++ b/.claude/skills/skill-creator/scripts/quick_validate.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Quick validation script for skills - minimal version
+"""
+
+import sys
+import os
+import re
+import yaml
+from pathlib import Path
+
+
+def validate_skill(skill_path):
+    """Basic validation of a skill"""
+    skill_path = Path(skill_path)
+
+    # Check SKILL.md exists
+    skill_md = skill_path / "SKILL.md"
+    if not skill_md.exists():
+        return False, "SKILL.md not found"
+
+    # Read and validate frontmatter
+    content = skill_md.read_text()
+    if not content.startswith("---"):
+        return False, "No YAML frontmatter found"
+
+    # Extract frontmatter
+    match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+    if not match:
+        return False, "Invalid frontmatter format"
+
+    frontmatter_text = match.group(1)
+
+    # Parse YAML frontmatter
+    try:
+        frontmatter = yaml.safe_load(frontmatter_text)
+        if not isinstance(frontmatter, dict):
+            return False, "Frontmatter must be a YAML dictionary"
+    except yaml.YAMLError as e:
+        return False, f"Invalid YAML in frontmatter: {e}"
+
+    # Define allowed properties
+    ALLOWED_PROPERTIES = {"name", "description", "license", "allowed-tools", "metadata"}
+
+    # Check for unexpected properties (excluding nested keys under metadata)
+    unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
+    if unexpected_keys:
+        return False, (
+            f"Unexpected key(s) in SKILL.md frontmatter: {', '.join(sorted(unexpected_keys))}. "
+            f"Allowed properties are: {', '.join(sorted(ALLOWED_PROPERTIES))}"
+        )
+
+    # Check required fields
+    if "name" not in frontmatter:
+        return False, "Missing 'name' in frontmatter"
+    if "description" not in frontmatter:
+        return False, "Missing 'description' in frontmatter"
+
+    # Extract name for validation
+    name = frontmatter.get("name", "")
+    if not isinstance(name, str):
+        return False, f"Name must be a string, got {type(name).__name__}"
+    name = name.strip()
+    if name:
+        # Check naming convention (hyphen-case: lowercase with hyphens)
+        if not re.match(r"^[a-z0-9-]+$", name):
+            return (
+                False,
+                f"Name '{name}' should be hyphen-case (lowercase letters, digits, and hyphens only)",
+            )
+        if name.startswith("-") or name.endswith("-") or "--" in name:
+            return (
+                False,
+                f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens",
+            )
+        # Check name length (max 64 characters per spec)
+        if len(name) > 64:
+            return (
+                False,
+                f"Name is too long ({len(name)} characters). Maximum is 64 characters.",
+            )
+
+    # Extract and validate description
+    description = frontmatter.get("description", "")
+    if not isinstance(description, str):
+        return False, f"Description must be a string, got {type(description).__name__}"
+    description = description.strip()
+    if description:
+        # Check for angle brackets
+        if "<" in description or ">" in description:
+            return False, "Description cannot contain angle brackets (< or >)"
+        # Check description length (max 1024 characters per spec)
+        if len(description) > 1024:
+            return (
+                False,
+                f"Description is too long ({len(description)} characters). Maximum is 1024 characters.",
+            )
+
+    return True, "Skill is valid!"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python quick_validate.py <skill_directory>")
+        sys.exit(1)
+
+    valid, message = validate_skill(sys.argv[1])
+    print(message)
+    sys.exit(0 if valid else 1)

--- a/.claude/skills/verify-trading/scripts/verify_system.py
+++ b/.claude/skills/verify-trading/scripts/verify_system.py
@@ -162,7 +162,10 @@ def check_recent_errors() -> dict:
     except ValueError:
         count = 0
 
-    return {"status": "pass" if count < 5 else "warn" if count < 20 else "fail", "count": count}
+    return {
+        "status": "pass" if count < 5 else "warn" if count < 20 else "fail",
+        "count": count,
+    }
 
 
 def main():

--- a/.claude/sync-docs.py
+++ b/.claude/sync-docs.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Claude Code Documentation Sync Script
+Downloads all documentation from https://docs.anthropic.com/en/docs/claude-code/
+"""
+
+import os
+import sys
+import requests
+from pathlib import Path
+import time
+from urllib.parse import urljoin
+
+# Configuration
+BASE_URL = "https://docs.anthropic.com/en/docs/claude-code"
+DOCS_DIR = Path(__file__).parent / "docs"
+
+# All Claude Code documentation pages
+PAGES = [
+    "overview",
+    "quickstart",
+    "memory",
+    "common-workflows",
+    "ide-integrations",
+    "mcp",
+    "github-actions",
+    "sdk",
+    "troubleshooting",
+    "third-party-integrations",
+    "amazon-bedrock",
+    "google-vertex-ai",
+    "corporate-proxy",
+    "llm-gateway",
+    "devcontainer",
+    "iam",
+    "security",
+    "monitoring-usage",
+    "costs",
+    "cli-reference",
+    "interactive-mode",
+    "slash-commands",
+    "settings",
+    "hooks",
+    "sub-agents",
+    "output-styles",
+    "hooks-guide",
+]
+
+
+def ensure_requests():
+    """Ensure requests library is available"""
+    try:
+        import requests
+
+        return True
+    except ImportError:
+        print("Error: requests library not found")
+        print("Please install it with: pip install requests")
+        return False
+
+
+def download_page(page_name):
+    """Download a single documentation page directly as markdown"""
+    url = f"{BASE_URL}/{page_name}.md"  # Direct markdown URL
+    output_file = DOCS_DIR / f"{page_name}.md"
+
+    try:
+        print(f"Downloading: {page_name}")
+        response = requests.get(url, timeout=30)
+        response.raise_for_status()
+
+        # Save the markdown content directly
+        content = response.text
+
+        # Add a header with metadata
+        header = f"""<!-- 
+Source: {url}
+Downloaded: {time.strftime('%Y-%m-%d %H:%M:%S')}
+-->
+
+"""
+
+        with open(output_file, "w", encoding="utf-8") as f:
+            f.write(header + content)
+
+        print(f"+ Downloaded: {page_name}")
+        return True
+
+    except requests.RequestException as e:
+        print(f"- Failed to download {page_name}: {e}")
+        return False
+    except Exception as e:
+        print(f"- Error processing {page_name}: {e}")
+        return False
+
+
+def main():
+    """Main sync function"""
+    if not ensure_requests():
+        return 1
+
+    # Parse command line arguments
+    if len(sys.argv) > 1:
+        # Sync specific pages
+        pages_to_sync = sys.argv[1:]
+        # Validate that requested pages exist in our known pages
+        invalid_pages = [p for p in pages_to_sync if p not in PAGES]
+        if invalid_pages:
+            print(f"Unknown pages: {', '.join(invalid_pages)}")
+            print(f"Available pages: {', '.join(PAGES)}")
+            return 1
+    else:
+        # Sync all pages
+        pages_to_sync = PAGES
+
+    # Create docs directory
+    DOCS_DIR.mkdir(exist_ok=True)
+
+    if len(pages_to_sync) == 1:
+        print(f"Syncing Claude Code documentation page: {pages_to_sync[0]}")
+    else:
+        print("Syncing Claude Code documentation...")
+    print(f"Target directory: {DOCS_DIR}")
+
+    success_count = 0
+    total_count = len(pages_to_sync)
+
+    for page in pages_to_sync:
+        if download_page(page):
+            success_count += 1
+        time.sleep(0.5)  # Be respectful to the server
+
+    print(f"\nSync complete! {success_count}/{total_count} pages downloaded")
+    print(f"Files saved to: {DOCS_DIR}")
+
+    return 0 if success_count == total_count else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/app.py
+++ b/app.py
@@ -187,7 +187,7 @@ def validate_portfolio(f):
     def decorated(*args, **kwargs):
         portfolio_id = request.args.get("portfolio_id", "default")
         try:
-            _portfolio_validator.validate_portfolio_id(portfolio_id)
+            portfolio_id = _portfolio_validator.validate_portfolio_id(portfolio_id)
         except ValidationError as e:
             return jsonify({"error": str(e)}), 400
         # Check if non-default portfolio actually exists

--- a/app.py
+++ b/app.py
@@ -1831,8 +1831,18 @@ HTML_TEMPLATE = """
                 // Calculate portfolio values from P&L
                 values = data.values.map(pnl => STARTING_CAPITAL + pnl);
                 labels = data.labels || values.map((_, i) => i);
-            } else {
-                // No data yet
+            }
+
+            // Need at least 2 data points to draw a line
+            if (values.length < 2) {
+                // Destroy existing chart and show message
+                if (overviewEquityChart) {
+                    overviewEquityChart.destroy();
+                    overviewEquityChart = null;
+                }
+                document.getElementById('ov-chart-range').textContent = values.length === 0
+                    ? 'No data yet'
+                    : 'Need more history';
                 return;
             }
 
@@ -1841,12 +1851,10 @@ HTML_TEMPLATE = """
             const lastValue = values[values.length - 1] || STARTING_CAPITAL;
             const isPositive = lastValue >= firstValue;
 
+            // Destroy and recreate chart when switching portfolios for clean state
             if (overviewEquityChart) {
-                overviewEquityChart.data.labels = labels;
-                overviewEquityChart.data.datasets[0].data = values;
-                overviewEquityChart.data.datasets[0].borderColor = isPositive ? '#4ade80' : '#f87171';
-                overviewEquityChart.update('none');
-                return;
+                overviewEquityChart.destroy();
+                overviewEquityChart = null;
             }
 
             const gradient = ctx.getContext('2d').createLinearGradient(0, 0, 0, 120);

--- a/docs/MULTIUSER_PLAN.md
+++ b/docs/MULTIUSER_PLAN.md
@@ -1,0 +1,360 @@
+# Multi-Portfolio / Multiuser Implementation Plan
+
+## Overview
+
+Transform the single-user RoboTrader into a multi-portfolio system where multiple independent portfolios can trade simultaneously through a shared IBKR Gateway connection. Start with 2 portfolios, architect for N.
+
+## Design Principles
+
+1. **Shared broker, isolated portfolios** - All portfolios use the same IBKR Gateway connection (port 4002) but have fully independent positions, trades, cash, risk parameters, and equity tracking
+2. **Single database, partitioned by portfolio_id** - One `trading_data.db` with a `portfolio_id` column on all user-scoped tables (not separate DB files)
+3. **Single process** - One runner process manages all portfolios sequentially within each cycle (no need for multiple OS processes)
+4. **Backward compatible** - Existing data migrates seamlessly as `portfolio_id = 'default'`
+5. **Minimal surface area** - Change only what's needed; market data, features, ticks remain global (shared across portfolios)
+
+## Architecture
+
+```
+                    ┌─────────────────────────┐
+                    │    IBKR Gateway :4002    │
+                    └────────────┬────────────┘
+                                 │ (shared connection)
+                    ┌────────────┴────────────┐
+                    │      AsyncRunner         │
+                    │  (orchestrates cycles)   │
+                    └────────────┬────────────┘
+                                 │
+              ┌──────────────────┼──────────────────┐
+              │                  │                   │
+    ┌─────────┴──────┐  ┌───────┴────────┐  ┌──────┴─────────┐
+    │  Portfolio "A"  │  │ Portfolio "B"  │  │ Portfolio "N"  │
+    │  ────────────── │  │ ────────────── │  │ ──────────────  │
+    │  Cash: $50,000  │  │ Cash: $50,000  │  │ Cash: ...      │
+    │  Symbols: AAPL  │  │ Symbols: TSLA  │  │ Symbols: ...   │
+    │  Risk: conserv. │  │ Risk: aggress. │  │ Risk: ...      │
+    │  Positions: own │  │ Positions: own │  │ Positions: own │
+    │  Stop-losses    │  │ Stop-losses    │  │ Stop-losses    │
+    └────────────────┘  └────────────────┘  └────────────────┘
+              │                  │                   │
+              └──────────────────┼──────────────────┘
+                                 │
+                    ┌────────────┴────────────┐
+                    │    trading_data.db       │
+                    │  (partitioned by         │
+                    │   portfolio_id)          │
+                    └────────────┬────────────┘
+                                 │
+              ┌──────────────────┼──────────────────┐
+              │                  │                   │
+    ┌─────────┴──────┐  ┌───────┴────────┐  ┌──────┴─────────┐
+    │  Dashboard :5000│  │ WebSocket :8765│  │ Mobile App     │
+    │  Portfolio picker│  │ Per-portfolio  │  │ Portfolio picker│
+    │  in header       │  │ channels      │  │                │
+    └────────────────┘  └────────────────┘  └────────────────┘
+```
+
+## What Changes vs What Stays the Same
+
+### STAYS THE SAME (Global / Shared)
+- IBKR Gateway connection (single port 4002)
+- Market data tables: `market_data`, `ticks`, `features` (prices are prices)
+- ML models and feature store (models are symbol-level, not portfolio-level)
+- AI Analyst / news fetcher (news is global)
+- Gateway manager, IBC, watchdog
+- Logger infrastructure
+
+### CHANGES (Per-Portfolio Isolation)
+- **Database schema**: Add `portfolio_id` to `positions`, `trades`, `account`, `equity_history`, `signals`
+- **New table**: `portfolios` (configuration for each portfolio)
+- **AsyncRunner**: Loop over portfolios each cycle instead of single portfolio
+- **Portfolio class**: Accept and carry `portfolio_id`
+- **Config**: Support per-portfolio overrides (symbols, cash, risk params)
+- **Dashboard API**: All endpoints accept `?portfolio_id=` query param
+- **WebSocket**: Include `portfolio_id` in messages; clients subscribe to specific portfolio
+- **Stop-loss monitor**: Tag stops with `portfolio_id`
+- **Order manager**: Tag orders with `portfolio_id`
+- **Start script**: Load portfolio configs on startup
+
+---
+
+## Phase 1: Database Schema & Migration (Foundation)
+
+### 1.1 New `portfolios` table
+
+```sql
+CREATE TABLE IF NOT EXISTS portfolios (
+    id TEXT PRIMARY KEY,           -- e.g., 'aggressive', 'conservative', 'default'
+    name TEXT NOT NULL,            -- Display name: "Aggressive Growth"
+    starting_cash REAL NOT NULL DEFAULT 100000,
+    symbols TEXT NOT NULL,         -- Comma-separated: "AAPL,NVDA,TSLA"
+    active INTEGER NOT NULL DEFAULT 1,
+    -- Per-portfolio risk overrides (NULL = use global default)
+    max_position_pct REAL,
+    max_daily_loss_pct REAL,
+    max_open_positions INTEGER,
+    stop_loss_pct REAL,
+    trailing_stop_pct REAL,
+    use_trailing_stop INTEGER,
+    -- Strategy overrides
+    enabled_strategies TEXT,       -- NULL = use global, else comma-separated
+    min_confidence REAL,
+    -- Metadata
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### 1.2 Add `portfolio_id` to existing tables
+
+Migration adds `portfolio_id TEXT NOT NULL DEFAULT 'default'` to:
+
+| Table | Current unique constraint | New unique constraint |
+|-------|--------------------------|----------------------|
+| `positions` | `UNIQUE(symbol)` | `UNIQUE(portfolio_id, symbol)` |
+| `trades` | none | none (add index on portfolio_id) |
+| `account` | `id = 1` hardcoded | `UNIQUE(portfolio_id)` |
+| `equity_history` | `UNIQUE(date)` | `UNIQUE(portfolio_id, date)` |
+| `signals` | none | none (add index on portfolio_id) |
+
+Tables that stay global (no `portfolio_id`):
+- `market_data`, `ticks`, `features` — market data is shared
+
+### 1.3 Migration strategy
+
+Since SQLite doesn't support `ALTER TABLE ADD CONSTRAINT`, use the rename-recreate pattern:
+
+```python
+async def migrate_to_multiuser(self):
+    """One-time migration to add portfolio_id support."""
+    # 1. Check if already migrated
+    # 2. Create portfolios table
+    # 3. Insert 'default' portfolio from current config
+    # 4. For each table needing portfolio_id:
+    #    a. CREATE new_table with portfolio_id column
+    #    b. INSERT INTO new_table SELECT *, 'default' FROM old_table
+    #    c. DROP old_table
+    #    d. ALTER TABLE new_table RENAME TO table
+    # 5. Update account table: portfolio_id instead of id=1
+```
+
+**Backward compatibility**: All existing data gets `portfolio_id = 'default'`. The system works identically to before if only one portfolio exists.
+
+### 1.4 Database method changes
+
+Every method that touches these tables gets an optional `portfolio_id` parameter:
+
+```python
+# Before:
+async def get_positions(self) -> List[Dict]:
+
+# After:
+async def get_positions(self, portfolio_id: str = 'default') -> List[Dict]:
+```
+
+Methods affected:
+- `update_position()` → add `portfolio_id` param
+- `get_positions()` → filter by `portfolio_id`
+- `record_trade()` → add `portfolio_id` param
+- `get_recent_trades()` → filter by `portfolio_id`
+- `has_recent_buy_trade()` → filter by `portfolio_id`
+- `has_recent_sell_trade()` → filter by `portfolio_id`
+- `update_account()` → use `portfolio_id` instead of `WHERE id = 1`
+- `get_account_info()` → filter by `portfolio_id`
+- `record_equity_history()` → add `portfolio_id` param
+- `get_equity_history()` → filter by `portfolio_id`
+- `_calculate_fifo_pnl()` → filter by `portfolio_id`
+- `record_signal()` → add `portfolio_id` param
+
+---
+
+## Phase 2: Portfolio Configuration System
+
+### 2.1 Portfolio config in `.env`
+
+```env
+# Portfolio definitions (JSON-encoded list)
+PORTFOLIOS=[{"id":"aggressive","name":"Aggressive Growth","starting_cash":50000,"symbols":"NVDA,TSLA,AMD,MARA","max_position_pct":0.04,"use_trailing_stop":true,"trailing_stop_pct":0.07},{"id":"conservative","name":"Conservative Income","starting_cash":50000,"symbols":"AAPL,MSFT,JNJ,PG,KO","max_position_pct":0.02,"use_trailing_stop":true,"trailing_stop_pct":0.04}]
+```
+
+If `PORTFOLIOS` is not set, auto-create a single `default` portfolio from the existing `SYMBOLS` and `DEFAULT_CASH` env vars (backward compatible).
+
+### 2.2 PortfolioConfig dataclass
+
+```python
+@dataclass
+class PortfolioConfig:
+    id: str
+    name: str
+    starting_cash: float
+    symbols: List[str]
+    active: bool = True
+    # Risk overrides (None = use global)
+    max_position_pct: Optional[float] = None
+    max_daily_loss_pct: Optional[float] = None
+    max_open_positions: Optional[int] = None
+    stop_loss_pct: Optional[float] = None
+    trailing_stop_pct: Optional[float] = None
+    use_trailing_stop: Optional[bool] = None
+    enabled_strategies: Optional[List[str]] = None
+    min_confidence: Optional[float] = None
+```
+
+### 2.3 Config loading
+
+`load_config()` gains a `portfolios: List[PortfolioConfig]` field. If no `PORTFOLIOS` env var, creates `[PortfolioConfig(id='default', ...)]` from existing settings.
+
+---
+
+## Phase 3: Runner Multi-Portfolio Loop
+
+### 3.1 Core loop change
+
+Currently:
+```python
+# Single portfolio per cycle
+async def run_cycle():
+    runner = AsyncRunner(...)
+    await runner.setup()
+    await runner.process_symbols(symbols)
+    await runner.update_account()
+```
+
+After:
+```python
+async def run_cycle():
+    for portfolio_config in active_portfolios:
+        runner = AsyncRunner(portfolio_id=portfolio_config.id, ...)
+        await runner.setup()  # Loads portfolio-specific positions/state
+        await runner.process_symbols(portfolio_config.symbols)
+        await runner.update_account()
+```
+
+### 3.2 AsyncRunner changes
+
+- Accept `portfolio_id` in constructor
+- Pass `portfolio_id` to all DB calls
+- `load_existing_positions()` only loads positions for this portfolio
+- `self.portfolio = Portfolio(starting_cash, portfolio_id=...)`
+- Stop-loss monitor tags stops with portfolio_id
+- WebSocket updates include portfolio_id
+
+### 3.3 Position isolation
+
+Critical: Two portfolios CAN hold the same symbol independently.
+- Portfolio A: 100 shares AAPL @ $180
+- Portfolio B: 50 shares AAPL @ $185
+
+The `positions` table uses `UNIQUE(portfolio_id, symbol)` to allow this.
+
+Duplicate buy protection (`has_recent_buy_trade`) must be scoped to portfolio_id.
+
+---
+
+## Phase 4: Dashboard Multi-Portfolio Support
+
+### 4.1 API changes
+
+All endpoints gain `portfolio_id` query parameter:
+
+```
+GET /api/positions?portfolio_id=aggressive
+GET /api/pnl?portfolio_id=aggressive
+GET /api/status?portfolio_id=aggressive
+GET /api/account?portfolio_id=aggressive
+GET /api/equity-history?portfolio_id=aggressive
+GET /api/trades?portfolio_id=aggressive
+```
+
+Default: If `portfolio_id` not specified, return data for `'default'` portfolio.
+
+New endpoint:
+```
+GET /api/portfolios  → List all portfolios with summary stats
+```
+
+### 4.2 Dashboard UI
+
+- Add portfolio selector dropdown in header (next to existing controls)
+- All dashboard panels update when portfolio is selected
+- "All Portfolios" aggregate view shows combined equity, all positions
+- Color-code or badge positions by portfolio
+
+### 4.3 SyncDatabaseReader
+
+The synchronous DB reader used by Flask also needs `portfolio_id` filtering on all queries.
+
+---
+
+## Phase 5: WebSocket Per-Portfolio Updates
+
+### 5.1 Message format change
+
+```json
+{
+    "type": "trade_update",
+    "portfolio_id": "aggressive",
+    "data": { "symbol": "NVDA", "side": "BUY", ... }
+}
+```
+
+### 5.2 Client subscription
+
+Clients send a subscribe message on connect:
+```json
+{"action": "subscribe", "portfolio_ids": ["aggressive", "conservative"]}
+```
+
+Or subscribe to all: `{"action": "subscribe", "portfolio_ids": ["*"]}`
+
+The WebSocket manager routes messages only to subscribed clients.
+
+---
+
+## Phase 6: Stop-Loss & Order Manager Updates
+
+### 6.1 Stop-loss monitor
+
+- `StopLossOrder` gets `portfolio_id` field
+- `add_stop_loss(symbol, ..., portfolio_id=...)`
+- Stop triggers only affect the correct portfolio
+- On restart, loads stops per-portfolio from DB positions
+
+### 6.2 Order manager
+
+- `OrderDetails` gets `portfolio_id` field
+- Order callbacks include portfolio_id for routing
+
+---
+
+## Implementation Order (Recommended)
+
+| Step | What | Risk | Effort |
+|------|------|------|--------|
+| **1** | Database migration + `portfolios` table | LOW - additive, backward compat | Medium |
+| **2** | DB method signatures (add `portfolio_id` param) | LOW - default='default' | Medium |
+| **3** | PortfolioConfig dataclass + config loading | LOW - new code | Small |
+| **4** | AsyncRunner accepts portfolio_id, passes to DB | MEDIUM - core logic | Large |
+| **5** | Multi-portfolio loop in `run_continuous()` | MEDIUM - orchestration | Medium |
+| **6** | Dashboard API `portfolio_id` support | LOW - additive | Medium |
+| **7** | Dashboard UI portfolio selector | LOW - frontend only | Medium |
+| **8** | WebSocket per-portfolio routing | LOW - additive | Small |
+| **9** | Stop-loss monitor portfolio isolation | MEDIUM - safety critical | Medium |
+| **10** | Start script + .env config | LOW - configuration | Small |
+| **11** | Testing & validation | - | Medium |
+
+## Risk Mitigation
+
+1. **Data safety**: Migration creates backup before any schema changes
+2. **Backward compat**: `portfolio_id='default'` means system works identically if only one portfolio
+3. **Incremental**: Each step is independently testable and deployable
+4. **Same IBKR account**: No broker-level changes needed; portfolios are virtual subdivisions of the same account
+5. **No data deletion**: Migration only adds columns and creates new tables
+
+## Future Extensions (Out of Scope for Now)
+
+- Full user authentication with JWT tokens
+- Per-user login and role-based access
+- Separate IBKR sub-accounts per user
+- Independent processes per user
+- User management admin panel
+- API key-based access for programmatic users

--- a/robo_trader/database_async.py
+++ b/robo_trader/database_async.py
@@ -1088,7 +1088,7 @@ class AsyncTradingDatabase:
                 (datetime.fromtimestamp(cutoff_date),),
             )
 
-            # Clean up old signals
+            # Clean up old signals (global across all portfolios - old signals have no value)
             await conn.execute(
                 "DELETE FROM signals WHERE timestamp < ?",
                 (datetime.fromtimestamp(cutoff_date),),

--- a/robo_trader/database_async.py
+++ b/robo_trader/database_async.py
@@ -626,11 +626,7 @@ class AsyncTradingDatabase:
         portfolio_id: str = DEFAULT_PORTFOLIO_ID,
     ) -> None:
         """Record a strategy signal asynchronously."""
-        try:
-            portfolio_id = DatabaseValidator.validate_portfolio_id(portfolio_id)
-        except ValidationError as e:
-            logger.error(f"Signal record validation failed: {e}")
-            raise ValueError(str(e)) from e
+        portfolio_id = DatabaseValidator.validate_portfolio_id(portfolio_id)
         async with self.get_connection() as conn:
             await conn.execute(
                 """
@@ -952,11 +948,7 @@ class AsyncTradingDatabase:
         This is the industry standard approach for tracking portfolio value over time.
         Called at end of each trading day or when account summary is updated.
         """
-        try:
-            portfolio_id = DatabaseValidator.validate_portfolio_id(portfolio_id)
-        except ValidationError as e:
-            logger.error(f"Equity snapshot validation failed: {e}")
-            raise ValueError(str(e)) from e
+        portfolio_id = DatabaseValidator.validate_portfolio_id(portfolio_id)
 
         if snapshot_date is None:
             snapshot_date = datetime.now().strftime("%Y-%m-%d")

--- a/robo_trader/database_validator.py
+++ b/robo_trader/database_validator.py
@@ -172,9 +172,9 @@ class DatabaseValidator:
         except (InvalidOperation, ValueError, TypeError) as e:
             raise ValidationError(f"Invalid {field_name}: {price} - {e}")
 
-        if not min_val:
+        if min_val is None:
             min_val = DatabaseValidator.MIN_PRICE
-        if not max_val:
+        if max_val is None:
             max_val = DatabaseValidator.MAX_PRICE
 
         if price_float < min_val:

--- a/robo_trader/database_validator.py
+++ b/robo_trader/database_validator.py
@@ -54,8 +54,8 @@ class DatabaseValidator:
     # Valid symbol pattern: 1-5 uppercase letters, optionally followed by dot and 1-2 letters
     SYMBOL_PATTERN = re.compile(r"^[A-Z]{1,5}(\.[A-Z]{1,2})?$")
 
-    # Valid portfolio_id pattern: alphanumeric + underscore/hyphen, 1-50 chars
-    PORTFOLIO_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{1,50}$")
+    # Valid portfolio_id pattern: alphanumeric + underscore/hyphen, 1-64 chars
+    PORTFOLIO_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
 
     # Maximum reasonable values for sanity checks
     MAX_PRICE = 1_000_000.0  # $1M per share max
@@ -131,7 +131,7 @@ class DatabaseValidator:
         if not DatabaseValidator.PORTFOLIO_ID_PATTERN.match(portfolio_id):
             raise ValidationError(
                 f"Invalid portfolio_id format: '{portfolio_id}'. "
-                "Must be 1-50 alphanumeric characters, underscores, or hyphens."
+                "Must be 1-64 alphanumeric characters, underscores, or hyphens."
             )
 
         # Check for SQL injection attempts

--- a/robo_trader/multiuser/__init__.py
+++ b/robo_trader/multiuser/__init__.py
@@ -1,0 +1,17 @@
+"""
+Multi-portfolio / multiuser support for RoboTrader.
+
+This package provides:
+- PortfolioConfig: Per-portfolio configuration with risk overrides
+- Database migration: Adds portfolio_id partitioning to existing tables
+- Portfolio registry: Load/save portfolio definitions
+"""
+
+from .portfolio_config import PortfolioConfig, load_portfolio_configs
+from .migration import MultiuserMigration
+
+__all__ = [
+    "PortfolioConfig",
+    "load_portfolio_configs",
+    "MultiuserMigration",
+]

--- a/robo_trader/multiuser/__init__.py
+++ b/robo_trader/multiuser/__init__.py
@@ -4,14 +4,17 @@ Multi-portfolio / multiuser support for RoboTrader.
 This package provides:
 - PortfolioConfig: Per-portfolio configuration with risk overrides
 - Database migration: Adds portfolio_id partitioning to existing tables
+- PortfolioScopedDB: Proxy that auto-injects portfolio_id into DB calls
 - Portfolio registry: Load/save portfolio definitions
 """
 
 from .portfolio_config import PortfolioConfig, load_portfolio_configs
 from .migration import MultiuserMigration
+from .db_proxy import PortfolioScopedDB
 
 __all__ = [
     "PortfolioConfig",
     "load_portfolio_configs",
     "MultiuserMigration",
+    "PortfolioScopedDB",
 ]

--- a/robo_trader/multiuser/db_proxy.py
+++ b/robo_trader/multiuser/db_proxy.py
@@ -35,8 +35,11 @@ _PORTFOLIO_SCOPED_METHODS = frozenset({
     "get_account_info",
     "save_equity_snapshot",
     "get_equity_history",
-    "upsert_portfolio",
 })
+
+# Methods that are portfolio-related but DON'T take portfolio_id as a kwarg
+# (e.g., upsert_portfolio takes portfolio_data dict with id inside)
+# These pass through unchanged.
 
 
 class PortfolioScopedDB:

--- a/robo_trader/multiuser/db_proxy.py
+++ b/robo_trader/multiuser/db_proxy.py
@@ -1,0 +1,64 @@
+"""
+Portfolio-scoped database proxy.
+
+Wraps AsyncTradingDatabase to automatically inject portfolio_id into all
+portfolio-scoped method calls. This avoids having to modify 30+ call sites
+in runner_async.py.
+
+Usage:
+    db = AsyncTradingDatabase()
+    scoped_db = PortfolioScopedDB(db, portfolio_id="aggressive")
+
+    # These automatically scope to the "aggressive" portfolio:
+    await scoped_db.get_positions()           # → db.get_positions(portfolio_id="aggressive")
+    await scoped_db.record_trade(...)         # → db.record_trade(..., portfolio_id="aggressive")
+    await scoped_db.update_account(...)       # → db.update_account(..., portfolio_id="aggressive")
+
+    # Global methods (no portfolio_id) pass through unchanged:
+    await scoped_db.store_market_data(...)    # → db.store_market_data(...)
+"""
+
+from robo_trader.database_async import DEFAULT_PORTFOLIO_ID
+
+
+# Methods that accept portfolio_id parameter
+_PORTFOLIO_SCOPED_METHODS = frozenset({
+    "update_position",
+    "record_trade",
+    "update_account",
+    "record_signal",
+    "get_position",
+    "get_positions",
+    "has_recent_buy_trade",
+    "has_recent_sell_trade",
+    "get_recent_trades",
+    "get_account_info",
+    "save_equity_snapshot",
+    "get_equity_history",
+    "upsert_portfolio",
+})
+
+
+class PortfolioScopedDB:
+    """Proxy that auto-injects portfolio_id into portfolio-scoped DB methods.
+
+    For global methods (market_data, ticks, features, etc.), calls pass through
+    to the underlying database unchanged.
+    """
+
+    def __init__(self, db, portfolio_id: str = DEFAULT_PORTFOLIO_ID):
+        self._db = db
+        self.portfolio_id = portfolio_id
+
+    def __getattr__(self, name):
+        attr = getattr(self._db, name)
+
+        if name in _PORTFOLIO_SCOPED_METHODS and callable(attr):
+            # Wrap to auto-inject portfolio_id
+            async def scoped_method(*args, **kwargs):
+                if "portfolio_id" not in kwargs:
+                    kwargs["portfolio_id"] = self.portfolio_id
+                return await attr(*args, **kwargs)
+            return scoped_method
+
+        return attr

--- a/robo_trader/multiuser/migration.py
+++ b/robo_trader/multiuser/migration.py
@@ -1,0 +1,344 @@
+"""
+Database migration for multiuser/multi-portfolio support.
+
+Adds portfolio_id column to positions, trades, account, equity_history, and signals.
+Creates new portfolios table. All existing data gets portfolio_id='default'.
+
+This migration is safe and backward-compatible:
+- Only runs once (checks migration version)
+- Creates backup before modifying tables
+- Existing single-portfolio usage continues to work unchanged
+"""
+
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+import aiosqlite
+
+from ..logger import get_logger
+
+logger = get_logger(__name__)
+
+MIGRATION_VERSION = 1  # Increment when adding new migrations
+
+
+class MultiuserMigration:
+    """Handles database schema migration for multi-portfolio support."""
+
+    def __init__(self, db_path: Path):
+        self.db_path = db_path
+
+    async def get_migration_version(self, conn: aiosqlite.Connection) -> int:
+        """Get current migration version from database."""
+        try:
+            cursor = await conn.execute(
+                "SELECT version FROM schema_migrations ORDER BY version DESC LIMIT 1"
+            )
+            row = await cursor.fetchone()
+            return row[0] if row else 0
+        except Exception:
+            # Table doesn't exist yet
+            return 0
+
+    async def needs_migration(self) -> bool:
+        """Check if the database needs the multiuser migration."""
+        async with aiosqlite.connect(self.db_path) as conn:
+            current = await self.get_migration_version(conn)
+            return current < MIGRATION_VERSION
+
+    def _create_backup(self) -> Optional[Path]:
+        """Create a backup of the database before migration.
+
+        Returns:
+            Path to backup file, or None if db doesn't exist
+        """
+        if not self.db_path.exists():
+            return None
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        backup_path = self.db_path.with_suffix(f".backup_premultiuser_{timestamp}.db")
+        shutil.copy2(self.db_path, backup_path)
+        logger.info(f"Created database backup at: {backup_path}")
+        return backup_path
+
+    async def migrate(self, default_cash: float = 100_000.0) -> bool:
+        """Run the multiuser migration.
+
+        Args:
+            default_cash: Starting cash for the 'default' portfolio record
+
+        Returns:
+            True if migration was applied, False if already up to date
+        """
+        if not self.db_path.exists():
+            logger.info("No database found - migration will be applied on first init")
+            return False
+
+        async with aiosqlite.connect(self.db_path) as conn:
+            await conn.execute("PRAGMA journal_mode=WAL")
+            await conn.execute("PRAGMA busy_timeout=10000")
+            await conn.execute("PRAGMA foreign_keys=OFF")
+
+            current_version = await self.get_migration_version(conn)
+            if current_version >= MIGRATION_VERSION:
+                logger.info(f"Database already at migration version {current_version}, skipping")
+                return False
+
+            # Create backup BEFORE any changes
+            backup_path = self._create_backup()
+            logger.info(f"Starting multiuser migration (v{current_version} → v{MIGRATION_VERSION})")
+
+            try:
+                await self._apply_migration_v1(conn, default_cash)
+                await conn.commit()
+                logger.info("Multiuser migration completed successfully")
+                return True
+
+            except Exception as e:
+                logger.error(f"Migration failed: {e}")
+                await conn.rollback()
+                if backup_path and backup_path.exists():
+                    logger.info(f"Restoring from backup: {backup_path}")
+                    shutil.copy2(backup_path, self.db_path)
+                raise
+
+    async def _apply_migration_v1(self, conn: aiosqlite.Connection, default_cash: float):
+        """Apply migration version 1: Add multi-portfolio support."""
+
+        # 1. Create schema_migrations table
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+                version INTEGER PRIMARY KEY,
+                description TEXT NOT NULL,
+                applied_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
+        # 2. Create portfolios table
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS portfolios (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                starting_cash REAL NOT NULL DEFAULT 100000,
+                symbols TEXT NOT NULL DEFAULT '',
+                active INTEGER NOT NULL DEFAULT 1,
+                max_position_pct REAL,
+                max_daily_loss_pct REAL,
+                max_open_positions INTEGER,
+                stop_loss_pct REAL,
+                trailing_stop_pct REAL,
+                use_trailing_stop INTEGER,
+                enabled_strategies TEXT,
+                min_confidence REAL,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
+        # 3. Insert 'default' portfolio if not exists
+        await conn.execute("""
+            INSERT OR IGNORE INTO portfolios (id, name, starting_cash)
+            VALUES ('default', 'Default Portfolio', ?)
+        """, (default_cash,))
+
+        # 4. Migrate positions table: add portfolio_id, change unique constraint
+        await self._migrate_table_add_portfolio_id(
+            conn,
+            table_name="positions",
+            create_sql="""
+                CREATE TABLE positions_new (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    portfolio_id TEXT NOT NULL DEFAULT 'default',
+                    symbol TEXT NOT NULL,
+                    quantity INTEGER NOT NULL,
+                    avg_cost REAL NOT NULL,
+                    market_price REAL,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    UNIQUE(portfolio_id, symbol)
+                )
+            """,
+            insert_sql="""
+                INSERT INTO positions_new (id, portfolio_id, symbol, quantity, avg_cost, market_price, timestamp)
+                SELECT id, 'default', symbol, quantity, avg_cost, market_price, timestamp
+                FROM positions
+            """,
+            index_sql=[
+                "CREATE INDEX IF NOT EXISTS idx_positions_portfolio ON positions (portfolio_id)",
+            ],
+        )
+
+        # 5. Migrate trades table: add portfolio_id
+        await self._migrate_table_add_portfolio_id(
+            conn,
+            table_name="trades",
+            create_sql="""
+                CREATE TABLE trades_new (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    portfolio_id TEXT NOT NULL DEFAULT 'default',
+                    symbol TEXT NOT NULL,
+                    side TEXT NOT NULL,
+                    quantity INTEGER NOT NULL,
+                    price REAL NOT NULL,
+                    notional REAL DEFAULT 0,
+                    slippage REAL DEFAULT 0,
+                    commission REAL DEFAULT 0,
+                    pnl REAL DEFAULT NULL,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+                )
+            """,
+            insert_sql="""
+                INSERT INTO trades_new (id, portfolio_id, symbol, side, quantity, price, notional, slippage, commission, pnl, timestamp)
+                SELECT id, 'default', symbol, side, quantity, price, notional, slippage, commission, pnl, timestamp
+                FROM trades
+            """,
+            index_sql=[
+                "CREATE INDEX IF NOT EXISTS idx_trades_portfolio ON trades (portfolio_id)",
+                "CREATE INDEX IF NOT EXISTS idx_trades_portfolio_symbol ON trades (portfolio_id, symbol, timestamp DESC)",
+            ],
+        )
+
+        # 6. Migrate account table: replace id=1 with portfolio_id
+        await self._migrate_table_add_portfolio_id(
+            conn,
+            table_name="account",
+            create_sql="""
+                CREATE TABLE account_new (
+                    portfolio_id TEXT PRIMARY KEY,
+                    cash REAL NOT NULL,
+                    equity REAL NOT NULL,
+                    daily_pnl REAL DEFAULT 0,
+                    realized_pnl REAL DEFAULT 0,
+                    unrealized_pnl REAL DEFAULT 0,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+                )
+            """,
+            insert_sql="""
+                INSERT INTO account_new (portfolio_id, cash, equity, daily_pnl, realized_pnl, unrealized_pnl, timestamp)
+                SELECT 'default', cash, equity, daily_pnl, realized_pnl, unrealized_pnl, timestamp
+                FROM account
+                WHERE id = 1
+            """,
+            index_sql=[],
+        )
+
+        # 7. Migrate equity_history table: add portfolio_id, change unique constraint
+        await self._migrate_table_add_portfolio_id(
+            conn,
+            table_name="equity_history",
+            create_sql="""
+                CREATE TABLE equity_history_new (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    portfolio_id TEXT NOT NULL DEFAULT 'default',
+                    date TEXT NOT NULL,
+                    equity REAL NOT NULL,
+                    cash REAL DEFAULT 0,
+                    positions_value REAL DEFAULT 0,
+                    realized_pnl REAL DEFAULT 0,
+                    unrealized_pnl REAL DEFAULT 0,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    UNIQUE(portfolio_id, date)
+                )
+            """,
+            insert_sql="""
+                INSERT INTO equity_history_new (id, portfolio_id, date, equity, cash, positions_value, realized_pnl, unrealized_pnl, timestamp)
+                SELECT id, 'default', date, equity, cash, positions_value, realized_pnl, unrealized_pnl, timestamp
+                FROM equity_history
+            """,
+            index_sql=[
+                "CREATE INDEX IF NOT EXISTS idx_equity_history_portfolio ON equity_history (portfolio_id, date)",
+            ],
+        )
+
+        # 8. Migrate signals table: add portfolio_id
+        await self._migrate_table_add_portfolio_id(
+            conn,
+            table_name="signals",
+            create_sql="""
+                CREATE TABLE signals_new (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    portfolio_id TEXT NOT NULL DEFAULT 'default',
+                    symbol TEXT NOT NULL,
+                    strategy TEXT NOT NULL,
+                    signal_type TEXT NOT NULL,
+                    strength REAL,
+                    metadata TEXT,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+                )
+            """,
+            insert_sql="""
+                INSERT INTO signals_new (id, portfolio_id, symbol, strategy, signal_type, strength, metadata, timestamp)
+                SELECT id, 'default', symbol, strategy, signal_type, strength, metadata, timestamp
+                FROM signals
+            """,
+            index_sql=[
+                "CREATE INDEX IF NOT EXISTS idx_signals_portfolio ON signals (portfolio_id)",
+            ],
+        )
+
+        # 9. Record migration
+        await conn.execute("""
+            INSERT INTO schema_migrations (version, description)
+            VALUES (?, ?)
+        """, (MIGRATION_VERSION, "Add multi-portfolio support: portfolio_id on positions, trades, account, equity_history, signals"))
+
+        logger.info("Migration v1 applied: multi-portfolio schema ready")
+
+    async def _migrate_table_add_portfolio_id(
+        self,
+        conn: aiosqlite.Connection,
+        table_name: str,
+        create_sql: str,
+        insert_sql: str,
+        index_sql: List[str],
+    ):
+        """Migrate a table by recreating it with portfolio_id column.
+
+        Uses the rename-recreate pattern since SQLite doesn't support
+        ALTER TABLE ADD CONSTRAINT.
+        """
+        # Check if table exists
+        cursor = await conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+            (table_name,),
+        )
+        exists = await cursor.fetchone()
+
+        if not exists:
+            # Table doesn't exist yet - create directly with portfolio_id
+            await conn.execute(create_sql.replace(f"{table_name}_new", table_name))
+            for idx_sql in index_sql:
+                await conn.execute(idx_sql)
+            logger.info(f"Created new table: {table_name} (with portfolio_id)")
+            return
+
+        # Check if already has portfolio_id column
+        cursor = await conn.execute(f"PRAGMA table_info({table_name})")
+        columns = await cursor.fetchall()
+        column_names = [col[1] for col in columns]
+
+        if "portfolio_id" in column_names:
+            logger.info(f"Table {table_name} already has portfolio_id column, skipping")
+            return
+
+        # Count existing rows for logging
+        cursor = await conn.execute(f"SELECT COUNT(*) FROM {table_name}")
+        row_count = (await cursor.fetchone())[0]
+
+        # Create new table
+        await conn.execute(create_sql)
+
+        # Copy data
+        if row_count > 0:
+            await conn.execute(insert_sql)
+
+        # Drop old table and rename new one
+        await conn.execute(f"DROP TABLE {table_name}")
+        await conn.execute(f"ALTER TABLE {table_name}_new RENAME TO {table_name}")
+
+        # Create indexes
+        for idx_sql in index_sql:
+            await conn.execute(idx_sql)
+
+        logger.info(f"Migrated table {table_name}: {row_count} rows, added portfolio_id column")

--- a/robo_trader/multiuser/portfolio_config.py
+++ b/robo_trader/multiuser/portfolio_config.py
@@ -83,10 +83,20 @@ class PortfolioConfig:
         elif not strategies:
             strategies = None
 
+        # Validate starting_cash with meaningful error
+        try:
+            starting_cash = float(data.get("starting_cash", 100_000))
+            if starting_cash <= 0:
+                raise ValueError(f"starting_cash must be positive, got {starting_cash}")
+        except (TypeError, ValueError) as e:
+            raise ValueError(
+                f"Invalid starting_cash for portfolio '{data.get('id', 'unknown')}': {e}"
+            ) from e
+
         return cls(
             id=data["id"],
             name=data.get("name", data["id"]),
-            starting_cash=float(data.get("starting_cash", 100_000)),
+            starting_cash=starting_cash,
             symbols=symbols,
             active=bool(data.get("active", True)),
             max_position_pct=data.get("max_position_pct"),

--- a/robo_trader/multiuser/portfolio_config.py
+++ b/robo_trader/multiuser/portfolio_config.py
@@ -1,0 +1,162 @@
+"""
+Per-portfolio configuration for multiuser support.
+
+Each portfolio has its own:
+- Symbol watchlist
+- Starting cash / current cash
+- Risk parameters (overrides global defaults)
+- Strategy settings (overrides global defaults)
+
+If no PORTFOLIOS env var is set, a single 'default' portfolio is created
+from the existing SYMBOLS and DEFAULT_CASH env vars for backward compatibility.
+"""
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from ..logger import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class PortfolioConfig:
+    """Configuration for a single portfolio."""
+
+    id: str
+    name: str
+    starting_cash: float = 100_000.0
+    symbols: List[str] = field(default_factory=list)
+    active: bool = True
+
+    # Risk overrides (None = use global default from Config.risk)
+    max_position_pct: Optional[float] = None
+    max_daily_loss_pct: Optional[float] = None
+    max_open_positions: Optional[int] = None
+    stop_loss_pct: Optional[float] = None
+    trailing_stop_pct: Optional[float] = None
+    use_trailing_stop: Optional[bool] = None
+
+    # Strategy overrides (None = use global default from Config.strategy)
+    enabled_strategies: Optional[List[str]] = None
+    min_confidence: Optional[float] = None
+
+    def get_risk_param(self, param_name: str, global_default):
+        """Get a risk parameter, falling back to global default if not overridden."""
+        local_value = getattr(self, param_name, None)
+        if local_value is not None:
+            return local_value
+        return global_default
+
+    def to_dict(self) -> Dict:
+        """Serialize to dict for database storage."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "starting_cash": self.starting_cash,
+            "symbols": ",".join(self.symbols),
+            "active": self.active,
+            "max_position_pct": self.max_position_pct,
+            "max_daily_loss_pct": self.max_daily_loss_pct,
+            "max_open_positions": self.max_open_positions,
+            "stop_loss_pct": self.stop_loss_pct,
+            "trailing_stop_pct": self.trailing_stop_pct,
+            "use_trailing_stop": self.use_trailing_stop,
+            "enabled_strategies": (
+                ",".join(self.enabled_strategies) if self.enabled_strategies else None
+            ),
+            "min_confidence": self.min_confidence,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> "PortfolioConfig":
+        """Deserialize from dict (database row or JSON)."""
+        symbols = data.get("symbols", "")
+        if isinstance(symbols, str):
+            symbols = [s.strip() for s in symbols.split(",") if s.strip()]
+
+        strategies = data.get("enabled_strategies")
+        if isinstance(strategies, str) and strategies:
+            strategies = [s.strip() for s in strategies.split(",") if s.strip()]
+        elif not strategies:
+            strategies = None
+
+        return cls(
+            id=data["id"],
+            name=data.get("name", data["id"]),
+            starting_cash=float(data.get("starting_cash", 100_000)),
+            symbols=symbols,
+            active=bool(data.get("active", True)),
+            max_position_pct=data.get("max_position_pct"),
+            max_daily_loss_pct=data.get("max_daily_loss_pct"),
+            max_open_positions=data.get("max_open_positions"),
+            stop_loss_pct=data.get("stop_loss_pct"),
+            trailing_stop_pct=data.get("trailing_stop_pct"),
+            use_trailing_stop=data.get("use_trailing_stop"),
+            enabled_strategies=strategies,
+            min_confidence=data.get("min_confidence"),
+        )
+
+
+def load_portfolio_configs() -> List[PortfolioConfig]:
+    """Load portfolio configurations from environment.
+
+    Reads PORTFOLIOS env var (JSON array of portfolio objects).
+    Falls back to creating a single 'default' portfolio from
+    SYMBOLS and DEFAULT_CASH env vars for backward compatibility.
+
+    Returns:
+        List of PortfolioConfig objects
+    """
+    portfolios_json = os.getenv("PORTFOLIOS")
+
+    if portfolios_json:
+        try:
+            raw_list = json.loads(portfolios_json)
+            if not isinstance(raw_list, list) or len(raw_list) == 0:
+                raise ValueError("PORTFOLIOS must be a non-empty JSON array")
+
+            configs = []
+            seen_ids = set()
+            for item in raw_list:
+                if not isinstance(item, dict):
+                    raise ValueError(f"Each portfolio must be a JSON object, got: {type(item)}")
+                if "id" not in item:
+                    raise ValueError(f"Each portfolio must have an 'id' field: {item}")
+                if item["id"] in seen_ids:
+                    raise ValueError(f"Duplicate portfolio id: {item['id']}")
+                seen_ids.add(item["id"])
+                configs.append(PortfolioConfig.from_dict(item))
+
+            active = [c for c in configs if c.active]
+            logger.info(
+                f"Loaded {len(configs)} portfolio configs ({len(active)} active): "
+                f"{[c.id for c in configs]}"
+            )
+            return configs
+
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse PORTFOLIOS env var: {e}")
+            raise ValueError(f"Invalid PORTFOLIOS JSON: {e}") from e
+
+    # Backward compatibility: create single 'default' portfolio from existing env vars
+    symbols_str = os.getenv("SYMBOLS", "AAPL,MSFT,SPY")
+    symbols = [s.strip() for s in symbols_str.split(",") if s.strip()]
+    default_cash = float(os.getenv("DEFAULT_CASH", "100000"))
+
+    logger.info(
+        f"No PORTFOLIOS env var found. Creating default portfolio: "
+        f"cash=${default_cash:,.0f}, symbols={symbols}"
+    )
+
+    return [
+        PortfolioConfig(
+            id="default",
+            name="Default Portfolio",
+            starting_cash=default_cash,
+            symbols=symbols,
+            active=True,
+        )
+    ]

--- a/robo_trader/runner_async.py
+++ b/robo_trader/runner_async.py
@@ -738,6 +738,7 @@ class AsyncRunner:
                 executor=self.executor,
                 risk_manager=self.risk,
                 emergency_shutdown_callback=emergency_shutdown_callback,
+                portfolio_id=self.portfolio_id,
             )
             await self.stop_loss_monitor.start_monitoring()
             if self.use_trailing_stop:

--- a/robo_trader/runner_async.py
+++ b/robo_trader/runner_async.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import hashlib
 import os
 import subprocess
 import sys
@@ -625,8 +626,8 @@ class AsyncRunner:
         # delivering stale data from a prior session that used the same id.
         base_client_id = self.cfg.ibkr.client_id
         if self.portfolio_id != "default":
-            # Deterministic offset: hash portfolio_id to stay within 0-999
-            offset = hash(self.portfolio_id) % 900 + 100
+            # Deterministic offset: use hashlib (not hash()) for cross-process stability
+            offset = int(hashlib.md5(self.portfolio_id.encode()).hexdigest(), 16) % 900 + 100
             self._client_id = (base_client_id + offset) % 1000
         else:
             self._client_id = base_client_id

--- a/robo_trader/stop_loss_monitor.py
+++ b/robo_trader/stop_loss_monitor.py
@@ -57,6 +57,7 @@ class StopLossOrder:
     stop_type: StopType
     created_at: datetime
     status: StopStatus = StopStatus.PENDING
+    portfolio_id: str = "default"  # Multi-portfolio support
 
     # For trailing stops
     trailing_amount: Optional[float] = None  # Dollar amount for trailing
@@ -111,7 +112,8 @@ class StopLossMonitor:
     automatically executing stop-loss orders when price thresholds are breached.
     """
 
-    def __init__(self, executor, risk_manager, emergency_shutdown_callback=None):
+    def __init__(self, executor, risk_manager, emergency_shutdown_callback=None,
+                 portfolio_id: str = "default"):
         """
         Initialize stop-loss monitor.
 
@@ -119,10 +121,12 @@ class StopLossMonitor:
             executor: Order executor for placing stop orders
             risk_manager: Risk manager for validation and limits
             emergency_shutdown_callback: Callback for emergency shutdown
+            portfolio_id: Portfolio this monitor is scoped to
         """
         self.executor = executor
         self.risk_manager = risk_manager
         self.emergency_shutdown = emergency_shutdown_callback
+        self.portfolio_id = portfolio_id
 
         # Active stop-loss orders by symbol
         self.active_stops: Dict[str, StopLossOrder] = {}
@@ -206,6 +210,7 @@ class StopLossMonitor:
             entry_price=avg_price_float,  # Use float, not Decimal
             stop_type=stop_type,
             created_at=datetime.now(),
+            portfolio_id=self.portfolio_id,
             trailing_amount=trailing_amount,
             trailing_percent=trailing_percent,
         )

--- a/robo_trader/websocket_server.py
+++ b/robo_trader/websocket_server.py
@@ -210,11 +210,13 @@ class WebSocketManager:
         )
 
     def send_trade_update(
-        self, symbol: str, side: str, quantity: int, price: float, status: str = "executed"
+        self, symbol: str, side: str, quantity: int, price: float, status: str = "executed",
+        portfolio_id: str = "default",
     ):
         """Queue a trade update for broadcast."""
         message = {
             "type": "trade",
+            "portfolio_id": portfolio_id,
             "symbol": symbol,
             "side": side,
             "quantity": quantity,
@@ -225,20 +227,22 @@ class WebSocketManager:
 
         self.message_queue.put(message)
 
-    def send_position_update(self, positions: Dict[str, Any]):
+    def send_position_update(self, positions: Dict[str, Any], portfolio_id: str = "default"):
         """Queue a position update for broadcast."""
         message = {
             "type": "positions",
+            "portfolio_id": portfolio_id,
             "positions": positions,
             "timestamp": datetime.now().isoformat(),
         }
 
         self.message_queue.put(message)
 
-    def send_signal_update(self, symbol: str, signal: str, strength: float):
+    def send_signal_update(self, symbol: str, signal: str, strength: float, portfolio_id: str = "default"):
         """Queue a trading signal update for broadcast."""
         message = {
             "type": "signal",
+            "portfolio_id": portfolio_id,
             "symbol": symbol,
             "signal": signal,
             "strength": strength,
@@ -247,10 +251,11 @@ class WebSocketManager:
 
         self.message_queue.put(message)
 
-    def send_performance_update(self, metrics: Dict[str, Any]):
+    def send_performance_update(self, metrics: Dict[str, Any], portfolio_id: str = "default"):
         """Queue a performance metrics update for broadcast."""
         message = {
             "type": "performance",
+            "portfolio_id": portfolio_id,
             "metrics": metrics,
             "timestamp": datetime.now().isoformat(),
         }

--- a/scripts/start_runner.sh
+++ b/scripts/start_runner.sh
@@ -63,7 +63,8 @@ echo "4. Starting runner..."
 echo "   Symbols: $SYMBOLS"
 
 export LOG_FILE="$SCRIPT_DIR/robo_trader.log"
-$PYTHON -m robo_trader.runner_async --symbols "$SYMBOLS" --force-connect &
+# Redirect output to log file so subprocess.run can complete
+$PYTHON -m robo_trader.runner_async --symbols "$SYMBOLS" --force-connect >> "$LOG_FILE" 2>&1 &
 RUNNER_PID=$!
 
 sleep 3

--- a/tests/test_api_multiportfolio.py
+++ b/tests/test_api_multiportfolio.py
@@ -1,0 +1,371 @@
+"""Tests for Flask API multi-portfolio endpoints.
+
+Tests the validate_portfolio decorator and endpoint behavior with
+various portfolio_id values (valid, invalid, non-existent).
+"""
+
+import os
+import sqlite3
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def client():
+    """Create a Flask test client with auth disabled."""
+    # Ensure auth is disabled for tests
+    with patch.dict(os.environ, {"DASH_AUTH_ENABLED": "false"}, clear=False):
+        from app import app
+
+        app.config["TESTING"] = True
+        with app.test_client() as c:
+            yield c
+
+
+# ──────────────────────────────────────────────
+# Validation Tests (400 responses)
+# These are rejected by the validate_portfolio decorator
+# before any DB access, so no mocking needed.
+# ──────────────────────────────────────────────
+
+
+class TestPortfolioIdValidation400:
+    """Test that invalid portfolio_id values are rejected with 400."""
+
+    ENDPOINTS = [
+        "/api/status",
+        "/api/pnl",
+        "/api/positions",
+        "/api/watchlist",
+        "/api/performance",
+        "/api/equity-curve",
+        "/api/trades",
+        "/api/strategies/status",
+    ]
+
+    def test_special_chars_rejected(self, client):
+        """Portfolio ID with special characters returns 400."""
+        for endpoint in self.ENDPOINTS:
+            resp = client.get(f"{endpoint}?portfolio_id=bad!id")
+            assert resp.status_code == 400, f"{endpoint} did not return 400 for 'bad!id'"
+            data = resp.get_json()
+            assert "error" in data
+
+    def test_spaces_rejected(self, client):
+        """Portfolio ID with spaces returns 400."""
+        resp = client.get("/api/positions?portfolio_id=has spaces")
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert "error" in data
+
+    def test_semicolon_rejected(self, client):
+        """Portfolio ID with semicolons returns 400."""
+        resp = client.get("/api/positions?portfolio_id=semi;colon")
+        assert resp.status_code == 400
+
+    def test_sql_injection_rejected(self, client):
+        """SQL injection payloads return 400."""
+        injections = [
+            "'; DROP TABLE trades; --",
+            "1 OR 1=1",
+            "default' UNION SELECT * FROM account --",
+            "x'; DELETE FROM positions; --",
+        ]
+        for payload in injections:
+            resp = client.get(f"/api/positions?portfolio_id={payload}")
+            assert resp.status_code == 400, f"SQL injection not blocked: {payload}"
+
+    def test_too_long_rejected(self, client):
+        """Portfolio ID exceeding 64 characters returns 400."""
+        long_id = "a" * 65
+        resp = client.get(f"/api/positions?portfolio_id={long_id}")
+        assert resp.status_code == 400
+
+    def test_dot_rejected(self, client):
+        """Portfolio ID with dots returns 400."""
+        resp = client.get("/api/trades?portfolio_id=has.dot")
+        assert resp.status_code == 400
+
+    def test_quote_rejected(self, client):
+        """Portfolio ID with quotes returns 400."""
+        resp = client.get("/api/trades?portfolio_id=has'quote")
+        assert resp.status_code == 400
+
+    def test_all_endpoints_reject_invalid(self, client):
+        """All 8 decorated endpoints reject invalid portfolio_id."""
+        for endpoint in self.ENDPOINTS:
+            resp = client.get(f"{endpoint}?portfolio_id=inv@lid!")
+            assert resp.status_code == 400, f"{endpoint} did not reject 'inv@lid!'"
+
+
+# ──────────────────────────────────────────────
+# Non-existent Portfolio Tests (404 responses)
+# The decorator checks sqlite3 for portfolio existence.
+# We mock sqlite3.connect to control what the decorator sees.
+# ──────────────────────────────────────────────
+
+
+class TestNonExistentPortfolio404:
+    """Test that valid-format but non-existent portfolios return 404."""
+
+    @pytest.fixture
+    def trading_db(self, tmp_path, monkeypatch):
+        """Create trading_data.db in a temp dir and chdir there.
+
+        The validate_portfolio decorator opens Path("trading_data.db") directly,
+        so we place a real DB file in the working directory.
+        """
+        db_path = tmp_path / "trading_data.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("""
+            CREATE TABLE account (
+                portfolio_id TEXT NOT NULL,
+                cash REAL NOT NULL,
+                equity REAL NOT NULL,
+                daily_pnl REAL DEFAULT 0,
+                realized_pnl REAL DEFAULT 0,
+                unrealized_pnl REAL DEFAULT 0,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE portfolios (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                starting_cash REAL DEFAULT 100000
+            )
+        """)
+        conn.execute(
+            "INSERT INTO account (portfolio_id, cash, equity) VALUES ('default', 100000, 100000)"
+        )
+        conn.commit()
+        conn.close()
+        monkeypatch.chdir(tmp_path)
+        return db_path
+
+    def test_nonexistent_portfolio_returns_404(self, client, trading_db):
+        """A valid-format portfolio_id that doesn't exist in DB returns 404."""
+        resp = client.get("/api/positions?portfolio_id=nonexistent")
+        assert resp.status_code == 404
+        data = resp.get_json()
+        assert "not found" in data["error"].lower()
+
+    def test_default_portfolio_not_checked_for_existence(self, client):
+        """The 'default' portfolio skips the DB existence check entirely."""
+        mock_reader = MagicMock()
+        mock_reader.get_positions.return_value = []
+        mock_reader.get_signals.return_value = []
+        with patch("sync_db_reader.SyncDatabaseReader", return_value=mock_reader):
+            resp = client.get("/api/positions?portfolio_id=default")
+            assert resp.status_code != 404
+
+
+# ──────────────────────────────────────────────
+# Default Behavior Tests (200 responses)
+# These need SyncDatabaseReader mocked to avoid
+# requiring a real database.
+# ──────────────────────────────────────────────
+
+
+class TestDefaultPortfolioBehavior:
+    """Test that endpoints work with default portfolio_id."""
+
+    @pytest.fixture
+    def mock_db_reader(self):
+        """Create a mock SyncDatabaseReader with sensible defaults."""
+        reader = MagicMock()
+        reader.get_positions.return_value = []
+        reader.get_recent_trades.return_value = []
+        reader.get_account_info.return_value = {
+            "cash": 100000,
+            "equity": 100000,
+            "daily_pnl": 0,
+            "realized_pnl": 0,
+            "unrealized_pnl": 0,
+        }
+        reader.get_equity_history.return_value = []
+        reader.get_signals.return_value = []
+        reader.get_portfolios.return_value = [
+            {"id": "default", "name": "Default Portfolio", "starting_cash": 100000}
+        ]
+        return reader
+
+    def test_positions_default_returns_200(self, client, mock_db_reader):
+        """GET /api/positions without portfolio_id returns 200."""
+        with patch("sync_db_reader.SyncDatabaseReader", return_value=mock_db_reader):
+            resp = client.get("/api/positions")
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert "positions" in data
+
+    def test_trades_default_returns_200(self, client, mock_db_reader):
+        """GET /api/trades without portfolio_id returns 200."""
+        with patch("sync_db_reader.SyncDatabaseReader", return_value=mock_db_reader):
+            resp = client.get("/api/trades")
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert "trades" in data
+
+    def test_pnl_default_returns_200(self, client, mock_db_reader):
+        """GET /api/pnl without portfolio_id returns 200."""
+        with patch("sync_db_reader.SyncDatabaseReader", return_value=mock_db_reader):
+            resp = client.get("/api/pnl")
+            assert resp.status_code == 200
+            data = resp.get_json()
+            # PnL endpoint returns equity, cash, etc.
+            assert "equity" in data or "total" in data
+
+    def test_equity_curve_default_returns_200(self, client, mock_db_reader):
+        """GET /api/equity-curve without portfolio_id returns 200."""
+        with patch("sync_db_reader.SyncDatabaseReader", return_value=mock_db_reader):
+            resp = client.get("/api/equity-curve")
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert "labels" in data or "portfolio_values" in data
+
+
+# ──────────────────────────────────────────────
+# Portfolio Scoping Tests
+# Verify portfolio_id is passed through to DB reader.
+# ──────────────────────────────────────────────
+
+
+class TestPortfolioScoping:
+    """Test that portfolio_id is correctly passed to the DB reader."""
+
+    @pytest.fixture
+    def mock_db_reader(self):
+        reader = MagicMock()
+        reader.get_positions.return_value = [
+            {
+                "symbol": "AAPL",
+                "quantity": 100,
+                "avg_cost": 180.0,
+                "market_price": 185.0,
+                "timestamp": "2026-02-06",
+            }
+        ]
+        reader.get_recent_trades.return_value = []
+        reader.get_account_info.return_value = {
+            "cash": 50000,
+            "equity": 55000,
+            "daily_pnl": 0,
+            "realized_pnl": 0,
+            "unrealized_pnl": 0,
+        }
+        reader.get_equity_history.return_value = []
+        reader.get_signals.return_value = []
+        reader.get_portfolios.return_value = [
+            {"id": "default", "name": "Default Portfolio", "starting_cash": 100000}
+        ]
+        return reader
+
+    @pytest.fixture
+    def trading_db_with_portfolio(self, tmp_path, monkeypatch):
+        """Create trading_data.db with a non-default portfolio in a temp dir."""
+        db_path = tmp_path / "trading_data.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("""
+            CREATE TABLE account (
+                portfolio_id TEXT NOT NULL,
+                cash REAL NOT NULL,
+                equity REAL NOT NULL,
+                daily_pnl REAL DEFAULT 0,
+                realized_pnl REAL DEFAULT 0,
+                unrealized_pnl REAL DEFAULT 0,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE portfolios (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                starting_cash REAL DEFAULT 100000
+            )
+        """)
+        conn.execute(
+            "INSERT INTO account (portfolio_id, cash, equity) VALUES ('default', 100000, 100000)"
+        )
+        conn.execute(
+            "INSERT INTO account (portfolio_id, cash, equity) VALUES ('aggressive', 50000, 55000)"
+        )
+        conn.commit()
+        conn.close()
+        monkeypatch.chdir(tmp_path)
+        return db_path
+
+    def test_positions_with_explicit_default(self, client, mock_db_reader):
+        """GET /api/positions?portfolio_id=default returns 200."""
+        with patch("sync_db_reader.SyncDatabaseReader", return_value=mock_db_reader):
+            resp = client.get("/api/positions?portfolio_id=default")
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert "positions" in data
+
+    def test_trades_with_explicit_default(self, client, mock_db_reader):
+        """GET /api/trades?portfolio_id=default returns 200."""
+        with patch("sync_db_reader.SyncDatabaseReader", return_value=mock_db_reader):
+            resp = client.get("/api/trades?portfolio_id=default")
+            assert resp.status_code == 200
+
+    def test_positions_passes_portfolio_id_to_reader(
+        self, client, mock_db_reader, trading_db_with_portfolio
+    ):
+        """Endpoint passes portfolio_id to SyncDatabaseReader.get_positions."""
+        with patch("sync_db_reader.SyncDatabaseReader", return_value=mock_db_reader):
+            resp = client.get("/api/positions?portfolio_id=aggressive")
+            assert resp.status_code == 200
+            mock_db_reader.get_positions.assert_called_with(portfolio_id="aggressive")
+
+    def test_trades_passes_portfolio_id_to_reader(
+        self, client, mock_db_reader, trading_db_with_portfolio
+    ):
+        """Endpoint passes portfolio_id to SyncDatabaseReader.get_recent_trades."""
+        with patch("sync_db_reader.SyncDatabaseReader", return_value=mock_db_reader):
+            resp = client.get("/api/trades?portfolio_id=aggressive")
+            assert resp.status_code == 200
+            mock_db_reader.get_recent_trades.assert_called()
+            # Check portfolio_id was in the call kwargs
+            call_kwargs = mock_db_reader.get_recent_trades.call_args
+            assert call_kwargs.kwargs.get("portfolio_id") == "aggressive" or (
+                len(call_kwargs.args) == 0 and "aggressive" in str(call_kwargs)
+            )
+
+
+# ──────────────────────────────────────────────
+# Valid portfolio_id format edge cases
+# ──────────────────────────────────────────────
+
+
+class TestValidPortfolioIdFormats:
+    """Test that valid portfolio_id formats pass the decorator."""
+
+    VALID_IDS = [
+        "default",
+        "aggressive",
+        "my-portfolio",
+        "port_1",
+        "A",
+        "abc123",
+        "a" * 64,  # max length
+        "user123_portfolio456",
+    ]
+
+    def test_valid_ids_not_rejected_as_400(self, client):
+        """Valid portfolio IDs should not get a 400 response.
+
+        They may get 404 (non-existent) or 200 (if default), but never 400.
+        """
+        for pid in self.VALID_IDS:
+            resp = client.get(f"/api/positions?portfolio_id={pid}")
+            assert resp.status_code != 400, f"Valid portfolio_id '{pid}' was rejected as 400"
+
+    def test_no_portfolio_id_defaults_to_default(self, client):
+        """Omitting portfolio_id should default to 'default' (not 400)."""
+        mock_reader = MagicMock()
+        mock_reader.get_positions.return_value = []
+        mock_reader.get_signals.return_value = []
+        with patch("sync_db_reader.SyncDatabaseReader", return_value=mock_reader):
+            resp = client.get("/api/positions")
+            assert resp.status_code != 400

--- a/tests/test_m4_performance.py
+++ b/tests/test_m4_performance.py
@@ -27,9 +27,10 @@ from robo_trader.analytics.strategy_performance import (
 )
 
 
-def generate_strategy_returns(n_days=252, strategy_type="momentum"):
+def generate_strategy_returns(n_days=252, strategy_type="momentum", dates=None):
     """Generate synthetic strategy returns for testing."""
-    dates = pd.date_range(end=datetime.now(), periods=n_days, freq="D")
+    if dates is None:
+        dates = pd.date_range(end=datetime.now(), periods=n_days, freq="D")
 
     if strategy_type == "momentum":
         # Momentum strategy: higher returns, higher volatility
@@ -252,7 +253,7 @@ async def test_ml_performance():
     # Simulate classification predictions (buy/sell signals)
     predictions = pd.Series(np.random.choice([0, 1], n_days, p=[0.45, 0.55]), index=dates)
 
-    actual_returns = generate_strategy_returns(n_days, "ml_ensemble")
+    actual_returns = generate_strategy_returns(n_days, "ml_ensemble", dates=dates)
     positions = generate_positions(dates)
 
     # Simulate feature importance

--- a/tests/test_multiuser.py
+++ b/tests/test_multiuser.py
@@ -1,0 +1,436 @@
+"""Tests for multiuser/multi-portfolio support."""
+
+import asyncio
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from robo_trader.multiuser.migration import MultiuserMigration
+from robo_trader.multiuser.portfolio_config import PortfolioConfig, load_portfolio_configs
+
+
+# ──────────────────────────────────────────────
+# PortfolioConfig Tests
+# ──────────────────────────────────────────────
+
+class TestPortfolioConfig:
+    def test_basic_creation(self):
+        cfg = PortfolioConfig(id="test", name="Test Portfolio", starting_cash=50000, symbols=["AAPL", "MSFT"])
+        assert cfg.id == "test"
+        assert cfg.name == "Test Portfolio"
+        assert cfg.starting_cash == 50000
+        assert cfg.symbols == ["AAPL", "MSFT"]
+        assert cfg.active is True
+
+    def test_risk_override_fallback(self):
+        cfg = PortfolioConfig(id="test", name="Test", max_position_pct=0.04)
+        # Has override
+        assert cfg.get_risk_param("max_position_pct", 0.02) == 0.04
+        # Falls back to global
+        assert cfg.get_risk_param("max_daily_loss_pct", 0.005) == 0.005
+
+    def test_to_dict_roundtrip(self):
+        original = PortfolioConfig(
+            id="aggressive",
+            name="Aggressive Growth",
+            starting_cash=75000,
+            symbols=["NVDA", "TSLA"],
+            max_position_pct=0.04,
+            enabled_strategies=["momentum", "ml_enhanced"],
+        )
+        d = original.to_dict()
+        restored = PortfolioConfig.from_dict(d)
+
+        assert restored.id == original.id
+        assert restored.name == original.name
+        assert restored.starting_cash == original.starting_cash
+        assert restored.symbols == original.symbols
+        assert restored.max_position_pct == original.max_position_pct
+        assert restored.enabled_strategies == original.enabled_strategies
+
+    def test_from_dict_with_string_symbols(self):
+        cfg = PortfolioConfig.from_dict({"id": "test", "name": "T", "symbols": "AAPL,MSFT,SPY"})
+        assert cfg.symbols == ["AAPL", "MSFT", "SPY"]
+
+    def test_from_dict_with_list_symbols(self):
+        cfg = PortfolioConfig.from_dict({"id": "test", "name": "T", "symbols": ["AAPL", "MSFT"]})
+        assert cfg.symbols == ["AAPL", "MSFT"]
+
+
+class TestLoadPortfolioConfigs:
+    def test_default_portfolio_when_no_env(self):
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("PORTFOLIOS", None)
+            configs = load_portfolio_configs()
+            assert len(configs) == 1
+            assert configs[0].id == "default"
+            assert configs[0].name == "Default Portfolio"
+
+    def test_default_portfolio_uses_symbols_env(self):
+        env = {"SYMBOLS": "NVDA,AMD,TSLA", "DEFAULT_CASH": "75000"}
+        with patch.dict(os.environ, env, clear=True):
+            configs = load_portfolio_configs()
+            assert len(configs) == 1
+            assert configs[0].symbols == ["NVDA", "AMD", "TSLA"]
+            assert configs[0].starting_cash == 75000
+
+    def test_multi_portfolio_from_json(self):
+        portfolios = [
+            {"id": "aggressive", "name": "Aggressive", "starting_cash": 50000, "symbols": "NVDA,TSLA"},
+            {"id": "conservative", "name": "Conservative", "starting_cash": 50000, "symbols": "AAPL,MSFT"},
+        ]
+        env = {"PORTFOLIOS": json.dumps(portfolios)}
+        with patch.dict(os.environ, env, clear=True):
+            configs = load_portfolio_configs()
+            assert len(configs) == 2
+            assert configs[0].id == "aggressive"
+            assert configs[1].id == "conservative"
+            assert configs[0].symbols == ["NVDA", "TSLA"]
+            assert configs[1].symbols == ["AAPL", "MSFT"]
+
+    def test_duplicate_id_raises(self):
+        portfolios = [
+            {"id": "same", "name": "A", "symbols": "AAPL"},
+            {"id": "same", "name": "B", "symbols": "MSFT"},
+        ]
+        env = {"PORTFOLIOS": json.dumps(portfolios)}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValueError, match="Duplicate portfolio id"):
+                load_portfolio_configs()
+
+    def test_missing_id_raises(self):
+        portfolios = [{"name": "No ID", "symbols": "AAPL"}]
+        env = {"PORTFOLIOS": json.dumps(portfolios)}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValueError, match="must have an 'id' field"):
+                load_portfolio_configs()
+
+    def test_invalid_json_raises(self):
+        env = {"PORTFOLIOS": "not valid json"}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValueError, match="Invalid PORTFOLIOS JSON"):
+                load_portfolio_configs()
+
+    def test_empty_array_raises(self):
+        env = {"PORTFOLIOS": "[]"}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValueError, match="non-empty JSON array"):
+                load_portfolio_configs()
+
+
+# ──────────────────────────────────────────────
+# Migration Tests
+# ──────────────────────────────────────────────
+
+@pytest.fixture
+def temp_db():
+    """Create a temporary database file."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = Path(f.name)
+    yield db_path
+    # Cleanup
+    db_path.unlink(missing_ok=True)
+    # Cleanup backup files too
+    for backup in db_path.parent.glob(f"{db_path.stem}.backup_*"):
+        backup.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def event_loop():
+    """Create an event loop for async tests."""
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+async def create_legacy_schema(db_path: Path):
+    """Create the legacy (pre-multiuser) database schema with test data."""
+    import aiosqlite
+
+    async with aiosqlite.connect(db_path) as conn:
+        await conn.execute("PRAGMA journal_mode=WAL")
+
+        # Positions table (legacy - no portfolio_id)
+        await conn.execute("""
+            CREATE TABLE positions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                symbol TEXT NOT NULL,
+                quantity INTEGER NOT NULL,
+                avg_cost REAL NOT NULL,
+                market_price REAL,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(symbol)
+            )
+        """)
+
+        # Trades table (legacy)
+        await conn.execute("""
+            CREATE TABLE trades (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                symbol TEXT NOT NULL,
+                side TEXT NOT NULL,
+                quantity INTEGER NOT NULL,
+                price REAL NOT NULL,
+                notional REAL DEFAULT 0,
+                slippage REAL DEFAULT 0,
+                commission REAL DEFAULT 0,
+                pnl REAL DEFAULT NULL,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
+        # Account table (legacy - id=1)
+        await conn.execute("""
+            CREATE TABLE account (
+                id INTEGER PRIMARY KEY,
+                cash REAL NOT NULL,
+                equity REAL NOT NULL,
+                daily_pnl REAL DEFAULT 0,
+                realized_pnl REAL DEFAULT 0,
+                unrealized_pnl REAL DEFAULT 0,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
+        # Equity history (legacy)
+        await conn.execute("""
+            CREATE TABLE equity_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                date TEXT NOT NULL UNIQUE,
+                equity REAL NOT NULL,
+                cash REAL DEFAULT 0,
+                positions_value REAL DEFAULT 0,
+                realized_pnl REAL DEFAULT 0,
+                unrealized_pnl REAL DEFAULT 0,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
+        # Signals (legacy)
+        await conn.execute("""
+            CREATE TABLE signals (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                symbol TEXT NOT NULL,
+                strategy TEXT NOT NULL,
+                signal_type TEXT NOT NULL,
+                strength REAL,
+                metadata TEXT,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
+        # Insert test data
+        await conn.execute(
+            "INSERT INTO positions (symbol, quantity, avg_cost, market_price) VALUES (?, ?, ?, ?)",
+            ("AAPL", 100, 180.50, 185.00),
+        )
+        await conn.execute(
+            "INSERT INTO positions (symbol, quantity, avg_cost, market_price) VALUES (?, ?, ?, ?)",
+            ("NVDA", 50, 450.00, 470.00),
+        )
+        await conn.execute(
+            "INSERT INTO trades (symbol, side, quantity, price, notional) VALUES (?, ?, ?, ?, ?)",
+            ("AAPL", "BUY", 100, 180.50, 18050.0),
+        )
+        await conn.execute(
+            "INSERT INTO account (id, cash, equity) VALUES (1, 80000, 100000)"
+        )
+        await conn.execute(
+            "INSERT INTO equity_history (date, equity, cash, positions_value) VALUES (?, ?, ?, ?)",
+            ("2026-02-05", 100000, 80000, 20000),
+        )
+        await conn.execute(
+            "INSERT INTO signals (symbol, strategy, signal_type, strength) VALUES (?, ?, ?, ?)",
+            ("AAPL", "momentum", "BUY", 0.8),
+        )
+
+        await conn.commit()
+
+
+class TestMultiuserMigration:
+    @pytest.mark.asyncio
+    async def test_migration_on_legacy_db(self, temp_db):
+        """Test that migration correctly adds portfolio_id to all tables."""
+        import aiosqlite
+
+        # Create legacy schema with data
+        await create_legacy_schema(temp_db)
+
+        # Run migration
+        migration = MultiuserMigration(temp_db)
+        assert await migration.needs_migration() is True
+        result = await migration.migrate(default_cash=100000)
+        assert result is True
+
+        # Verify migration applied
+        assert await migration.needs_migration() is False
+
+        # Verify data integrity
+        async with aiosqlite.connect(temp_db) as conn:
+            # Check portfolios table exists with default entry
+            cursor = await conn.execute("SELECT id, name, starting_cash FROM portfolios")
+            rows = await cursor.fetchall()
+            assert len(rows) == 1
+            assert rows[0][0] == "default"
+
+            # Check positions have portfolio_id
+            cursor = await conn.execute("SELECT portfolio_id, symbol, quantity FROM positions")
+            rows = await cursor.fetchall()
+            assert len(rows) == 2
+            assert all(row[0] == "default" for row in rows)
+
+            # Check trades have portfolio_id
+            cursor = await conn.execute("SELECT portfolio_id, symbol, side FROM trades")
+            rows = await cursor.fetchall()
+            assert len(rows) == 1
+            assert rows[0][0] == "default"
+
+            # Check account uses portfolio_id instead of id=1
+            cursor = await conn.execute("SELECT portfolio_id, cash, equity FROM account")
+            rows = await cursor.fetchall()
+            assert len(rows) == 1
+            assert rows[0][0] == "default"
+            assert rows[0][1] == 80000  # cash preserved
+
+            # Check equity_history has portfolio_id
+            cursor = await conn.execute("SELECT portfolio_id, date, equity FROM equity_history")
+            rows = await cursor.fetchall()
+            assert len(rows) == 1
+            assert rows[0][0] == "default"
+
+            # Check signals have portfolio_id
+            cursor = await conn.execute("SELECT portfolio_id, symbol, strategy FROM signals")
+            rows = await cursor.fetchall()
+            assert len(rows) == 1
+            assert rows[0][0] == "default"
+
+    @pytest.mark.asyncio
+    async def test_migration_is_idempotent(self, temp_db):
+        """Running migration twice should be safe."""
+        await create_legacy_schema(temp_db)
+
+        migration = MultiuserMigration(temp_db)
+        result1 = await migration.migrate()
+        assert result1 is True
+
+        result2 = await migration.migrate()
+        assert result2 is False  # Already applied
+
+    @pytest.mark.asyncio
+    async def test_migration_creates_backup(self, temp_db):
+        """Migration should create a backup file."""
+        await create_legacy_schema(temp_db)
+
+        migration = MultiuserMigration(temp_db)
+        await migration.migrate()
+
+        backups = list(temp_db.parent.glob(f"{temp_db.stem}.backup_premultiuser_*"))
+        assert len(backups) >= 1
+
+    @pytest.mark.asyncio
+    async def test_migration_on_empty_db(self, temp_db):
+        """Migration on a fresh/empty database should work."""
+        import aiosqlite
+
+        # Create empty DB with just the tables (no data)
+        async with aiosqlite.connect(temp_db) as conn:
+            await conn.execute("""
+                CREATE TABLE positions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    symbol TEXT NOT NULL,
+                    quantity INTEGER NOT NULL,
+                    avg_cost REAL NOT NULL,
+                    market_price REAL,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    UNIQUE(symbol)
+                )
+            """)
+            await conn.execute("""
+                CREATE TABLE trades (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    symbol TEXT NOT NULL,
+                    side TEXT NOT NULL,
+                    quantity INTEGER NOT NULL,
+                    price REAL NOT NULL,
+                    notional REAL DEFAULT 0,
+                    slippage REAL DEFAULT 0,
+                    commission REAL DEFAULT 0,
+                    pnl REAL DEFAULT NULL,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+            await conn.execute("""
+                CREATE TABLE account (
+                    id INTEGER PRIMARY KEY,
+                    cash REAL NOT NULL,
+                    equity REAL NOT NULL,
+                    daily_pnl REAL DEFAULT 0,
+                    realized_pnl REAL DEFAULT 0,
+                    unrealized_pnl REAL DEFAULT 0,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+            await conn.execute("""
+                CREATE TABLE equity_history (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    date TEXT NOT NULL UNIQUE,
+                    equity REAL NOT NULL,
+                    cash REAL DEFAULT 0,
+                    positions_value REAL DEFAULT 0,
+                    realized_pnl REAL DEFAULT 0,
+                    unrealized_pnl REAL DEFAULT 0,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+            await conn.execute("""
+                CREATE TABLE signals (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    symbol TEXT NOT NULL,
+                    strategy TEXT NOT NULL,
+                    signal_type TEXT NOT NULL,
+                    strength REAL,
+                    metadata TEXT,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+            await conn.commit()
+
+        migration = MultiuserMigration(temp_db)
+        result = await migration.migrate()
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_unique_constraint_portfolio_symbol(self, temp_db):
+        """Two portfolios can hold the same symbol independently."""
+        import aiosqlite
+
+        await create_legacy_schema(temp_db)
+        migration = MultiuserMigration(temp_db)
+        await migration.migrate()
+
+        async with aiosqlite.connect(temp_db) as conn:
+            # Portfolio A has AAPL (from migration, portfolio_id='default')
+            # Portfolio B can also have AAPL
+            await conn.execute(
+                "INSERT INTO positions (portfolio_id, symbol, quantity, avg_cost) VALUES (?, ?, ?, ?)",
+                ("portfolio_b", "AAPL", 50, 190.00),
+            )
+            await conn.commit()
+
+            cursor = await conn.execute("SELECT portfolio_id, symbol, quantity FROM positions WHERE symbol = 'AAPL'")
+            rows = await cursor.fetchall()
+            assert len(rows) == 2
+            portfolios = {row[0] for row in rows}
+            assert portfolios == {"default", "portfolio_b"}
+
+    @pytest.mark.asyncio
+    async def test_no_db_file_returns_false(self, temp_db):
+        """If no database file exists, migration returns False."""
+        temp_db.unlink()
+        migration = MultiuserMigration(temp_db)
+        result = await migration.migrate()
+        assert result is False

--- a/tests/test_multiuser.py
+++ b/tests/test_multiuser.py
@@ -658,3 +658,985 @@ class TestPortfolioScopedDB:
         pos_other = await proxy.get_positions(portfolio_id="other")
         assert len(pos_other) == 1
         assert pos_other[0]["symbol"] == "MSFT"
+
+
+# ──────────────────────────────────────────────
+# Extended Database Isolation Tests
+# ──────────────────────────────────────────────
+
+class TestDatabaseIsolationEdgeCases:
+    """Edge cases for cross-portfolio data isolation."""
+
+    @pytest.fixture
+    async def db(self, temp_db):
+        database = AsyncTradingDatabase(db_path=temp_db)
+        await database.initialize()
+        yield database
+        await database.close()
+
+    @pytest.mark.asyncio
+    async def test_has_recent_sell_trade_scoped(self, db):
+        """has_recent_sell_trade is scoped to portfolio."""
+        await db.record_trade("AAPL", "SELL", 100, 195.0, portfolio_id="portfolio_a")
+
+        assert await db.has_recent_sell_trade("AAPL", 600, portfolio_id="portfolio_a") is True
+        assert await db.has_recent_sell_trade("AAPL", 600, portfolio_id="portfolio_b") is False
+
+    @pytest.mark.asyncio
+    async def test_get_all_positions_returns_all_portfolios(self, db):
+        """get_all_positions returns positions from ALL portfolios with portfolio_id."""
+        await db.update_position("AAPL", 100, 180.0, portfolio_id="portfolio_a")
+        await db.update_position("MSFT", 50, 300.0, portfolio_id="portfolio_b")
+        await db.update_position("AAPL", 25, 185.0, portfolio_id="portfolio_b")
+
+        all_pos = await db.get_all_positions()
+        assert len(all_pos) == 3
+
+        # Verify portfolio_id field is present
+        portfolio_ids = {p["portfolio_id"] for p in all_pos}
+        assert portfolio_ids == {"portfolio_a", "portfolio_b"}
+
+        # Verify both AAPL positions have correct quantities
+        aapl_positions = [p for p in all_pos if p["symbol"] == "AAPL"]
+        assert len(aapl_positions) == 2
+        qtys = {p["quantity"] for p in aapl_positions}
+        assert qtys == {100, 25}
+
+    @pytest.mark.asyncio
+    async def test_get_all_positions_excludes_closed(self, db):
+        """get_all_positions excludes positions with quantity=0."""
+        await db.update_position("AAPL", 100, 180.0, portfolio_id="portfolio_a")
+        await db.update_position("MSFT", 0, 0, portfolio_id="portfolio_b")
+
+        all_pos = await db.get_all_positions()
+        assert len(all_pos) == 1
+        assert all_pos[0]["symbol"] == "AAPL"
+
+    @pytest.mark.asyncio
+    async def test_equity_snapshots_same_date_different_portfolios(self, db):
+        """Two portfolios can save equity for the same date independently."""
+        date = "2026-02-06"
+        await db.save_equity_snapshot(55000, 50000, 5000, snapshot_date=date, portfolio_id="portfolio_a")
+        await db.save_equity_snapshot(82000, 80000, 2000, snapshot_date=date, portfolio_id="portfolio_b")
+
+        hist_a = await db.get_equity_history(portfolio_id="portfolio_a")
+        hist_b = await db.get_equity_history(portfolio_id="portfolio_b")
+
+        assert len(hist_a) == 1
+        assert hist_a[0]["equity"] == 55000
+        assert hist_a[0]["date"] == date
+
+        assert len(hist_b) == 1
+        assert hist_b[0]["equity"] == 82000
+        assert hist_b[0]["date"] == date
+
+    @pytest.mark.asyncio
+    async def test_equity_snapshot_upsert_same_date_same_portfolio(self, db):
+        """Saving equity twice for same date+portfolio replaces the old value."""
+        date = "2026-02-06"
+        await db.save_equity_snapshot(50000, 48000, 2000, snapshot_date=date, portfolio_id="portfolio_a")
+        await db.save_equity_snapshot(52000, 48000, 4000, snapshot_date=date, portfolio_id="portfolio_a")
+
+        hist = await db.get_equity_history(portfolio_id="portfolio_a")
+        assert len(hist) == 1
+        assert hist[0]["equity"] == 52000  # Updated value
+
+    @pytest.mark.asyncio
+    async def test_trades_symbol_filter_scoped_to_portfolio(self, db):
+        """get_recent_trades with symbol filter respects portfolio scoping."""
+        await db.record_trade("AAPL", "BUY", 100, 180.0, portfolio_id="portfolio_a")
+        await db.record_trade("AAPL", "BUY", 50, 185.0, portfolio_id="portfolio_b")
+
+        trades_a = await db.get_recent_trades(symbol="AAPL", portfolio_id="portfolio_a")
+        trades_b = await db.get_recent_trades(symbol="AAPL", portfolio_id="portfolio_b")
+
+        assert len(trades_a) == 1
+        assert trades_a[0]["quantity"] == 100
+
+        assert len(trades_b) == 1
+        assert trades_b[0]["quantity"] == 50
+
+    @pytest.mark.asyncio
+    async def test_fifo_pnl_scoped_to_portfolio(self, db):
+        """SELL trade PnL calculation only considers BUY trades from same portfolio."""
+        # Portfolio A bought AAPL at 180
+        await db.record_trade("AAPL", "BUY", 100, 180.0, portfolio_id="portfolio_a")
+        # Portfolio B bought AAPL at 200 (higher cost basis)
+        await db.record_trade("AAPL", "BUY", 100, 200.0, portfolio_id="portfolio_b")
+
+        # Sell from portfolio A at 190 - should use A's cost basis (180), PnL = +$1000
+        await db.update_position("AAPL", 100, 180.0, portfolio_id="portfolio_a")
+        await db.record_trade("AAPL", "SELL", 100, 190.0, portfolio_id="portfolio_a")
+
+        trades_a = await db.get_recent_trades(symbol="AAPL", portfolio_id="portfolio_a")
+        sell_trade = [t for t in trades_a if t["side"] == "SELL"][0]
+        assert sell_trade["pnl"] == pytest.approx(1000.0, abs=0.01)
+
+    @pytest.mark.asyncio
+    async def test_account_update_preserves_other_portfolio(self, db):
+        """Updating one portfolio's account doesn't touch the other."""
+        await db.update_account(50000, 55000, daily_pnl=500, portfolio_id="portfolio_a")
+        await db.update_account(80000, 82000, daily_pnl=1000, portfolio_id="portfolio_b")
+
+        # Update portfolio_a again
+        await db.update_account(48000, 53000, daily_pnl=-200, portfolio_id="portfolio_a")
+
+        # portfolio_b should be unchanged
+        acct_b = await db.get_account_info(portfolio_id="portfolio_b")
+        assert acct_b["cash"] == 80000
+        assert acct_b["daily_pnl"] == 1000
+
+        acct_a = await db.get_account_info(portfolio_id="portfolio_a")
+        assert acct_a["cash"] == 48000
+        assert acct_a["daily_pnl"] == -200
+
+    @pytest.mark.asyncio
+    async def test_position_replace_same_portfolio_symbol(self, db):
+        """Updating a position for same portfolio+symbol replaces it (not duplicates)."""
+        await db.update_position("AAPL", 100, 180.0, portfolio_id="portfolio_a")
+        await db.update_position("AAPL", 150, 185.0, portfolio_id="portfolio_a")
+
+        pos = await db.get_positions(portfolio_id="portfolio_a")
+        assert len(pos) == 1
+        assert pos[0]["quantity"] == 150
+        assert pos[0]["avg_cost"] == 185.0
+
+    @pytest.mark.asyncio
+    async def test_get_position_single_symbol_scoped(self, db):
+        """get_position for a single symbol is scoped to portfolio."""
+        await db.update_position("AAPL", 100, 180.0, portfolio_id="portfolio_a")
+        await db.update_position("AAPL", 50, 190.0, portfolio_id="portfolio_b")
+
+        pos_a = await db.get_position("AAPL", portfolio_id="portfolio_a")
+        pos_b = await db.get_position("AAPL", portfolio_id="portfolio_b")
+
+        assert pos_a is not None
+        assert pos_a["quantity"] == 100
+
+        assert pos_b is not None
+        assert pos_b["quantity"] == 50
+
+    @pytest.mark.asyncio
+    async def test_get_position_returns_none_for_other_portfolio(self, db):
+        """get_position returns None when symbol exists only in another portfolio."""
+        await db.update_position("AAPL", 100, 180.0, portfolio_id="portfolio_a")
+
+        pos = await db.get_position("AAPL", portfolio_id="portfolio_b")
+        assert pos is None
+
+
+# ──────────────────────────────────────────────
+# Non-Existent Portfolio Query Tests
+# ──────────────────────────────────────────────
+
+class TestNonExistentPortfolioQueries:
+    """Verify graceful behavior when querying a portfolio that has no data."""
+
+    @pytest.fixture
+    async def db(self, temp_db):
+        database = AsyncTradingDatabase(db_path=temp_db)
+        await database.initialize()
+        yield database
+        await database.close()
+
+    @pytest.mark.asyncio
+    async def test_get_positions_empty_for_unknown_portfolio(self, db):
+        """Querying positions for a non-existent portfolio returns empty list."""
+        pos = await db.get_positions(portfolio_id="nonexistent")
+        assert pos == []
+
+    @pytest.mark.asyncio
+    async def test_get_recent_trades_empty_for_unknown_portfolio(self, db):
+        """Querying trades for a non-existent portfolio returns empty list."""
+        trades = await db.get_recent_trades(portfolio_id="nonexistent")
+        assert trades == []
+
+    @pytest.mark.asyncio
+    async def test_get_account_info_empty_for_unknown_portfolio(self, db):
+        """Account info for non-existent portfolio returns empty dict."""
+        acct = await db.get_account_info(portfolio_id="nonexistent")
+        assert acct == {}
+
+    @pytest.mark.asyncio
+    async def test_get_equity_history_empty_for_unknown_portfolio(self, db):
+        """Equity history for non-existent portfolio returns empty list."""
+        hist = await db.get_equity_history(portfolio_id="nonexistent")
+        assert hist == []
+
+    @pytest.mark.asyncio
+    async def test_has_recent_buy_trade_false_for_unknown_portfolio(self, db):
+        """Recent buy check returns False for non-existent portfolio."""
+        result = await db.has_recent_buy_trade("AAPL", 600, portfolio_id="nonexistent")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_has_recent_sell_trade_false_for_unknown_portfolio(self, db):
+        """Recent sell check returns False for non-existent portfolio."""
+        result = await db.has_recent_sell_trade("AAPL", 600, portfolio_id="nonexistent")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_get_position_none_for_unknown_portfolio(self, db):
+        """get_position returns None for non-existent portfolio."""
+        pos = await db.get_position("AAPL", portfolio_id="nonexistent")
+        assert pos is None
+
+
+# ──────────────────────────────────────────────
+# Extended PortfolioScopedDB Tests
+# ──────────────────────────────────────────────
+
+class TestPortfolioScopedDBExtended:
+    """Test all scoped methods via the proxy."""
+
+    @pytest.fixture
+    async def raw_db(self, temp_db):
+        database = AsyncTradingDatabase(db_path=temp_db)
+        await database.initialize()
+        yield database
+        await database.close()
+
+    @pytest.mark.asyncio
+    async def test_proxy_has_recent_buy_trade(self, raw_db):
+        """has_recent_buy_trade correctly scoped via proxy."""
+        proxy_a = PortfolioScopedDB(raw_db, portfolio_id="alpha")
+        proxy_b = PortfolioScopedDB(raw_db, portfolio_id="beta")
+
+        await proxy_a.record_trade("AAPL", "BUY", 100, 180.0)
+
+        assert await proxy_a.has_recent_buy_trade("AAPL", 600) is True
+        assert await proxy_b.has_recent_buy_trade("AAPL", 600) is False
+
+    @pytest.mark.asyncio
+    async def test_proxy_has_recent_sell_trade(self, raw_db):
+        """has_recent_sell_trade correctly scoped via proxy."""
+        proxy_a = PortfolioScopedDB(raw_db, portfolio_id="alpha")
+        proxy_b = PortfolioScopedDB(raw_db, portfolio_id="beta")
+
+        await proxy_a.record_trade("AAPL", "SELL", 100, 195.0)
+
+        assert await proxy_a.has_recent_sell_trade("AAPL", 600) is True
+        assert await proxy_b.has_recent_sell_trade("AAPL", 600) is False
+
+    @pytest.mark.asyncio
+    async def test_proxy_record_signal(self, raw_db):
+        """record_signal correctly scoped via proxy."""
+        proxy_a = PortfolioScopedDB(raw_db, portfolio_id="alpha")
+        proxy_b = PortfolioScopedDB(raw_db, portfolio_id="beta")
+
+        await proxy_a.record_signal("AAPL", "momentum", "BUY", 0.8)
+        await proxy_b.record_signal("MSFT", "ml_enhanced", "SELL", 0.7)
+
+        # Verify isolation via raw DB query
+        import aiosqlite
+        async with aiosqlite.connect(raw_db.db_path) as conn:
+            cursor = await conn.execute(
+                "SELECT portfolio_id, symbol FROM signals ORDER BY symbol"
+            )
+            rows = await cursor.fetchall()
+            assert len(rows) == 2
+            assert rows[0] == ("alpha", "AAPL")
+            assert rows[1] == ("beta", "MSFT")
+
+    @pytest.mark.asyncio
+    async def test_proxy_save_equity_snapshot(self, raw_db):
+        """save_equity_snapshot correctly scoped via proxy."""
+        proxy_a = PortfolioScopedDB(raw_db, portfolio_id="alpha")
+        proxy_b = PortfolioScopedDB(raw_db, portfolio_id="beta")
+
+        await proxy_a.save_equity_snapshot(55000, 50000, 5000)
+        await proxy_b.save_equity_snapshot(82000, 80000, 2000)
+
+        hist_a = await proxy_a.get_equity_history()
+        hist_b = await proxy_b.get_equity_history()
+
+        assert len(hist_a) == 1
+        assert hist_a[0]["equity"] == 55000
+        assert len(hist_b) == 1
+        assert hist_b[0]["equity"] == 82000
+
+    @pytest.mark.asyncio
+    async def test_proxy_upsert_portfolio_passes_through(self, raw_db):
+        """upsert_portfolio passes through proxy (not portfolio-scoped kwarg)."""
+        proxy = PortfolioScopedDB(raw_db, portfolio_id="alpha")
+
+        # upsert_portfolio takes portfolio_data dict (id is inside dict, not a kwarg)
+        await proxy.upsert_portfolio({
+            "id": "alpha",
+            "name": "Alpha Portfolio",
+            "starting_cash": 75000,
+            "symbols": "AAPL,NVDA",
+        })
+
+        portfolios = await raw_db.get_portfolios()
+        alpha = [p for p in portfolios if p["id"] == "alpha"]
+        assert len(alpha) == 1
+        assert alpha[0]["name"] == "Alpha Portfolio"
+
+    @pytest.mark.asyncio
+    async def test_proxy_portfolio_id_attribute(self, raw_db):
+        """Proxy exposes its portfolio_id."""
+        proxy = PortfolioScopedDB(raw_db, portfolio_id="my_portfolio")
+        assert proxy.portfolio_id == "my_portfolio"
+
+    @pytest.mark.asyncio
+    async def test_proxy_underlying_db_accessible(self, raw_db):
+        """Proxy gives access to the underlying DB via _db."""
+        proxy = PortfolioScopedDB(raw_db, portfolio_id="test")
+        assert proxy._db is raw_db
+
+    @pytest.mark.asyncio
+    async def test_proxy_get_position_single_symbol(self, raw_db):
+        """get_position (single symbol) works through proxy."""
+        proxy = PortfolioScopedDB(raw_db, portfolio_id="alpha")
+
+        await proxy.update_position("AAPL", 100, 180.0)
+
+        pos = await proxy.get_position("AAPL")
+        assert pos is not None
+        assert pos["quantity"] == 100
+
+        # Different portfolio should not see it
+        proxy_b = PortfolioScopedDB(raw_db, portfolio_id="beta")
+        pos_b = await proxy_b.get_position("AAPL")
+        assert pos_b is None
+
+    @pytest.mark.asyncio
+    async def test_multiple_proxies_concurrent_operations(self, raw_db):
+        """Multiple proxies operating concurrently don't interfere."""
+        proxy_a = PortfolioScopedDB(raw_db, portfolio_id="alpha")
+        proxy_b = PortfolioScopedDB(raw_db, portfolio_id="beta")
+        proxy_c = PortfolioScopedDB(raw_db, portfolio_id="gamma")
+
+        # Write positions concurrently
+        await asyncio.gather(
+            proxy_a.update_position("AAPL", 100, 180.0),
+            proxy_b.update_position("AAPL", 50, 185.0),
+            proxy_c.update_position("AAPL", 25, 190.0),
+        )
+
+        # Verify isolation
+        pos_a = await proxy_a.get_positions()
+        pos_b = await proxy_b.get_positions()
+        pos_c = await proxy_c.get_positions()
+
+        assert len(pos_a) == 1 and pos_a[0]["quantity"] == 100
+        assert len(pos_b) == 1 and pos_b[0]["quantity"] == 50
+        assert len(pos_c) == 1 and pos_c[0]["quantity"] == 25
+
+
+# ──────────────────────────────────────────────
+# Portfolio Config Validation Edge Cases
+# ──────────────────────────────────────────────
+
+class TestPortfolioConfigEdgeCases:
+    """Edge cases for portfolio configuration."""
+
+    def test_from_dict_empty_symbols_string(self):
+        """Empty symbols string produces empty list."""
+        cfg = PortfolioConfig.from_dict({"id": "test", "name": "T", "symbols": ""})
+        assert cfg.symbols == []
+
+    def test_from_dict_whitespace_symbols(self):
+        """Whitespace in symbols is stripped."""
+        cfg = PortfolioConfig.from_dict({"id": "test", "name": "T", "symbols": "  AAPL  ,  MSFT  "})
+        assert cfg.symbols == ["AAPL", "MSFT"]
+
+    def test_from_dict_missing_name_uses_id(self):
+        """Missing name falls back to id."""
+        cfg = PortfolioConfig.from_dict({"id": "my_portfolio"})
+        assert cfg.name == "my_portfolio"
+
+    def test_from_dict_all_risk_overrides(self):
+        """All risk override fields are preserved in from_dict."""
+        data = {
+            "id": "test",
+            "name": "Test",
+            "max_position_pct": 0.05,
+            "max_daily_loss_pct": 0.01,
+            "max_open_positions": 5,
+            "stop_loss_pct": 3.0,
+            "trailing_stop_pct": 5.0,
+            "use_trailing_stop": True,
+            "min_confidence": 0.6,
+        }
+        cfg = PortfolioConfig.from_dict(data)
+        assert cfg.max_position_pct == 0.05
+        assert cfg.max_daily_loss_pct == 0.01
+        assert cfg.max_open_positions == 5
+        assert cfg.stop_loss_pct == 3.0
+        assert cfg.trailing_stop_pct == 5.0
+        assert cfg.use_trailing_stop is True
+        assert cfg.min_confidence == 0.6
+
+    def test_from_dict_strategy_string_split(self):
+        """enabled_strategies as comma-separated string is split correctly."""
+        cfg = PortfolioConfig.from_dict({
+            "id": "test",
+            "name": "T",
+            "enabled_strategies": "momentum, ml_enhanced , pairs",
+        })
+        assert cfg.enabled_strategies == ["momentum", "ml_enhanced", "pairs"]
+
+    def test_from_dict_extra_fields_ignored(self):
+        """Unknown fields in dict don't cause errors."""
+        cfg = PortfolioConfig.from_dict({
+            "id": "test",
+            "name": "T",
+            "unknown_field": "value",
+            "future_feature": True,
+        })
+        assert cfg.id == "test"
+        assert not hasattr(cfg, "unknown_field")
+
+    def test_to_dict_inactive_portfolio(self):
+        """Inactive portfolio serializes active=False correctly."""
+        cfg = PortfolioConfig(id="disabled", name="Disabled", active=False)
+        d = cfg.to_dict()
+        assert d["active"] is False
+
+    def test_get_risk_param_nonexistent_attribute(self):
+        """get_risk_param with non-existent attribute returns global default."""
+        cfg = PortfolioConfig(id="test", name="Test")
+        result = cfg.get_risk_param("nonexistent_param", 42)
+        assert result == 42
+
+    def test_to_dict_none_strategies(self):
+        """to_dict handles None enabled_strategies."""
+        cfg = PortfolioConfig(id="test", name="T")
+        d = cfg.to_dict()
+        assert d["enabled_strategies"] is None
+
+    def test_inactive_portfolio_in_multi_config(self):
+        """Inactive portfolios are loaded but identifiable."""
+        portfolios = [
+            {"id": "active", "name": "Active", "active": True, "symbols": "AAPL"},
+            {"id": "disabled", "name": "Disabled", "active": False, "symbols": "MSFT"},
+        ]
+        env = {"PORTFOLIOS": json.dumps(portfolios)}
+        with patch.dict(os.environ, env, clear=True):
+            configs = load_portfolio_configs()
+            assert len(configs) == 2
+            active_configs = [c for c in configs if c.active]
+            assert len(active_configs) == 1
+            assert active_configs[0].id == "active"
+
+    def test_portfolio_not_json_object(self):
+        """Non-object items in PORTFOLIOS array raise ValueError."""
+        env = {"PORTFOLIOS": json.dumps(["just_a_string"])}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValueError, match="JSON object"):
+                load_portfolio_configs()
+
+
+# ──────────────────────────────────────────────
+# Upsert Portfolio Tests
+# ──────────────────────────────────────────────
+
+class TestUpsertPortfolio:
+    """Test portfolio definition insert and update behavior."""
+
+    @pytest.fixture
+    async def db(self, temp_db):
+        database = AsyncTradingDatabase(db_path=temp_db)
+        await database.initialize()
+        yield database
+        await database.close()
+
+    @pytest.mark.asyncio
+    async def test_upsert_creates_new_portfolio(self, db):
+        """upsert_portfolio creates a new portfolio definition."""
+        await db.upsert_portfolio({
+            "id": "new_portfolio",
+            "name": "New Portfolio",
+            "starting_cash": 75000,
+            "symbols": "AAPL,NVDA",
+            "active": True,
+        })
+
+        portfolios = await db.get_portfolios()
+        new = [p for p in portfolios if p["id"] == "new_portfolio"]
+        assert len(new) == 1
+        assert new[0]["name"] == "New Portfolio"
+        assert new[0]["starting_cash"] == 75000
+
+    @pytest.mark.asyncio
+    async def test_upsert_updates_existing_portfolio(self, db):
+        """upsert_portfolio updates an existing portfolio definition."""
+        await db.upsert_portfolio({
+            "id": "evolving",
+            "name": "Version 1",
+            "starting_cash": 50000,
+            "symbols": "AAPL",
+        })
+
+        # Update it
+        await db.upsert_portfolio({
+            "id": "evolving",
+            "name": "Version 2",
+            "starting_cash": 75000,
+            "symbols": "AAPL,NVDA,TSLA",
+        })
+
+        portfolios = await db.get_portfolios()
+        evolving = [p for p in portfolios if p["id"] == "evolving"]
+        assert len(evolving) == 1
+        assert evolving[0]["name"] == "Version 2"
+        assert evolving[0]["starting_cash"] == 75000
+
+    @pytest.mark.asyncio
+    async def test_upsert_preserves_risk_overrides(self, db):
+        """upsert_portfolio preserves risk override fields."""
+        await db.upsert_portfolio({
+            "id": "risky",
+            "name": "Risky",
+            "max_position_pct": 0.08,
+            "max_daily_loss_pct": 0.02,
+            "max_open_positions": 10,
+            "stop_loss_pct": 5.0,
+            "trailing_stop_pct": 7.0,
+            "use_trailing_stop": True,
+            "min_confidence": 0.4,
+        })
+
+        portfolios = await db.get_portfolios()
+        risky = [p for p in portfolios if p["id"] == "risky"][0]
+        assert risky["max_position_pct"] == 0.08
+        assert risky["max_daily_loss_pct"] == 0.02
+        assert risky["max_open_positions"] == 10
+        assert risky["use_trailing_stop"] is True
+
+    @pytest.mark.asyncio
+    async def test_upsert_default_portfolio_exists(self, db):
+        """The 'default' portfolio is created during DB init."""
+        portfolios = await db.get_portfolios()
+        default = [p for p in portfolios if p["id"] == "default"]
+        assert len(default) == 1
+        assert default[0]["name"] == "Default Portfolio"
+
+
+# ──────────────────────────────────────────────
+# Migration Edge Cases
+# ──────────────────────────────────────────────
+
+class TestMigrationEdgeCases:
+    """Additional migration edge cases."""
+
+    @pytest.mark.asyncio
+    async def test_migration_version_recorded_correctly(self, temp_db):
+        """Migration version is recorded in schema_migrations table."""
+        import aiosqlite
+
+        await create_legacy_schema(temp_db)
+        migration = MultiuserMigration(temp_db)
+        await migration.migrate()
+
+        async with aiosqlite.connect(temp_db) as conn:
+            cursor = await conn.execute(
+                "SELECT version, description FROM schema_migrations"
+            )
+            rows = await cursor.fetchall()
+            assert len(rows) == 1
+            assert rows[0][0] == 1  # Version 1
+            assert "multi-portfolio" in rows[0][1].lower()
+
+    @pytest.mark.asyncio
+    async def test_migration_preserves_null_market_price(self, temp_db):
+        """Migration preserves NULL market_price values."""
+        import aiosqlite
+
+        await create_legacy_schema(temp_db)
+
+        # Add a position with NULL market_price
+        async with aiosqlite.connect(temp_db) as conn:
+            await conn.execute(
+                "INSERT INTO positions (symbol, quantity, avg_cost) VALUES (?, ?, ?)",
+                ("TSLA", 30, 250.00),
+            )
+            await conn.commit()
+
+        migration = MultiuserMigration(temp_db)
+        await migration.migrate()
+
+        async with aiosqlite.connect(temp_db) as conn:
+            cursor = await conn.execute(
+                "SELECT symbol, market_price FROM positions WHERE symbol = 'TSLA'"
+            )
+            row = await cursor.fetchone()
+            assert row[0] == "TSLA"
+            assert row[1] is None  # NULL preserved
+
+    @pytest.mark.asyncio
+    async def test_migration_preserves_trade_pnl(self, temp_db):
+        """Migration preserves PnL values on trades."""
+        import aiosqlite
+
+        await create_legacy_schema(temp_db)
+
+        async with aiosqlite.connect(temp_db) as conn:
+            await conn.execute(
+                "INSERT INTO trades (symbol, side, quantity, price, notional, pnl) VALUES (?, ?, ?, ?, ?, ?)",
+                ("AAPL", "SELL", 50, 195.0, 9750.0, 750.0),
+            )
+            await conn.commit()
+
+        migration = MultiuserMigration(temp_db)
+        await migration.migrate()
+
+        async with aiosqlite.connect(temp_db) as conn:
+            cursor = await conn.execute(
+                "SELECT symbol, side, pnl FROM trades WHERE side = 'SELL'"
+            )
+            row = await cursor.fetchone()
+            assert row[0] == "AAPL"
+            assert row[2] == 750.0  # PnL preserved
+
+    @pytest.mark.asyncio
+    async def test_migration_backup_is_valid_sqlite(self, temp_db):
+        """Backup file created by migration is a valid SQLite database."""
+        import aiosqlite
+
+        await create_legacy_schema(temp_db)
+        migration = MultiuserMigration(temp_db)
+        await migration.migrate()
+
+        backups = list(temp_db.parent.glob(f"{temp_db.stem}.backup_premultiuser_*"))
+        assert len(backups) >= 1
+
+        # Verify backup is valid SQLite
+        async with aiosqlite.connect(backups[0]) as conn:
+            cursor = await conn.execute("SELECT COUNT(*) FROM positions")
+            count = (await cursor.fetchone())[0]
+            assert count == 2  # Original 2 positions
+
+    @pytest.mark.asyncio
+    async def test_migration_with_many_trades(self, temp_db):
+        """Migration handles a moderate number of trades correctly."""
+        import aiosqlite
+
+        await create_legacy_schema(temp_db)
+
+        # Insert 500 additional trades
+        async with aiosqlite.connect(temp_db) as conn:
+            for i in range(500):
+                symbol = ["AAPL", "NVDA", "MSFT", "TSLA", "GOOG"][i % 5]
+                side = "BUY" if i % 3 != 0 else "SELL"
+                price = 100.0 + (i % 50)
+                await conn.execute(
+                    "INSERT INTO trades (symbol, side, quantity, price, notional) VALUES (?, ?, ?, ?, ?)",
+                    (symbol, side, 10, price, 10 * price),
+                )
+            await conn.commit()
+
+        migration = MultiuserMigration(temp_db)
+        await migration.migrate()
+
+        async with aiosqlite.connect(temp_db) as conn:
+            cursor = await conn.execute("SELECT COUNT(*) FROM trades")
+            count = (await cursor.fetchone())[0]
+            assert count == 501  # 1 original + 500 added
+
+            # All should have portfolio_id='default'
+            cursor = await conn.execute(
+                "SELECT COUNT(*) FROM trades WHERE portfolio_id = 'default'"
+            )
+            default_count = (await cursor.fetchone())[0]
+            assert default_count == 501
+
+
+# ──────────────────────────────────────────────
+# SyncDatabaseReader Portfolio Scoping Tests
+# ──────────────────────────────────────────────
+
+class TestSyncDatabaseReaderPortfolioScoping:
+    """Test that SyncDatabaseReader correctly scopes queries by portfolio_id."""
+
+    @pytest.fixture
+    async def populated_db(self, temp_db):
+        """Create a database with data in multiple portfolios."""
+        database = AsyncTradingDatabase(db_path=temp_db)
+        await database.initialize()
+
+        # Portfolio A data
+        await database.update_position("AAPL", 100, 180.0, portfolio_id="portfolio_a")
+        await database.update_position("NVDA", 50, 450.0, portfolio_id="portfolio_a")
+        await database.record_trade("AAPL", "BUY", 100, 180.0, portfolio_id="portfolio_a")
+        await database.update_account(50000, 55000, portfolio_id="portfolio_a")
+        await database.save_equity_snapshot(55000, 50000, 5000, snapshot_date="2026-02-06", portfolio_id="portfolio_a")
+        await database.record_signal("AAPL", "momentum", "BUY", 0.8, portfolio_id="portfolio_a")
+
+        # Portfolio B data
+        await database.update_position("MSFT", 200, 300.0, portfolio_id="portfolio_b")
+        await database.record_trade("MSFT", "BUY", 200, 300.0, portfolio_id="portfolio_b")
+        await database.update_account(80000, 82000, portfolio_id="portfolio_b")
+        await database.save_equity_snapshot(82000, 80000, 2000, snapshot_date="2026-02-06", portfolio_id="portfolio_b")
+        await database.record_signal("MSFT", "ml_enhanced", "SELL", 0.7, portfolio_id="portfolio_b")
+
+        # Portfolio definitions
+        await database.upsert_portfolio({"id": "portfolio_a", "name": "Portfolio A", "symbols": "AAPL,NVDA"})
+        await database.upsert_portfolio({"id": "portfolio_b", "name": "Portfolio B", "symbols": "MSFT"})
+
+        await database.close()
+        yield temp_db
+
+    def test_get_positions_scoped(self, populated_db):
+        """SyncDatabaseReader.get_positions scoped to portfolio."""
+        from sync_db_reader import SyncDatabaseReader
+        reader = SyncDatabaseReader(db_path=str(populated_db))
+
+        pos_a = reader.get_positions(portfolio_id="portfolio_a")
+        pos_b = reader.get_positions(portfolio_id="portfolio_b")
+
+        assert len(pos_a) == 2
+        symbols_a = {p["symbol"] for p in pos_a}
+        assert symbols_a == {"AAPL", "NVDA"}
+
+        assert len(pos_b) == 1
+        assert pos_b[0]["symbol"] == "MSFT"
+
+    def test_get_all_positions_cross_portfolio(self, populated_db):
+        """SyncDatabaseReader.get_all_positions returns all portfolios."""
+        from sync_db_reader import SyncDatabaseReader
+        reader = SyncDatabaseReader(db_path=str(populated_db))
+
+        all_pos = reader.get_all_positions()
+        assert len(all_pos) == 3
+
+        portfolio_ids = {p["portfolio_id"] for p in all_pos}
+        assert portfolio_ids == {"portfolio_a", "portfolio_b"}
+
+    def test_get_recent_trades_scoped(self, populated_db):
+        """SyncDatabaseReader.get_recent_trades scoped to portfolio."""
+        from sync_db_reader import SyncDatabaseReader
+        reader = SyncDatabaseReader(db_path=str(populated_db))
+
+        trades_a = reader.get_recent_trades(portfolio_id="portfolio_a")
+        trades_b = reader.get_recent_trades(portfolio_id="portfolio_b")
+
+        assert len(trades_a) == 1
+        assert trades_a[0]["symbol"] == "AAPL"
+
+        assert len(trades_b) == 1
+        assert trades_b[0]["symbol"] == "MSFT"
+
+    def test_get_account_info_scoped(self, populated_db):
+        """SyncDatabaseReader.get_account_info scoped to portfolio."""
+        from sync_db_reader import SyncDatabaseReader
+        reader = SyncDatabaseReader(db_path=str(populated_db))
+
+        acct_a = reader.get_account_info(portfolio_id="portfolio_a")
+        acct_b = reader.get_account_info(portfolio_id="portfolio_b")
+
+        assert acct_a["cash"] == 50000
+        assert acct_b["cash"] == 80000
+
+    def test_get_equity_history_scoped(self, populated_db):
+        """SyncDatabaseReader.get_equity_history scoped to portfolio."""
+        from sync_db_reader import SyncDatabaseReader
+        reader = SyncDatabaseReader(db_path=str(populated_db))
+
+        hist_a = reader.get_equity_history(portfolio_id="portfolio_a")
+        hist_b = reader.get_equity_history(portfolio_id="portfolio_b")
+
+        assert len(hist_a) == 1
+        assert hist_a[0]["equity"] == 55000
+
+        assert len(hist_b) == 1
+        assert hist_b[0]["equity"] == 82000
+
+    def test_get_signals_scoped(self, populated_db):
+        """SyncDatabaseReader.get_signals scoped to portfolio."""
+        from sync_db_reader import SyncDatabaseReader
+        reader = SyncDatabaseReader(db_path=str(populated_db))
+
+        signals_a = reader.get_signals(hours=24, portfolio_id="portfolio_a")
+        signals_b = reader.get_signals(hours=24, portfolio_id="portfolio_b")
+
+        assert len(signals_a) == 1
+        assert signals_a[0]["symbol"] == "AAPL"
+
+        assert len(signals_b) == 1
+        assert signals_b[0]["symbol"] == "MSFT"
+
+    def test_get_portfolios_returns_all(self, populated_db):
+        """SyncDatabaseReader.get_portfolios returns all portfolios."""
+        from sync_db_reader import SyncDatabaseReader
+        reader = SyncDatabaseReader(db_path=str(populated_db))
+
+        portfolios = reader.get_portfolios()
+        ids = {p["id"] for p in portfolios}
+        assert "default" in ids
+        assert "portfolio_a" in ids
+        assert "portfolio_b" in ids
+
+    def test_default_portfolio_backward_compat(self, populated_db):
+        """SyncDatabaseReader defaults to 'default' portfolio when no portfolio_id."""
+        from sync_db_reader import SyncDatabaseReader
+        reader = SyncDatabaseReader(db_path=str(populated_db))
+
+        # No data in 'default' portfolio, should return empty
+        pos = reader.get_positions()  # No portfolio_id = 'default'
+        assert pos == []
+
+    def test_nonexistent_portfolio_returns_empty(self, populated_db):
+        """SyncDatabaseReader returns empty for non-existent portfolio."""
+        from sync_db_reader import SyncDatabaseReader
+        reader = SyncDatabaseReader(db_path=str(populated_db))
+
+        pos = reader.get_positions(portfolio_id="nonexistent")
+        trades = reader.get_recent_trades(portfolio_id="nonexistent")
+        hist = reader.get_equity_history(portfolio_id="nonexistent")
+
+        assert pos == []
+        assert trades == []
+        assert hist == []
+
+
+# ──────────────────────────────────────────────
+# Portfolio ID Edge Cases
+# ──────────────────────────────────────────────
+
+class TestPortfolioIdEdgeCases:
+    """Test edge cases for portfolio_id values."""
+
+    @pytest.fixture
+    async def db(self, temp_db):
+        database = AsyncTradingDatabase(db_path=temp_db)
+        await database.initialize()
+        yield database
+        await database.close()
+
+    @pytest.mark.asyncio
+    async def test_portfolio_id_case_sensitive(self, db):
+        """Portfolio IDs are case-sensitive."""
+        await db.update_position("AAPL", 100, 180.0, portfolio_id="Alpha")
+        await db.update_position("AAPL", 50, 190.0, portfolio_id="alpha")
+
+        pos_upper = await db.get_positions(portfolio_id="Alpha")
+        pos_lower = await db.get_positions(portfolio_id="alpha")
+
+        assert len(pos_upper) == 1
+        assert pos_upper[0]["quantity"] == 100
+
+        assert len(pos_lower) == 1
+        assert pos_lower[0]["quantity"] == 50
+
+    @pytest.mark.asyncio
+    async def test_portfolio_id_with_special_chars(self, db):
+        """Portfolio IDs with hyphens and underscores work."""
+        await db.update_position("AAPL", 100, 180.0, portfolio_id="my-portfolio_v2")
+
+        pos = await db.get_positions(portfolio_id="my-portfolio_v2")
+        assert len(pos) == 1
+        assert pos[0]["symbol"] == "AAPL"
+
+    @pytest.mark.asyncio
+    async def test_portfolio_id_with_numbers(self, db):
+        """Portfolio IDs with numbers work."""
+        await db.update_position("AAPL", 100, 180.0, portfolio_id="user123_portfolio456")
+
+        pos = await db.get_positions(portfolio_id="user123_portfolio456")
+        assert len(pos) == 1
+
+    @pytest.mark.asyncio
+    async def test_many_portfolios_isolation(self, db):
+        """20 portfolios with the same symbol maintain complete isolation."""
+        num_portfolios = 20
+
+        # Create positions in 20 portfolios
+        for i in range(num_portfolios):
+            pid = f"portfolio_{i}"
+            await db.update_position("AAPL", i + 1, 180.0 + i, portfolio_id=pid)
+
+        # Verify each portfolio has the correct quantity
+        for i in range(num_portfolios):
+            pid = f"portfolio_{i}"
+            pos = await db.get_positions(portfolio_id=pid)
+            assert len(pos) == 1
+            assert pos[0]["quantity"] == i + 1
+            assert pos[0]["avg_cost"] == 180.0 + i
+
+        # Verify get_all_positions returns all 20
+        all_pos = await db.get_all_positions()
+        assert len(all_pos) == num_portfolios
+
+
+# ──────────────────────────────────────────────
+# Concurrent Cross-Portfolio Operations
+# ──────────────────────────────────────────────
+
+class TestConcurrentCrossPortfolio:
+    """Test concurrent operations across multiple portfolios."""
+
+    @pytest.fixture
+    async def db(self, temp_db):
+        database = AsyncTradingDatabase(db_path=temp_db)
+        await database.initialize()
+        yield database
+        await database.close()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_position_writes(self, db):
+        """Concurrent position writes to different portfolios succeed."""
+        tasks = [
+            db.update_position("AAPL", 100, 180.0, portfolio_id=f"portfolio_{i}")
+            for i in range(10)
+        ]
+        await asyncio.gather(*tasks)
+
+        all_pos = await db.get_all_positions()
+        assert len(all_pos) == 10
+
+    @pytest.mark.asyncio
+    async def test_concurrent_trade_recording(self, db):
+        """Concurrent trade recording to different portfolios doesn't lose data."""
+        tasks = [
+            db.record_trade("AAPL", "BUY", 10 + i, 180.0, portfolio_id=f"portfolio_{i}")
+            for i in range(10)
+        ]
+        await asyncio.gather(*tasks)
+
+        # Verify each portfolio has exactly 1 trade
+        for i in range(10):
+            trades = await db.get_recent_trades(portfolio_id=f"portfolio_{i}")
+            assert len(trades) == 1
+            assert trades[0]["quantity"] == 10 + i
+
+    @pytest.mark.asyncio
+    async def test_concurrent_account_updates(self, db):
+        """Concurrent account updates to different portfolios are isolated."""
+        tasks = [
+            db.update_account(50000 + i * 1000, 55000 + i * 1000, portfolio_id=f"portfolio_{i}")
+            for i in range(10)
+        ]
+        await asyncio.gather(*tasks)
+
+        for i in range(10):
+            acct = await db.get_account_info(portfolio_id=f"portfolio_{i}")
+            assert acct["cash"] == 50000 + i * 1000
+            assert acct["equity"] == 55000 + i * 1000
+
+    @pytest.mark.asyncio
+    async def test_concurrent_mixed_operations(self, db):
+        """Concurrent mixed operations (positions, trades, account) across portfolios."""
+        async def portfolio_operations(pid, qty, price):
+            await db.update_position("AAPL", qty, price, portfolio_id=pid)
+            await db.record_trade("AAPL", "BUY", qty, price, portfolio_id=pid)
+            await db.update_account(100000 - qty * price, 100000, portfolio_id=pid)
+
+        tasks = [
+            portfolio_operations(f"portfolio_{i}", 10 * (i + 1), 180.0)
+            for i in range(5)
+        ]
+        await asyncio.gather(*tasks)
+
+        for i in range(5):
+            pid = f"portfolio_{i}"
+            pos = await db.get_positions(portfolio_id=pid)
+            trades = await db.get_recent_trades(portfolio_id=pid)
+            acct = await db.get_account_info(portfolio_id=pid)
+
+            assert len(pos) == 1
+            assert pos[0]["quantity"] == 10 * (i + 1)
+            assert len(trades) == 1
+            assert acct is not None

--- a/tests/test_sql_injection_multiportfolio.py
+++ b/tests/test_sql_injection_multiportfolio.py
@@ -1,0 +1,382 @@
+"""SQL injection security tests for portfolio_id parameter.
+
+Verifies that all database methods using portfolio_id are safe against
+SQL injection attacks, whether through parameterized queries (SQLite ?
+placeholders) or input validation (DatabaseValidator.validate_portfolio_id).
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from robo_trader.database_async import AsyncTradingDatabase
+from robo_trader.database_validator import ValidationError
+
+# SQL injection payloads to test
+INJECTION_PAYLOADS = [
+    "default' OR '1'='1",
+    "default'; DROP TABLE positions; --",
+    "default' UNION SELECT * FROM positions WHERE '1'='1",
+    "'; DELETE FROM trades; --",
+    "default' OR portfolio_id IS NOT NULL --",
+]
+
+
+@pytest.fixture
+def temp_db():
+    """Create a temporary database file."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = Path(f.name)
+    yield db_path
+    db_path.unlink(missing_ok=True)
+
+
+@pytest.fixture
+async def db(temp_db):
+    """Create an initialized async database with seed data in two portfolios."""
+    database = AsyncTradingDatabase(db_path=temp_db)
+    await database.initialize()
+
+    # Seed portfolio_a
+    await database.update_position("AAPL", 100, 180.0, portfolio_id="portfolio_a")
+    await database.record_trade("AAPL", "BUY", 100, 180.0, portfolio_id="portfolio_a")
+    await database.update_account(50000, 55000, portfolio_id="portfolio_a")
+    await database.save_equity_snapshot(
+        55000, 50000, 5000, snapshot_date="2026-02-10", portfolio_id="portfolio_a"
+    )
+    await database.record_signal("AAPL", "momentum", "BUY", 0.8, portfolio_id="portfolio_a")
+
+    # Seed portfolio_b
+    await database.update_position("MSFT", 50, 300.0, portfolio_id="portfolio_b")
+    await database.record_trade("MSFT", "BUY", 50, 300.0, portfolio_id="portfolio_b")
+    await database.update_account(80000, 82000, portfolio_id="portfolio_b")
+    await database.save_equity_snapshot(
+        82000, 80000, 2000, snapshot_date="2026-02-10", portfolio_id="portfolio_b"
+    )
+    await database.record_signal("MSFT", "ml_enhanced", "SELL", 0.7, portfolio_id="portfolio_b")
+
+    yield database
+    await database.close()
+
+
+# ──────────────────────────────────────────────
+# SELECT Injection Tests
+# ──────────────────────────────────────────────
+
+
+class TestSelectInjection:
+    """Verify that SELECT queries with injected portfolio_id cannot leak data."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", INJECTION_PAYLOADS)
+    async def test_get_positions_injection(self, db, payload):
+        """get_positions with injection payload returns empty, not all data."""
+        try:
+            result = await db.get_positions(portfolio_id=payload)
+            assert result == [], f"Injection payload returned data: {result}"
+        except (ValidationError, ValueError):
+            pass  # Format validation caught it
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", INJECTION_PAYLOADS)
+    async def test_get_position_single_injection(self, db, payload):
+        """get_position with injection payload returns None."""
+        try:
+            result = await db.get_position("AAPL", portfolio_id=payload)
+            assert result is None, f"Injection payload returned data: {result}"
+        except (ValidationError, ValueError):
+            pass
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", INJECTION_PAYLOADS)
+    async def test_get_recent_trades_injection(self, db, payload):
+        """get_recent_trades with injection payload returns empty."""
+        try:
+            result = await db.get_recent_trades(portfolio_id=payload)
+            assert result == [], f"Injection payload returned data: {result}"
+        except (ValidationError, ValueError):
+            pass
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", INJECTION_PAYLOADS)
+    async def test_get_account_info_injection(self, db, payload):
+        """get_account_info with injection payload returns empty dict."""
+        try:
+            result = await db.get_account_info(portfolio_id=payload)
+            assert result == {}, f"Injection payload returned data: {result}"
+        except (ValidationError, ValueError):
+            pass
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", INJECTION_PAYLOADS)
+    async def test_get_equity_history_injection(self, db, payload):
+        """get_equity_history with injection payload returns empty."""
+        try:
+            result = await db.get_equity_history(portfolio_id=payload)
+            assert result == [], f"Injection payload returned data: {result}"
+        except (ValidationError, ValueError):
+            pass
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", INJECTION_PAYLOADS)
+    async def test_has_recent_buy_trade_injection(self, db, payload):
+        """has_recent_buy_trade with injection payload returns False."""
+        try:
+            result = await db.has_recent_buy_trade("AAPL", 600, portfolio_id=payload)
+            assert result is False, f"Injection payload returned True"
+        except (ValidationError, ValueError):
+            pass
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", INJECTION_PAYLOADS)
+    async def test_has_recent_sell_trade_injection(self, db, payload):
+        """has_recent_sell_trade with injection payload returns False."""
+        try:
+            result = await db.has_recent_sell_trade("AAPL", 600, portfolio_id=payload)
+            assert result is False, f"Injection payload returned True"
+        except (ValidationError, ValueError):
+            pass
+
+
+# ──────────────────────────────────────────────
+# INSERT Injection Tests (DROP TABLE attempts)
+# ──────────────────────────────────────────────
+
+
+class TestInsertInjection:
+    """Verify that INSERT operations with injected portfolio_id cannot destroy data."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", INJECTION_PAYLOADS)
+    async def test_record_trade_drop_table(self, db, payload):
+        """record_trade with DROP TABLE payload does not destroy tables."""
+        import aiosqlite
+
+        try:
+            await db.record_trade("AAPL", "BUY", 10, 180.0, portfolio_id=payload)
+        except (ValidationError, ValueError):
+            pass  # Validation caught it
+
+        # Verify all tables still exist
+        async with aiosqlite.connect(db.db_path) as conn:
+            for table in ["positions", "trades", "account", "equity_history", "signals"]:
+                cursor = await conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+                    (table,),
+                )
+                row = await cursor.fetchone()
+                assert row is not None, f"Table '{table}' was destroyed by injection"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", INJECTION_PAYLOADS)
+    async def test_record_signal_drop_table(self, db, payload):
+        """record_signal with injection payload does not destroy tables."""
+        import aiosqlite
+
+        try:
+            await db.record_signal("AAPL", "test", "BUY", 0.5, portfolio_id=payload)
+        except (ValidationError, ValueError):
+            pass
+
+        async with aiosqlite.connect(db.db_path) as conn:
+            cursor = await conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='signals'"
+            )
+            assert await cursor.fetchone() is not None, "signals table destroyed"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", INJECTION_PAYLOADS)
+    async def test_save_equity_snapshot_drop_table(self, db, payload):
+        """save_equity_snapshot with injection payload does not destroy tables."""
+        import aiosqlite
+
+        try:
+            await db.save_equity_snapshot(50000, 48000, 2000, portfolio_id=payload)
+        except (ValidationError, ValueError):
+            pass
+
+        async with aiosqlite.connect(db.db_path) as conn:
+            cursor = await conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='equity_history'"
+            )
+            assert await cursor.fetchone() is not None, "equity_history table destroyed"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", INJECTION_PAYLOADS)
+    async def test_update_account_drop_table(self, db, payload):
+        """update_account with injection payload does not destroy tables."""
+        import aiosqlite
+
+        try:
+            await db.update_account(50000, 55000, portfolio_id=payload)
+        except (ValidationError, ValueError):
+            pass
+
+        async with aiosqlite.connect(db.db_path) as conn:
+            cursor = await conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='account'"
+            )
+            assert await cursor.fetchone() is not None, "account table destroyed"
+
+
+# ──────────────────────────────────────────────
+# UPDATE Injection Tests (cross-portfolio leaks)
+# ──────────────────────────────────────────────
+
+
+class TestUpdateInjection:
+    """Verify that UPDATE/INSERT with injected portfolio_id cannot modify other portfolios."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", INJECTION_PAYLOADS)
+    async def test_update_position_no_cross_portfolio_leak(self, db, payload):
+        """update_position with injection payload does not alter other portfolios."""
+        # Record original state
+        pos_a_before = await db.get_positions(portfolio_id="portfolio_a")
+        pos_b_before = await db.get_positions(portfolio_id="portfolio_b")
+
+        try:
+            await db.update_position("AAPL", 999, 1.0, portfolio_id=payload)
+        except (ValidationError, ValueError):
+            pass
+
+        # Verify both portfolios unchanged
+        pos_a_after = await db.get_positions(portfolio_id="portfolio_a")
+        pos_b_after = await db.get_positions(portfolio_id="portfolio_b")
+
+        assert pos_a_after == pos_a_before, "portfolio_a positions changed by injection"
+        assert pos_b_after == pos_b_before, "portfolio_b positions changed by injection"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", INJECTION_PAYLOADS)
+    async def test_update_account_no_cross_portfolio_leak(self, db, payload):
+        """update_account with injection payload does not alter other portfolios."""
+        acct_a_before = await db.get_account_info(portfolio_id="portfolio_a")
+        acct_b_before = await db.get_account_info(portfolio_id="portfolio_b")
+
+        try:
+            await db.update_account(0, 0, portfolio_id=payload)
+        except (ValidationError, ValueError):
+            pass
+
+        acct_a_after = await db.get_account_info(portfolio_id="portfolio_a")
+        acct_b_after = await db.get_account_info(portfolio_id="portfolio_b")
+
+        assert acct_a_after == acct_a_before, "portfolio_a account changed by injection"
+        assert acct_b_after == acct_b_before, "portfolio_b account changed by injection"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", INJECTION_PAYLOADS)
+    async def test_record_trade_no_cross_portfolio_leak(self, db, payload):
+        """record_trade with injection payload does not add trades to other portfolios."""
+        trades_a_before = await db.get_recent_trades(portfolio_id="portfolio_a")
+        trades_b_before = await db.get_recent_trades(portfolio_id="portfolio_b")
+
+        try:
+            await db.record_trade("AAPL", "BUY", 10, 180.0, portfolio_id=payload)
+        except (ValidationError, ValueError):
+            pass
+
+        trades_a_after = await db.get_recent_trades(portfolio_id="portfolio_a")
+        trades_b_after = await db.get_recent_trades(portfolio_id="portfolio_b")
+
+        assert len(trades_a_after) == len(trades_a_before), "portfolio_a trades changed"
+        assert len(trades_b_after) == len(trades_b_before), "portfolio_b trades changed"
+
+
+# ──────────────────────────────────────────────
+# Data Integrity After All Injections
+# ──────────────────────────────────────────────
+
+
+class TestDataIntegrityAfterInjections:
+    """Run all injection payloads and verify seed data remains intact."""
+
+    @pytest.mark.asyncio
+    async def test_full_injection_barrage_preserves_data(self, db):
+        """Fire all payloads at all methods, then verify seed data integrity."""
+        import aiosqlite
+
+        for payload in INJECTION_PAYLOADS:
+            # SELECT methods
+            for method_name in [
+                "get_positions",
+                "get_account_info",
+                "get_equity_history",
+                "get_recent_trades",
+            ]:
+                try:
+                    method = getattr(db, method_name)
+                    await method(portfolio_id=payload)
+                except (ValidationError, ValueError):
+                    pass
+
+            # has_recent_*
+            try:
+                await db.has_recent_buy_trade("AAPL", 600, portfolio_id=payload)
+            except (ValidationError, ValueError):
+                pass
+            try:
+                await db.has_recent_sell_trade("AAPL", 600, portfolio_id=payload)
+            except (ValidationError, ValueError):
+                pass
+
+            # WRITE methods
+            try:
+                await db.record_trade("AAPL", "BUY", 10, 180.0, portfolio_id=payload)
+            except (ValidationError, ValueError):
+                pass
+            try:
+                await db.update_position("AAPL", 999, 1.0, portfolio_id=payload)
+            except (ValidationError, ValueError):
+                pass
+            try:
+                await db.update_account(0, 0, portfolio_id=payload)
+            except (ValidationError, ValueError):
+                pass
+            try:
+                await db.save_equity_snapshot(0, 0, 0, portfolio_id=payload)
+            except (ValidationError, ValueError):
+                pass
+            try:
+                await db.record_signal("AAPL", "test", "BUY", 0.5, portfolio_id=payload)
+            except (ValidationError, ValueError):
+                pass
+
+        # Verify all tables still exist
+        async with aiosqlite.connect(db.db_path) as conn:
+            for table in ["positions", "trades", "account", "equity_history", "signals"]:
+                cursor = await conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+                    (table,),
+                )
+                assert await cursor.fetchone() is not None, f"Table '{table}' destroyed"
+
+        # Verify portfolio_a data intact
+        pos_a = await db.get_positions(portfolio_id="portfolio_a")
+        assert len(pos_a) == 1
+        assert pos_a[0]["symbol"] == "AAPL"
+        assert pos_a[0]["quantity"] == 100
+
+        trades_a = await db.get_recent_trades(portfolio_id="portfolio_a")
+        assert len(trades_a) == 1
+        assert trades_a[0]["symbol"] == "AAPL"
+
+        acct_a = await db.get_account_info(portfolio_id="portfolio_a")
+        assert acct_a["cash"] == 50000
+        assert acct_a["equity"] == 55000
+
+        # Verify portfolio_b data intact
+        pos_b = await db.get_positions(portfolio_id="portfolio_b")
+        assert len(pos_b) == 1
+        assert pos_b[0]["symbol"] == "MSFT"
+        assert pos_b[0]["quantity"] == 50
+
+        trades_b = await db.get_recent_trades(portfolio_id="portfolio_b")
+        assert len(trades_b) == 1
+        assert trades_b[0]["symbol"] == "MSFT"
+
+        acct_b = await db.get_account_info(portfolio_id="portfolio_b")
+        assert acct_b["cash"] == 80000
+        assert acct_b["equity"] == 82000


### PR DESCRIPTION
## Summary

- Independent portfolios (aggressive, conservative, etc.) trading through a single IBKR Gateway connection
- Database partitioned by `portfolio_id` across positions, trades, account, equity_history, and signals tables
- Dashboard portfolio switcher with per-portfolio API endpoints (`?portfolio_id=<id>`)
- Backward compatible -- without `PORTFOLIOS` env var, behaves identically to single-portfolio mode

## Key changes

- `robo_trader/multiuser/` -- portfolio config, DB proxy with scope-leak detection, schema migration with backup/restore
- `robo_trader/database_async.py` -- all queries scoped by `portfolio_id`, input validation via `DatabaseValidator`
- `robo_trader/runner_async.py` -- spawns independent runner per portfolio, shared IBKR connection
- `app.py` -- portfolio switcher UI, `validate_portfolio` decorator, per-portfolio API endpoints
- 2,800+ lines of new tests (multiuser, API, SQL injection)

## Test plan

- [x] 383 tests passing (`pytest tests/`)
- [x] Black formatting clean on all changed files
- [x] Flake8 zero critical errors
- [x] Two-phase code review completed (13 findings, 7 filtered as false positives, 6 fixed)
- [x] Migration tested: existing data gets `portfolio_id='default'`, backup created before changes
- [ ] Manual test with `PORTFOLIOS` env var set to run multiple portfolios simultaneously