### PR TITLE
Preflight safety gate (stacked on #72)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ Icon
 *.db-wal
 launchd_*.log
 
+# Test artifacts (per-pytest-session log + temp DB)
+.test_artifacts/
+
 # Runtime data files
 logs/monitoring/metrics_*.jsonl
 logs/monitoring/dashboard.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -504,6 +504,15 @@ STOP_LOSS_PERCENT=2.0           # Fixed 2% stop
 |---------|-----------------|------|
 | `self.cfg.portfolio.initial_capital` | Use `self.cfg.default_cash` - no portfolio.initial_capital | 2026-01-26 |
 
+### Test Isolation Errors
+| Mistake | Correct Approach | Date |
+|---------|-----------------|------|
+| Tests inherit `LOG_FILE=robo_trader.log` from prod env → pytest output pollutes prod log | `conftest.py` sets `LOG_FILE` to `.test_artifacts/` before any `robo_trader` import | 2026-05-26 |
+| Tests hit hardcoded `trading_data.db` → DB teardown closes live trader's pool | All 3 DB modules read `RT_DB_PATH` env var (prod fallback `trading_data.db`); conftest sets it to a per-PID temp file | 2026-05-26 |
+| Running pytest while the trader is live (caused the 2026-05-24 → 05-26 outage) | Test isolation makes this safe; otherwise pytest's `Closed all database connections` teardown kills the runner | 2026-05-26 |
+| `START_TRADER.sh` killed Gateway after 30s port-not-listening | Wait 180s for port bind, early-exit only if Gateway process actually dies (IBC + 2FA routinely needs 60-180s) | 2026-05-26 |
+| `start_gateway()` cold-start timeout 120s | 240s — IBC + Gateway + 2FA approval often exceeds 120s | 2026-05-26 |
+
 ### Trading Logic Errors
 | Mistake | Correct Approach | Date |
 |---------|-----------------|------|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,51 @@ launchctl load ~/Library/LaunchAgents/com.robotrader.watchdog.plist    # Start
 
 ---
 
+## Preflight Safety Gate
+
+**Always invoked automatically by `./START_TRADER.sh` — runs BEFORE the runner spins up.**
+
+The gate inspects six conditions and refuses to start if any BLOCKs. Built after the 2026-05-22 incident where a triggered kill switch caused 18 silent failed restarts over 4 hours.
+
+### What it checks
+1. `data/kill_switch_state.json` — BLOCK if `triggered=True`
+2. `data/kill_switch.lock` — BLOCK if file exists (deny-by-default signal)
+3. `equity_history` freshness — BLOCK if last row is >1 trading day old
+4. `RISK_MAX_POSITION_LOSS_PCT` — WARN <2%, BLOCK <1%
+5. Gateway port LISTEN — BLOCK if port 4002 (paper) / 4001 (live) not listening
+6. Zombie CLOSE_WAIT connections — BLOCK if any present
+
+### When it BLOCKs
+The script prints a boxed remediation per BLOCK with the exact command to fix the condition. Three response patterns:
+- **Real problem** (e.g., real loss-based kill switch trigger): fix the underlying issue, re-run `./START_TRADER.sh`
+- **Stale state from a transient issue** (e.g., the 2026-05-22 NVDA event): clear the state file after confirming, re-run
+- **Known-but-acceptable** (e.g., diagnosing why preflight thinks there's a problem): bypass with `python3 scripts/preflight_check.py --force "real-sentence reason"` and re-run `./START_TRADER.sh`
+
+### Bypass mechanics
+- `--force` requires a reason string ≥10 chars, not a placeholder (`force`, `bypass`, `idk`, etc. rejected)
+- Every bypass appends a JSONL entry to `data/preflight_bypass.log` with operator, timestamp, reason
+- Bypass exits the script with code 2 (distinct from clean 0) so downstream tooling can tell "started with bypass" vs "all clean"
+- Bypass is per-invocation only — does NOT persist; the next `./START_TRADER.sh` runs preflight again
+
+### Output formats
+```bash
+python3 scripts/preflight_check.py           # plaintext, default
+python3 scripts/preflight_check.py --json    # machine-readable
+python3 scripts/preflight_check.py --verbose # add per-check details block
+```
+
+### When NOT to bypass
+Loss-based kill switches (e.g., "Position loss limit exceeded for NVDA") are real risk signals. Bypassing them resumes trading with the underlying loss still active. Either close the position, raise `RISK_MAX_POSITION_LOSS_PCT` in `.env`, or both — then clear and re-run.
+
+### Files
+- `scripts/preflight_check.py` — CLI entry point
+- `robo_trader/preflight/` — check classes and runner
+- `data/preflight_bypass.log` — audit log (append-only)
+- `data/.preflight_last_ok` — last-pass timestamp (read by runner-side enforcement)
+- `docs/superpowers/specs/2026-05-23-startup-safety-gate-design.md` — design spec
+
+---
+
 ## Mobile App & Parallel Development
 
 | Location | Branch | Purpose |
@@ -218,6 +263,7 @@ Any code that hard-codes one of these forms will `AttributeError`, the broad `ex
 12. ✅ ML/MTF Disagreement Threshold - FIXED (adaptive threshold)
 13. ✅ Stop-losses on restart - FIXED (recreated from DB positions)
 14. ✅ Persistent IBKR Connection - IMPLEMENTED (2026-05-16, prevents IBKR-throttle cascade from per-cycle reconnects)
+15. ✅ Startup safety gate - IMPLEMENTED (2026-05-23, prevents 2026-05-22-style silent livelock)
 
 ---
 
@@ -380,6 +426,7 @@ STOP_LOSS_PERCENT=2.0           # Fixed 2% stop
 | Using `socket.connect_ex()` for port check | Use `lsof -nP -iTCP:PORT -sTCP:LISTEN` | 2025-12-06 |
 | Not checking for zombies before connect | Check CLOSE_WAIT connections first | 2025-11-24 |
 | Reading subprocess stdout too early | Wait for `isConnected()` polling loop | 2025-11-24 |
+| Skipping the preflight safety gate when restarting after an incident | Always run `./START_TRADER.sh` (preflight runs automatically). If it blocks, fix the condition or use `--force "<reason>"`. The gate exists because of the 2026-05-22 4-hour silent livelock. | 2026-05-23 |
 
 ### Async/Await Errors
 | Mistake | Correct Approach | Date |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -485,6 +485,9 @@ STOP_LOSS_PERCENT=2.0           # Fixed 2% stop
 | Not checking for zombies before connect | Check CLOSE_WAIT connections first | 2025-11-24 |
 | Reading subprocess stdout too early | Wait for `isConnected()` polling loop | 2025-11-24 |
 | Skipping the preflight safety gate when restarting after an incident | Always run `./START_TRADER.sh` (preflight runs automatically). If it blocks, fix the condition or use `--force "<reason>"`. The gate exists because of the 2026-05-22 4-hour silent livelock. | 2026-05-23 |
+| Bare `lsof` in code the launchd watchdog runs (`START_TRADER.sh`, preflight checks) | The watchdog plist PATH lacks `/usr/sbin` where `lsof` lives, so a bare `lsof` is "command not found"; the `2>/dev/null` on every port check silently turns that into "port not listening" → START_TRADER kills a healthy Gateway in a 472-restart storm (2026-05-29). Resolve `lsof` to an absolute path and FAIL LOUD if missing; keep `/usr/sbin:/sbin` in the watchdog plist PATH. Works when run by hand (interactive PATH has `/usr/sbin`), fails only under the watchdog — classic env-only bug. | 2026-05-29 |
+| Restart storm where START_TRADER says "port not listening" but a manual `lsof` shows LISTEN | This is an environment/detection bug (lsof not found under launchd PATH), NOT 2FA/timing. Commit `0719769` mis-blamed 2FA and widened the wait windows; the storm continued (89→472 restarts). When a documented "fix" doesn't stop the symptom, re-investigate root cause — don't re-apply it. | 2026-05-29 |
+| `cmd` on its own line then `RC=$?` under `set -e` (e.g. the preflight call in START_TRADER) | `set -e` aborts the script on `cmd`'s non-zero exit BEFORE `RC=$?` runs, so the exit-code `case` was dead code — preflight's `2=--force bypass` / `1=BLOCK` handling never ran and `--force` could never start the trader. Capture with `cmd \|\| RC=$?`, which is exempt from `set -e`. | 2026-05-29 |
 
 ### Async/Await Errors
 | Mistake | Correct Approach | Date |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,64 @@ Adding new code? See `DEV_SETUP.md` Section 3 for the things that now fail diffe
 
 ---
 
+## 🔄 Persistent IBKR Connection — Rollback Procedure
+
+**Added 2026-05-16:** the IBKR connection now persists across trading cycles instead of reconnecting per-cycle (commits `f8388f3..6f195a3`). If this causes a new class of production failure, here is the documented rollback path.
+
+### Rollback target
+
+Annotated tag `pre-persistent-connection` marks the last commit before persistent-connection work began:
+
+```bash
+git log -1 pre-persistent-connection
+# 1a68a0a ops: watchdog Layer 6 — escalate after repeated Gateway 2FA failures
+```
+
+### How to revert
+
+```bash
+# Inspect what would change:
+git log --oneline pre-persistent-connection..HEAD -- robo_trader/runner_async.py robo_trader/connection_health.py
+
+# Revert the persistent-connection commits:
+git revert --no-edit f8388f3^..6f195a3
+# Resolve any conflicts (most likely in robo_trader/runner_async.py and CLAUDE.md).
+
+# Confirm cycles disconnect again:
+grep -n "teardown.*full_cleanup" robo_trader/runner_async.py
+# Post-rollback should show full_cleanup=True per cycle.
+
+# Validate:
+.venv/bin/pytest --tb=short
+```
+
+### What you LOSE by rolling back
+
+- The 2026-05-13-style per-cycle throttle cascade returns as a known risk
+- `ConnectionHealth` state machine + `recover_connection()` become unused
+- Multi-portfolio Gateway recovery serialization (no-op for single portfolio anyway)
+
+### What you KEEP (independent of persistent connection)
+
+These commits are NOT part of the `f8388f3..6f195a3` range — they survive a revert:
+
+- KillSwitch loss-trigger and config plumbing (env-configurable `RISK_MAX_POSITION_LOSS_PCT`)
+- Per-path kill-switch check centralization + log throttle
+- Recovery-exhaustion exit propagation (no zombie loop)
+- Stop-loss price re-warm after recovery (no-op if recover_connection isn't called)
+- Auto-reset kill switch on connection-related triggers
+- The preflight safety gate (separate PR, builds on this branch)
+
+### When NOT to roll back
+
+- **Preflight blocking startup** → that is the gate working as designed. Use `python3 scripts/preflight_check.py --force "<reason>"`.
+- **Real loss-trigger** → close the position or raise `RISK_MAX_POSITION_LOSS_PCT`, don't revert.
+- **Intermittent IBKR disconnects** → persistent connection is helping, not hurting. Check Gateway/IBC config first.
+
+Rollback is reserved for: persistent socket state causing a NEW class of failure not seen pre-persistence.
+
+---
+
 ## Project Phase Plan
 **IMPORTANT:** The authoritative phase plan is in `IMPLEMENTATION_PLAN.md`. This is the ML-focused 4-phase plan:
 - Phase 1: Foundation & Quick Wins (Tasks F1-F5) - COMPLETE ✅

--- a/START_TRADER.sh
+++ b/START_TRADER.sh
@@ -330,6 +330,45 @@ if ! $PYTHON -c "import pandas" 2>/dev/null; then
 fi
 echo ""
 
+# Step 4.5: Preflight safety gate
+# Runs scripts/preflight_check.py which validates system state before launch.
+# Exit codes:
+#   0 -> all checks passed, proceed
+#   2 -> operator used --force to bypass a BLOCK (audited); proceed with warning banner
+#   1, 3, * -> BLOCKED or preflight itself failed; abort startup
+echo "4.5. Running preflight safety gate..."
+$PYTHON scripts/preflight_check.py
+PREFLIGHT_RC=$?
+case "$PREFLIGHT_RC" in
+    0)
+        echo "   ✓ Preflight gate passed"
+        ;;
+    2)
+        echo ""
+        echo "=========================================="
+        echo "⚠️  PREFLIGHT BYPASSED VIA --force"
+        echo "=========================================="
+        echo "Operator override was used. See data/preflight_bypass.log for audit trail."
+        echo "Proceeding with launch."
+        echo ""
+        ;;
+    *)
+        # 1 (BLOCKED), 3 (preflight failed), or anything else.
+        echo ""
+        echo "=========================================="
+        echo "❌ PREFLIGHT SAFETY GATE BLOCKED STARTUP"
+        echo "=========================================="
+        echo ""
+        echo "Preflight reported blocking issues above (exit code $PREFLIGHT_RC)."
+        echo "Resolve each one and re-run ./START_TRADER.sh, or"
+        echo "bypass with: $PYTHON scripts/preflight_check.py --force \"<reason>\""
+        echo "(then re-run ./START_TRADER.sh — bypass is per-invocation, not persistent)"
+        echo ""
+        exit 1
+        ;;
+esac
+echo ""
+
 # Step 5: Start dashboard (includes WebSocket server)
 echo "5. Starting dashboard with WebSocket server..."
 export DASH_PORT=5555

--- a/START_TRADER.sh
+++ b/START_TRADER.sh
@@ -136,8 +136,10 @@ start_gateway() {
 
     # Wait for Gateway to start and API port to open
     # CRITICAL: Use lsof, NOT nc -z (nc creates zombie connections that block API handshakes!)
+    # 240s window: IBC + Gateway cold-start + 2FA approval routinely needs >120s.
+    # The previous 120s window was tight enough to lose 89 races over 13 days.
     echo "   Waiting for Gateway to start..."
-    for i in $(seq 1 120); do
+    for i in $(seq 1 240); do
         if lsof -nP -iTCP:$PORT -sTCP:LISTEN 2>/dev/null | grep -q LISTEN; then
             echo "   ✓ Gateway API port $PORT is now open!"
             # Wait for Gateway to fully initialize after port opens
@@ -164,7 +166,7 @@ start_gateway() {
         fi
     done
 
-    echo "   TIMEOUT: Gateway did not start within 120 seconds"
+    echo "   TIMEOUT: Gateway did not start within 240 seconds"
     return 1
 }
 
@@ -217,19 +219,31 @@ while [ "$API_CONNECTED" = false ] && [ $GATEWAY_RETRY -lt $MAX_GATEWAY_RETRIES 
     # Check if port is listening (using lsof to avoid zombie connections)
     if ! is_port_listening; then
         echo "   ⚠️  API port $PORT is NOT listening"
-        echo "   Gateway may be starting or needs restart..."
+        echo "   Gateway process is alive but API port not bound yet."
+        echo "   Normal during startup/2FA — waiting up to 180s before assuming Gateway is stuck."
+        echo "   (Killing Gateway prematurely triggers a fresh 2FA prompt and causes restart storms.)"
 
-        # Wait a bit for Gateway to fully start
-        for i in $(seq 1 30); do
+        # Wait for Gateway to bind the API port. Gateway+IBC+2FA routinely needs 60-180s,
+        # especially after a SIGTERM cycle. The previous 30s window was the root cause of
+        # the 2026-05-13 → 05-26 restart storm (89 consecutive failed restarts).
+        for i in $(seq 1 180); do
             if is_port_listening; then
-                echo "   ✓ API port $PORT is now listening"
+                echo "   ✓ API port $PORT is now listening (after ${i}s)"
+                break
+            fi
+            # Early-exit if Gateway actually died during the wait — no point waiting longer.
+            if ! pgrep -f "IB Gateway" > /dev/null 2>&1 && ! pgrep -f "ibcalpha.ibc" > /dev/null 2>&1; then
+                echo "   Gateway process died during wait — restart needed"
                 break
             fi
             sleep 1
+            if [ $((i % 30)) -eq 0 ]; then
+                echo "   Still waiting for port bind... (${i}s) — check IBKR Mobile for 2FA prompt"
+            fi
         done
 
         if ! is_port_listening; then
-            echo "   Port still not listening - restarting Gateway..."
+            echo "   Port still not listening after 180s - restarting Gateway..."
             start_gateway
             continue
         fi

--- a/START_TRADER.sh
+++ b/START_TRADER.sh
@@ -24,6 +24,21 @@ PORT=4002
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MAX_GATEWAY_RETRIES=3
 
+# Resolve lsof to an absolute path and refuse to run without it.
+# The watchdog launches us under launchd, whose PATH omits /usr/sbin (where lsof
+# lives). A bare `lsof` there is "command not found"; the `2>/dev/null` on every
+# port check silently turns that into "port not listening", so START_TRADER kills
+# a perfectly healthy Gateway and the watchdog restart-storms. This was the real
+# root cause of the 2026-05-13 → 2026-05-29 storms (472 failed restarts) — NOT
+# 2FA timing. Fail loud instead of starting blind.
+LSOF="$(command -v lsof 2>/dev/null || true)"
+[ -z "$LSOF" ] && [ -x /usr/sbin/lsof ] && LSOF=/usr/sbin/lsof
+if [ -z "$LSOF" ]; then
+    echo "FATAL: lsof not found on PATH ($PATH) and not at /usr/sbin/lsof." >&2
+    echo "       Port checks cannot run; refusing to start to avoid a Gateway-kill restart storm." >&2
+    exit 3
+fi
+
 # Load defaults from .env if present
 if [ -f "$SCRIPT_DIR/.env" ]; then
     # Source only SYMBOLS to avoid polluting environment
@@ -34,8 +49,16 @@ fi
 SYMBOLS="${SYMBOLS:-AAPL,NVDA,TSLA}"
 
 # Parse arguments (override .env if provided)
+# --force="<reason>" is forwarded to the preflight gate so the documented
+# bypass (CLAUDE.md "Bypass mechanics") actually works through this entrypoint;
+# previously the gate was always called with no args, so re-running START_TRADER
+# could never clear a BLOCK.
+PREFLIGHT_FORCE_REASON=""
 for arg in "$@"; do
     case $arg in
+        --force=*)
+            PREFLIGHT_FORCE_REASON="${arg#--force=}"
+            ;;
         *)
             SYMBOLS="$arg"
             ;;
@@ -140,7 +163,7 @@ start_gateway() {
     # The previous 120s window was tight enough to lose 89 races over 13 days.
     echo "   Waiting for Gateway to start..."
     for i in $(seq 1 240); do
-        if lsof -nP -iTCP:$PORT -sTCP:LISTEN 2>/dev/null | grep -q LISTEN; then
+        if "$LSOF" -nP -iTCP:$PORT -sTCP:LISTEN 2>/dev/null | grep -q LISTEN; then
             echo "   ✓ Gateway API port $PORT is now open!"
             # Wait for Gateway to fully initialize after port opens
             # Gateway needs time to complete login/2FA before API is responsive
@@ -177,14 +200,14 @@ start_gateway() {
 # Function to check if port is listening (uses lsof to avoid creating zombie connections)
 # CRITICAL: Do NOT use nc -z for port checking - it creates zombie connections that block API handshakes!
 is_port_listening() {
-    lsof -nP -iTCP:$PORT -sTCP:LISTEN 2>/dev/null | grep -q LISTEN
+    "$LSOF" -nP -iTCP:$PORT -sTCP:LISTEN 2>/dev/null | grep -q LISTEN
 }
 
 # Function to check for zombie connections
 check_zombies() {
     # Count actual zombie lines - use wc -l and trim whitespace
     local count
-    count=$(lsof -nP -iTCP:$PORT -sTCP:CLOSE_WAIT 2>/dev/null | grep "CLOSE_WAIT" | wc -l | tr -d ' ')
+    count=$("$LSOF" -nP -iTCP:$PORT -sTCP:CLOSE_WAIT 2>/dev/null | grep "CLOSE_WAIT" | wc -l | tr -d ' ')
     # Return 0 if empty
     echo "${count:-0}"
 }
@@ -258,7 +281,7 @@ while [ "$API_CONNECTED" = false ] && [ $GATEWAY_RETRY -lt $MAX_GATEWAY_RETRIES 
         echo "   Zombies block API handshakes - restarting Gateway..."
 
         # Kill Python zombies first
-        lsof -nP -iTCP:$PORT -sTCP:CLOSE_WAIT 2>/dev/null | grep -i python | awk '{print $2}' | sort -u | while read pid; do
+        "$LSOF" -nP -iTCP:$PORT -sTCP:CLOSE_WAIT 2>/dev/null | grep -i python | awk '{print $2}' | sort -u | while read pid; do
             kill -9 $pid 2>/dev/null && echo "   Killed Python zombie PID $pid" || true
         done
         sleep 1
@@ -302,7 +325,7 @@ echo "3. Final zombie cleanup..."
 ZOMBIES=$(check_zombies)
 if [ "$ZOMBIES" -gt 0 ]; then
     echo "   Killing $ZOMBIES zombie connection(s)..."
-    lsof -nP -iTCP:$PORT -sTCP:CLOSE_WAIT 2>/dev/null | grep -i python | awk '{print $2}' | sort -u | while read pid; do
+    "$LSOF" -nP -iTCP:$PORT -sTCP:CLOSE_WAIT 2>/dev/null | grep -i python | awk '{print $2}' | sort -u | while read pid; do
         kill -9 $pid 2>/dev/null || true
     done
     sleep 1
@@ -351,8 +374,18 @@ echo ""
 #   2 -> operator used --force to bypass a BLOCK (audited); proceed with warning banner
 #   1, 3, * -> BLOCKED or preflight itself failed; abort startup
 echo "4.5. Running preflight safety gate..."
-$PYTHON scripts/preflight_check.py
-PREFLIGHT_RC=$?
+# preflight intentionally exits non-zero (1=BLOCK, 2=--force bypass-and-proceed).
+# Under `set -e` a bare invocation aborts the script before the case below can
+# interpret the code — capture it via `|| PREFLIGHT_RC=$?`, which is exempt from
+# set -e. (Without this, the 2=proceed branch was dead code and --force could
+# never actually start the trader.)
+PREFLIGHT_RC=0
+if [ -n "$PREFLIGHT_FORCE_REASON" ]; then
+    echo "   (operator --force supplied — bypass will be audited to data/preflight_bypass.log)"
+    $PYTHON scripts/preflight_check.py --force "$PREFLIGHT_FORCE_REASON" || PREFLIGHT_RC=$?
+else
+    $PYTHON scripts/preflight_check.py || PREFLIGHT_RC=$?
+fi
 case "$PREFLIGHT_RC" in
     0)
         echo "   ✓ Preflight gate passed"

--- a/conftest.py
+++ b/conftest.py
@@ -1,13 +1,38 @@
 """
 Test configuration for pytest.
 Handles async event loop setup for ib_insync and other async tests.
+
+CRITICAL: Isolates tests from production paths (log file, database).
+Without this, a test teardown that closes its DB connections will tear down
+the live trader's pool too, and any log line a test writes will land in the
+production robo_trader.log. This caused a 2.5-day outage on 2026-05-24 when
+pytest's database teardown crashed the running trader.
 """
 
 import asyncio
+import os
 import platform
 import sys
+import tempfile
+from pathlib import Path
 
 import pytest
+
+# --- production-path isolation: runs before pytest collects test files ---
+# Test files import robo_trader modules (logger, database_async) which read
+# these env vars at import time, so they MUST be set before collection. This
+# module body executes during pytest's conftest-loading phase, BEFORE any test
+# file is imported, so the ordering holds.
+_TEST_ARTIFACTS = Path(__file__).parent / ".test_artifacts"
+_TEST_ARTIFACTS.mkdir(exist_ok=True)
+os.environ["LOG_FILE"] = str(_TEST_ARTIFACTS / f"pytest_{os.getpid()}.log")
+_test_db_fd, _test_db_path = tempfile.mkstemp(
+    suffix=".db", prefix=f"rt_test_{os.getpid()}_", dir=str(_TEST_ARTIFACTS)
+)
+os.close(_test_db_fd)
+os.environ["RT_DB_PATH"] = _test_db_path
+os.environ["RT_TEST_MODE"] = "1"
+# -------------------------------------------------------------------------
 
 
 @pytest.fixture(scope="session")

--- a/docs/superpowers/plans/2026-05-23-robust-startup-safety-plan.md
+++ b/docs/superpowers/plans/2026-05-23-robust-startup-safety-plan.md
@@ -1,0 +1,103 @@
+# Robust Startup Safety — Plan
+
+**Status:** Plan approved 2026-05-23. MVP-1 (startup safety gate) selected as first implementation. This document is the input to the design-spec session.
+
+## Incident that motivated this plan
+
+On 2026-05-22 the trader was dead for ~4 hours after a normal NVDA -2.93% daily move tripped a hardcoded 2% per-position-loss kill switch. The switch state persisted to `data/kill_switch_state.json`. Every watchdog restart re-loaded `triggered=True`, the process died within seconds, and the watchdog logged 18 consecutive "Restart FAILED" lines without escalating — because its liveness check is mtime-based and the restart loop kept producing fresh log lines.
+
+Root pattern: **failure modes that look healthy enough to fool monitoring**. Each layer (config → preflight → runtime → watchdog → escalation) was "working as designed," but no layer could see that the chain was stuck.
+
+## Defense-in-depth model
+
+```
+   Layer            Concern                        2026-05-22 status
+   ───────────────  ─────────────────────────────  ──────────────────────────────
+   Configuration    Are thresholds realistic?      Hardcoded 2% in source
+   Preflight        Is the system safe to start?   NO GATE — just runs and crashes
+   Runtime          Detect operational anomalies   ConnectionHealth ✓ (this branch)
+   Cleanup          Recovery on transient issues   recover_connection ✓ (this branch)
+   Watchdog         Restart on hard failure        mtime-only, can't see livelock
+   Escalation       Wake the operator              Layer 6 exists but trigger weak
+   Observability    Was the right thing done?      Logs only, no synthesis
+```
+
+Runtime + Cleanup were strengthened by this session's commits. The weak links remaining are **Preflight, Watchdog content-liveness, and Escalation**.
+
+## Already done (2026-05-23 audit + fix session)
+
+Commits on `feature/persistent-ibkr-connection`:
+- `b142d2a` C2 — RecoveryExhaustedError propagation (recovery exhaustion exits cleanly, not zombie loop)
+- `c3a4cbe` C3 — RECOVERING state wired (no recovery re-entrancy)
+- `009a7a4` C4 — stop_loss_monitor price re-warm after recovery (no blind window)
+- `315ea6a` H1 — kill switch auto-reset on connection-related triggers
+- `b8062bc` C1 — removed dead `restart_subprocess()` reference
+- `a666015` M5 — `consecutive_failures` public property
+- `0d7831f` M4 — `IBKRClientProtocol` type contract
+- `baadd26` config — `max_position_loss_pct` env-configurable, default raised 2% → 5% (also absorbed M1's kill-switch log throttle + per-path check removals)
+- `6f195a3` H2 — process-wide Gateway recovery lock (multi-portfolio race prevention)
+
+Also: kill switch state files cleared, backup at `data/kill_switch_state.json.bak.2026-05-22-1627`.
+
+## MVP — three components, ordered by leverage
+
+### MVP-1: Startup safety gate (HIGHEST LEVERAGE — would have prevented 2026-05-22)
+
+A preflight script `scripts/preflight_check.py` invoked by `START_TRADER.sh` BEFORE launching the runner. Exits non-zero if any of:
+
+- `data/kill_switch_state.json` shows `triggered=True`
+- `data/kill_switch.lock` exists
+- Last `equity_history` row is >24h old (suggests stale state)
+- Any of `RISK_MAX_*` env vars are below "sane minimum" (e.g., `MAX_POSITION_LOSS_PCT < 0.02` warns; `< 0.01` blocks)
+- IBKR Gateway port not listening
+- Zombie CLOSE_WAIT connections on port 4002
+
+Each failure prints **what's wrong + what to do** in plain English. Critical: runs ONCE per startup, BEFORE the process forks into "trying to recover" mode. Operator sees the message immediately.
+
+Converts a 4-hour silent livelock into a 30-second clear-message-on-startup. The persisted state stays the same — the *response* changes.
+
+### MVP-2: Content-based watchdog liveness
+
+Replace `mtime > T` check with a structured-event check: the runner must emit `event=cycle_heartbeat` every N seconds. The watchdog parses the last K log lines, finds the most recent heartbeat, escalates if older than 2N.
+
+Distinguishes:
+- **Healthy**: heartbeat fresh ✓
+- **Degraded but alive**: process running, logs being written, but no heartbeat → escalate
+- **Dead**: no logs at all → restart
+
+### MVP-3: Fast-fail watchdog escalation
+
+If the process dies within 60s of startup **3 times in a row**, the watchdog stops retrying and immediately:
+- Sends macOS notification (Layer 6 already exists)
+- Writes a `data/.startup_blocked` flag file
+- Logs `event=startup_blocked_persistent` (queryable)
+- Exits its restart loop entirely until the flag file is removed
+
+"consecutive_failures: 18" should never happen. After 3 fast-fails, the system **declares defeat and asks for help**, not silently retries.
+
+## Phase 2
+
+- **P2-1**: Loud startup config logging (one structured event with every safety threshold)
+- **P2-2**: H2 multi-portfolio Gateway lock — ✅ DONE (committed `6f195a3`)
+- **P2-3**: Self-expiring kill switch (severity field: `transient` / `sticky` / `permanent`)
+- **P2-4**: `/api/health` endpoint exposing single source of truth
+- **P2-5**: Chaos drills in CI (`@pytest.mark.chaos`)
+
+## Implementation order
+
+1. **MVP-1** (Startup safety gate) ← biggest win, ~half day. THIS IS THE NEXT THING TO DESIGN.
+2. MVP-3 (Fast-fail escalation) — ties into existing Layer 6, ~few hours
+3. P2-1 (Loud config logging) — tiny change, big diagnostic payoff
+4. MVP-2 (Content liveness) — needs heartbeat plumbing
+5. P2-3 (Self-expiring kill switch)
+6. P2-4, P2-5 (longer-term observability + CI)
+
+## Related artifacts
+
+- `CLAUDE.md` — project guidelines, especially "🚨 CRITICAL: NEVER DELETE USER DATA", common-mistakes table, gateway management section
+- `START_TRADER.sh` — the entry point preflight must hook into
+- `scripts/install_watchdog.sh`, `~/Library/LaunchAgents/com.robotrader.watchdog.plist` — watchdog setup
+- `~/.claude/projects/-Users-oliver-Projects-robo-trader/memory/project_watchdog_layer6.md` — existing Layer 6 escalation
+- `docs/superpowers/plans/2026-05-16-persistent-ibkr-connection.md` — prior plan style/format to mirror
+- `docs/superpowers/specs/2026-05-16-persistent-ibkr-connection-design.md` — prior design spec style/format to mirror
+- `data/kill_switch_state.json.bak.2026-05-22-1627` — the actual triggered state from the incident, useful as preflight test fixture

--- a/docs/superpowers/specs/2026-05-23-startup-safety-gate-design.md
+++ b/docs/superpowers/specs/2026-05-23-startup-safety-gate-design.md
@@ -1,0 +1,921 @@
+# Startup Safety Gate — Design Spec
+
+**Status:** Draft — pending implementation
+**Branch:** authored on `worktree-agent-ae6a40f59c516cb74` (worktree branched off `feature/persistent-ibkr-connection`); caller may cherry-pick or rebase onto whichever integration branch is current.
+**Date:** 2026-05-23
+**Supersedes:** Nothing — this is a new component (MVP-1 in `docs/superpowers/plans/2026-05-23-robust-startup-safety-plan.md`)
+**Related:** `docs/superpowers/plans/2026-05-23-robust-startup-safety-plan.md` (motivating plan), `docs/superpowers/specs/2026-05-16-persistent-ibkr-connection-design.md` (style precedent)
+
+---
+
+## 1. Status & Context
+
+This spec designs the **Startup Safety Gate**, the first of three MVP components in the robust-startup-safety plan. It is a preflight script (`scripts/preflight_check.py`) that runs **before** `runner_async.py` starts. Its job is to convert silently-fatal misconfigurations and stale state into a **30-second, plain-English error message at the operator's terminal**, instead of a 4-hour silent livelock.
+
+It is bounded scope by design. It does NOT fix the runtime loops, it does NOT modify the watchdog liveness check, and it does NOT escalate. Those are MVP-2 and MVP-3.
+
+The full plan (defense-in-depth layer model, the 2026-05-22 incident, and what was already fixed) is in `docs/superpowers/plans/2026-05-23-robust-startup-safety-plan.md`. Read that first if you haven't.
+
+---
+
+## 2. Motivation
+
+### The 2026-05-22 incident (one paragraph)
+The trader was dead for ~4 hours after a normal NVDA -2.93% daily move tripped a hardcoded 2% per-position-loss kill switch. The state persisted to `data/kill_switch_state.json` (`triggered=True`). Every subsequent watchdog restart loaded the persisted state, the runner died within seconds of startup, and the watchdog's mtime-based liveness check kept seeing fresh log lines from the rapid restart loop, so it never escalated. 18 consecutive "Restart FAILED" lines, no notification.
+
+The root pattern: **failure modes that look healthy enough to fool monitoring.** The kill switch was *correctly* persisted (no bug there) and the watchdog was *correctly* restarting (no bug there). The thing missing was anyone telling the operator "you have a persisted kill switch — clear it or raise the threshold."
+
+A preflight gate would have surfaced that within 30 seconds of the first restart, before the runner even called `connect()`.
+
+### Why a gate, not a fix
+The persisted kill switch state is **correct behavior** — we don't want it auto-cleared on every restart, because then loss-based triggers would lose their meaning. The fix is to make the persisted state **visible at startup**, so the operator can make an informed clear-or-keep decision, with the system refusing to proceed until they do.
+
+### Coverage
+The plan enumerates six classes of preflight failure that could waste hours of operator time. The 2026-05-22 incident hit class #1 (persisted kill switch). Classes #4 (misconfigured loss limit) and #5 (Gateway port not listening) are equally capable of producing the same "silent restart loop" pattern. Each check below covers one such class.
+
+---
+
+## 3. Goals
+
+Numbered, testable, in priority order:
+
+1. **G1 — Block on triggered kill switch.** If `data/kill_switch_state.json` shows `triggered=True` OR `data/kill_switch.lock` exists, exit non-zero with a message naming the state file, the trigger reason, and the remediation command.
+2. **G2 — Block on stale equity history.** If the most recent `equity_history` row is more than 24h old (and the market has been open at least once in that window), exit non-zero. Stale equity is the strongest signal that a prior session died uncleanly.
+3. **G3 — Block on dangerously-low loss thresholds.** If `RISK_MAX_POSITION_LOSS_PCT < 0.01` (i.e., less than 1%) exit non-zero. If `< 0.02` (less than 2%) warn but allow start.
+4. **G4 — Block on unreachable Gateway.** If the Gateway API port (`4002` paper, `4001` live, determined by `EXECUTION_MODE`) is not in `LISTEN` state via `lsof`, exit non-zero with the relevant `START_TRADER.sh` step to run.
+5. **G5 — Block on zombie connections.** If `lsof` shows any `CLOSE_WAIT` on the Gateway port, exit non-zero with the kill-or-restart instructions.
+6. **G6 — All-pass output is observable.** Happy path prints one structured line per check (status=PASS) and a summary line, so the operator can see *what was checked* not just *that it passed*.
+7. **G7 — Auditable bypass exists.** The operator can override any BLOCK with a single, logged action that survives in shell history (`--force` + reason string). No env var that silently disables checks forever.
+8. **G8 — Latency budget ≤ 5s wall clock** on a healthy system. Slow checks (lsof, sqlite) are bounded by per-check timeouts and run in parallel where independent.
+9. **G9 — Each check is independently testable.** Pure-Python check objects with a `tmp_path` pytest fixture for filesystem state and a subprocess mock for `lsof`. No real IBKR Gateway needed.
+10. **G10 — Pluggable check registry.** Adding a new check (Phase 2 will add more) is one entry in a list, not a refactor.
+
+---
+
+## 4. Non-Goals
+
+Explicit scope boundaries — these are NOT in this spec:
+
+- **N1 — Does NOT modify state.** Never auto-clears a triggered kill switch, never kills zombies, never restarts Gateway. Preflight observes and reports; the operator (or a separate script) acts.
+- **N2 — Does NOT replace `gateway_manager.py` checks.** That script's `status` command is more granular and stays the source of truth for Gateway diagnostics. Preflight uses lsof directly because shelling out to gateway_manager would couple us to its CLI evolution.
+- **N3 — Does NOT touch the watchdog.** Content-based liveness is MVP-2.
+- **N4 — Does NOT do escalation.** Fast-fail-after-3 is MVP-3.
+- **N5 — Does NOT do health checks during operation.** This runs once, before the runner starts. The runtime `ConnectionHealth` module (already shipped on `feature/persistent-ibkr-connection`) handles in-flight health.
+- **N6 — Does NOT call IBKR.** No `ib.connect()`, no socket connections to the API port. Port-listening check is `lsof -sTCP:LISTEN` only — never `socket.connect_ex` (creates zombies, see CLAUDE.md 2025-12-06 mistake row).
+- **N7 — Does NOT modify config files.** If a threshold is wrong, preflight tells the operator the env var name and the fix command. It does not edit `.env`.
+- **N8 — Does NOT block on warnings.** WARN status surfaces but proceeds with exit 0.
+- **N9 — No multi-step ritual to bypass.** Bypass is a single flag (see §6.3). Operator paged at 3am should not have to navigate a menu.
+
+---
+
+## 5. Architecture
+
+### 5.1 Script location and entry point
+
+```
+scripts/preflight_check.py        # CLI + main()
+robo_trader/preflight/__init__.py # package
+robo_trader/preflight/checks.py   # Check classes + registry
+robo_trader/preflight/runner.py   # orchestration (parallelism, output)
+robo_trader/preflight/result.py   # CheckResult dataclass
+tests/test_preflight_checks.py    # unit tests per check
+tests/test_preflight_runner.py    # orchestration tests
+```
+
+The thin script in `scripts/preflight_check.py` is just a CLI wrapper that imports from `robo_trader.preflight` and exits with the appropriate code. The actual logic lives in the package so it is unit-testable without subprocess invocation.
+
+### 5.2 Exit codes
+
+```
+0    All checks PASS or WARN — safe to proceed
+1    At least one check BLOCKED — abort startup
+2    Operator passed --force on a BLOCK — proceeded with audit log
+3    Preflight itself failed (uncaught exception, broken environment)
+```
+
+Code 2 distinguishes "we knew about a block and chose to bypass" from "no blocks at all." Useful in operational logs.
+
+Note: code 3 must be impossible in normal operation — every check catches its own exceptions and converts them to `BLOCK` status with a "preflight check N raised" message. Code 3 only fires for things like `ImportError` at module-load time.
+
+### 5.3 `CheckResult` dataclass
+
+```python
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+class CheckStatus(Enum):
+    PASS = "PASS"
+    WARN = "WARN"
+    BLOCK = "BLOCK"
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str                          # short identifier: "kill_switch_state"
+    status: CheckStatus                # PASS / WARN / BLOCK
+    message: str                       # one-line summary for human display
+    remediation: str = ""              # operator instructions, multiline OK
+    details: dict[str, Any] = field(default_factory=dict)
+    duration_ms: int = 0               # populated by runner
+```
+
+Why `frozen=True`: results are immutable once produced — easier to reason about in tests, and the runner serializes them to JSON without worrying about late mutation.
+
+Why `remediation` as a separate field from `message`: the message goes on stdout next to the status badge; the remediation goes on its own indented block. JSON output exposes both as separate keys, useful for downstream tooling.
+
+Why `details: dict`: machine-readable extras (file paths, threshold values, port numbers). Stays out of the human display unless `--verbose` is set, always present in JSON output.
+
+### 5.4 Check protocol
+
+```python
+from typing import Protocol
+
+class Check(Protocol):
+    name: str                          # stable identifier (kebab-case)
+    description: str                   # human label, e.g., "Kill switch state"
+    timeout_seconds: float             # per-check soft budget (G8)
+
+    def run(self, context: PreflightContext) -> CheckResult: ...
+```
+
+`PreflightContext` is a small dataclass passed to every check, holding shared inputs (project root path, `.env`-resolved env dict, target port, dry-run flag). Avoids re-reading `.env` per check and lets tests inject fakes.
+
+### 5.5 Registry pattern (G10)
+
+```python
+# robo_trader/preflight/checks.py
+ALL_CHECKS: list[Check] = [
+    KillSwitchStateCheck(),
+    KillSwitchLockCheck(),
+    EquityHistoryFreshnessCheck(),
+    RiskThresholdCheck(),
+    GatewayPortListeningCheck(),
+    ZombieConnectionsCheck(),
+]
+```
+
+Adding a Phase 2 check (e.g., "DB schema migrations applied") is one line. Tests reference checks by index/name, not by import path of a module-internal function.
+
+Checks are independent — order in the list determines display order but not pass/fail interdependence. The runner runs them all even if early ones fail; the operator wants to see *all* the problems at once, not fix one and re-run only to discover the next.
+
+### 5.6 Severity model — flat vs. tiered (Q1)
+
+**Decision: three-level (PASS / WARN / BLOCK), no REQUIRE_CONFIRM tier.**
+
+Justification by check:
+
+| Check | Why this severity model | Concrete example |
+|---|---|---|
+| Kill switch state | BLOCK only — no warning tier. If `triggered=True`, the system has affirmatively decided not to trade. Anything weaker than BLOCK is a regression to the 2026-05-22 behavior. | `triggered=True` → BLOCK |
+| Kill switch lock file | BLOCK only — symmetric with state file (deny-by-default fail-closed signal per CLAUDE.md). | `data/kill_switch.lock` exists → BLOCK |
+| Equity history stale | BLOCK if >24h, no WARN tier. The window itself is the threshold. | Last row at T-26h → BLOCK |
+| Risk thresholds | **WARN + BLOCK tiers**. Below 2% is suspicious (the 2026-05-22 value), below 1% is almost certainly an accidental typo. Two thresholds catch both. | `0.018` → WARN; `0.005` → BLOCK |
+| Gateway port | BLOCK only — the runner cannot do useful work without it. | port `4002` not in LISTEN → BLOCK |
+| Zombies | BLOCK only — zombies guarantee a handshake failure within a few cycles. | Any `CLOSE_WAIT` count > 0 → BLOCK |
+
+REQUIRE_CONFIRM was considered (force an interactive prompt) and rejected: at 3am with a watchdog auto-restart, there is no human at the keyboard. An interactive prompt becomes a hang. The bypass mechanism (§6.3) is the right knob for "I know about this block."
+
+### 5.7 What checks **do not** do (cross-check vs. N1)
+
+No check ever:
+- Modifies a file (no `.unlink()`, no `.touch()`, no writing JSON state)
+- Sends a network packet (no `socket.connect_ex`, no IBKR API call, no HTTP request — `lsof` is local kernel state)
+- Spawns the gateway, the runner, or any other long-lived process
+- Reads secrets out of `.env` (the threshold values are not secret; we don't need credentials)
+
+Enforcing this in code review is easier when each check is a small class with a single `run()` method.
+
+---
+
+## 6. Operational behavior
+
+### 6.1 Parallelism (G8)
+
+The six initial checks split into:
+- **I/O-cheap (parallel)**: kill switch state read, kill switch lock stat, risk threshold env-var read, equity-history sqlite SELECT — all bounded by per-check 1s timeout, all run concurrently in a thread pool.
+- **subprocess-bound**: lsof for port-listening and lsof for zombies. These two run sequentially (same binary, fast) but the pair runs in parallel with the I/O checks.
+
+Worst case latency on a healthy system: 1–2 seconds (lsof on macOS is fast). With degraded I/O (slow disk, large `equity_history` table), the per-check timeout caps each check at its `timeout_seconds`. Total budget is `max(check.timeout_seconds for check in ALL_CHECKS)`, not the sum.
+
+If a check exceeds its timeout, it returns `CheckResult(status=BLOCK, message="check exceeded timeout", ...)`. We prefer to BLOCK over silently allowing start with unverified state.
+
+### 6.2 Hook into `START_TRADER.sh` (Q4)
+
+**Decision: invoke as a subprocess after the existing Gateway/zombie steps, before launching the dashboard and runner.**
+
+Why subprocess instead of `import & call`:
+- `START_TRADER.sh` already shells out to Python for the readonly API check pattern; consistent.
+- Exit code is the contract — bash's `if !` natural fit.
+- Failure isolation: a preflight import error doesn't take out the shell script's error reporting.
+
+Why after the existing Gateway/zombie steps:
+- The current Gateway-management block in START_TRADER.sh (steps 2 and 3 in the file) is what makes the port LISTEN and clears zombies in the first place. Preflight then **verifies** the state the shell script just established. Running preflight *before* the Gateway block would always block on "port not listening."
+- However, preflight runs *before* the Python environment is fully exercised, so we don't waste time spinning up the dashboard if the safety gate blocks.
+
+Exact slot — between current Step 4 ("Set up Python environment") and Step 5 ("Start dashboard"):
+
+```bash
+# Step 4.5: Preflight safety gate
+echo "4.5. Running preflight safety gate..."
+if ! $PYTHON scripts/preflight_check.py; then
+    echo ""
+    echo "=========================================="
+    echo "❌ PREFLIGHT SAFETY GATE BLOCKED STARTUP"
+    echo "=========================================="
+    echo ""
+    echo "Preflight reported blocking issues above."
+    echo "Resolve each one and re-run ./START_TRADER.sh, or"
+    echo "bypass with: $PYTHON scripts/preflight_check.py --force \"<reason>\""
+    echo "(then re-run ./START_TRADER.sh — bypass is per-invocation, not persistent)"
+    echo ""
+    exit 1
+fi
+echo ""
+```
+
+Preflight's own non-zero exit already prints the BLOCK details. The wrapping bash block adds the meta-instruction (how to bypass).
+
+### 6.3 Bypass mechanism (Q2, G7)
+
+**Decision: `--force "<reason>"` CLI flag. No env var. Reason string is mandatory.**
+
+```bash
+# Operator runs (after explicit decision):
+python3 scripts/preflight_check.py --force "cleared NVDA kill switch, raised threshold to 5%, ticket #1234"
+```
+
+Behavior of `--force`:
+1. All checks still run and print their results (so the operator sees what they're overriding).
+2. If any check returns BLOCK and `--force` is set:
+   - The operator's reason string is logged to `robo_trader.log` at WARNING level with `event=preflight_bypass`.
+   - A line is appended to `data/preflight_bypass.log` (newline-delimited JSON, one entry per bypass) with timestamp, reason, and the list of bypassed check names.
+   - Exit code is **2** (not 0), so START_TRADER.sh can show "started with bypass" rather than "all clean."
+3. If `--force` is given but no checks BLOCKed, exit 0 with a "force not needed" warning. (Prevents operators from leaving `--force` in their shell history as a copy-paste default.)
+4. Reason string must be ≥10 characters and not match a small denylist of placeholders (`force`, `bypass`, `whatever`, `idk`). Forces a real-sentence rationale.
+
+Why not an env var (e.g., `PREFLIGHT_BYPASS=1`):
+- Env vars get set in `.env` and silently disable the gate forever. The whole point of the gate is that the operator stops and looks. A persistent bypass is worse than no gate.
+- Bypass needs to be visible at the call site — `.bash_history` `grep` finds the `--force` invocations later.
+
+Why not a delete-this-file mechanism (e.g., remove `data/.preflight_required`):
+- Same problem as env var: easy to leave deleted, hard to audit.
+
+Why a reason string:
+- "What did I bypass and why" is the question 24 hours later. Capturing it at the moment of decision is much better than reconstructing from logs.
+- Mirrors how `git commit --allow-empty -m "reason"` works — bypass requires an utterance.
+
+Audit trail at `data/preflight_bypass.log` is **append-only by convention** — the gate writes to it, no other component reads from it. A Phase 2 dashboard view can render the log. For now, `tail data/preflight_bypass.log` is the operator query.
+
+### 6.4 Output format (Q3)
+
+**Decision: human-readable plaintext by default; `--json` flag for structured output. No mixing.**
+
+The 3am-page operator sees plaintext. Tooling that wants to parse uses `--json`.
+
+#### 6.4.1 Plaintext format
+
+```
+Preflight Safety Gate — checking 6 conditions
+─────────────────────────────────────────────
+[PASS] kill_switch_state      no triggered state                      (3ms)
+[PASS] kill_switch_lock       no lock file                            (1ms)
+[PASS] equity_history         last row 12h ago (within 24h window)    (18ms)
+[PASS] risk_thresholds        max_position_loss_pct=0.05              (0ms)
+[PASS] gateway_port           port 4002 listening                     (42ms)
+[PASS] zombies                no CLOSE_WAIT connections               (39ms)
+─────────────────────────────────────────────
+6/6 checks passed. Safe to proceed.
+```
+
+Status badge widths (`[PASS]`, `[WARN]`, `[BLOCK]`) are uniform 7 chars including brackets. Check names left-padded to a column.
+
+#### 6.4.2 Plaintext on BLOCK (the 2026-05-22 scenario)
+
+```
+Preflight Safety Gate — checking 6 conditions
+─────────────────────────────────────────────
+[BLOCK] kill_switch_state    triggered=True since 2026-05-22T22:58 ET  (4ms)
+[PASS]  kill_switch_lock     no lock file                              (1ms)
+[BLOCK] equity_history       last row 38h ago (stale; >24h)            (22ms)
+[PASS]  risk_thresholds      max_position_loss_pct=0.05                (0ms)
+[PASS]  gateway_port         port 4002 listening                       (44ms)
+[PASS]  zombies              no CLOSE_WAIT connections                 (37ms)
+─────────────────────────────────────────────
+2/6 checks BLOCKED. Cannot proceed.
+
+╔══════════════════════════════════════════════════════════════════════╗
+║ BLOCK #1 — kill_switch_state                                         ║
+╠══════════════════════════════════════════════════════════════════════╣
+║ Kill switch is triggered.                                            ║
+║                                                                      ║
+║ Trigger reason: "Position loss limit exceeded for AAPL: 3.33% loss"  ║
+║ Triggered at:   2026-05-22T22:58:12-04:00 (about 16 hours ago)       ║
+║ State file:     /Users/oliver/Projects/robo_trader/data/kill_switch_state.json
+║                                                                      ║
+║ What to do:                                                          ║
+║   1. Decide if the loss-trigger is still relevant.                   ║
+║      - If a real loss event: review positions before clearing.       ║
+║      - If a stale trip from a transient issue: clear it.             ║
+║   2. To clear (DESTRUCTIVE — review first):                          ║
+║        cp data/kill_switch_state.json data/kill_switch_state.json.bak.$(date +%Y-%m-%d-%H%M)
+║        rm data/kill_switch_state.json data/kill_switch.lock          ║
+║   3. Re-run: ./START_TRADER.sh                                       ║
+║                                                                      ║
+║ To proceed anyway (NOT recommended without step 1):                  ║
+║   python3 scripts/preflight_check.py --force "<your reason here>"    ║
+║   then re-run ./START_TRADER.sh                                      ║
+╚══════════════════════════════════════════════════════════════════════╝
+
+╔══════════════════════════════════════════════════════════════════════╗
+║ BLOCK #2 — equity_history                                            ║
+╠══════════════════════════════════════════════════════════════════════╣
+║ Last equity_history row is 38 hours old (>24h threshold).            ║
+║                                                                      ║
+║ Most recent date: 2026-05-22                                         ║
+║ Database:         /Users/oliver/Projects/robo_trader/trading_data.db ║
+║                                                                      ║
+║ This usually means a prior session died without writing an equity    ║
+║ snapshot. State files may be inconsistent.                           ║
+║                                                                      ║
+║ What to do:                                                          ║
+║   1. Check for an unclean shutdown:                                  ║
+║        tail -100 robo_trader.log | grep -E "(Traceback|ERROR|killed)"║
+║   2. Verify positions match IBKR before starting:                    ║
+║        python3 scripts/reconcile_positions.py                        ║
+║   3. If positions reconcile, you may proceed:                        ║
+║        python3 scripts/preflight_check.py --force "verified positions reconcile, ticket #N"
+║                                                                      ║
+║ This check does NOT auto-clear. Operator must confirm system state.  ║
+╚══════════════════════════════════════════════════════════════════════╝
+```
+
+Each BLOCK gets its own boxed block. Operator can fix them in any order — preflight is not transactional, just diagnostic.
+
+#### 6.4.3 Plaintext on WARN
+
+```
+Preflight Safety Gate — checking 6 conditions
+─────────────────────────────────────────────
+[PASS] kill_switch_state    no triggered state                       (3ms)
+[PASS] kill_switch_lock     no lock file                             (1ms)
+[PASS] equity_history       last row 4h ago (within 24h window)      (19ms)
+[WARN] risk_thresholds      max_position_loss_pct=0.018 (<0.02)      (0ms)
+[PASS] gateway_port         port 4002 listening                      (44ms)
+[PASS] zombies              no CLOSE_WAIT connections                (40ms)
+─────────────────────────────────────────────
+6/6 checks passed (1 with warnings). Safe to proceed.
+
+⚠ WARN — risk_thresholds
+  max_position_loss_pct is 0.018 (1.8%), below the recommended 2.0%
+  floor. A normal daily move on a volatile stock can trip the kill
+  switch at this level (see 2026-05-22 incident with NVDA at -2.93%).
+  Consider RISK_MAX_POSITION_LOSS_PCT=0.05 in .env (current default).
+  Not blocking — proceeding.
+```
+
+WARNs go after the summary line so the operator's eye still lands on "Safe to proceed."
+
+#### 6.4.4 JSON output (`--json` flag)
+
+```json
+{
+  "version": 1,
+  "started_at": "2026-05-23T14:32:01.123-04:00",
+  "completed_at": "2026-05-23T14:32:02.847-04:00",
+  "duration_ms": 1724,
+  "exit_code": 0,
+  "summary": {
+    "total": 6,
+    "passed": 5,
+    "warned": 1,
+    "blocked": 0
+  },
+  "checks": [
+    {
+      "name": "kill_switch_state",
+      "status": "PASS",
+      "message": "no triggered state",
+      "remediation": "",
+      "details": {"state_path": "/Users/oliver/Projects/robo_trader/data/kill_switch_state.json", "exists": false},
+      "duration_ms": 3
+    },
+    {
+      "name": "risk_thresholds",
+      "status": "WARN",
+      "message": "max_position_loss_pct=0.018 (<0.02)",
+      "remediation": "Consider RISK_MAX_POSITION_LOSS_PCT=0.05 in .env",
+      "details": {"value": 0.018, "warn_threshold": 0.02, "block_threshold": 0.01, "env_var": "RISK_MAX_POSITION_LOSS_PCT"},
+      "duration_ms": 0
+    }
+  ]
+}
+```
+
+JSON output is suitable for piping into Phase 2's `/api/health` endpoint or for chaos-drill assertions.
+
+---
+
+## 7. The Checks
+
+Each check below: rationale, inputs, decision logic, remediation text, and edge cases. The full implementation is sketched for the first check; subsequent checks follow the same pattern at less detail.
+
+### 7.1 KillSwitchStateCheck (G1)
+
+**Why this check exists.** This is the check that would have prevented 2026-05-22. The KillSwitch class loads state from disk on construction; once `triggered=True` is persisted, every new runner sees it and refuses to trade. Without this preflight, that state is invisible at startup.
+
+**Inputs:**
+- `data/kill_switch_state.json` (or path via `KILL_SWITCH_STATE_PATH` env var if set in future)
+
+**Decision:**
+- File missing → PASS
+- File parseable, `triggered=False` → PASS (`details.previous_trigger_reason` populated if present)
+- File parseable, `triggered=True` → BLOCK
+- File unparseable (corrupt JSON, permission denied) → BLOCK (matches KillSwitch's own fail-closed behavior in `_load_persisted_state`)
+
+**Sketch:**
+
+```python
+class KillSwitchStateCheck:
+    name = "kill_switch_state"
+    description = "Kill switch persisted state"
+    timeout_seconds = 1.0
+
+    def run(self, context: PreflightContext) -> CheckResult:
+        path = context.project_root / "data" / "kill_switch_state.json"
+        if not path.exists():
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.PASS,
+                message="no triggered state",
+                details={"state_path": str(path), "exists": False},
+            )
+        try:
+            payload = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError) as exc:
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.BLOCK,
+                message=f"state file unreadable ({exc.__class__.__name__})",
+                remediation=(
+                    "Kill switch state file is corrupt. Fail-closed policy "
+                    "blocks startup.\n"
+                    f"  Inspect:   cat {path}\n"
+                    f"  Backup:    cp {path} {path}.bak.$(date +%Y-%m-%d-%H%M)\n"
+                    f"  Clear:     rm {path}\n"
+                    "  Then re-run ./START_TRADER.sh"
+                ),
+                details={"state_path": str(path), "error": str(exc)},
+            )
+
+        if not payload.get("triggered"):
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.PASS,
+                message="no triggered state",
+                details={
+                    "state_path": str(path),
+                    "exists": True,
+                    "triggered": False,
+                },
+            )
+
+        reason = payload.get("trigger_reason", "unknown")
+        trigger_time = payload.get("trigger_time", "unknown")
+        return CheckResult(
+            name=self.name,
+            status=CheckStatus.BLOCK,
+            message=f'triggered=True since {trigger_time}',
+            remediation=self._build_remediation(path, reason, trigger_time),
+            details={
+                "state_path": str(path),
+                "trigger_reason": reason,
+                "trigger_time": trigger_time,
+            },
+        )
+
+    def _build_remediation(self, path, reason, trigger_time) -> str:
+        return (
+            f'Kill switch is triggered.\n\n'
+            f'Trigger reason: "{reason}"\n'
+            f'Triggered at:   {trigger_time}\n'
+            f'State file:     {path}\n\n'
+            'What to do:\n'
+            '  1. Decide if the loss-trigger is still relevant.\n'
+            '     - If a real loss event: review positions before clearing.\n'
+            '     - If a stale trip from a transient issue: clear it.\n'
+            '  2. To clear (DESTRUCTIVE — review first):\n'
+            f'       cp {path} {path}.bak.$(date +%Y-%m-%d-%H%M)\n'
+            f'       rm {path} data/kill_switch.lock\n'
+            '  3. Re-run: ./START_TRADER.sh\n\n'
+            'To proceed anyway (NOT recommended without step 1):\n'
+            '  python3 scripts/preflight_check.py --force "<your reason here>"\n'
+            '  then re-run ./START_TRADER.sh'
+        )
+```
+
+**Test fixtures:**
+- `tmp_path / "data" / "kill_switch_state.json"` containing each of: triggered, untriggered, missing, malformed, permission-denied.
+- A `PreflightContext` factory that sets `project_root = tmp_path`.
+
+**Edge cases:**
+- `trigger_time` may be missing for old state files written before TC-M5 — display "unknown" not crash.
+- `trigger_reason` may contain quotes — escape for display in the remediation text.
+- Symlink at the path: follow it (matches KillSwitch behavior).
+
+### 7.2 KillSwitchLockCheck (G1)
+
+**Why this check exists.** The plan calls out `data/kill_switch.lock` as the deny-by-default fail-closed signal. The KillSwitch class's `_load_persisted_state` already treats the lock file's presence as triggered (`R2-M2`), but the lock can exist independently — for example, if an operator created it manually to force a stop. Preflight surfaces it explicitly rather than letting the runner spin up and immediately die.
+
+**Inputs:** `data/kill_switch.lock`
+
+**Decision:**
+- File missing → PASS
+- File exists → BLOCK
+
+**Remediation:** "Kill switch lock file present. This is a deny-by-default safety signal. Either:
+- Remove the lock: `rm data/kill_switch.lock` (after confirming nothing intentionally placed it)
+- Or proceed with `--force "reason"`"
+
+**Edge case:** The lock and the state file are *related but independent*. Don't dedupe — show both BLOCKs separately if both fire, because the remediation actions differ.
+
+### 7.3 EquityHistoryFreshnessCheck (G2)
+
+**Why this check exists.** Equity snapshots are written to `equity_history` at the end of every successful trading day. A row older than 24h means either (a) the system hasn't completed a full day in over a day (unclean shutdown candidate) or (b) the database itself is stale/wrong. Either case warrants an operator look before resuming trading. A stale state usually means stale positions.
+
+**Inputs:**
+- `trading_data.db` SQLite file
+- Query: `SELECT MAX(date), MAX(timestamp) FROM equity_history` (across all portfolios)
+- Current time (system clock)
+
+**Decision:**
+- DB file missing → BLOCK (system unconfigured)
+- Empty `equity_history` table → WARN (first-run; not a livelock indicator)
+- Max(timestamp) within last 24h → PASS
+- Max(timestamp) older than 24h → BLOCK
+- Sqlite read error → BLOCK (consistent fail-closed)
+
+**Important nuance — weekends and holidays.** The market is closed Sat/Sun and on holidays. A Monday morning startup could legitimately see a "Friday" last-row that is 60+ hours old.
+
+**Resolution:** Use a *trading-day* delta, not wall-clock delta. The check measures "how many trading days since last row." Threshold: more than 1 trading day → BLOCK.
+
+```python
+# Pseudocode
+from robo_trader.utils.market_hours import MarketHours, get_market_time
+
+trading_days_elapsed = MarketHours.count_trading_days(
+    start=max_timestamp,
+    end=get_market_time(),
+)
+if trading_days_elapsed > 1:
+    return BLOCK
+```
+
+This handles Monday-after-Friday (0–1 trading days) correctly, AND catches "haven't run since last Tuesday" (3+ trading days, real problem).
+
+**Remediation text:** "Last equity row is N trading days old. This usually means a prior session died without writing a snapshot. Verify positions match IBKR (`scripts/reconcile_positions.py`) before resuming, or `--force` if you've already confirmed."
+
+**Edge case:** Multi-portfolio. `equity_history` is partitioned by `portfolio_id`. We check the max across all portfolios — if any portfolio is fresh, we PASS. (A portfolio that hasn't traded in weeks because it's disabled shouldn't block startup.)
+
+**Edge case 2:** Test environment / CI. Skip via `PREFLIGHT_SKIP_CHECKS` env var? No — better to fail loudly and force CI to set up a fixture. The CheckResult's `details.skip_reason` field is reserved for future use but not exposed by current checks.
+
+### 7.4 RiskThresholdCheck (G3)
+
+**Why this check exists.** The 2026-05-22 incident's root cause was `max_position_loss_pct=0.02`. The audit raised the default to 0.05 (commit `baadd26`), but if a stale `.env` overrides it back to 0.02 or lower, the trader will trip again. This check surfaces the value at startup.
+
+**Inputs:**
+- Env var `RISK_MAX_POSITION_LOSS_PCT` (resolved through `.env` + shell environment)
+- Compare against thresholds 0.02 (warn) and 0.01 (block)
+
+**Decision:**
+- Not set → PASS (use code default, which is 0.05 per `baadd26`)
+- Set but unparseable as float → BLOCK ("config corrupt — preflight cannot evaluate")
+- `< 0.01` → BLOCK
+- `< 0.02` → WARN
+- `>= 0.02` → PASS
+
+**Remediation (BLOCK):** "RISK_MAX_POSITION_LOSS_PCT=N is below 1%. Almost any intraday move will trip the kill switch. Either remove the line from `.env` to use the default 0.05, or set to a realistic value (≥0.02). To proceed with this value anyway, `--force`."
+
+**Remediation (WARN):** "RISK_MAX_POSITION_LOSS_PCT=N is below the 2% recommended floor. A normal daily move on a volatile stock can trip the kill switch at this level (see 2026-05-22 NVDA incident). Consider raising. Not blocking."
+
+**Extensibility note:** Phase 2 may add similar checks for `RISK_MAX_DAILY_LOSS_PCT`, `RISK_MAX_DRAWDOWN_PCT`, `MAX_POSITION_PCT`. Each is a separate check class so each fails independently.
+
+### 7.5 GatewayPortListeningCheck (G4)
+
+**Why this check exists.** START_TRADER.sh tries to bring up Gateway and waits for `lsof -sTCP:LISTEN` on port 4002. If Gateway never came up successfully (2FA failure, license issue, IBC misconfig), START_TRADER fails its own check and exits before preflight runs. **But:** the watchdog can invoke runner_async directly in restart mode, bypassing START_TRADER. In that path, preflight is the first line of defense.
+
+**Inputs:**
+- `lsof -nP -iTCP:<port> -sTCP:LISTEN` (port from `EXECUTION_MODE`: `4002` for paper, `4001` for live, default 4002)
+- Subprocess timeout: 3 seconds
+
+**Decision:**
+- lsof returns 0 with output → PASS
+- lsof returns non-zero (no LISTEN found) → BLOCK
+- lsof times out → BLOCK ("port check timed out — system likely overloaded")
+- lsof binary missing → BLOCK ("lsof not installed — required for safety checks"; should never happen on macOS, but worth catching)
+
+**Remediation:** "Gateway API port 4002 is not listening. Run `./scripts/start_gateway.sh` or `python3 scripts/gateway_manager.py start --paper` to bring it up. If 2FA is pending, check your IBKR Mobile app."
+
+**Critical constraint (CLAUDE.md, 2025-12-06 row):** Use `lsof`, never `socket.connect_ex`. The latter creates a zombie connection that blocks subsequent API handshakes — exactly the failure class we're checking *for*. The implementation MUST go through `subprocess.run(["lsof", ...])` — there is NO Python-API alternative that is safe.
+
+### 7.6 ZombieConnectionsCheck (G5)
+
+**Why this check exists.** A `CLOSE_WAIT` connection on the Gateway port will block the runner's `ib.connect()` with cryptic timeouts. START_TRADER.sh already does a zombie sweep but preflight verifies it took.
+
+**Inputs:**
+- `lsof -nP -iTCP:<port> -sTCP:CLOSE_WAIT` (same port as 7.5)
+- Subprocess timeout: 3 seconds
+
+**Decision:**
+- Output empty → PASS
+- Any line in output → BLOCK with the zombie count and PIDs
+
+**Remediation:** "Found N zombie connections on port <port>. These will block API handshakes. Either:
+- Kill Python-owned zombies: `python3 scripts/gateway_manager.py clear-zombies`
+- For Gateway-owned zombies: restart Gateway with `python3 scripts/gateway_manager.py restart`
+- Then re-run ./START_TRADER.sh"
+
+**Edge case:** Race with START_TRADER.sh's own zombie cleanup. Preflight runs after step 3 of the shell script, so this should not occur, but if it does the message is still actionable.
+
+---
+
+## 8. The H1 coordination question (Q7)
+
+**Recap.** H1 (commit `315ea6a`) is the runner's in-flight kill-switch auto-reset: when `recover_connection` succeeds, if the kill switch was tripped *and* its `trigger_reason` contains connection-related keywords (`connection`, `handshake`, `gateway`, `timeout`, `subprocess`, `ibkr`), the runner force-resets it. The justification is "the proximate cause is resolved; the trigger was incidental." Loss-based triggers are explicitly preserved.
+
+**The question.** Preflight runs BEFORE recover_connection has a chance to fire (the runner isn't up yet). If preflight blocks on a triggered kill switch, the operator might be in the position of "yeah, this is just the same connection-related trip from last night; the runner would have auto-cleared this in its first health cycle anyway." Should preflight apply the same heuristic?
+
+**Decision: NO. Preflight always blocks on a triggered kill switch, even if the reason looks connection-related. The operator must explicitly clear or `--force`.**
+
+**Justification (the trade-off).**
+
+**Arguments for auto-clearing in preflight (rejected):**
+1. Symmetric with H1 — operator already opted into "connection trips can self-heal."
+2. Saves an operator wakeup when the trigger was a known-transient.
+3. The 2026-05-22 incident itself would have been blocked correctly by preflight under either policy, because that trigger was loss-based, not connection-based.
+
+**Arguments against auto-clearing in preflight (winning):**
+1. **Different scope.** H1 runs *after* `recover_connection` actually succeeded — there is direct evidence the connection issue is resolved. Preflight runs before any connection attempt. "Looks connection-related" is a *guess* without that recovery evidence. Auto-clearing here would clear triggers for problems we haven't actually fixed yet.
+2. **Reason-string fragility.** The keyword list (`connection`, `handshake`, etc.) is a heuristic that's fine when paired with explicit recovery success. As a standalone preflight rule, a future kill-switch trigger reason like `"Could not connect to historical data feed"` would auto-clear a real data-quality trip.
+3. **The bypass exists.** `--force "transient connection trip from yesterday, ticket #1234"` is the supported escape hatch. It is one command, fast at 3am, and audited.
+4. **Defense in depth.** H1 and preflight are different layers. H1 handles "we were running, hit a blip, recovered." Preflight handles "we are NOT running, why?" Conflating them weakens both.
+5. **Plan intent.** The motivating plan explicitly frames preflight as *adding* a gate, not as *auto-fixing* state. "The persisted state stays the same — the response changes." (Plan §MVP-1.)
+
+**Implication for operator UX.** After a connection-related trip:
+- H1 *might* have auto-cleared it before the runner finally exited. If so, preflight passes — no issue.
+- If H1 didn't fire (because the runner died too fast, or the trigger was loss-based, or the recovery itself failed), preflight blocks. Operator sees the trigger reason and the remediation. Worst case: 30-second `rm` + bypass. The 2026-05-22 4-hour loss is the failure mode we're optimizing against, not 30 seconds of operator decision-making.
+
+**Future revisit trigger.** If post-deploy logs show frequent `event=preflight_bypass` entries with reason strings citing "transient connection," that's evidence the heuristic-symmetry argument has merit and we should reconsider. Until then: simpler is safer.
+
+---
+
+## 9. Testing Strategy (G9)
+
+### 9.1 Unit tests — per check
+
+Pattern: each check class has a corresponding test class in `tests/test_preflight_checks.py`. All checks accept a `PreflightContext` with `project_root=tmp_path`, so no real filesystem state is touched.
+
+#### KillSwitchStateCheck
+- `test_returns_pass_when_state_file_missing`
+- `test_returns_pass_when_triggered_false`
+- `test_returns_block_when_triggered_true`
+- `test_returns_block_when_state_file_corrupt_json`
+- `test_returns_block_when_state_file_unreadable_permissions`
+- `test_remediation_text_includes_state_path_and_reason`
+- `test_handles_missing_trigger_time_field` (regression: old state files)
+- `test_does_not_modify_state_file` (verify file mtime unchanged after run)
+
+#### KillSwitchLockCheck
+- `test_returns_pass_when_lock_missing`
+- `test_returns_block_when_lock_present`
+- `test_does_not_remove_lock_file`
+
+#### EquityHistoryFreshnessCheck
+- `test_returns_block_when_db_missing`
+- `test_returns_warn_when_table_empty`
+- `test_returns_pass_when_max_row_within_24h`
+- `test_returns_block_when_max_row_older_than_one_trading_day`
+- `test_returns_pass_on_monday_morning_with_friday_max` (weekend gap)
+- `test_returns_pass_on_post_holiday_morning` (holiday gap)
+- `test_returns_block_when_three_trading_days_old`
+- `test_aggregates_max_across_portfolios`
+- `test_returns_block_on_sqlite_read_error`
+
+#### RiskThresholdCheck
+- `test_returns_pass_when_env_var_unset`
+- `test_returns_pass_when_value_above_warn`
+- `test_returns_warn_when_value_between_warn_and_block`
+- `test_returns_block_when_value_below_block_threshold`
+- `test_returns_block_when_value_unparseable`
+- `test_returns_block_when_value_zero_or_negative`
+- `test_remediation_names_env_var_and_recommended_value`
+
+#### GatewayPortListeningCheck
+- `test_returns_pass_when_lsof_finds_listener` (mock subprocess.run)
+- `test_returns_block_when_lsof_finds_no_listener`
+- `test_returns_block_when_lsof_times_out`
+- `test_returns_block_when_lsof_binary_missing`
+- `test_uses_paper_port_by_default`
+- `test_uses_live_port_when_execution_mode_live`
+- `test_does_not_use_socket_connect_ex` (static check; greps source for forbidden API)
+
+#### ZombieConnectionsCheck
+- `test_returns_pass_when_no_close_wait_lines`
+- `test_returns_block_when_close_wait_lines_present`
+- `test_includes_pid_list_in_details`
+
+### 9.2 Integration tests — runner
+
+`tests/test_preflight_runner.py`:
+
+- `test_all_checks_pass_returns_exit_zero`
+- `test_any_block_returns_exit_one`
+- `test_warns_do_not_block`
+- `test_force_with_blocks_returns_exit_two`
+- `test_force_without_blocks_returns_exit_zero_with_warning`
+- `test_force_rejects_empty_reason`
+- `test_force_rejects_placeholder_reason`
+- `test_force_logs_to_bypass_log_file`
+- `test_runner_logs_event_preflight_bypass_to_main_log`
+- `test_checks_run_in_parallel` (verify total duration < sum of individual)
+- `test_check_timeout_returns_block` (mock a slow check)
+- `test_check_exception_returns_block` (mock a raising check)
+- `test_json_output_well_formed`
+- `test_json_output_contains_all_fields`
+- `test_plaintext_output_format_stable` (golden output comparison)
+
+### 9.3 Required fixtures and helpers
+
+| Fixture | Purpose |
+|---|---|
+| `tmp_path` (pytest built-in) | Sandbox for state files |
+| `PreflightContext.for_test(tmp_path)` factory | Inject project_root, port, env dict |
+| `lsof_subprocess_mock` (monkeypatch on `subprocess.run`) | Simulate `lsof` output for the two port checks |
+| `sqlite_fixture(tmp_path, snapshots)` | Populate trading_data.db with N equity_history rows at given timestamps |
+| `kill_switch_state_fixture(tmp_path, **payload)` | Write a state file with given fields |
+| `frozen_market_time(monkeypatch, dt)` | Override `get_market_time` so trading-day math is deterministic |
+| `bypass_log_isolated(tmp_path)` | Redirect `data/preflight_bypass.log` writes into tmp_path |
+
+### 9.4 Out-of-scope tests
+
+| Skipped | Why |
+|---|---|
+| Real `lsof` calls in CI | Non-portable; subprocess mock is sufficient |
+| Real Gateway port checking | Requires running Gateway; manual verification only |
+| Real `equity_history` with year of data | Tested with synthetic 10-row fixtures; large-table perf tested via `--timeout` |
+| Concurrency stress (1000 parallel preflights) | Single-process by design; not a use case |
+
+### 9.5 Regression: must stay green
+
+- All existing `tests/security/` tests (per CLAUDE.md)
+- All existing `tests/test_connection_health.py` (this branch's prior work)
+- All existing `tests/test_recover_connection.py` (this branch's prior work)
+
+Preflight is a new entry point — no existing tests cross-cut into it. If any unrelated test breaks during implementation, root-cause and don't paper over.
+
+### 9.6 Manual canary
+
+Before merging:
+1. Trigger preflight against a clean state — expect `[PASS]` summary, exit 0, latency <2s.
+2. Manually `touch data/kill_switch.lock` — re-run, expect BLOCK on `kill_switch_lock`, exit 1.
+3. Restore `data/kill_switch_state.json.bak.2026-05-22-1627` to `data/kill_switch_state.json` — re-run, expect BLOCK on `kill_switch_state` with the actual trigger reason from the incident.
+4. With both BLOCKs present, run with `--force "manual canary test"` — expect exit 2, log entry in `data/preflight_bypass.log`.
+5. Remove the staged state, set `RISK_MAX_POSITION_LOSS_PCT=0.005` in shell env, re-run — expect BLOCK on threshold.
+6. Set `RISK_MAX_POSITION_LOSS_PCT=0.018` — expect WARN, exit 0.
+7. `pkill -f "IB Gateway"` — re-run, expect BLOCK on `gateway_port`.
+
+Document outcomes in the implementation PR.
+
+---
+
+## 10. Performance Budget (G8)
+
+**Target:** preflight wall-clock latency ≤ 5 seconds on a healthy system. 95th percentile (degraded I/O, slow `lsof`) ≤ 10 seconds.
+
+**Per-check budgets:**
+
+| Check | Soft timeout | Typical | Worst case |
+|---|---|---|---|
+| KillSwitchStateCheck | 1.0s | <5ms | Disk-full triggers timeout |
+| KillSwitchLockCheck | 0.5s | <2ms | NFS-mounted path triggers timeout |
+| EquityHistoryFreshnessCheck | 3.0s | <50ms | Sqlite WAL recovery on large DB |
+| RiskThresholdCheck | 0.1s | <1ms | None plausible |
+| GatewayPortListeningCheck | 3.0s | <100ms | `lsof` hang under load |
+| ZombieConnectionsCheck | 3.0s | <100ms | Same as above |
+
+**Total budget assuming parallelism:** ~3s (longest of the bunch). Sequential fallback: ~10.6s. Hence parallelism is required to meet G8.
+
+**Threading model:** `concurrent.futures.ThreadPoolExecutor(max_workers=6)`. Each check submitted as a future with its `timeout_seconds` enforced via `future.result(timeout=...)`. Checks have no shared mutable state — pure functions over read-only context — so thread safety is structurally guaranteed.
+
+**Subprocess timeout enforcement:** `subprocess.run(..., timeout=N)` raises `TimeoutExpired`; the check catches and returns BLOCK.
+
+**Why not asyncio?** Could do it. Threading is simpler, the checks are I/O-bound, and there's no event loop to share with the runner (preflight is a separate process). Six threads vs. an event loop is the lower-overhead choice for a once-per-startup tool.
+
+---
+
+## 11. Open Questions
+
+These need human input before implementation:
+
+### Q11.1 — `equity_history` for first-run / newly-created portfolios
+A brand-new portfolio (Phase 2 dynamic portfolio creation, hypothetical) would have zero `equity_history` rows. The check returns WARN under current spec, which means the operator sees the WARN line and proceeds. Is that the right default, or should "I am intentionally bootstrapping" need a `--force`? **Proposal:** WARN is fine; a bootstrap is rare enough that visibility is sufficient. **Need confirmation.**
+
+### Q11.2 — `EXECUTION_MODE=live` port detection
+The port check uses 4001 for live and 4002 for paper. The current codebase defaults to paper everywhere; the live path is rarely exercised. Worth a sanity test that a `live`-set environment correctly selects port 4001? **Proposal:** Yes, add unit test. **No spec change needed.**
+
+### Q11.3 — bypass log retention / rotation
+`data/preflight_bypass.log` will grow forever. Acceptable for now (entries are small JSON lines, write rate is low) but should rotate eventually. **Proposal:** Defer to Phase 2 (could roll into observability work P2-4). **Flagged.**
+
+### Q11.4 — Should preflight also write a "last successful preflight" timestamp?
+Phase 2 health endpoint could expose "last preflight passed at T." Cheap to add. **Proposal:** Defer; not in MVP-1 scope, but trivial future addition. **Flagged.**
+
+### Q11.5 — How to handle multi-portfolio risk threshold overrides?
+The plan check is on the *global* `RISK_MAX_POSITION_LOSS_PCT`. Multi-portfolio configs can override `max_position_pct` per-portfolio. If a portfolio overrides to a dangerous value, we don't currently catch it. **Proposal:** out of scope for MVP-1; multi-portfolio risk validation is a separate larger work item. **Acknowledged gap.**
+
+### Q11.6 — Coexistence with the watchdog
+If the watchdog auto-restarts the trader, it currently calls START_TRADER.sh, so preflight runs. But the launchd plist might evolve to invoke `runner_async` directly. **Proposal:** Keep preflight invocation in START_TRADER.sh AND add it as a recommended invocation in the watchdog plist as a follow-up. **Flagged for Phase 2.**
+
+---
+
+## 12. Sequenced Implementation Tasks
+
+Each task is small enough for a single commit + atomic review. Strict TDD: write the test first.
+
+1. **Skeleton + CheckResult dataclass.**
+   - Add `robo_trader/preflight/__init__.py`, `result.py` with `CheckStatus` and `CheckResult`.
+   - Test: instantiation, frozen-ness, JSON serializability.
+   - Commit: `feat(preflight): scaffold preflight package with CheckResult`
+
+2. **Check protocol + PreflightContext.**
+   - `robo_trader/preflight/checks.py` with the `Check` Protocol and `PreflightContext` dataclass.
+   - Test: nothing yet, but next commits build on it.
+   - Commit: `feat(preflight): add Check protocol and PreflightContext`
+
+3. **KillSwitchStateCheck.**
+   - Write tests (8 cases above).
+   - Implement.
+   - Commit: `feat(preflight): kill-switch state check`
+
+4. **KillSwitchLockCheck.**
+   - Tests + impl.
+   - Commit: `feat(preflight): kill-switch lock check`
+
+5. **EquityHistoryFreshnessCheck.**
+   - Tests including weekend/holiday cases.
+   - Impl, with MarketHours.count_trading_days helper if it doesn't exist yet.
+   - Commit: `feat(preflight): equity history freshness check`
+
+6. **RiskThresholdCheck.**
+   - Tests + impl.
+   - Commit: `feat(preflight): risk threshold check`
+
+7. **GatewayPortListeningCheck.**
+   - Tests with `subprocess.run` mocking.
+   - Impl using `lsof -nP -iTCP:<port> -sTCP:LISTEN`.
+   - Commit: `feat(preflight): gateway port listening check`
+
+8. **ZombieConnectionsCheck.**
+   - Tests + impl.
+   - Commit: `feat(preflight): zombie connections check`
+
+9. **Runner orchestration (parallel execution, output formatting).**
+   - `robo_trader/preflight/runner.py` with `run_all_checks(context) -> RunReport`.
+   - Tests for parallelism, timeout, exception isolation, output formats.
+   - Commit: `feat(preflight): parallel runner with plaintext + JSON output`
+
+10. **CLI script + bypass mechanism.**
+    - `scripts/preflight_check.py` with argparse, `--json`, `--force "reason"`, `--verbose`.
+    - Bypass log writer (`data/preflight_bypass.log`).
+    - Exit code logic (0/1/2/3).
+    - Tests for CLI integration.
+    - Commit: `feat(preflight): CLI entrypoint with auditable bypass`
+
+11. **START_TRADER.sh integration.**
+    - Add Step 4.5 block after Python env, before dashboard.
+    - Manual canary per §9.6.
+    - Commit: `feat(start-trader): wire preflight safety gate before runner launch`
+
+12. **CLAUDE.md entry.**
+    - Add row to Common Mistakes table:
+      > "Skipping the preflight safety gate when restarting after an incident | Always run START_TRADER.sh (preflight runs automatically). If it blocks, fix the condition or use `--force "<reason>"`. The gate exists because of the 2026-05-22 4-hour silent livelock. | 2026-05-23"
+    - Commit: `docs(claude-md): document preflight safety gate behavior`
+
+13. **Final integration test + canary.**
+    - End-to-end smoke: trigger each BLOCK condition in turn, verify message and exit code.
+    - Commit: none (canary results recorded in PR description).
+
+Total estimated effort: ~half a day, matching the plan's estimate.
+
+---
+
+## 13. References
+
+- `docs/superpowers/plans/2026-05-23-robust-startup-safety-plan.md` — the motivating plan
+- `docs/superpowers/specs/2026-05-16-persistent-ibkr-connection-design.md` — design spec style precedent
+- `robo_trader/risk/advanced_risk.py:285-619` — KillSwitch class (state, lock, persistence)
+- `robo_trader/runner_async.py:4240-4280` — H1 auto-reset heuristic (do NOT mirror in preflight; see §8)
+- `START_TRADER.sh` — entry point; preflight slots in at the marked location
+- `scripts/gateway_manager.py` — sibling operational tool; CLI shape precedent
+- `data/kill_switch_state.json.bak.2026-05-22-1627` — actual triggered state from the incident, useful as test fixture
+- `CLAUDE.md` "🚨 CRITICAL: NEVER DELETE USER DATA" — informs N1 (preflight does not modify state)
+- `CLAUDE.md` row 2025-12-06 (use lsof, not socket.connect_ex) — informs 7.5 and 7.6
+- `CLAUDE.md` row 2026-05-12 (load watchdog) — adjacent operational concern, referenced in Q11.6

--- a/robo_trader/database.py
+++ b/robo_trader/database.py
@@ -4,15 +4,18 @@ This module provides a synchronous wrapper around the async database.
 """
 
 import asyncio
+import os
 from typing import Any, Dict, List, Optional
 
 from robo_trader.database_async import AsyncTradingDatabase
+
+_DEFAULT_DB_PATH = os.getenv("RT_DB_PATH", "trading_data.db")
 
 
 class TradingDatabase:
     """Synchronous wrapper for AsyncTradingDatabase for backward compatibility."""
 
-    def __init__(self, db_path: str = "trading_data.db"):
+    def __init__(self, db_path: str = _DEFAULT_DB_PATH):
         self.async_db = AsyncTradingDatabase(db_path)
         self._loop = None
         self._initialized = False

--- a/robo_trader/database_async.py
+++ b/robo_trader/database_async.py
@@ -22,7 +22,7 @@ from robo_trader.logger import get_logger
 
 logger = get_logger(__name__)
 
-DB_PATH = Path("trading_data.db")
+DB_PATH = Path(os.getenv("RT_DB_PATH", "trading_data.db"))
 
 # Default portfolio ID for backward compatibility
 DEFAULT_PORTFOLIO_ID = "default"

--- a/robo_trader/database_monitor.py
+++ b/robo_trader/database_monitor.py
@@ -20,11 +20,13 @@ from .logger import get_logger
 
 logger = get_logger(__name__)
 
+_DEFAULT_DB_PATH = os.getenv("RT_DB_PATH", "trading_data.db")
+
 
 class DatabaseMonitor:
     """Monitor database health and manage connections."""
 
-    def __init__(self, db_path: str = "trading_data.db", check_interval: int = 60):
+    def __init__(self, db_path: str = _DEFAULT_DB_PATH, check_interval: int = 60):
         self.db_path = Path(db_path)
         self.check_interval = check_interval
         self.running = False
@@ -300,7 +302,7 @@ class DatabaseMonitor:
 _monitor_instance: Optional[DatabaseMonitor] = None
 
 
-async def start_database_monitor(db_path: str = "trading_data.db", check_interval: int = 60):
+async def start_database_monitor(db_path: str = _DEFAULT_DB_PATH, check_interval: int = 60):
     """Start the global database monitor."""
     global _monitor_instance
 

--- a/robo_trader/market_hours.py
+++ b/robo_trader/market_hours.py
@@ -383,3 +383,58 @@ def seconds_until_market_open() -> int:
 
     delta = next_open - now
     return int(delta.total_seconds())
+
+
+def count_trading_days(start: datetime, end: datetime) -> int:
+    """
+    Count trading days strictly between two datetimes.
+
+    A trading day is any Mon–Fri that is not on the NYSE holiday calendar
+    (see :func:`_is_market_holiday`). Used by the preflight equity-history
+    freshness check to distinguish "data is one day stale" from "data is
+    several trading days stale", so a Monday startup after a Friday close
+    correctly counts as 0 trading days elapsed, not 3.
+
+    The interval is the open–open range ``(start.date(), end.date()]`` —
+    the start day itself is excluded (it's "as of" the snapshot's day) and
+    the end day is included if it is a trading day. Same-day or reversed
+    intervals return 0. Sub-day time-of-day is ignored for the comparison;
+    we work at date granularity because equity_history snapshots are
+    end-of-day.
+
+    Examples
+    --------
+    * Friday → Monday (next): 1 (Monday is the only counted trading day)
+    * Friday → Friday (same day): 0
+    * Monday → Wednesday (next): 2 (Tuesday + Wednesday)
+    * Friday → Friday (one week later): 5 (Mon, Tue, Wed, Thu, Fri)
+    * Wed before Thanksgiving → Friday after: 1 (Thursday is a holiday,
+      so only Friday counts)
+    * end < start: 0 (callers should never see negative)
+
+    Args:
+        start: Earlier datetime (timezone-aware or naive — only the date
+            portion is used).
+        end: Later datetime.
+
+    Returns:
+        Non-negative count of trading days in ``(start.date(), end.date()]``.
+    """
+    start_date = start.date() if isinstance(start, datetime) else start
+    end_date = end.date() if isinstance(end, datetime) else end
+
+    if end_date <= start_date:
+        return 0
+
+    count = 0
+    cursor = start_date + timedelta(days=1)
+    while cursor <= end_date:
+        # Weekend check (Monday=0, Sunday=6)
+        if cursor.weekday() < 5:
+            # Reuse holiday logic; pass through a datetime so the helper's
+            # isinstance(check, datetime) branch is taken consistently.
+            if not _is_market_holiday(datetime(cursor.year, cursor.month, cursor.day)):
+                count += 1
+        cursor += timedelta(days=1)
+
+    return count

--- a/robo_trader/preflight/__init__.py
+++ b/robo_trader/preflight/__init__.py
@@ -1,0 +1,19 @@
+"""Startup safety gate (MVP-1).
+
+A preflight package that runs BEFORE the trading runner spins up. Each
+``Check`` is a small class that inspects one piece of on-disk or process
+state and returns a :class:`CheckResult`. The script ``scripts/preflight_check.py``
+runs them all in parallel and exits with a non-zero code if anything BLOCKs.
+
+The motivating incident (2026-05-22): a hardcoded 2% per-position-loss
+kill switch tripped on a normal NVDA daily move, persisted to disk, and
+every watchdog restart re-loaded ``triggered=True`` — 18 silent failures
+before the human noticed. With this gate, the same condition surfaces as
+a clear, actionable message on the first restart.
+
+Design spec: ``docs/superpowers/specs/2026-05-23-startup-safety-gate-design.md``
+"""
+
+from .result import CheckResult, CheckStatus
+
+__all__ = ["CheckResult", "CheckStatus"]

--- a/robo_trader/preflight/__init__.py
+++ b/robo_trader/preflight/__init__.py
@@ -14,6 +14,7 @@ a clear, actionable message on the first restart.
 Design spec: ``docs/superpowers/specs/2026-05-23-startup-safety-gate-design.md``
 """
 
+from .protocol import Check, PreflightContext
 from .result import CheckResult, CheckStatus
 
-__all__ = ["CheckResult", "CheckStatus"]
+__all__ = ["Check", "CheckResult", "CheckStatus", "PreflightContext"]

--- a/robo_trader/preflight/checks.py
+++ b/robo_trader/preflight/checks.py
@@ -1,0 +1,20 @@
+"""Registry of all preflight checks (spec §5.5).
+
+This module is the single import point the runner reads. Adding a new
+check is one line: import the class, instantiate it, append to
+:data:`ALL_CHECKS`. Checks execute in list order for display, but they
+are otherwise independent — the runner runs them all even if early ones
+fail, so the operator sees every problem at once.
+
+Empty registry is a deliberate Task-#2 state — each check is added by its
+own commit in tasks #3-#8. The empty list still imports cleanly so the
+runner can be scaffolded in parallel.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from .protocol import Check
+
+ALL_CHECKS: List[Check] = []

--- a/robo_trader/preflight/checks.py
+++ b/robo_trader/preflight/checks.py
@@ -6,15 +6,29 @@ check is one line: import the class, instantiate it, append to
 are otherwise independent — the runner runs them all even if early ones
 fail, so the operator sees every problem at once.
 
-Empty registry is a deliberate Task-#2 state — each check is added by its
-own commit in tasks #3-#8. The empty list still imports cleanly so the
-runner can be scaffolded in parallel.
+Display order rationale: kill-switch checks first (most likely cause of
+the 2026-05-22-style livelock), then state-freshness, then config, then
+network-state checks (the latter are most likely to be transient and
+self-resolve on the next launcher attempt).
 """
 
 from __future__ import annotations
 
 from typing import List
 
+from .equity_history_freshness_check import EquityHistoryFreshnessCheck
+from .gateway_port_listening_check import GatewayPortListeningCheck
+from .kill_switch_lock_check import KillSwitchLockCheck
+from .kill_switch_state_check import KillSwitchStateCheck
 from .protocol import Check
+from .risk_threshold_check import RiskThresholdCheck
+from .zombie_connections_check import ZombieConnectionsCheck
 
-ALL_CHECKS: List[Check] = []
+ALL_CHECKS: List[Check] = [
+    KillSwitchStateCheck(),
+    KillSwitchLockCheck(),
+    EquityHistoryFreshnessCheck(),
+    RiskThresholdCheck(),
+    GatewayPortListeningCheck(),
+    ZombieConnectionsCheck(),
+]

--- a/robo_trader/preflight/equity_history_freshness_check.py
+++ b/robo_trader/preflight/equity_history_freshness_check.py
@@ -1,0 +1,195 @@
+"""G2 — EquityHistoryFreshnessCheck.
+
+Verifies that ``trading_data.db`` has a recent ``equity_history`` row.
+Equity snapshots are written at end-of-day for every active portfolio.
+A row that is more than 1 *trading day* old means the system did not
+complete its last expected EOD cycle — usually a sign of an unclean
+shutdown that left positions out of sync with IBKR.
+
+Why trading-day delta, not wall-clock delta
+-------------------------------------------
+A Monday morning startup will legitimately see a Friday row that is
+60+ hours old. Counting wall-clock hours would false-positive every
+Monday and every holiday Tuesday. :func:`count_trading_days` already
+knows the NYSE calendar, so we lean on it.
+
+Decision matrix (spec §7.3)
+---------------------------
+======================================  ======  =================================
+condition                               result  rationale
+======================================  ======  =================================
+``trading_data.db`` missing             BLOCK   system unconfigured
+empty ``equity_history`` table          WARN    first-run; not a livelock
+                                                (per Q11.1 design decision)
+MAX(timestamp) within 1 trading day     PASS    normal startup
+MAX(timestamp) > 1 trading day old      BLOCK   stale; positions may not match
+sqlite read error                       BLOCK   fail-closed
+======================================  ======  =================================
+
+Multi-portfolio note
+--------------------
+``equity_history`` is partitioned by ``portfolio_id``. We take the
+**max timestamp across all portfolios** — if any portfolio is fresh,
+the whole startup passes. This avoids blocking when a disabled
+portfolio hasn't traded in weeks.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from typing import Optional
+
+from robo_trader.market_hours import count_trading_days
+from robo_trader.utils.market_time import get_market_time
+
+from .protocol import PreflightContext
+from .result import CheckResult, CheckStatus
+
+# SQLite stores DATETIME values written via ``CURRENT_TIMESTAMP`` as naive
+# UTC strings in this format (``YYYY-MM-DD HH:MM:SS[.ffffff]``). We parse
+# without assuming a timezone offset, then compare against the date portion
+# of ``get_market_time()`` — :func:`count_trading_days` operates on
+# ``.date()`` so the cross-timezone fuzziness doesn't affect the count.
+_SQLITE_TIMESTAMP_FORMATS = (
+    "%Y-%m-%d %H:%M:%S.%f",
+    "%Y-%m-%d %H:%M:%S",
+    "%Y-%m-%dT%H:%M:%S.%f",
+    "%Y-%m-%dT%H:%M:%S",
+)
+
+
+def _parse_sqlite_timestamp(raw: str) -> Optional[datetime]:
+    """Parse a sqlite ``CURRENT_TIMESTAMP``-style string. Returns None on failure."""
+    for fmt in _SQLITE_TIMESTAMP_FORMATS:
+        try:
+            return datetime.strptime(raw, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+class EquityHistoryFreshnessCheck:
+    """Confirms the latest equity_history row is no more than 1 trading day old."""
+
+    name = "equity_history_freshness"
+    description = "Equity history freshness"
+    timeout_seconds = 3.0
+
+    def run(self, context: PreflightContext) -> CheckResult:
+        db_path = context.project_root / "trading_data.db"
+
+        if not db_path.exists():
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.BLOCK,
+                message=f"trading_data.db not found at {db_path}",
+                remediation=(
+                    "The trading database is missing. This usually means the system "
+                    "has never been started or the data directory was wiped. Run "
+                    "./START_TRADER.sh to initialize, then re-run preflight."
+                ),
+                details={"db_path": str(db_path)},
+            )
+
+        try:
+            max_ts_raw = self._query_max_timestamp(db_path)
+        except sqlite3.Error as exc:
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.BLOCK,
+                message=f"sqlite read error: {exc}",
+                remediation=(
+                    "Could not read equity_history from trading_data.db. The DB may "
+                    "be locked, corrupted, or schema-mismatched. Try "
+                    "`sqlite3 trading_data.db 'PRAGMA integrity_check;'`. If this "
+                    "is a known-good transient (e.g. another process is writing), "
+                    "wait and re-run; otherwise `--force` after investigating."
+                ),
+                details={"db_path": str(db_path), "error": str(exc)},
+            )
+
+        if max_ts_raw is None:
+            # Empty table — first-run case per Q11.1.
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.WARN,
+                message="equity_history is empty (first-run portfolio)",
+                remediation=(
+                    "No equity snapshots have been written yet. This is normal for "
+                    "a brand-new install or a newly-created portfolio. The first "
+                    "successful EOD cycle will populate this table. Not blocking; "
+                    "verify positions manually if you weren't expecting an empty "
+                    "history."
+                ),
+                details={"db_path": str(db_path), "row_count": 0},
+            )
+
+        max_ts = _parse_sqlite_timestamp(max_ts_raw)
+        if max_ts is None:
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.BLOCK,
+                message=f"could not parse equity_history MAX(timestamp)={max_ts_raw!r}",
+                remediation=(
+                    "The most recent equity_history row has a timestamp that "
+                    "doesn't match the expected SQLite CURRENT_TIMESTAMP format. "
+                    "The DB schema may be out of date. Run any pending migrations, "
+                    "or `--force` if you've confirmed positions match IBKR."
+                ),
+                details={"db_path": str(db_path), "raw_timestamp": max_ts_raw},
+            )
+
+        now = get_market_time()
+        trading_days_elapsed = count_trading_days(start=max_ts, end=now)
+
+        details = {
+            "db_path": str(db_path),
+            "max_timestamp": max_ts_raw,
+            "trading_days_elapsed": trading_days_elapsed,
+        }
+
+        if trading_days_elapsed <= 1:
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.PASS,
+                message=(
+                    f"latest equity row at {max_ts_raw} "
+                    f"({trading_days_elapsed} trading day(s) ago)"
+                ),
+                details=details,
+            )
+
+        return CheckResult(
+            name=self.name,
+            status=CheckStatus.BLOCK,
+            message=(
+                f"latest equity row at {max_ts_raw} is " f"{trading_days_elapsed} trading days old"
+            ),
+            remediation=(
+                f"Last equity row is {trading_days_elapsed} trading days old. "
+                "This usually means a prior session died without writing a "
+                "snapshot. Verify positions match IBKR "
+                "(`scripts/reconcile_positions.py`) before resuming, or `--force` "
+                "if you've already confirmed."
+            ),
+            details=details,
+        )
+
+    @staticmethod
+    def _query_max_timestamp(db_path) -> Optional[str]:
+        """Return the freshest ``timestamp`` across all portfolios, or None if empty.
+
+        Opens the DB read-only via the ``file:...?mode=ro`` URI so the check
+        cannot accidentally mutate state — preflight is observation-only
+        (spec §5.7).
+        """
+        uri = f"file:{db_path}?mode=ro"
+        conn = sqlite3.connect(uri, uri=True, timeout=2.0)
+        try:
+            cursor = conn.cursor()
+            cursor.execute("SELECT MAX(timestamp) FROM equity_history")
+            row = cursor.fetchone()
+            return row[0] if row else None
+        finally:
+            conn.close()

--- a/robo_trader/preflight/gateway_port_listening_check.py
+++ b/robo_trader/preflight/gateway_port_listening_check.py
@@ -1,0 +1,133 @@
+"""Gateway API port LISTEN check (spec §7.5, G4).
+
+Why this check exists
+---------------------
+START_TRADER.sh already waits for the Gateway API port to enter LISTEN
+state before launching the runner. But the watchdog can — and does —
+restart ``runner_async.py`` directly without going through START_TRADER.
+In that path, preflight is the first (and only) line of defense against
+"runner started, IBKR Gateway never came up, runner immediately dies in
+a loop." That cycle is one of the silent failure modes the gate exists
+to surface.
+
+The check is intentionally narrow: it reports only whether something is
+listening on the configured port (4002 for paper, 4001 for live). It
+does NOT try to verify the listener is actually IB Gateway, nor does it
+attempt an API handshake. The next layer (the runner's own connect
+call) is responsible for that. Preflight just rules out the trivially
+hopeless case.
+
+Critical implementation constraint
+----------------------------------
+**Use ``subprocess.run(["lsof", ...])``. NEVER use ``socket.connect_ex``.**
+
+Per CLAUDE.md row dated 2025-12-06 (and as called out explicitly in spec
+§7.5): ``socket.connect_ex`` opens a TCP socket which, even when closed
+immediately, leaves a ``CLOSE_WAIT`` zombie connection on the Gateway
+port. That zombie then blocks the *real* ib_insync handshake the runner
+attempts microseconds later. The very failure class this check exists
+to guard against — port-not-actually-available — would be CREATED by a
+naive Python port check.
+
+``lsof`` reads kernel socket tables without opening any new socket and
+is the only safe option. There is no portable Python-API equivalent.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+from .protocol import PreflightContext
+from .result import CheckResult, CheckStatus
+
+
+class GatewayPortListeningCheck:
+    """BLOCK when no process is LISTENing on the configured Gateway port.
+
+    Satisfies :class:`robo_trader.preflight.protocol.Check` structurally.
+
+    The runner enforces ``timeout_seconds`` as a hard wall budget; the
+    inner subprocess timeout (3s, passed to ``subprocess.run``) is the
+    primary defense against an ``lsof`` hang under system load.
+    """
+
+    name = "gateway_port_listening"
+    description = "Gateway port listening"
+    timeout_seconds = 3.0
+
+    def run(self, context: PreflightContext) -> CheckResult:
+        port = context.target_port
+        # NEVER replace this with socket.connect_ex (CLAUDE.md 2025-12-06):
+        # that call leaves a CLOSE_WAIT zombie on the Gateway port which
+        # blocks the runner's subsequent ib.connect() handshake — i.e. it
+        # MANUFACTURES the failure class this check is meant to detect.
+        # lsof reads kernel socket tables without opening a socket.
+        argv = ["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN"]
+        try:
+            result = subprocess.run(
+                argv,
+                capture_output=True,
+                text=True,
+                timeout=3,
+            )
+        except subprocess.TimeoutExpired:
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.BLOCK,
+                message="port check timed out — system likely overloaded",
+                remediation=self._build_remediation(port),
+                details={"port": port, "error": "lsof timeout after 3s"},
+            )
+        except FileNotFoundError:
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.BLOCK,
+                message="lsof not installed — required for safety checks",
+                remediation=(
+                    "The preflight gateway-port check shells out to `lsof`, "
+                    "which is missing on this system. On macOS lsof is part of "
+                    "the base install; on Linux install via your package "
+                    "manager (e.g. `apt install lsof` or `yum install lsof`).\n"
+                    "Without lsof there is no safe way to probe a TCP port "
+                    "without creating a CLOSE_WAIT zombie (see CLAUDE.md "
+                    "2025-12-06 row), so this check fails closed."
+                ),
+                details={"port": port, "error": "lsof binary not found"},
+            )
+
+        # Treat empty stdout the same as non-zero returncode: nothing
+        # is actually LISTENing. lsof returns 1 when no matching socket
+        # exists, but a defensive check against stdout handles the edge
+        # case of a returncode-0 + empty-output combination some lsof
+        # builds produce.
+        if result.returncode == 0 and result.stdout.strip():
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.PASS,
+                message=f"port {port} listening",
+                details={"port": port},
+            )
+
+        return CheckResult(
+            name=self.name,
+            status=CheckStatus.BLOCK,
+            message=f"port {port} not listening",
+            remediation=self._build_remediation(port),
+            details={
+                "port": port,
+                "lsof_returncode": result.returncode,
+                "lsof_stdout": result.stdout.strip(),
+            },
+        )
+
+    def _build_remediation(self, port: int) -> str:
+        return (
+            f"Gateway API port {port} is not listening. Without it the runner "
+            "cannot connect to IBKR and will spin in a restart loop.\n\n"
+            "To bring it up:\n"
+            "  ./scripts/start_gateway.sh\n"
+            "    (or)\n"
+            "  python3 scripts/gateway_manager.py start --paper\n\n"
+            "If 2FA is pending, check your IBKR Mobile app on your phone.\n"
+            "Once Gateway is up, re-run ./START_TRADER.sh."
+        )

--- a/robo_trader/preflight/kill_switch_lock_check.py
+++ b/robo_trader/preflight/kill_switch_lock_check.py
@@ -1,0 +1,74 @@
+"""Block startup when ``data/kill_switch.lock`` is present (spec §7.2).
+
+Why this check exists
+---------------------
+``data/kill_switch.lock`` is the deny-by-default fail-closed signal called
+out in the plan. :class:`robo_trader.risk.KillSwitch` already treats the
+lock's presence as triggered (``R2-M2``), but the lock can exist
+independently of the JSON state file — for example, an operator may have
+created it manually to force a stop. Surfacing it during preflight gives
+the operator an actionable message ("remove the lock") rather than
+letting the runner spin up and immediately die.
+
+The lock check and the state check (§7.1) are intentionally separate:
+both BLOCKs may fire on the same startup, and that's fine — the
+remediation actions differ, so the operator wants both messages.
+
+Symlink semantics
+-----------------
+We use :meth:`pathlib.Path.is_file`, which *follows* symlinks. That
+matches :class:`KillSwitch._load_persisted_state` and gives sensible
+behavior for operators who symlink the lock into a shared location:
+
+- symlink pointing at an existing file → BLOCK (lock is effectively present)
+- symlink whose target is missing (broken symlink) → PASS
+  (``is_file`` returns ``False`` for broken symlinks; the runner would
+  see the same "no lock" state, so preflight must agree)
+"""
+
+from __future__ import annotations
+
+from .protocol import PreflightContext
+from .result import CheckResult, CheckStatus
+
+
+class KillSwitchLockCheck:
+    """Preflight check for ``data/kill_switch.lock``.
+
+    Satisfies :class:`robo_trader.preflight.protocol.Check` structurally.
+    """
+
+    name = "kill_switch_lock"
+    description = "Kill switch lock file"
+    timeout_seconds = 1.0
+
+    def run(self, context: PreflightContext) -> CheckResult:
+        lock_path = context.project_root / "data" / "kill_switch.lock"
+
+        # Path.is_file() follows symlinks: a symlink to a real file is
+        # "present"; a broken symlink reports False. Matches the runtime
+        # KillSwitch behavior so preflight and runner agree.
+        if not lock_path.is_file():
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.PASS,
+                message="no lock file",
+                details={"lock_path": str(lock_path)},
+            )
+
+        remediation = (
+            "Kill switch lock file present. This is a deny-by-default safety "
+            "signal — the runner will refuse to trade while it exists.\n"
+            "Either:\n"
+            f"  - Remove the lock: rm {lock_path} "
+            "(after confirming nothing intentionally placed it)\n"
+            '  - Or proceed with: scripts/preflight_check.py --force "reason"'
+        )
+
+        return CheckResult(
+            name=self.name,
+            status=CheckStatus.BLOCK,
+            message=f"lock file present at {lock_path}",
+            remediation=remediation,
+            details={"lock_path": str(lock_path)},
+        )

--- a/robo_trader/preflight/kill_switch_state_check.py
+++ b/robo_trader/preflight/kill_switch_state_check.py
@@ -1,0 +1,129 @@
+"""Kill-switch persisted state check (spec §7.1, G1).
+
+This is the check that would have prevented the 2026-05-22 4-hour silent
+livelock. The ``KillSwitch`` class persists ``triggered=True`` to
+``data/kill_switch_state.json`` once a per-position loss limit fires;
+every subsequent runner load reads that state and refuses to trade. The
+runtime side of that is correct behavior (we don't want auto-reset on
+loss-based trips). What was missing was operator visibility: the
+watchdog kept restarting, the runner kept dying within seconds, and
+nothing told the human "you have a persisted kill switch — clear it or
+raise the threshold."
+
+This check surfaces that condition before the runner even calls
+``connect()``: file missing or ``triggered=False`` → PASS; everything
+else (triggered, corrupt JSON, unreadable) → BLOCK with remediation that
+names the file, the trigger reason, and the exact commands to back it up
+and clear it.
+
+The check is **read-only by design** (spec §5.7, N1). It never modifies
+the state file. The H1 in-flight auto-reset heuristic in
+``runner_async.py`` is deliberately NOT mirrored here — see spec §8 for
+the full justification, but in short: H1 has direct evidence that
+``recover_connection`` succeeded; preflight runs before any connection
+attempt and has no such evidence. The bypass is ``--force "<reason>"``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .protocol import PreflightContext
+from .result import CheckResult, CheckStatus
+
+
+class KillSwitchStateCheck:
+    """BLOCK if ``data/kill_switch_state.json`` shows ``triggered=True``.
+
+    Fail-closed on parse / read errors — matches the KillSwitch class's
+    own behavior in ``_load_persisted_state``. A corrupt state file is
+    treated as "we cannot prove the switch is safe to ignore," so we
+    refuse to proceed.
+    """
+
+    name = "kill_switch_state"
+    description = "Kill switch persisted state"
+    timeout_seconds = 1.0
+
+    def run(self, context: PreflightContext) -> CheckResult:
+        path = context.project_root / "data" / "kill_switch_state.json"
+
+        if not path.exists():
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.PASS,
+                message="no triggered state",
+                details={"state_path": str(path), "exists": False},
+            )
+
+        try:
+            payload = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError) as exc:
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.BLOCK,
+                message=f"state file unreadable ({exc.__class__.__name__})",
+                remediation=(
+                    "Kill switch state file is corrupt. Fail-closed policy "
+                    "blocks startup.\n"
+                    f"  Inspect:   cat {path}\n"
+                    f"  Backup:    cp {path} {path}.bak.$(date +%Y-%m-%d-%H%M)\n"
+                    f"  Clear:     rm {path}\n"
+                    "  Then re-run ./START_TRADER.sh"
+                ),
+                details={"state_path": str(path), "error": str(exc)},
+            )
+
+        if not payload.get("triggered"):
+            details = {
+                "state_path": str(path),
+                "exists": True,
+                "triggered": False,
+            }
+            previous = payload.get("previous_trigger_reason")
+            if previous is not None:
+                details["previous_trigger_reason"] = previous
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.PASS,
+                message="no triggered state",
+                details=details,
+            )
+
+        reason = payload.get("trigger_reason", "unknown")
+        trigger_time = payload.get("trigger_time", "unknown")
+        return CheckResult(
+            name=self.name,
+            status=CheckStatus.BLOCK,
+            message=f"triggered=True since {trigger_time}",
+            remediation=self._build_remediation(path, reason, trigger_time),
+            details={
+                "state_path": str(path),
+                "trigger_reason": reason,
+                "trigger_time": trigger_time,
+            },
+        )
+
+    def _build_remediation(self, path: Path, reason: str, trigger_time: str) -> str:
+        # Escape embedded double-quotes so the remediation text (which
+        # wraps the reason in quotes for display) doesn't render with a
+        # broken quote and confuse the operator at 3am.
+        safe_reason = str(reason).replace('"', '\\"')
+        return (
+            f"Kill switch is triggered.\n\n"
+            f'Trigger reason: "{safe_reason}"\n'
+            f"Triggered at:   {trigger_time}\n"
+            f"State file:     {path}\n\n"
+            "What to do:\n"
+            "  1. Decide if the loss-trigger is still relevant.\n"
+            "     - If a real loss event: review positions before clearing.\n"
+            "     - If a stale trip from a transient issue: clear it.\n"
+            "  2. To clear (DESTRUCTIVE — review first):\n"
+            f"       cp {path} {path}.bak.$(date +%Y-%m-%d-%H%M)\n"
+            f"       rm {path} data/kill_switch.lock\n"
+            "  3. Re-run: ./START_TRADER.sh\n\n"
+            "To proceed anyway (NOT recommended without step 1):\n"
+            '  python3 scripts/preflight_check.py --force "<your reason here>"\n'
+            "  then re-run ./START_TRADER.sh"
+        )

--- a/robo_trader/preflight/protocol.py
+++ b/robo_trader/preflight/protocol.py
@@ -1,0 +1,117 @@
+"""Check protocol + shared context for the preflight runner.
+
+Every check implements the :class:`Check` Protocol. The runner instantiates
+each check, builds a single :class:`PreflightContext`, and calls
+``run(context)`` in parallel.
+
+Design notes
+------------
+- The Protocol is structural (PEP 544): checks don't need to inherit from a
+  base class, just satisfy the shape. Keeps test doubles small.
+- ``PreflightContext`` carries everything a check needs to inspect state.
+  Resolving env once (in the script) and passing it down avoids the
+  ``os.getenv`` lookup race where two checks see different env states.
+- ``PreflightContext.for_test(tmp_path)`` is the test factory referenced
+  in spec §9.3 — keeps test setup boilerplate minimal.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Mapping, Protocol
+
+if TYPE_CHECKING:
+    from .result import CheckResult
+
+
+@dataclass(frozen=True)
+class PreflightContext:
+    """Shared inputs passed to every check.
+
+    Attributes
+    ----------
+    project_root
+        Absolute path to the repo root. Checks resolve state file paths
+        relative to this (e.g. ``project_root / "data" / "kill_switch_state.json"``)
+        so tests can swap in a ``tmp_path``.
+    env
+        Frozen snapshot of the resolved environment (``.env`` + shell).
+        Pass to checks instead of having them call ``os.getenv`` directly
+        — keeps the test fixtures hermetic.
+    target_port
+        Gateway port to inspect: 4002 paper (default), 4001 live.
+        Derived from ``EXECUTION_MODE`` env var by the script.
+    dry_run
+        When True, checks may skip expensive operations and just report
+        what they *would* check. Not currently used by any check — reserved
+        for a future ``preflight_check.py --dry-run`` flag.
+    """
+
+    project_root: Path
+    env: Mapping[str, str]
+    target_port: int = 4002
+    dry_run: bool = False
+
+    @classmethod
+    def for_test(
+        cls,
+        tmp_path: Path,
+        env: Mapping[str, str] | None = None,
+        target_port: int = 4002,
+    ) -> "PreflightContext":
+        """Test factory — see spec §9.3.
+
+        Creates ``tmp_path / "data"`` so checks that read from
+        ``project_root / "data" / ...`` can write fixtures into it. Uses
+        an empty env dict by default; tests inject what they need.
+        """
+        (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+        return cls(
+            project_root=tmp_path,
+            env=dict(env or {}),
+            target_port=target_port,
+            dry_run=False,
+        )
+
+
+class Check(Protocol):
+    """Structural protocol every preflight check must satisfy.
+
+    Implementations live in ``robo_trader/preflight/<name>_check.py`` and
+    are listed in :data:`robo_trader.preflight.checks.ALL_CHECKS`.
+
+    Why a Protocol, not an ABC: checks need zero shared behavior. A
+    Protocol lets test doubles be three-line classes (or even dataclasses
+    with a callable ``run``) without inheriting machinery.
+    """
+
+    name: str
+    """Stable identifier (kebab/snake-case), e.g. ``"kill_switch_state"``.
+    Used as the JSON-output key and for grep-friendly log lines.
+    """
+
+    description: str
+    """Human label shown in plaintext output, e.g. ``"Kill switch state"``."""
+
+    timeout_seconds: float
+    """Soft per-check budget (G8 in spec). The runner enforces this with
+    a future to allow killing a runaway check without blocking siblings.
+    Most checks set 1-3s; lsof-based checks set 3s; the total budget
+    across all checks is 5s wall-clock.
+    """
+
+    def run(self, context: PreflightContext) -> "CheckResult":
+        """Return the result of inspecting this aspect of the system.
+
+        Must NOT (per spec §5.7):
+        - Modify any file
+        - Send a network packet (use ``lsof`` for local kernel state)
+        - Spawn any long-lived process
+        - Read secrets out of env (we only check threshold values)
+
+        Should raise rather than return a malformed result if something
+        truly unexpected happens — the runner catches all exceptions and
+        synthesizes a BLOCK result with the traceback in ``details``.
+        """
+        ...

--- a/robo_trader/preflight/result.py
+++ b/robo_trader/preflight/result.py
@@ -1,0 +1,79 @@
+"""Immutable result type for preflight checks.
+
+Each :class:`~robo_trader.preflight.protocol.Check` returns a
+:class:`CheckResult`. The runner aggregates results and decides exit code
+based on the worst severity seen.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any, Dict
+
+
+class CheckStatus(Enum):
+    """Severity tiers (spec §5.6).
+
+    - ``PASS``  — the check found no issue.
+    - ``WARN``  — found something the operator should know but not a blocker.
+    - ``BLOCK`` — found something that should prevent startup until resolved.
+
+    ``REQUIRE_CONFIRM`` was considered and rejected (the runner can be
+    invoked from the watchdog at 3am with no human at the keyboard; an
+    interactive prompt becomes a hang). The bypass mechanism in
+    ``scripts/preflight_check.py --force "reason"`` is the right knob for
+    "I know about this block and I'm proceeding anyway."
+    """
+
+    PASS = "PASS"
+    WARN = "WARN"
+    BLOCK = "BLOCK"
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """The result of running a single :class:`Check`.
+
+    Frozen so a result can be passed around the runner without anyone
+    accidentally mutating its severity mid-flight. Tests rely on
+    frozen-ness to assert immutability invariants.
+
+    Attributes
+    ----------
+    name
+        Stable identifier (kebab-case), e.g. ``"kill_switch_state"``.
+        Used as the JSON-output dict key and for grep-friendly logging.
+    status
+        One of :class:`CheckStatus`.
+    message
+        One-line summary for human display next to the status badge.
+    remediation
+        Operator instructions, multiline OK. Shown indented below the
+        message in plaintext output; exposed as a separate key in JSON
+        output for downstream tooling.
+    details
+        Machine-readable extras (file paths, threshold values, port
+        numbers). Stays out of the human display unless ``--verbose`` is
+        set, always present in JSON output.
+    duration_ms
+        Populated by the runner; left as 0 by the check itself.
+    """
+
+    name: str
+    status: CheckStatus
+    message: str
+    remediation: str = ""
+    details: Dict[str, Any] = field(default_factory=dict)
+    duration_ms: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize for JSON output.
+
+        Returns a plain dict with the enum collapsed to its string value
+        so the result round-trips through ``json.dumps`` without a custom
+        encoder.
+        """
+        payload = asdict(self)
+        payload["status"] = self.status.value
+        return payload

--- a/robo_trader/preflight/risk_threshold_check.py
+++ b/robo_trader/preflight/risk_threshold_check.py
@@ -1,0 +1,169 @@
+"""Surface ``RISK_MAX_POSITION_LOSS_PCT`` at startup (spec §7.4).
+
+Why this check exists
+---------------------
+The 2026-05-22 incident's root cause was a hardcoded ``max_position_loss_pct``
+of 2%, which tripped on a normal NVDA intraday move and silently persisted
+across 18 watchdog restarts. Commit ``baadd26`` raised the default to 5% and
+made the value env-overridable (``RISK_MAX_POSITION_LOSS_PCT``). This check
+catches the regression case where a stale ``.env`` overrides it back to a
+suspicious value — i.e. the operator's safety net is now mostly cosmetic
+without it.
+
+Two tiers, intentional
+----------------------
+The spec uses a two-tier decision so a tight-but-defensible value (e.g.
+0.018 for a very-low-vol strategy) warns rather than blocks, while an
+almost-certainly-typo value (e.g. 0.005) hard-blocks:
+
+- ``< 0.01`` → BLOCK ("almost any intraday move will trip the kill switch")
+- ``< 0.02`` → WARN  ("below the 2% recommended floor")
+- ``>= 0.02`` → PASS
+
+A negative value (e.g. ``-0.05`` from a copy/paste error) also flows into
+the BLOCK branch — it's strictly less than 0.01.
+
+What this check does NOT do
+---------------------------
+- It does not reject values *above* 0.10. The ``RiskConfig`` Pydantic
+  validator (`config.py` lines 105-110) already rejects with ``le=0.10``
+  when the runner actually loads, and that's the right place for it.
+  Preflight's job here is to catch *low* values that would trip the kill
+  switch on noise — not to duplicate the schema validation.
+- It does not read ``os.environ`` directly. The env is passed through
+  :class:`PreflightContext` so the runner resolves it once and every
+  check sees the same snapshot (avoids the env-mutation race called out
+  in ``protocol.py``).
+
+# TODO(Q11.5): Multi-portfolio per-portfolio ``max_position_pct`` overrides
+# are out of scope for MVP-1. A portfolio that overrides to a dangerous
+# value won't be caught by this check — it only sees the global env var.
+# See spec §11 Q11.5 (Acknowledged gap; separate work item).
+"""
+
+from __future__ import annotations
+
+from .protocol import PreflightContext
+from .result import CheckResult, CheckStatus
+
+# Constants pulled out so tests and remediation strings reference the same
+# numbers. Changing these is a policy decision; bump the spec too.
+ENV_VAR = "RISK_MAX_POSITION_LOSS_PCT"
+BLOCK_THRESHOLD = 0.01
+WARN_THRESHOLD = 0.02
+CODE_DEFAULT = 0.05  # matches RiskConfig.max_position_loss_pct default
+
+
+class RiskThresholdCheck:
+    """Preflight check for ``RISK_MAX_POSITION_LOSS_PCT`` env override.
+
+    Satisfies :class:`robo_trader.preflight.protocol.Check` structurally.
+    """
+
+    name = "risk_threshold"
+    description = "Risk thresholds"
+    timeout_seconds = 0.5
+
+    def run(self, context: PreflightContext) -> CheckResult:
+        raw = context.env.get(ENV_VAR)
+
+        # Not set is the common, healthy case — RiskConfig will apply its
+        # 0.05 default. Surface that explicitly so operators reading the
+        # output don't wonder "did it skip this check?"
+        if raw is None:
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.PASS,
+                message=f"{ENV_VAR} unset; using code default {CODE_DEFAULT}",
+                details={
+                    "env_var": ENV_VAR,
+                    "value": None,
+                    "code_default": CODE_DEFAULT,
+                    "warn_threshold": WARN_THRESHOLD,
+                    "block_threshold": BLOCK_THRESHOLD,
+                },
+            )
+
+        # An empty string is "set but holds no value" — treat as unparseable
+        # rather than equivalent to unset. Operators who want the default
+        # should remove the line; a literal `RISK_MAX_POSITION_LOSS_PCT=`
+        # is a config-authoring bug worth flagging.
+        try:
+            value = float(raw)
+        except ValueError:
+            remediation = (
+                f"{ENV_VAR}={raw!r} is not a number. Config corrupt — preflight cannot "
+                "evaluate the per-position loss threshold.\n"
+                "Either:\n"
+                f"  - Remove the {ENV_VAR} line from `.env` to use the default "
+                f"{CODE_DEFAULT}\n"
+                f"  - Or set it to a valid float (e.g. {ENV_VAR}={CODE_DEFAULT})"
+            )
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.BLOCK,
+                message=f"{ENV_VAR}={raw!r} unparseable (config corrupt)",
+                remediation=remediation,
+                details={
+                    "env_var": ENV_VAR,
+                    "raw_value": raw,
+                    "parse_error": True,
+                },
+            )
+
+        if value < BLOCK_THRESHOLD:
+            remediation = (
+                f"{ENV_VAR}={value} is below 1%. Almost any intraday move will trip "
+                "the kill switch.\n"
+                "Either:\n"
+                f"  - Remove the line from `.env` to use the default {CODE_DEFAULT}\n"
+                f"  - Or set to a realistic value (>= {WARN_THRESHOLD})\n"
+                '  - To proceed with this value anyway, use --force "reason"'
+            )
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.BLOCK,
+                message=f"{ENV_VAR}={value} < {BLOCK_THRESHOLD}",
+                remediation=remediation,
+                details={
+                    "env_var": ENV_VAR,
+                    "value": value,
+                    "warn_threshold": WARN_THRESHOLD,
+                    "block_threshold": BLOCK_THRESHOLD,
+                },
+            )
+
+        if value < WARN_THRESHOLD:
+            remediation = (
+                f"{ENV_VAR}={value} is below the 2% recommended floor. A normal "
+                "daily move on a volatile stock can trip the kill switch at this "
+                "level (see 2026-05-22 NVDA incident). Consider raising. Not "
+                "blocking."
+            )
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.WARN,
+                message=f"{ENV_VAR}={value} (<{WARN_THRESHOLD})",
+                remediation=remediation,
+                details={
+                    "env_var": ENV_VAR,
+                    "value": value,
+                    "warn_threshold": WARN_THRESHOLD,
+                    "block_threshold": BLOCK_THRESHOLD,
+                },
+            )
+
+        # value >= WARN_THRESHOLD — the healthy case. Includes values above
+        # 0.10 (RiskConfig will reject those when the runner loads; not
+        # preflight's job to duplicate the schema ceiling).
+        return CheckResult(
+            name=self.name,
+            status=CheckStatus.PASS,
+            message=f"{ENV_VAR}={value}",
+            details={
+                "env_var": ENV_VAR,
+                "value": value,
+                "warn_threshold": WARN_THRESHOLD,
+                "block_threshold": BLOCK_THRESHOLD,
+            },
+        )

--- a/robo_trader/preflight/runner.py
+++ b/robo_trader/preflight/runner.py
@@ -1,0 +1,300 @@
+"""Parallel preflight check runner with plaintext + JSON output.
+
+Coordinates execution of the registered :data:`~robo_trader.preflight.checks.ALL_CHECKS`,
+enforces per-check timeouts via ``future.result(timeout=...)``, and
+synthesizes BLOCK results for any check that times out or raises.
+
+Threading model
+---------------
+``ThreadPoolExecutor(max_workers=6)``. Checks are pure functions over a
+frozen :class:`PreflightContext` — no shared mutable state — so thread
+safety is structural, not requiring locks.
+
+Output
+------
+Two formatters: :func:`format_plaintext` (the 3am-page operator view)
+and :func:`format_json` (for downstream tooling and Phase 2 health
+endpoint). Both consume a :class:`RunReport`.
+
+Exit code
+---------
+Pulled off ``report.exit_code``:
+
+- ``0`` if all checks PASS or WARN
+- ``1`` if any check BLOCKs
+- ``2`` reserved for the CLI script's ``--force`` bypass path
+- ``3`` reserved for "preflight itself failed" (handled in CLI)
+
+The runner returns the report; the script translates to exit codes per §5.2.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import time
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as _FutureTimeout
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence
+
+from .protocol import Check, PreflightContext
+from .result import CheckResult, CheckStatus
+
+
+@dataclass(frozen=True)
+class RunReport:
+    """Aggregated result of running every check in :data:`ALL_CHECKS`.
+
+    Frozen for the same reason as :class:`CheckResult` — the CLI script
+    consumes this without worrying about late mutation by formatters.
+    """
+
+    started_at: _dt.datetime
+    completed_at: _dt.datetime
+    results: List[CheckResult]
+    context: PreflightContext = field(repr=False)
+
+    @property
+    def duration_ms(self) -> int:
+        return int((self.completed_at - self.started_at).total_seconds() * 1000)
+
+    @property
+    def passed(self) -> List[CheckResult]:
+        return [r for r in self.results if r.status is CheckStatus.PASS]
+
+    @property
+    def warned(self) -> List[CheckResult]:
+        return [r for r in self.results if r.status is CheckStatus.WARN]
+
+    @property
+    def blocked(self) -> List[CheckResult]:
+        return [r for r in self.results if r.status is CheckStatus.BLOCK]
+
+    @property
+    def exit_code(self) -> int:
+        """``0`` if all PASS/WARN, ``1`` if any BLOCKs.
+
+        The ``--force`` bypass path is handled by the CLI script, not
+        here — this property reflects the raw check outcome.
+        """
+        return 1 if self.blocked else 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "version": 1,
+            "started_at": self.started_at.isoformat(),
+            "completed_at": self.completed_at.isoformat(),
+            "duration_ms": self.duration_ms,
+            "exit_code": self.exit_code,
+            "summary": {
+                "total": len(self.results),
+                "passed": len(self.passed),
+                "warned": len(self.warned),
+                "blocked": len(self.blocked),
+            },
+            "checks": [r.to_dict() for r in self.results],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Execution
+# ---------------------------------------------------------------------------
+
+
+def run_all_checks(
+    context: PreflightContext,
+    checks: Optional[Sequence[Check]] = None,
+    max_workers: int = 6,
+) -> RunReport:
+    """Run every check in parallel and aggregate results.
+
+    Parameters
+    ----------
+    context
+        Shared context passed to every check.
+    checks
+        Sequence of checks to run. Defaults to :data:`ALL_CHECKS` (resolved
+        lazily so tests can pass an empty list or a subset without
+        importing the full registry).
+    max_workers
+        Thread pool size. Defaults to 6 (matches MVP-1's six checks).
+
+    Returns
+    -------
+    A :class:`RunReport` with one :class:`CheckResult` per check, in the
+    same order as ``checks``.
+    """
+    if checks is None:
+        # Lazy import so tests can construct a RunReport without importing
+        # the heavy concrete check classes.
+        from .checks import ALL_CHECKS
+
+        checks = ALL_CHECKS
+
+    started_at = _dt.datetime.now().astimezone()
+
+    # Submit every check, then collect by index so display order matches
+    # registry order regardless of completion order.
+    results_by_index: Dict[int, CheckResult] = {}
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        future_to_index = {
+            pool.submit(_run_one, check, context): idx for idx, check in enumerate(checks)
+        }
+        for future, idx in future_to_index.items():
+            check = checks[idx]
+            try:
+                results_by_index[idx] = future.result(timeout=check.timeout_seconds)
+            except _FutureTimeout:
+                results_by_index[idx] = CheckResult(
+                    name=getattr(check, "name", f"check_{idx}"),
+                    status=CheckStatus.BLOCK,
+                    message=f"check exceeded {check.timeout_seconds}s timeout",
+                    remediation=(
+                        f"The {getattr(check, 'name', 'check')} check did not return "
+                        f"within its {check.timeout_seconds}s budget. This usually "
+                        "indicates a degraded subprocess (lsof hang) or a stuck I/O "
+                        "operation. Investigate before re-running."
+                    ),
+                    details={"timeout_seconds": check.timeout_seconds},
+                    duration_ms=int(check.timeout_seconds * 1000),
+                )
+            except BaseException as exc:  # noqa: BLE001 — boundary handler
+                # Per spec §5.4: checks "should raise rather than return a
+                # malformed result"; the runner wraps unexpected exceptions
+                # in a BLOCK with the exception info. Code 3 (preflight
+                # itself failed) is reserved for things like ImportError at
+                # module-load — not per-check failures.
+                results_by_index[idx] = CheckResult(
+                    name=getattr(check, "name", f"check_{idx}"),
+                    status=CheckStatus.BLOCK,
+                    message=f"check raised {exc.__class__.__name__}: {exc}",
+                    remediation=(
+                        "An unexpected exception escaped the check. Likely a bug — "
+                        "report with the JSON output from --json mode."
+                    ),
+                    details={
+                        "exception_type": exc.__class__.__name__,
+                        "exception_message": str(exc),
+                    },
+                )
+
+    completed_at = _dt.datetime.now().astimezone()
+    ordered = [results_by_index[i] for i in range(len(checks))]
+    return RunReport(
+        started_at=started_at,
+        completed_at=completed_at,
+        results=ordered,
+        context=context,
+    )
+
+
+def _run_one(check: Check, context: PreflightContext) -> CheckResult:
+    """Invoke one check and stamp its ``duration_ms``.
+
+    The check itself leaves ``duration_ms=0`` (the dataclass default);
+    the runner replaces it with the measured wall-clock elapsed so
+    timings are authoritative.
+    """
+    start = time.monotonic()
+    result = check.run(context)
+    elapsed_ms = int((time.monotonic() - start) * 1000)
+    # CheckResult is frozen — build a copy with duration filled in.
+    return CheckResult(
+        name=result.name,
+        status=result.status,
+        message=result.message,
+        remediation=result.remediation,
+        details=result.details,
+        duration_ms=elapsed_ms,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Output formatters
+# ---------------------------------------------------------------------------
+
+_STATUS_BADGE = {
+    CheckStatus.PASS: "[PASS]",
+    CheckStatus.WARN: "[WARN]",
+    CheckStatus.BLOCK: "[BLOCK]",
+}
+
+
+def format_plaintext(report: RunReport, *, verbose: bool = False) -> str:
+    """Render a 3am-page-friendly summary + boxed remediation blocks.
+
+    Format mirrors spec §6.4.1–§6.4.3 exactly.
+    """
+    n = len(report.results)
+    name_width = max((len(r.name) for r in report.results), default=20)
+    name_width = max(name_width, 20)
+    msg_width = max((len(r.message) for r in report.results), default=40)
+
+    lines: List[str] = []
+    lines.append(f"Preflight Safety Gate — checking {n} conditions")
+    lines.append("─" * 60)
+    for r in report.results:
+        badge = _STATUS_BADGE[r.status]
+        # uniform-width badge column so columns align
+        lines.append(
+            f"{badge:<7} {r.name:<{name_width}}  {r.message:<{msg_width}}  ({r.duration_ms}ms)"
+        )
+    lines.append("─" * 60)
+
+    n_blocked = len(report.blocked)
+    n_warned = len(report.warned)
+    if n_blocked:
+        lines.append(f"{n_blocked}/{n} checks BLOCKED. Cannot proceed.")
+    elif n_warned:
+        lines.append(f"{n}/{n} checks passed ({n_warned} with warnings). Safe to proceed.")
+    else:
+        lines.append(f"{n}/{n} checks passed. Safe to proceed.")
+
+    # Boxed remediation per BLOCK
+    for idx, r in enumerate(report.blocked, start=1):
+        lines.append("")
+        lines.extend(_box(f"BLOCK #{idx} — {r.name}", r.remediation or r.message))
+
+    # Indented WARN footer
+    for r in report.warned:
+        lines.append("")
+        lines.append(f"⚠ WARN — {r.name}")
+        for ln in (r.remediation or r.message).splitlines():
+            lines.append(f"  {ln}")
+        lines.append("  Not blocking — proceeding.")
+
+    if verbose:
+        lines.append("")
+        lines.append("--- details ---")
+        for r in report.results:
+            if r.details:
+                lines.append(f"{r.name}: {json.dumps(r.details, default=str)}")
+
+    return "\n".join(lines) + "\n"
+
+
+def format_json(report: RunReport) -> str:
+    """Render the run as a single JSON object suitable for piping."""
+    return json.dumps(report.to_dict(), indent=2, default=str) + "\n"
+
+
+def _box(title: str, body: str, width: int = 72) -> List[str]:
+    """Render a unicode-bordered box for a BLOCK remediation block."""
+    inner = width - 2
+    top = "╔" + "═" * inner + "╗"
+    mid = "╠" + "═" * inner + "╣"
+    bot = "╚" + "═" * inner + "╝"
+
+    def _row(s: str) -> str:
+        # Pad/truncate so the right border lines up. Truncate long lines
+        # with an ellipsis rather than wrap, to keep the box readable in
+        # narrow terminals.
+        if len(s) > inner - 2:
+            s = s[: inner - 3] + "…"
+        return "║ " + s.ljust(inner - 2) + " ║"
+
+    out: List[str] = [top, _row(title), mid]
+    for ln in body.splitlines():
+        out.append(_row(ln))
+    out.append(bot)
+    return out

--- a/robo_trader/preflight/zombie_connections_check.py
+++ b/robo_trader/preflight/zombie_connections_check.py
@@ -1,0 +1,188 @@
+"""Zombie (CLOSE_WAIT) connection check on the Gateway port (spec §7.6, G5).
+
+Why this check exists
+---------------------
+A ``CLOSE_WAIT`` connection sitting on the Gateway API port will block
+the runner's next ``ib.connect()`` handshake. The handshake times out
+with a cryptic error several seconds in, the runner dies, the watchdog
+restarts it, the zombie is still there, and the loop repeats — exactly
+the "looks healthy enough to fool monitoring" failure pattern the
+preflight gate exists to surface.
+
+START_TRADER.sh already runs a zombie sweep as part of its boot
+sequence, but preflight verifies it *took*. The watchdog can also
+launch ``runner_async.py`` directly without going through START_TRADER,
+so this check is the only line of defense in that path.
+
+Critical implementation constraint
+----------------------------------
+**Use ``subprocess.run(["lsof", ...])``. NEVER use ``socket.connect_ex``.**
+
+Per CLAUDE.md row 2025-12-06: ``socket.connect_ex`` opens a real socket
+which, even when immediately closed, leaves a fresh ``CLOSE_WAIT``
+zombie on the port — i.e. a naive Python probe would *create* the
+exact failure class this check exists to detect. ``lsof`` reads
+kernel socket tables without opening any socket.
+
+Why both Python-zombie AND Gateway-zombie remediation paths
+-----------------------------------------------------------
+Spec §7.6: zombies come from two sources.
+
+- A prior Python process (runner, sweep script) that opened a socket
+  and exited without ``close()`` — these clear with
+  ``python3 scripts/gateway_manager.py clear-zombies``.
+- The Gateway itself holding stale half-open sockets — these only
+  clear with a full Gateway restart
+  (``python3 scripts/gateway_manager.py restart``).
+
+We can't tell the two apart from ``lsof`` output alone (the owning PID
+in column 2 distinguishes them, but the operator-actionable answer is
+"try the cheap option first, then the expensive one"), so the
+remediation lists both in order of escalating cost.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import List
+
+from .protocol import PreflightContext
+from .result import CheckResult, CheckStatus
+
+
+class ZombieConnectionsCheck:
+    """BLOCK when any ``CLOSE_WAIT`` connection is present on the Gateway port.
+
+    Satisfies :class:`robo_trader.preflight.protocol.Check` structurally.
+
+    The runner enforces ``timeout_seconds`` as a hard wall budget; the
+    inner subprocess timeout (3s, passed to ``subprocess.run``) is the
+    primary defense against an ``lsof`` hang under system load.
+    """
+
+    name = "zombie_connections"
+    description = "Zombie connections"
+    timeout_seconds = 3.0
+
+    def run(self, context: PreflightContext) -> CheckResult:
+        port = context.target_port
+        # NEVER replace this with socket.connect_ex (CLAUDE.md 2025-12-06):
+        # that call leaves a CLOSE_WAIT zombie on the Gateway port — i.e.
+        # it would MANUFACTURE the failure class this check is meant to
+        # detect. lsof reads kernel socket tables without opening a socket.
+        argv = ["lsof", "-nP", f"-iTCP:{port}", "-sTCP:CLOSE_WAIT"]
+        try:
+            result = subprocess.run(
+                argv,
+                capture_output=True,
+                text=True,
+                timeout=3,
+            )
+        except subprocess.TimeoutExpired:
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.BLOCK,
+                message="zombie check timed out — system likely overloaded",
+                remediation=self._build_remediation(port, count=None),
+                details={"port": port, "error": "lsof timeout after 3s"},
+            )
+        except FileNotFoundError:
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.BLOCK,
+                message="lsof not installed — required for safety checks",
+                remediation=(
+                    "The preflight zombie-connections check shells out to "
+                    "`lsof`, which is missing on this system. On macOS lsof "
+                    "is part of the base install; on Linux install via your "
+                    "package manager (e.g. `apt install lsof` or "
+                    "`yum install lsof`).\n"
+                    "Without lsof there is no safe way to enumerate stale "
+                    "CLOSE_WAIT sockets without creating new zombies (see "
+                    "CLAUDE.md 2025-12-06 row), so this check fails closed."
+                ),
+                details={"port": port, "error": "lsof binary not found"},
+            )
+
+        # lsof exit-code semantics on macOS (verified 2026-05-24):
+        #   no matches    → returncode 1, stdout empty   → PASS (normal case)
+        #   matches found → returncode 0, stdout has hdr + rows → BLOCK
+        # Any other (returncode, stdout) combination is ambiguous; we
+        # treat it as PASS but stash the exit code in details so future
+        # debugging has the breadcrumb (per task brief).
+        stdout = result.stdout or ""
+        zombie_pids = _parse_zombie_pids(stdout)
+        if zombie_pids:
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.BLOCK,
+                message=(
+                    f"{len(zombie_pids)} zombie connection"
+                    f"{'s' if len(zombie_pids) != 1 else ''} on port {port}"
+                ),
+                remediation=self._build_remediation(port, count=len(zombie_pids)),
+                details={
+                    "port": port,
+                    "zombie_count": len(zombie_pids),
+                    "zombie_pids": zombie_pids,
+                    "lsof_exit_code": result.returncode,
+                },
+            )
+
+        # Empty parse: PASS. Stash exit code for the "ambiguous returncode
+        # with no parseable rows" diagnostic case mentioned above.
+        details = {"port": port, "zombie_count": 0}
+        if result.returncode not in (0, 1):
+            details["lsof_exit_code"] = result.returncode
+        return CheckResult(
+            name=self.name,
+            status=CheckStatus.PASS,
+            message=f"no CLOSE_WAIT connections on port {port}",
+            details=details,
+        )
+
+    def _build_remediation(self, port: int, count: int | None) -> str:
+        count_phrase = (
+            f"Found {count} zombie connection{'s' if count != 1 else ''}"
+            if count is not None
+            else "Zombie connections may be present"
+        )
+        return (
+            f"{count_phrase} on port {port}. These will block the runner's "
+            "next ib.connect() handshake and cause a silent restart loop.\n\n"
+            "Try the cheap fix first (Python-owned zombies):\n"
+            "  python3 scripts/gateway_manager.py clear-zombies\n\n"
+            "If zombies persist, the Gateway itself is holding stale sockets "
+            "— restart it:\n"
+            "  python3 scripts/gateway_manager.py restart\n"
+            "  (this requires 2FA approval on your IBKR Mobile app)\n\n"
+            "Then re-run ./START_TRADER.sh."
+        )
+
+
+def _parse_zombie_pids(stdout: str) -> List[str]:
+    """Extract PIDs from lsof CLOSE_WAIT output, skipping any header line.
+
+    lsof on macOS prints a ``COMMAND PID USER ...`` header row when it
+    has results, followed by one data row per matching socket. With the
+    ``-nP`` flags (no name/port resolution) the header is still present.
+    We detect and skip it by spotting the literal ``PID`` token in
+    column 2 of the first line, which is unambiguous because real PIDs
+    are integers.
+    """
+    pids: List[str] = []
+    for raw_line in stdout.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        # Skip the header row (column 2 is the literal "PID", not a number).
+        if parts[1] == "PID":
+            continue
+        # Defensive: only accept numeric PIDs. Filters any noise lines.
+        if not parts[1].isdigit():
+            continue
+        pids.append(parts[1])
+    return pids

--- a/robo_trader/runner_async.py
+++ b/robo_trader/runner_async.py
@@ -239,6 +239,65 @@ def _fire_runner_exit_alert(reason: str, extra: Optional[dict] = None) -> None:
             pass
 
 
+def _enforce_preflight_or_exit(
+    project_root: Optional[Path] = None, max_age_seconds: int = 300
+) -> None:
+    """Refuse to start if preflight hasn't passed within max_age_seconds.
+
+    Q11.6 server-side enforcement: scripts/preflight_check.py writes
+    data/.preflight_last_ok on every clean exit (PASS or --force). This
+    function reads the file's mtime/contents and exits the process if:
+    - the file is missing (preflight was never run, or START_TRADER.sh
+      was bypassed)
+    - the file is older than max_age_seconds (preflight ran but stale)
+
+    The bypass is itself bypassable via PREFLIGHT_ENFORCEMENT=off env var —
+    intentional escape hatch for test/dev shells, NOT for production. The
+    bypass is logged at WARNING level so anyone reviewing logs sees it.
+    """
+    import os
+    import sys
+    import time
+    from pathlib import Path
+
+    if os.environ.get("PREFLIGHT_ENFORCEMENT", "").lower() == "off":
+        # Logger may not exist yet at this point in startup — use stderr.
+        print(
+            "WARNING: PREFLIGHT_ENFORCEMENT=off — runner-side gate bypassed",
+            file=sys.stderr,
+        )
+        return
+
+    if project_root is None:
+        # Default: this file lives at robo_trader/runner_async.py
+        project_root = Path(__file__).resolve().parent.parent
+
+    flag_path = project_root / "data" / ".preflight_last_ok"
+    if not flag_path.exists():
+        print(
+            "❌ PREFLIGHT NOT RUN — runner refuses to start.\n"
+            f"   Expected: {flag_path}\n"
+            "   Fix: run ./START_TRADER.sh (which invokes preflight automatically)\n"
+            "        or run scripts/preflight_check.py directly first.\n"
+            "   Emergency bypass (NOT for production): PREFLIGHT_ENFORCEMENT=off",
+            file=sys.stderr,
+        )
+        sys.exit(4)  # new exit code, distinct from preflight's 1/2/3
+
+    age_seconds = time.time() - flag_path.stat().st_mtime
+    if age_seconds > max_age_seconds:
+        mins = int(age_seconds / 60)
+        print(
+            f"❌ PREFLIGHT STALE — last passed {mins} minutes ago "
+            f"(threshold {int(max_age_seconds/60)} min).\n"
+            f"   Flag file:  {flag_path}\n"
+            "   Fix: run ./START_TRADER.sh to re-run preflight.\n"
+            "   Emergency bypass (NOT for production): PREFLIGHT_ENFORCEMENT=off",
+            file=sys.stderr,
+        )
+        sys.exit(5)  # distinct exit code for stale-vs-missing
+
+
 # Import mean reversion strategies if available
 
 try:
@@ -4754,6 +4813,11 @@ def check_gateway_zombies(port: int = 4002) -> bool:
 
 def main() -> None:
     """Main entry point with CLI argument parsing."""
+    # Q11.6: Refuse to start if preflight hasn't passed recently. This is the
+    # FIRST action of main() — before argparse, before config load, before any
+    # IBKR connection. Catches operators who invoke
+    # `python3 -m robo_trader.runner_async` directly, bypassing START_TRADER.sh.
+    _enforce_preflight_or_exit()
     parser = argparse.ArgumentParser(
         description="Async Robo Trader with parallel symbol processing"
     )

--- a/scripts/com.robotrader.watchdog.plist
+++ b/scripts/com.robotrader.watchdog.plist
@@ -38,7 +38,7 @@
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin</string>
     </dict>
 </dict>
 </plist>

--- a/scripts/preflight_check.py
+++ b/scripts/preflight_check.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Preflight safety gate — runs before the trading runner starts.
+
+Usage::
+
+    python3 scripts/preflight_check.py            # standard run, plaintext
+    python3 scripts/preflight_check.py --json     # machine-readable
+    python3 scripts/preflight_check.py --verbose  # add details block
+    python3 scripts/preflight_check.py --force "<reason>"  # bypass BLOCKs
+
+Exit codes (spec §5.2):
+
+    0  All checks PASS or WARN — safe to proceed
+    1  At least one check BLOCKED — abort startup
+    2  Operator passed --force on a BLOCK — proceeded with audit log
+    3  Preflight itself failed (uncaught exception, broken environment)
+
+START_TRADER.sh wraps this in step 4.5. The bash side adds the
+meta-instruction ("re-run after fixing") so this script focuses on
+diagnosis.
+
+Coordination with later layers
+------------------------------
+On a clean run (exit code 0), writes ``data/.preflight_last_ok`` with
+the current ISO timestamp. This is the "preflight is happy" signal that
+the watchdog content-liveness work (MVP-2) and ``runner_async``'s
+optional server-side enforcement (Q11.6) will both read. Operator-side
+this is invisible.
+
+Spec: docs/superpowers/specs/2026-05-23-startup-safety-gate-design.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import logging
+import os
+import sys
+import traceback
+from pathlib import Path
+from typing import List, Optional
+
+# When invoked via START_TRADER.sh, the cwd is the repo root.
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+# Ensure the repo's source is importable when the script is run from any cwd.
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from robo_trader.preflight import PreflightContext  # noqa: E402
+from robo_trader.preflight.checks import ALL_CHECKS  # noqa: E402
+from robo_trader.preflight.result import CheckStatus  # noqa: E402
+from robo_trader.preflight.runner import (  # noqa: E402
+    RunReport,
+    format_json,
+    format_plaintext,
+    run_all_checks,
+)
+
+# Reason denylist (spec §6.3 step 4): reject obviously-low-effort
+# justifications. Forces a real-sentence rationale at the moment of
+# decision so 24h-later "what did I bypass and why" can be answered.
+_REASON_MIN_LENGTH = 10
+_REASON_DENYLIST = frozenset(
+    {
+        "force",
+        "bypass",
+        "whatever",
+        "idk",
+        "test",
+        "skip",
+        "ignore",
+        "go",
+        "yes",
+        "ok",
+    }
+)
+
+_BYPASS_LOG_PATH = "data/preflight_bypass.log"
+_LAST_OK_FLAG_PATH = "data/.preflight_last_ok"
+
+
+def _build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="preflight_check",
+        description="Pre-startup safety gate for the robo_trader runner.",
+        epilog=(
+            "On BLOCKs, fix the underlying condition and re-run, or use "
+            "--force with a real-sentence reason to override (audited)."
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of plaintext.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Append a per-check details block (plaintext only).",
+    )
+    parser.add_argument(
+        "--force",
+        metavar="REASON",
+        help=(
+            "Bypass any BLOCKs. Requires a real-sentence reason (>=10 chars, "
+            "not a placeholder). Exit code becomes 2 (not 0) and the bypass "
+            f"is appended to {_BYPASS_LOG_PATH}."
+        ),
+    )
+    return parser
+
+
+def _resolve_target_port() -> int:
+    """4001 for live, 4002 for paper (default)."""
+    mode = os.environ.get("EXECUTION_MODE", "paper").strip().lower()
+    return 4001 if mode == "live" else 4002
+
+
+def _build_context(project_root: Path) -> PreflightContext:
+    """Build the shared PreflightContext from the resolved env.
+
+    Env is snapshotted into a plain dict here so the checks see the same
+    state regardless of subprocess timing. We do NOT call ``load_dotenv``
+    in this script — START_TRADER.sh has already exported `.env` into
+    the shell environment by the time this runs.
+    """
+    return PreflightContext(
+        project_root=project_root,
+        env=dict(os.environ),
+        target_port=_resolve_target_port(),
+        dry_run=False,
+    )
+
+
+def _validate_force_reason(reason: str) -> Optional[str]:
+    """Return None if the reason is acceptable, else a complaint string."""
+    stripped = reason.strip()
+    if len(stripped) < _REASON_MIN_LENGTH:
+        return (
+            f"--force reason must be at least {_REASON_MIN_LENGTH} characters "
+            f"(got {len(stripped)})"
+        )
+    low = stripped.lower()
+    if low in _REASON_DENYLIST:
+        return f"--force reason cannot be a placeholder like {low!r} — explain what and why"
+    return None
+
+
+def _write_bypass_log_entry(
+    project_root: Path,
+    reason: str,
+    blocked_check_names: List[str],
+) -> None:
+    """Append one newline-delimited JSON entry to data/preflight_bypass.log."""
+    path = project_root / _BYPASS_LOG_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "timestamp": _dt.datetime.now().astimezone().isoformat(),
+        "reason": reason,
+        "bypassed_checks": blocked_check_names,
+        "operator": os.environ.get("USER", "unknown"),
+    }
+    with path.open("a", encoding="utf-8") as fp:
+        fp.write(json.dumps(entry) + "\n")
+
+
+def _write_last_ok_flag(project_root: Path) -> None:
+    """Write ``data/.preflight_last_ok`` with the current ISO timestamp.
+
+    Q11.4 decision: a tiny signal future tooling can poll. Cost is one
+    file write; benefit is the runner can refuse to start if preflight
+    hasn't passed recently (Q11.6 server-side enforcement).
+    """
+    path = project_root / _LAST_OK_FLAG_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_dt.datetime.now().astimezone().isoformat() + "\n", encoding="utf-8")
+
+
+def _log_bypass_event(reason: str, blocked_names: List[str]) -> None:
+    """Emit a WARNING-level structured log line for the bypass.
+
+    We use Python's stdlib logger here (no robo_trader logger setup) so
+    this script stays standalone — if it's invoked outside START_TRADER.sh
+    (e.g. by an operator probing state), it still works. The line lands
+    on stderr by default.
+    """
+    logger = logging.getLogger("preflight")
+    if not logger.handlers:
+        # Standalone setup — single stderr handler.
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(levelname)s %(name)s %(message)s"))
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    logger.warning(
+        "event=preflight_bypass reason=%r bypassed=%s operator=%s",
+        reason,
+        ",".join(blocked_names) or "<none>",
+        os.environ.get("USER", "unknown"),
+    )
+
+
+def _decide_exit_code(report: RunReport, force_reason: Optional[str]) -> int:
+    """Translate the run outcome into the §5.2 exit code."""
+    blocks = report.blocked
+    if force_reason is not None:
+        if not blocks:
+            # --force was passed but nothing actually blocked. Don't silently
+            # exit 2 — the operator may have copy-pasted a stale invocation.
+            # Exit 0 with a warning printed by main().
+            return 0
+        return 2
+    return 1 if blocks else 0
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = _build_argparser()
+    args = parser.parse_args(argv)
+
+    # Validate --force early so we don't run checks just to reject the bypass.
+    force_reason: Optional[str] = None
+    if args.force is not None:
+        complaint = _validate_force_reason(args.force)
+        if complaint:
+            print(f"error: {complaint}", file=sys.stderr)
+            return 1
+        force_reason = args.force.strip()
+
+    project_root = PROJECT_ROOT
+
+    try:
+        context = _build_context(project_root)
+        report = run_all_checks(context, checks=ALL_CHECKS)
+    except BaseException:
+        # Code 3 territory: preflight itself failed before/around the
+        # check loop. Per spec §5.2 this should be impossible in normal
+        # operation since per-check exceptions are caught by the runner.
+        print("error: preflight itself failed:", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
+        return 3
+
+    # Print results
+    if args.json:
+        sys.stdout.write(format_json(report))
+    else:
+        sys.stdout.write(format_plaintext(report, verbose=args.verbose))
+
+    blocked_names = [r.name for r in report.blocked]
+
+    # --force bookkeeping
+    if force_reason is not None and blocked_names:
+        try:
+            _write_bypass_log_entry(project_root, force_reason, blocked_names)
+        except OSError as exc:
+            # Audit log write failed. We refuse to bypass without an
+            # audit trail — that's the whole point of the mechanism.
+            print(
+                f"\nerror: could not write bypass audit log ({exc}); refusing to bypass",
+                file=sys.stderr,
+            )
+            return 1
+        _log_bypass_event(force_reason, blocked_names)
+        print(
+            f"\n⚠ PREFLIGHT BYPASS — operator override: {force_reason!r}",
+            file=sys.stderr,
+        )
+        print(
+            f"   Bypassed checks: {', '.join(blocked_names)}",
+            file=sys.stderr,
+        )
+        print(
+            f"   Audit log entry appended to {_BYPASS_LOG_PATH}",
+            file=sys.stderr,
+        )
+    elif force_reason is not None and not blocked_names:
+        # --force given but nothing blocked. Per §6.3 step 3, exit 0 with
+        # a warning so operators don't leave --force in shell history as
+        # a copy-paste default.
+        print(
+            "\nwarning: --force given but no checks BLOCKED. Force was not needed.",
+            file=sys.stderr,
+        )
+
+    exit_code = _decide_exit_code(report, force_reason)
+
+    # Q11.4: write the last-ok flag on any clean exit (0 or 2 — bypass
+    # still counts as "preflight has run and the operator made a
+    # decision"). The runner's Q11.6 check reads this file's mtime; the
+    # presence of the flag (regardless of how it was earned) means
+    # preflight has been run recently.
+    if exit_code in (0, 2):
+        try:
+            _write_last_ok_flag(project_root)
+        except OSError:
+            # Non-fatal — the gate did its job, the flag is just a hint
+            # for downstream tooling.
+            pass
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/test_runner_death_recovery.py
+++ b/tests/integration/test_runner_death_recovery.py
@@ -54,8 +54,10 @@ def _agent_b_exit_audit_landed() -> bool:
 def _agent_b_lsof_retry_landed() -> bool:
     """Agent B: lsof pre-flight tolerates TimeoutExpired transients.
 
-    The retry helper is defined inline inside `AsyncRunner.run()`, so we
-    detect it structurally via the source.
+    The retry contract now lives in the module-level ``_lsof_port_listening``
+    helper (refactored out of the inline ``test_port_open_lsof`` that existed
+    when this probe was first written), so we detect it structurally via the
+    source.
     """
     try:
         src = pathlib.Path(
@@ -65,11 +67,12 @@ def _agent_b_lsof_retry_landed() -> bool:
         ).read_text()
     except OSError:
         return False
-    # The fix introduces max_attempts + TimeoutExpired retry.
+    # The fix introduces max_attempts + TimeoutExpired retry, surfaced via
+    # the _lsof_port_listening helper.
     return (
         "TimeoutExpired" in src
         and "max_attempts" in src
-        and "test_port_open_lsof" in src
+        and "_lsof_port_listening" in src
     )
 
 

--- a/tests/preflight/conftest.py
+++ b/tests/preflight/conftest.py
@@ -1,0 +1,112 @@
+"""Shared fixtures for preflight check tests (spec §9.3).
+
+Each individual ``test_*_check.py`` imports these. Defining them centrally
+ensures every check uses the same isolation pattern (``tmp_path``-rooted
+``project_root``, mocked ``lsof``, etc.) and makes it trivial to add new
+checks: just import the fixture and write the test.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+import pytest
+
+from robo_trader.preflight import PreflightContext
+
+
+@pytest.fixture
+def preflight_context(tmp_path: Path) -> PreflightContext:
+    """A bare PreflightContext rooted in ``tmp_path`` with an empty env.
+
+    Use this when your check only inspects on-disk state. For env-driven
+    checks, build your own via ``PreflightContext.for_test(tmp_path, env=...)``.
+    """
+    return PreflightContext.for_test(tmp_path)
+
+
+@pytest.fixture
+def write_kill_switch_state(tmp_path: Path) -> Callable[..., Path]:
+    """Factory that writes ``data/kill_switch_state.json`` and returns its path.
+
+    Usage::
+
+        def test_x(write_kill_switch_state, preflight_context):
+            write_kill_switch_state(triggered=True, trigger_reason="...")
+            ...
+    """
+
+    def _write(**payload: Any) -> Path:
+        path = tmp_path / "data" / "kill_switch_state.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload))
+        return path
+
+    return _write
+
+
+@pytest.fixture
+def touch_kill_switch_lock(tmp_path: Path) -> Callable[[], Path]:
+    """Factory that creates ``data/kill_switch.lock`` (empty file)."""
+
+    def _touch() -> Path:
+        path = tmp_path / "data" / "kill_switch.lock"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+        return path
+
+    return _touch
+
+
+@pytest.fixture
+def mock_lsof(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
+    """Factory that patches ``subprocess.run`` to return a faked ``lsof`` result.
+
+    Why we mock ``subprocess.run`` rather than the lsof binary itself:
+    matches the boundary the check actually crosses, and works on CI where
+    lsof's output format may vary by macOS/linux version.
+
+    Usage::
+
+        def test_port_listening(mock_lsof, preflight_context):
+            mock_lsof(returncode=0, stdout="java   1234 oliver  ... TCP *:4002 (LISTEN)")
+            result = GatewayPortListeningCheck().run(preflight_context)
+            assert result.status is CheckStatus.PASS
+    """
+
+    def _install(
+        returncode: int = 0,
+        stdout: str = "",
+        stderr: str = "",
+        *,
+        side_effect: BaseException | None = None,
+    ) -> None:
+        real_run = subprocess.run
+
+        def fake_run(*args: Any, **kwargs: Any):  # type: ignore[no-untyped-def]
+            argv = args[0] if args else kwargs.get("args", [])
+            # Only intercept lsof calls; let other subprocess.run() through.
+            if not (isinstance(argv, (list, tuple)) and argv and argv[0] == "lsof"):
+                return real_run(*args, **kwargs)
+            if side_effect is not None:
+                raise side_effect
+            return subprocess.CompletedProcess(
+                args=argv, returncode=returncode, stdout=stdout, stderr=stderr
+            )
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+    return _install
+
+
+@pytest.fixture
+def env_factory() -> Callable[[Mapping[str, str]], Mapping[str, str]]:
+    """Build a frozen env mapping for ``PreflightContext.for_test(..., env=...)``."""
+
+    def _build(extra: Mapping[str, str]) -> Mapping[str, str]:
+        return dict(extra)
+
+    return _build

--- a/tests/preflight/test_cli.py
+++ b/tests/preflight/test_cli.py
@@ -1,0 +1,295 @@
+"""Tests for the ``scripts/preflight_check.py`` CLI entry point.
+
+Exercises the script as a Python module (via ``importlib``) to keep tests
+fast — subprocess invocation is reserved for the §9.6 manual canary.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any, Callable, List
+
+import pytest
+
+from robo_trader.preflight.protocol import PreflightContext
+from robo_trader.preflight.result import CheckResult, CheckStatus
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent.parent / "scripts" / "preflight_check.py"
+
+
+@pytest.fixture(scope="module")
+def cli_module():
+    """Load ``scripts/preflight_check.py`` as a module so we can call ``main()`` directly."""
+    spec = importlib.util.spec_from_file_location("preflight_cli_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Test doubles — same shape as test_runner._FakeCheck but in isolation here.
+# ---------------------------------------------------------------------------
+
+
+class _StubCheck:
+    def __init__(
+        self,
+        name: str,
+        status: CheckStatus = CheckStatus.PASS,
+        message: str = "ok",
+        remediation: str = "",
+    ):
+        self.name = name
+        self.description = name
+        self.timeout_seconds = 1.0
+        self._status = status
+        self._message = message
+        self._remediation = remediation
+
+    def run(self, context: PreflightContext) -> CheckResult:
+        return CheckResult(
+            name=self.name,
+            status=self._status,
+            message=self._message,
+            remediation=self._remediation,
+        )
+
+
+@pytest.fixture
+def patch_checks_and_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, cli_module):
+    """Helper: swap ALL_CHECKS and PROJECT_ROOT so tests don't touch real state."""
+
+    def _install(checks: List[Any], env: dict | None = None) -> Path:
+        # ALL_CHECKS is imported into the script's module namespace as a
+        # bare name reference — patch it where the script reads it.
+        monkeypatch.setattr(cli_module, "ALL_CHECKS", checks)
+        monkeypatch.setattr(cli_module, "PROJECT_ROOT", tmp_path)
+        if env is not None:
+            monkeypatch.setattr(cli_module.os, "environ", env)
+        return tmp_path
+
+    return _install
+
+
+# ---------------------------------------------------------------------------
+# Exit codes (spec §5.2)
+# ---------------------------------------------------------------------------
+
+
+class TestExitCodes:
+    def test_all_pass_exits_zero(self, patch_checks_and_root, capsys, cli_module) -> None:
+        patch_checks_and_root([_StubCheck("a"), _StubCheck("b")])
+        rc = cli_module.main([])
+        assert rc == 0
+
+    def test_warn_only_exits_zero(self, patch_checks_and_root, capsys, cli_module) -> None:
+        patch_checks_and_root([_StubCheck("warn1", status=CheckStatus.WARN, message="meh")])
+        rc = cli_module.main([])
+        assert rc == 0
+
+    def test_any_block_exits_one(self, patch_checks_and_root, capsys, cli_module) -> None:
+        patch_checks_and_root(
+            [
+                _StubCheck("ok"),
+                _StubCheck("bad", status=CheckStatus.BLOCK, message="boom"),
+            ]
+        )
+        rc = cli_module.main([])
+        assert rc == 1
+
+    def test_force_with_block_exits_two(self, patch_checks_and_root, capsys, cli_module) -> None:
+        patch_checks_and_root(
+            [_StubCheck("bad", status=CheckStatus.BLOCK, message="boom", remediation="fix it")]
+        )
+        rc = cli_module.main(["--force", "I have reviewed and approved this bypass for test"])
+        assert rc == 2
+
+    def test_force_without_block_exits_zero_with_warning(
+        self, patch_checks_and_root, capsys, cli_module
+    ) -> None:
+        patch_checks_and_root([_StubCheck("ok")])
+        rc = cli_module.main(["--force", "I have approved this bypass for test purposes"])
+        # exit 0 (force was unnecessary) + warning to stderr
+        assert rc == 0
+        err = capsys.readouterr().err
+        assert "force was not needed" in err.lower() or "not needed" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# --force validation
+# ---------------------------------------------------------------------------
+
+
+class TestForceValidation:
+    def test_reason_too_short_rejected(self, patch_checks_and_root, capsys, cli_module) -> None:
+        patch_checks_and_root([_StubCheck("ok")])
+        rc = cli_module.main(["--force", "tiny"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "at least 10" in err
+
+    @pytest.mark.parametrize("placeholder", ["force", "bypass", "whatever", "idk", "test"])
+    def test_placeholder_denylist(
+        self, placeholder: str, patch_checks_and_root, capsys, cli_module
+    ) -> None:
+        patch_checks_and_root([_StubCheck("ok")])
+        # Pad to >= MIN_LENGTH so it gets to the denylist check, but the
+        # CORE word should still be detected as placeholder.
+        rc = cli_module.main(["--force", placeholder])
+        # If the placeholder happens to be <10 chars, length check fires first;
+        # if it's >=10, denylist fires. Either way, rc must be non-zero.
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert ("placeholder" in err.lower()) or ("at least 10" in err)
+
+    def test_real_sentence_reason_accepted(self, patch_checks_and_root, capsys, cli_module) -> None:
+        patch_checks_and_root([_StubCheck("ok")])
+        rc = cli_module.main(["--force", "verified positions reconcile ticket 1234"])
+        assert rc == 0  # nothing to bypass
+
+
+# ---------------------------------------------------------------------------
+# Bypass audit log (spec §6.3)
+# ---------------------------------------------------------------------------
+
+
+class TestBypassAuditLog:
+    def test_force_with_block_appends_log_entry(
+        self, patch_checks_and_root, capsys, cli_module
+    ) -> None:
+        root = patch_checks_and_root([_StubCheck("bad", status=CheckStatus.BLOCK, message="boom")])
+        rc = cli_module.main(["--force", "verified state by hand, ticket #999"])
+        assert rc == 2
+        log_path = root / "data" / "preflight_bypass.log"
+        assert log_path.exists()
+        entries = [json.loads(line) for line in log_path.read_text().splitlines() if line]
+        assert len(entries) == 1
+        assert entries[0]["reason"] == "verified state by hand, ticket #999"
+        assert entries[0]["bypassed_checks"] == ["bad"]
+        assert "timestamp" in entries[0]
+        assert "operator" in entries[0]
+
+    def test_multiple_bypasses_append_not_overwrite(
+        self, patch_checks_and_root, capsys, cli_module
+    ) -> None:
+        root = patch_checks_and_root([_StubCheck("bad", status=CheckStatus.BLOCK, message="boom")])
+        cli_module.main(["--force", "first bypass with adequate reason"])
+        cli_module.main(["--force", "second bypass with adequate reason"])
+        log_path = root / "data" / "preflight_bypass.log"
+        entries = [json.loads(line) for line in log_path.read_text().splitlines() if line]
+        assert len(entries) == 2
+
+    def test_force_without_block_does_not_log(
+        self, patch_checks_and_root, capsys, cli_module
+    ) -> None:
+        root = patch_checks_and_root([_StubCheck("ok")])
+        cli_module.main(["--force", "unnecessary force flag for testing only"])
+        log_path = root / "data" / "preflight_bypass.log"
+        # No blocks => no log entry written (the gate didn't bypass anything).
+        assert not log_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# .preflight_last_ok flag (Q11.4 — coordinates with Q11.6 runner enforcement)
+# ---------------------------------------------------------------------------
+
+
+class TestLastOkFlag:
+    def test_written_on_clean_exit(self, patch_checks_and_root, capsys, cli_module) -> None:
+        root = patch_checks_and_root([_StubCheck("ok")])
+        rc = cli_module.main([])
+        assert rc == 0
+        flag = root / "data" / ".preflight_last_ok"
+        assert flag.exists()
+        # Content should be a parseable ISO timestamp
+        from datetime import datetime
+
+        ts = flag.read_text().strip()
+        datetime.fromisoformat(ts)  # raises if malformed
+
+    def test_written_on_bypass_exit(self, patch_checks_and_root, capsys, cli_module) -> None:
+        # --force-with-bypass (exit 2) counts as "preflight ran and operator
+        # made a decision" per Q11.4. Flag is written so the runner doesn't
+        # refuse to start after a deliberately-forced launch.
+        root = patch_checks_and_root([_StubCheck("bad", status=CheckStatus.BLOCK, message="boom")])
+        rc = cli_module.main(["--force", "operator override with adequate reason"])
+        assert rc == 2
+        assert (root / "data" / ".preflight_last_ok").exists()
+
+    def test_not_written_on_block_exit(self, patch_checks_and_root, capsys, cli_module) -> None:
+        root = patch_checks_and_root([_StubCheck("bad", status=CheckStatus.BLOCK, message="boom")])
+        rc = cli_module.main([])
+        assert rc == 1
+        # No flag — preflight blocked, operator must resolve.
+        assert not (root / "data" / ".preflight_last_ok").exists()
+
+
+# ---------------------------------------------------------------------------
+# Output format selection
+# ---------------------------------------------------------------------------
+
+
+class TestOutputFormat:
+    def test_default_is_plaintext(self, patch_checks_and_root, capsys, cli_module) -> None:
+        patch_checks_and_root([_StubCheck("ok", message="all good")])
+        cli_module.main([])
+        out = capsys.readouterr().out
+        assert "Preflight Safety Gate" in out
+        assert "Safe to proceed" in out
+
+    def test_json_flag_emits_json(self, patch_checks_and_root, capsys, cli_module) -> None:
+        patch_checks_and_root([_StubCheck("ok", message="all good")])
+        cli_module.main(["--json"])
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+        assert payload["summary"]["passed"] == 1
+        assert payload["exit_code"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Port resolution
+# ---------------------------------------------------------------------------
+
+
+class TestPortResolution:
+    def test_paper_mode_uses_4002(self, monkeypatch: pytest.MonkeyPatch, cli_module) -> None:
+        monkeypatch.setenv("EXECUTION_MODE", "paper")
+        assert cli_module._resolve_target_port() == 4002
+
+    def test_live_mode_uses_4001(self, monkeypatch: pytest.MonkeyPatch, cli_module) -> None:
+        monkeypatch.setenv("EXECUTION_MODE", "live")
+        assert cli_module._resolve_target_port() == 4001
+
+    def test_unset_defaults_to_paper(self, monkeypatch: pytest.MonkeyPatch, cli_module) -> None:
+        monkeypatch.delenv("EXECUTION_MODE", raising=False)
+        assert cli_module._resolve_target_port() == 4002
+
+    def test_unknown_mode_defaults_to_paper(
+        self, monkeypatch: pytest.MonkeyPatch, cli_module
+    ) -> None:
+        monkeypatch.setenv("EXECUTION_MODE", "backtest")
+        # Anything that isn't "live" → paper (4002)
+        assert cli_module._resolve_target_port() == 4002
+
+
+# ---------------------------------------------------------------------------
+# Code 3 path (preflight itself fails)
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightFailureCode3:
+    def test_uncaught_exception_in_build_context_exits_three(
+        self, monkeypatch: pytest.MonkeyPatch, capsys, cli_module
+    ) -> None:
+        def _broken_build_context(*args, **kwargs):
+            raise RuntimeError("preflight is broken")
+
+        monkeypatch.setattr(cli_module, "_build_context", _broken_build_context)
+        rc = cli_module.main([])
+        assert rc == 3
+        err = capsys.readouterr().err
+        assert "preflight itself failed" in err

--- a/tests/preflight/test_equity_history_freshness_check.py
+++ b/tests/preflight/test_equity_history_freshness_check.py
@@ -1,0 +1,339 @@
+"""Tests for :class:`EquityHistoryFreshnessCheck` (spec §7.3).
+
+Covers the decision matrix:
+
+- missing DB file → BLOCK
+- empty table → WARN (first-run)
+- fresh row → PASS
+- Friday-row, Monday-now → PASS (weekend bridge)
+- 3-day-old row → BLOCK
+- multi-portfolio: any-fresh-passes
+- sqlite read error → BLOCK
+- parsing edge cases on ``count_trading_days``
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from robo_trader.market_hours import count_trading_days
+from robo_trader.preflight import CheckStatus, PreflightContext
+from robo_trader.preflight.equity_history_freshness_check import (
+    EquityHistoryFreshnessCheck,
+)
+
+
+@pytest.fixture
+def equity_db(tmp_path: Path) -> Callable[..., Path]:
+    """Build a minimal ``trading_data.db`` mirroring the production schema.
+
+    Returns a function ``add(portfolio_id, timestamp, equity=...)`` that
+    inserts a row. The DB file lives at ``tmp_path / "trading_data.db"`` so
+    it's discovered by ``EquityHistoryFreshnessCheck`` running with
+    ``project_root=tmp_path``.
+
+    Mirrors the production schema (database_async.py:343) — same column
+    names and types, just without the ancillary tables we don't query.
+    """
+    db_path = tmp_path / "trading_data.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("""
+        CREATE TABLE equity_history (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            portfolio_id TEXT NOT NULL DEFAULT 'default',
+            date TEXT NOT NULL,
+            equity REAL NOT NULL,
+            cash REAL DEFAULT 0,
+            positions_value REAL DEFAULT 0,
+            realized_pnl REAL DEFAULT 0,
+            unrealized_pnl REAL DEFAULT 0,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(portfolio_id, date)
+        )
+        """)
+    conn.commit()
+
+    def add(portfolio_id: str, timestamp: str, equity: float = 100_000.0) -> None:
+        # Use the timestamp string as the date too — tests don't care about
+        # date column, only timestamp.
+        date_str = timestamp[:10]
+        conn.execute(
+            "INSERT INTO equity_history "
+            "(portfolio_id, date, equity, timestamp) VALUES (?, ?, ?, ?)",
+            (portfolio_id, date_str, equity, timestamp),
+        )
+        conn.commit()
+
+    yield add
+    conn.close()
+
+
+def _freeze_market_time(monkeypatch: pytest.MonkeyPatch, when: datetime) -> None:
+    """Patch ``get_market_time`` everywhere the check imports it from.
+
+    The check imports ``get_market_time`` into its own module namespace, so
+    we patch the binding the check actually uses — patching the source
+    module would have no effect since the name is already resolved.
+    """
+    monkeypatch.setattr(
+        "robo_trader.preflight.equity_history_freshness_check.get_market_time",
+        lambda: when,
+    )
+
+
+class TestDBFileMissing:
+    def test_missing_db_blocks(self, preflight_context: PreflightContext) -> None:
+        # tmp_path has no trading_data.db by default.
+        result = EquityHistoryFreshnessCheck().run(preflight_context)
+        assert result.status is CheckStatus.BLOCK
+        assert "trading_data.db not found" in result.message
+        assert "START_TRADER.sh" in result.remediation
+        assert result.details["db_path"].endswith("trading_data.db")
+
+
+class TestEmptyTable:
+    def test_empty_table_warns_with_first_run_message(
+        self,
+        equity_db: Callable[..., Path],  # fixture creates schema only
+        preflight_context: PreflightContext,
+    ) -> None:
+        # Don't add any rows — fixture creates an empty table.
+        result = EquityHistoryFreshnessCheck().run(preflight_context)
+        assert result.status is CheckStatus.WARN
+        assert "first-run" in result.message
+        assert result.details["row_count"] == 0
+
+
+class TestFreshRow:
+    def test_single_row_from_today_passes(
+        self,
+        equity_db: Callable[..., Path],
+        preflight_context: PreflightContext,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Wednesday 2026-05-20 mid-morning.
+        now = datetime(2026, 5, 20, 10, 30, 0)
+        equity_db("default", now.strftime("%Y-%m-%d %H:%M:%S"))
+        _freeze_market_time(monkeypatch, now)
+
+        result = EquityHistoryFreshnessCheck().run(preflight_context)
+        assert result.status is CheckStatus.PASS
+        assert result.details["trading_days_elapsed"] == 0
+
+
+class TestWeekendBridge:
+    def test_friday_row_monday_now_passes(
+        self,
+        equity_db: Callable[..., Path],
+        preflight_context: PreflightContext,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Row written Friday 2026-05-15 16:30 (EOD), startup Monday 2026-05-18 09:00.
+        # Trading-day delta is 1 (Monday), wall-clock is ~64h.
+        friday_ts = "2026-05-15 16:30:00"
+        monday_now = datetime(2026, 5, 18, 9, 0, 0)
+        equity_db("default", friday_ts)
+        _freeze_market_time(monkeypatch, monday_now)
+
+        result = EquityHistoryFreshnessCheck().run(preflight_context)
+        assert result.status is CheckStatus.PASS
+        assert result.details["trading_days_elapsed"] == 1
+
+
+class TestStaleRow:
+    def test_three_trading_days_old_blocks(
+        self,
+        equity_db: Callable[..., Path],
+        preflight_context: PreflightContext,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Row written Wed 2026-05-13, startup the following Wed 2026-05-20.
+        # That's 5 trading days in between.
+        equity_db("default", "2026-05-13 16:30:00")
+        _freeze_market_time(monkeypatch, datetime(2026, 5, 20, 9, 0, 0))
+
+        result = EquityHistoryFreshnessCheck().run(preflight_context)
+        assert result.status is CheckStatus.BLOCK
+        assert result.details["trading_days_elapsed"] == 5
+        assert "trading days old" in result.message
+        assert "reconcile_positions.py" in result.remediation
+
+
+class TestMultiPortfolio:
+    def test_any_fresh_portfolio_passes(
+        self,
+        equity_db: Callable[..., Path],
+        preflight_context: PreflightContext,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Aggressive portfolio is stale (10 trading days ago).
+        # Conservative is fresh (today). PASS overall — MAX wins.
+        now = datetime(2026, 5, 20, 10, 0, 0)
+        equity_db("aggressive", "2026-05-04 16:30:00")
+        equity_db("conservative", now.strftime("%Y-%m-%d %H:%M:%S"))
+        _freeze_market_time(monkeypatch, now)
+
+        result = EquityHistoryFreshnessCheck().run(preflight_context)
+        assert result.status is CheckStatus.PASS
+        assert result.details["trading_days_elapsed"] == 0
+
+
+class TestSqliteError:
+    def test_sqlite_error_blocks(
+        self,
+        equity_db: Callable[..., Path],
+        preflight_context: PreflightContext,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Force the check's sqlite3.connect to raise. We patch sqlite3.connect
+        # inside the check module since that's the binding it resolves.
+        def boom(*_args, **_kwargs):
+            raise sqlite3.OperationalError("database is locked")
+
+        monkeypatch.setattr(
+            "robo_trader.preflight.equity_history_freshness_check.sqlite3.connect",
+            boom,
+        )
+
+        result = EquityHistoryFreshnessCheck().run(preflight_context)
+        assert result.status is CheckStatus.BLOCK
+        assert "sqlite read error" in result.message
+        assert "database is locked" in result.details["error"]
+
+
+class TestMalformedTimestamp:
+    def test_unparseable_timestamp_blocks(
+        self,
+        equity_db: Callable[..., Path],
+        preflight_context: PreflightContext,
+    ) -> None:
+        # Inject a junk timestamp the parser can't match.
+        equity_db("default", "garbage-not-a-timestamp")
+
+        result = EquityHistoryFreshnessCheck().run(preflight_context)
+        assert result.status is CheckStatus.BLOCK
+        assert "could not parse" in result.message
+
+
+class TestCheckMetadata:
+    def test_protocol_attributes_present(self) -> None:
+        check = EquityHistoryFreshnessCheck()
+        assert check.name == "equity_history_freshness"
+        assert check.description == "Equity history freshness"
+        assert check.timeout_seconds == 3.0
+
+
+# ---------------------------------------------------------------------------
+# count_trading_days unit tests (lives in robo_trader.market_hours but
+# introduced in this commit, so its tests live alongside the consumer).
+# ---------------------------------------------------------------------------
+
+
+class TestCountTradingDays:
+    def test_same_day_returns_zero(self) -> None:
+        # Mid-day Wednesday → mid-day Wednesday.
+        d = datetime(2026, 5, 20, 12, 0, 0)
+        assert count_trading_days(d, d) == 0
+
+    def test_reversed_interval_returns_zero(self) -> None:
+        # end < start should not produce negative counts.
+        later = datetime(2026, 5, 20, 12, 0, 0)
+        earlier = datetime(2026, 5, 18, 12, 0, 0)
+        assert count_trading_days(later, earlier) == 0
+
+    def test_weekend_bridge_friday_to_monday(self) -> None:
+        # Fri 2026-05-15 EOD → Mon 2026-05-18 morning: only Monday counts.
+        friday = datetime(2026, 5, 15, 16, 30, 0)
+        monday = datetime(2026, 5, 18, 9, 0, 0)
+        assert count_trading_days(friday, monday) == 1
+
+    def test_full_week_bridge(self) -> None:
+        # Fri 2026-05-15 → Fri 2026-05-22: Mon, Tue, Wed, Thu, Fri = 5.
+        assert (
+            count_trading_days(
+                datetime(2026, 5, 15, 16, 30, 0),
+                datetime(2026, 5, 22, 16, 30, 0),
+            )
+            == 5
+        )
+
+    def test_holiday_bridge_excludes_thanksgiving(self) -> None:
+        # Wed before Thanksgiving 2026 → Fri after.
+        # 2026 Thanksgiving = Thursday Nov 26. Wed Nov 25 → Fri Nov 27.
+        # Interval (start, end] = {Nov 26 (holiday, skip), Nov 27 (Fri)} → 1.
+        wed_before = datetime(2026, 11, 25, 16, 0, 0)
+        fri_after = datetime(2026, 11, 27, 13, 0, 0)
+        assert count_trading_days(wed_before, fri_after) == 1
+
+    def test_multi_week_gap(self) -> None:
+        # 2 calendar weeks: Mon 2026-05-04 → Mon 2026-05-18.
+        # Trading days in (May 4, May 18]: Tue 5, Wed 6, Thu 7, Fri 8,
+        # Mon 11, Tue 12, Wed 13, Thu 14, Fri 15, Mon 18 = 10.
+        start = datetime(2026, 5, 4, 12, 0, 0)
+        end = datetime(2026, 5, 18, 9, 0, 0)
+        assert count_trading_days(start, end) == 10
+
+    def test_one_calendar_day_weekday_to_weekday(self) -> None:
+        # Tue 2026-05-19 → Wed 2026-05-20: just Wednesday = 1.
+        assert (
+            count_trading_days(
+                datetime(2026, 5, 19, 16, 0, 0),
+                datetime(2026, 5, 20, 16, 0, 0),
+            )
+            == 1
+        )
+
+    def test_accepts_naive_or_aware_datetimes(self) -> None:
+        # The helper works on .date() so timezone shouldn't matter for
+        # day-counting. Naive vs aware should produce the same answer.
+        from datetime import timezone
+
+        naive_start = datetime(2026, 5, 15, 16, 30, 0)
+        aware_start = naive_start.replace(tzinfo=timezone.utc)
+        end = datetime(2026, 5, 18, 9, 0, 0)
+        assert count_trading_days(naive_start, end) == count_trading_days(aware_start, end)
+
+
+# ---------------------------------------------------------------------------
+# Smoke: ensure the timedelta-based logic and "row from yesterday" produce
+# a sensible PASS too, so we know we haven't off-by-one'd the boundary.
+# ---------------------------------------------------------------------------
+
+
+class TestBoundary:
+    def test_one_trading_day_old_passes(
+        self,
+        equity_db: Callable[..., Path],
+        preflight_context: PreflightContext,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Row Tue, now Wed → 1 trading day elapsed → still PASS (<=1).
+        equity_db("default", "2026-05-19 16:30:00")
+        _freeze_market_time(monkeypatch, datetime(2026, 5, 20, 9, 0, 0))
+
+        result = EquityHistoryFreshnessCheck().run(preflight_context)
+        assert result.status is CheckStatus.PASS
+        assert result.details["trading_days_elapsed"] == 1
+
+    def test_two_trading_days_old_blocks(
+        self,
+        equity_db: Callable[..., Path],
+        preflight_context: PreflightContext,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Row Mon, now Wed → Tue + Wed = 2 trading days → BLOCK (>1).
+        equity_db("default", "2026-05-18 16:30:00")
+        _freeze_market_time(monkeypatch, datetime(2026, 5, 20, 9, 0, 0))
+
+        result = EquityHistoryFreshnessCheck().run(preflight_context)
+        assert result.status is CheckStatus.BLOCK
+        assert result.details["trading_days_elapsed"] == 2
+
+
+# Silence the unused-import warning for timedelta if it ever gets pruned.
+_ = timedelta

--- a/tests/preflight/test_gateway_port_listening_check.py
+++ b/tests/preflight/test_gateway_port_listening_check.py
@@ -1,0 +1,209 @@
+"""Unit tests for :class:`GatewayPortListeningCheck` (spec §9.1).
+
+The check shells out to ``lsof`` and decodes the result. Every test
+patches ``subprocess.run`` rather than executing real lsof so the suite
+is hermetic across CI runners (macOS / linux lsof flag differences) and
+fast.
+
+The single most important invariant — enforced by ``mock_lsof`` in
+``conftest.py`` and by the live-mode test below — is that the
+implementation goes through ``subprocess.run(["lsof", ...])`` and NEVER
+through ``socket.connect_ex``. The latter manufactures the very zombie
+that breaks IBKR handshakes (CLAUDE.md 2025-12-06).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from robo_trader.preflight import CheckStatus, PreflightContext
+from robo_trader.preflight.gateway_port_listening_check import GatewayPortListeningCheck
+
+# Sample line shaped like real macOS lsof output. Format isn't parsed by
+# the check (only stripped emptiness matters), but realistic fixtures
+# make failures easier to debug at 3am.
+SAMPLE_LISTEN_LINE = "java       1234 oliver   42u  IPv4 0xabc12345      0t0  TCP *:4002 (LISTEN)\n"
+
+
+class TestGatewayPortListeningCheckPass:
+    def test_returns_pass_when_lsof_finds_listener(self, mock_lsof, preflight_context):
+        mock_lsof(returncode=0, stdout=SAMPLE_LISTEN_LINE)
+
+        result = GatewayPortListeningCheck().run(preflight_context)
+
+        assert result.status is CheckStatus.PASS
+        assert result.name == "gateway_port_listening"
+        assert "4002" in result.message
+        assert result.details["port"] == 4002
+
+    def test_pass_result_has_no_remediation(self, mock_lsof, preflight_context):
+        # PASS results shouldn't carry remediation text — it's noise in
+        # the JSON output and tooling may key off non-empty remediation
+        # to flag "this needs operator attention."
+        mock_lsof(returncode=0, stdout=SAMPLE_LISTEN_LINE)
+
+        result = GatewayPortListeningCheck().run(preflight_context)
+
+        assert result.remediation == ""
+
+
+class TestGatewayPortListeningCheckBlock:
+    def test_returns_block_when_lsof_returns_zero_but_empty_stdout(
+        self, mock_lsof, preflight_context
+    ):
+        # Defensive: some lsof builds report rc=0 with an empty body
+        # when given a filter that matches nothing. Treat as "nothing
+        # listening" — same outcome as rc=1.
+        mock_lsof(returncode=0, stdout="")
+
+        result = GatewayPortListeningCheck().run(preflight_context)
+
+        assert result.status is CheckStatus.BLOCK
+        assert "4002" in result.message
+        assert "not listening" in result.message
+
+    def test_returns_block_when_lsof_returns_nonzero(self, mock_lsof, preflight_context):
+        # rc=1 is the canonical "no matching socket" lsof exit.
+        mock_lsof(returncode=1, stdout="")
+
+        result = GatewayPortListeningCheck().run(preflight_context)
+
+        assert result.status is CheckStatus.BLOCK
+        assert "not listening" in result.message
+        assert result.details["lsof_returncode"] == 1
+
+    def test_block_remediation_names_start_gateway_path(self, mock_lsof, preflight_context):
+        mock_lsof(returncode=1, stdout="")
+
+        result = GatewayPortListeningCheck().run(preflight_context)
+
+        # Remediation must point the operator at the canonical fix.
+        assert "start_gateway" in result.remediation
+        assert "2FA" in result.remediation
+
+    def test_returns_block_when_lsof_times_out(self, mock_lsof, preflight_context):
+        mock_lsof(side_effect=subprocess.TimeoutExpired(cmd="lsof", timeout=3))
+
+        result = GatewayPortListeningCheck().run(preflight_context)
+
+        assert result.status is CheckStatus.BLOCK
+        assert "timed out" in result.message
+        assert result.details["error"].startswith("lsof timeout")
+
+    def test_returns_block_when_lsof_binary_missing(self, mock_lsof, preflight_context):
+        mock_lsof(side_effect=FileNotFoundError("lsof"))
+
+        result = GatewayPortListeningCheck().run(preflight_context)
+
+        assert result.status is CheckStatus.BLOCK
+        assert "lsof not installed" in result.message
+        # Remediation must include the OS hint so a fresh-machine
+        # operator doesn't have to think.
+        assert "apt install" in result.remediation or "package manager" in result.remediation
+
+
+class TestGatewayPortListeningCheckPortSelection:
+    def test_uses_paper_port_by_default(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+        captured: dict[str, Any] = {}
+
+        def fake_run(argv, **kwargs):
+            captured["argv"] = argv
+            return subprocess.CompletedProcess(
+                args=argv, returncode=0, stdout=SAMPLE_LISTEN_LINE, stderr=""
+            )
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        # PreflightContext.for_test defaults target_port=4002 (paper).
+        context = PreflightContext.for_test(tmp_path)
+        GatewayPortListeningCheck().run(context)
+
+        assert "-iTCP:4002" in captured["argv"]
+
+    def test_uses_live_port_when_target_port_4001(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        # Spec Q11.2: live mode (EXECUTION_MODE=live) wires the script
+        # to construct the context with target_port=4001. The check
+        # itself just reads context.target_port; verify it passes
+        # through to the lsof argv.
+        captured: dict[str, Any] = {}
+
+        def fake_run(argv, **kwargs):
+            captured["argv"] = argv
+            return subprocess.CompletedProcess(
+                args=argv, returncode=0, stdout=SAMPLE_LISTEN_LINE, stderr=""
+            )
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        context = PreflightContext.for_test(tmp_path, target_port=4001)
+        result = GatewayPortListeningCheck().run(context)
+
+        assert "-iTCP:4001" in captured["argv"]
+        # And the port surfaces in the human-readable message + details
+        # so the operator can tell which port was probed.
+        assert "4001" in result.message
+        assert result.details["port"] == 4001
+
+
+class TestGatewayPortListeningCheckSubprocessInvocation:
+    def test_invokes_lsof_with_required_flags(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        # -nP avoids slow name resolution; -sTCP:LISTEN narrows to the
+        # state we care about. If either flag is dropped, lsof either
+        # hangs on DNS or returns mixed-state output and the rc/stdout
+        # heuristic stops being meaningful. Lock the contract here.
+        captured: dict[str, Any] = {}
+
+        def fake_run(argv, **kwargs):
+            captured["argv"] = argv
+            captured["kwargs"] = kwargs
+            return subprocess.CompletedProcess(
+                args=argv, returncode=0, stdout=SAMPLE_LISTEN_LINE, stderr=""
+            )
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        GatewayPortListeningCheck().run(PreflightContext.for_test(tmp_path))
+
+        argv = captured["argv"]
+        assert argv[0] == "lsof"
+        assert "-nP" in argv
+        assert "-sTCP:LISTEN" in argv
+        # Subprocess timeout must be set — defends against an lsof
+        # hang independent of the runner's per-check budget.
+        assert captured["kwargs"].get("timeout") == 3
+        assert captured["kwargs"].get("capture_output") is True
+        assert captured["kwargs"].get("text") is True
+
+
+class TestGatewayPortListeningCheckUnexpectedErrors:
+    def test_unexpected_oserror_propagates(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+        # Per spec §5.4, checks should let truly unexpected errors
+        # propagate; the runner wraps them into a synthesized BLOCK
+        # with traceback. The check itself MUST NOT silently swallow
+        # arbitrary exceptions and return a misleading PASS/BLOCK.
+        class BoomError(RuntimeError):
+            pass
+
+        def fake_run(*args, **kwargs):
+            raise BoomError("disk on fire")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        with pytest.raises(BoomError):
+            GatewayPortListeningCheck().run(PreflightContext.for_test(tmp_path))
+
+
+class TestGatewayPortListeningCheckMetadata:
+    def test_implements_check_protocol_attrs(self):
+        check = GatewayPortListeningCheck()
+        assert check.name == "gateway_port_listening"
+        assert check.description == "Gateway port listening"
+        assert check.timeout_seconds == 3.0

--- a/tests/preflight/test_kill_switch_lock_check.py
+++ b/tests/preflight/test_kill_switch_lock_check.py
@@ -1,0 +1,156 @@
+"""Tests for :class:`KillSwitchLockCheck` (spec §7.2).
+
+The check is intentionally tiny — "does ``data/kill_switch.lock`` exist?"
+— but the contract it satisfies is important: it's the deny-by-default
+fail-closed signal called out in CLAUDE.md. These tests pin down the
+decisions that matter:
+
+1. Missing file → PASS (the common case)
+2. Empty file → BLOCK (presence is the signal, contents don't matter)
+3. Non-empty file (e.g. a stale PID) → still BLOCK
+4. Symlink to a real file → BLOCK (effectively present)
+5. Broken symlink → PASS (matches ``Path.is_file()`` and KillSwitch behavior)
+
+The shared ``touch_kill_switch_lock`` and ``preflight_context`` fixtures
+live in ``tests/preflight/conftest.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+from robo_trader.preflight import CheckStatus, PreflightContext
+from robo_trader.preflight.kill_switch_lock_check import KillSwitchLockCheck
+
+
+class TestMetadata:
+    def test_check_identifier_is_stable(self) -> None:
+        # The name is the JSON output key and the grep target in logs;
+        # changing it is a breaking change for downstream tooling.
+        check = KillSwitchLockCheck()
+        assert check.name == "kill_switch_lock"
+        assert check.description == "Kill switch lock file"
+
+    def test_timeout_is_one_second(self) -> None:
+        # A single stat() call — anything more than 1s would mean the
+        # filesystem itself is wedged, which is its own problem.
+        assert KillSwitchLockCheck().timeout_seconds == 1.0
+
+
+class TestLockMissing:
+    def test_missing_file_passes(self, preflight_context: PreflightContext) -> None:
+        # The data/ dir exists (the fixture creates it) but no lock file.
+        result = KillSwitchLockCheck().run(preflight_context)
+        assert result.status is CheckStatus.PASS
+        assert "no lock" in result.message.lower()
+
+    def test_missing_file_pass_exposes_path_in_details(
+        self, preflight_context: PreflightContext
+    ) -> None:
+        # Even on PASS we expose the path, so operator tooling can verify
+        # WHICH path was checked (matters when project_root is unusual).
+        result = KillSwitchLockCheck().run(preflight_context)
+        expected = preflight_context.project_root / "data" / "kill_switch.lock"
+        assert result.details["lock_path"] == str(expected)
+
+
+class TestLockPresent:
+    def test_empty_lock_file_blocks(
+        self,
+        touch_kill_switch_lock: Callable[[], Path],
+        preflight_context: PreflightContext,
+    ) -> None:
+        # Presence is the signal — even a zero-byte file must BLOCK.
+        lock_path = touch_kill_switch_lock()
+        result = KillSwitchLockCheck().run(preflight_context)
+        assert result.status is CheckStatus.BLOCK
+        assert str(lock_path) in result.message
+
+    def test_block_result_includes_path_in_details(
+        self,
+        touch_kill_switch_lock: Callable[[], Path],
+        preflight_context: PreflightContext,
+    ) -> None:
+        lock_path = touch_kill_switch_lock()
+        result = KillSwitchLockCheck().run(preflight_context)
+        assert result.details["lock_path"] == str(lock_path)
+
+    def test_block_remediation_offers_rm_path(
+        self,
+        touch_kill_switch_lock: Callable[[], Path],
+        preflight_context: PreflightContext,
+    ) -> None:
+        # The remediation MUST give the operator a copy-pasteable rm
+        # command. The lock's full path is included so they don't have to
+        # guess where the project root is.
+        lock_path = touch_kill_switch_lock()
+        result = KillSwitchLockCheck().run(preflight_context)
+        assert f"rm {lock_path}" in result.remediation
+
+    def test_block_remediation_mentions_force_bypass(
+        self,
+        touch_kill_switch_lock: Callable[[], Path],
+        preflight_context: PreflightContext,
+    ) -> None:
+        # The other escape hatch — operator confirmed it's expected,
+        # wants to proceed without removing the file.
+        touch_kill_switch_lock()
+        result = KillSwitchLockCheck().run(preflight_context)
+        assert "--force" in result.remediation
+
+    def test_block_remediation_explains_deny_by_default(
+        self,
+        touch_kill_switch_lock: Callable[[], Path],
+        preflight_context: PreflightContext,
+    ) -> None:
+        # Operators reading the message at 3am need to know WHY the lock
+        # blocks startup — it's the fail-closed safety contract from
+        # CLAUDE.md, not an arbitrary check.
+        touch_kill_switch_lock()
+        result = KillSwitchLockCheck().run(preflight_context)
+        assert "deny-by-default" in result.remediation.lower()
+
+    def test_lock_with_stale_pid_content_still_blocks(
+        self, preflight_context: PreflightContext
+    ) -> None:
+        # Some operators write a PID into the lock as a debugging
+        # convenience. The contract is "presence triggers" — content is
+        # irrelevant. A stale PID must NOT downgrade the result.
+        lock_path = preflight_context.project_root / "data" / "kill_switch.lock"
+        lock_path.write_text("99999\n")
+        result = KillSwitchLockCheck().run(preflight_context)
+        assert result.status is CheckStatus.BLOCK
+
+
+class TestSymlinkSemantics:
+    def test_symlink_to_existing_file_blocks(
+        self, preflight_context: PreflightContext, tmp_path: Path
+    ) -> None:
+        # An operator who symlinks the lock into a shared location
+        # expects "lock present" to behave the same as a regular file.
+        # Path.is_file() follows symlinks, so the check agrees.
+        target = tmp_path / "real_lock"
+        target.write_text("")
+        lock_path = preflight_context.project_root / "data" / "kill_switch.lock"
+        lock_path.symlink_to(target)
+
+        result = KillSwitchLockCheck().run(preflight_context)
+        assert result.status is CheckStatus.BLOCK
+
+    def test_broken_symlink_passes(
+        self, preflight_context: PreflightContext, tmp_path: Path
+    ) -> None:
+        # A symlink whose target was deleted is functionally "no lock":
+        # the KillSwitch class can't read it either, so preflight must
+        # agree to avoid a false BLOCK that the runner would never hit.
+        missing_target = tmp_path / "does_not_exist"
+        lock_path = preflight_context.project_root / "data" / "kill_switch.lock"
+        lock_path.symlink_to(missing_target)
+
+        # Sanity check: the symlink itself exists, but is_file() is False.
+        assert lock_path.is_symlink()
+        assert not lock_path.is_file()
+
+        result = KillSwitchLockCheck().run(preflight_context)
+        assert result.status is CheckStatus.PASS

--- a/tests/preflight/test_kill_switch_state_check.py
+++ b/tests/preflight/test_kill_switch_state_check.py
@@ -1,0 +1,258 @@
+"""Tests for :class:`KillSwitchStateCheck` (spec §7.1, §9.1).
+
+These exercise the eight cases enumerated in the spec plus the documented
+edge cases:
+
+1. File missing → PASS
+2. File with ``triggered=False`` → PASS
+3. File with ``triggered=False`` and ``previous_trigger_reason`` → details
+   exposes it (regression: don't drop useful audit context on the floor).
+4. File with ``triggered=True`` + reason + trigger_time → BLOCK, message
+   includes the trigger_time, remediation includes the reason.
+5. File with ``triggered=True`` but missing ``trigger_time`` → BLOCK,
+   displays ``"unknown"`` and does not crash. Old state files written
+   before TC-M5 lack this field; we must not regress on them.
+6. Malformed JSON → BLOCK with "state file unreadable" message
+   (fail-closed per spec §7.1 decision table).
+7. ``read_text`` raises ``OSError`` (permission denied, mocked) → BLOCK,
+   error class surfaced in the message.
+8. ``trigger_reason`` containing a literal double-quote → properly
+   escaped in the remediation (the remediation wraps the reason in
+   quotes, so an unescaped quote would break the formatting).
+
+The fixtures ``write_kill_switch_state`` and ``preflight_context`` come
+from ``tests/preflight/conftest.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from robo_trader.preflight import PreflightContext
+from robo_trader.preflight.kill_switch_state_check import KillSwitchStateCheck
+from robo_trader.preflight.result import CheckStatus
+
+
+@pytest.fixture
+def check() -> KillSwitchStateCheck:
+    return KillSwitchStateCheck()
+
+
+class TestMetadata:
+    def test_check_metadata_matches_spec(self, check: KillSwitchStateCheck) -> None:
+        # These three attributes are part of the Check Protocol contract;
+        # the runner reads them for output formatting and timeout
+        # enforcement. Asserting them here keeps the spec and the impl
+        # honest with each other.
+        assert check.name == "kill_switch_state"
+        assert check.description == "Kill switch persisted state"
+        assert check.timeout_seconds == 1.0
+
+
+class TestMissingFile:
+    def test_returns_pass_when_state_file_missing(
+        self,
+        check: KillSwitchStateCheck,
+        preflight_context: PreflightContext,
+    ) -> None:
+        # Case 1: cold-start fresh checkout. The file genuinely doesn't
+        # exist yet, which is the most common "happy path."
+        result = check.run(preflight_context)
+        assert result.status is CheckStatus.PASS
+        assert result.message == "no triggered state"
+        assert result.details["exists"] is False
+        assert result.details["state_path"].endswith("kill_switch_state.json")
+
+
+class TestUntriggered:
+    def test_returns_pass_when_triggered_false(
+        self,
+        check: KillSwitchStateCheck,
+        preflight_context: PreflightContext,
+        write_kill_switch_state,
+    ) -> None:
+        # Case 2: a prior session ran, triggered the switch, and the
+        # operator cleared it (which leaves the file with triggered=False
+        # rather than deleting the file). Should PASS.
+        write_kill_switch_state(triggered=False)
+        result = check.run(preflight_context)
+        assert result.status is CheckStatus.PASS
+        assert result.message == "no triggered state"
+        assert result.details["triggered"] is False
+        assert result.details["exists"] is True
+
+    def test_previous_trigger_reason_exposed_in_details(
+        self,
+        check: KillSwitchStateCheck,
+        preflight_context: PreflightContext,
+        write_kill_switch_state,
+    ) -> None:
+        # Case 3: when the operator clears a trip, the previous reason
+        # may be retained as a breadcrumb. Pass it through to details so
+        # downstream tooling (--json output, future dashboard) can show it
+        # even though we PASS.
+        write_kill_switch_state(
+            triggered=False,
+            previous_trigger_reason="Position loss limit exceeded for NVDA: 2.93% loss",
+        )
+        result = check.run(preflight_context)
+        assert result.status is CheckStatus.PASS
+        assert (
+            result.details["previous_trigger_reason"]
+            == "Position loss limit exceeded for NVDA: 2.93% loss"
+        )
+
+
+class TestTriggered:
+    def test_returns_block_when_triggered_true(
+        self,
+        check: KillSwitchStateCheck,
+        preflight_context: PreflightContext,
+        write_kill_switch_state,
+    ) -> None:
+        # Case 4: the 2026-05-22 scenario. triggered=True with a real
+        # reason and timestamp. Must BLOCK; message must include the
+        # trigger_time so the operator knows how stale the trip is;
+        # remediation must include the reason verbatim.
+        write_kill_switch_state(
+            triggered=True,
+            trigger_reason="Position loss limit exceeded for NVDA: 2.93% loss",
+            trigger_time="2026-05-22T22:58:12-04:00",
+        )
+        result = check.run(preflight_context)
+        assert result.status is CheckStatus.BLOCK
+        assert "2026-05-22T22:58:12-04:00" in result.message
+        assert "triggered=True" in result.message
+        assert "Position loss limit exceeded for NVDA: 2.93% loss" in result.remediation
+        assert result.details["trigger_reason"] == (
+            "Position loss limit exceeded for NVDA: 2.93% loss"
+        )
+        assert result.details["trigger_time"] == "2026-05-22T22:58:12-04:00"
+
+    def test_handles_missing_trigger_time(
+        self,
+        check: KillSwitchStateCheck,
+        preflight_context: PreflightContext,
+        write_kill_switch_state,
+    ) -> None:
+        # Case 5: state files written before TC-M5 didn't include
+        # trigger_time. Per spec §7.1 edge cases, display "unknown" and
+        # do not crash. This is a hard regression guard.
+        write_kill_switch_state(
+            triggered=True,
+            trigger_reason="Stale trip from old version",
+        )
+        result = check.run(preflight_context)
+        assert result.status is CheckStatus.BLOCK
+        assert "unknown" in result.message
+        assert result.details["trigger_time"] == "unknown"
+
+    def test_remediation_includes_state_path_and_clear_command(
+        self,
+        check: KillSwitchStateCheck,
+        preflight_context: PreflightContext,
+        write_kill_switch_state,
+    ) -> None:
+        # Operator UX: at 3am we want the actual file path and the rm
+        # command on screen. No "see docs" indirection.
+        path = write_kill_switch_state(triggered=True, trigger_reason="x")
+        result = check.run(preflight_context)
+        assert str(path) in result.remediation
+        # The backup + rm pattern is the supported clear procedure; keep
+        # them both present so an operator can copy-paste with confidence.
+        assert "cp " in result.remediation
+        assert "rm " in result.remediation
+        # And the bypass mechanism must be visible — otherwise an operator
+        # who has decided to proceed has no idea --force exists.
+        assert "--force" in result.remediation
+
+
+class TestCorruptFile:
+    def test_returns_block_when_state_file_is_malformed_json(
+        self,
+        check: KillSwitchStateCheck,
+        preflight_context: PreflightContext,
+        tmp_path: Path,
+    ) -> None:
+        # Case 6: half-written file from a crash mid-flush, or manual
+        # edit gone wrong. Fail-closed per spec §7.1 decision table.
+        path = tmp_path / "data" / "kill_switch_state.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{not valid json")
+        result = check.run(preflight_context)
+        assert result.status is CheckStatus.BLOCK
+        assert "state file unreadable" in result.message
+        # Surfacing the exception class name in the message helps the
+        # operator distinguish "the JSON is bad" from "the disk is gone."
+        assert "JSONDecodeError" in result.message
+        assert result.details["error"]
+
+    def test_returns_block_when_read_text_raises_oserror(
+        self,
+        check: KillSwitchStateCheck,
+        preflight_context: PreflightContext,
+        write_kill_switch_state,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Case 7: permission denied on the state file. We can't easily
+        # chmod a file to be unreadable in a portable way (CI runs as
+        # root in containers, chmod is a no-op), so mock the read.
+        write_kill_switch_state(triggered=False)  # file exists so we get past the exists() branch
+
+        real_read_text = Path.read_text
+
+        def boom(self: Path, *args, **kwargs):
+            if self.name == "kill_switch_state.json":
+                raise PermissionError("Permission denied")
+            return real_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", boom)
+        result = check.run(preflight_context)
+        assert result.status is CheckStatus.BLOCK
+        assert "state file unreadable" in result.message
+        assert "PermissionError" in result.message
+
+
+class TestRemediationEscaping:
+    def test_trigger_reason_with_quotes_is_escaped(
+        self,
+        check: KillSwitchStateCheck,
+        preflight_context: PreflightContext,
+        write_kill_switch_state,
+    ) -> None:
+        # Case 8: a reason like ``He said "stop"`` would otherwise close
+        # the quoted region in the remediation text and confuse the
+        # operator's eye. Verify the quote is backslash-escaped.
+        write_kill_switch_state(
+            triggered=True,
+            trigger_reason='He said "stop trading"',
+            trigger_time="2026-05-22T22:58:12-04:00",
+        )
+        result = check.run(preflight_context)
+        assert result.status is CheckStatus.BLOCK
+        # The remediation embeds the reason in quotes; the inner quotes
+        # must be escaped so the display stays readable.
+        assert '"He said \\"stop trading\\""' in result.remediation
+        # The unescaped reason is still preserved in details for tooling.
+        assert result.details["trigger_reason"] == 'He said "stop trading"'
+
+
+class TestReadOnly:
+    def test_does_not_modify_state_file(
+        self,
+        check: KillSwitchStateCheck,
+        preflight_context: PreflightContext,
+        write_kill_switch_state,
+    ) -> None:
+        # Spec §5.7, N1: checks NEVER modify state. If we ever
+        # accidentally start writing to the file, this test catches it
+        # via mtime comparison. The motivating principle is "preflight
+        # observes and reports; the operator acts."
+        path = write_kill_switch_state(triggered=True, trigger_reason="x", trigger_time="t")
+        mtime_before = path.stat().st_mtime
+        contents_before = path.read_text()
+        check.run(preflight_context)
+        assert path.stat().st_mtime == mtime_before
+        assert path.read_text() == contents_before

--- a/tests/preflight/test_result.py
+++ b/tests/preflight/test_result.py
@@ -1,0 +1,124 @@
+"""Tests for the immutable :class:`CheckResult` dataclass.
+
+These exercise the contract every check in
+``robo_trader/preflight/<name>_check.py`` depends on:
+
+1. The status enum has exactly the three documented tiers.
+2. Results are frozen — can't be mutated after construction.
+3. Default values are sensible (no shared mutable default for ``details``).
+4. ``to_dict()`` produces a JSON-serializable mapping with the enum
+   collapsed to its string value.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+
+import pytest
+
+from robo_trader.preflight.result import CheckResult, CheckStatus
+
+
+class TestCheckStatus:
+    def test_three_tiers_only(self) -> None:
+        # If a 4th tier ever sneaks in (e.g. REQUIRE_CONFIRM), the
+        # runner's exit-code logic in scripts/preflight_check.py would
+        # need updating in lockstep. This test forces that conversation.
+        assert {s.name for s in CheckStatus} == {"PASS", "WARN", "BLOCK"}
+
+    def test_values_are_uppercase_strings(self) -> None:
+        # JSON output uses .value; uppercase is the convention every
+        # check's remediation text assumes.
+        assert CheckStatus.PASS.value == "PASS"
+        assert CheckStatus.WARN.value == "WARN"
+        assert CheckStatus.BLOCK.value == "BLOCK"
+
+
+class TestCheckResultConstruction:
+    def test_minimal_construction(self) -> None:
+        r = CheckResult(name="x", status=CheckStatus.PASS, message="ok")
+        assert r.name == "x"
+        assert r.status is CheckStatus.PASS
+        assert r.message == "ok"
+        assert r.remediation == ""
+        assert r.details == {}
+        assert r.duration_ms == 0
+
+    def test_full_construction(self) -> None:
+        r = CheckResult(
+            name="kill_switch_state",
+            status=CheckStatus.BLOCK,
+            message="triggered=True since 2026-05-22T16:27",
+            remediation="rm data/kill_switch_state.json",
+            details={"state_path": "data/kill_switch_state.json", "triggered": True},
+            duration_ms=42,
+        )
+        assert r.status is CheckStatus.BLOCK
+        assert r.details["triggered"] is True
+        assert r.duration_ms == 42
+
+    def test_details_default_is_not_shared(self) -> None:
+        # Using field(default_factory=dict) prevents the classic "shared
+        # mutable default" bug. Constructing two results without details
+        # MUST yield two independent dicts, not the same instance.
+        a = CheckResult(name="a", status=CheckStatus.PASS, message="")
+        b = CheckResult(name="b", status=CheckStatus.PASS, message="")
+        assert a.details is not b.details
+
+
+class TestCheckResultIsFrozen:
+    def test_cannot_mutate_status(self) -> None:
+        r = CheckResult(name="x", status=CheckStatus.PASS, message="ok")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            r.status = CheckStatus.BLOCK  # type: ignore[misc]
+
+    def test_cannot_mutate_message(self) -> None:
+        r = CheckResult(name="x", status=CheckStatus.PASS, message="ok")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            r.message = "hacked"  # type: ignore[misc]
+
+    def test_details_dict_still_mutable_inside(self) -> None:
+        # Frozen only protects the OUTER fields. The inner dict is still
+        # a regular dict — by design, since checks build it up. Tests in
+        # individual check modules verify they don't accidentally leak
+        # shared state.
+        r = CheckResult(name="x", status=CheckStatus.PASS, message="ok", details={"k": 1})
+        r.details["k"] = 2  # not a FrozenInstanceError
+        assert r.details["k"] == 2
+
+
+class TestCheckResultSerialization:
+    def test_to_dict_collapses_enum_to_string(self) -> None:
+        r = CheckResult(name="x", status=CheckStatus.BLOCK, message="bad")
+        payload = r.to_dict()
+        assert payload["status"] == "BLOCK"
+        assert isinstance(payload["status"], str)
+
+    def test_to_dict_round_trips_through_json(self) -> None:
+        r = CheckResult(
+            name="kill_switch_state",
+            status=CheckStatus.BLOCK,
+            message="m",
+            remediation="r",
+            details={"int": 1, "str": "s", "bool": True, "list": [1, 2]},
+            duration_ms=10,
+        )
+        encoded = json.dumps(r.to_dict())
+        decoded = json.loads(encoded)
+        assert decoded["name"] == "kill_switch_state"
+        assert decoded["status"] == "BLOCK"
+        assert decoded["details"] == {"int": 1, "str": "s", "bool": True, "list": [1, 2]}
+        assert decoded["duration_ms"] == 10
+
+    def test_to_dict_exposes_all_fields(self) -> None:
+        r = CheckResult(name="x", status=CheckStatus.PASS, message="m")
+        payload = r.to_dict()
+        assert set(payload.keys()) == {
+            "name",
+            "status",
+            "message",
+            "remediation",
+            "details",
+            "duration_ms",
+        }

--- a/tests/preflight/test_risk_threshold_check.py
+++ b/tests/preflight/test_risk_threshold_check.py
@@ -1,0 +1,183 @@
+"""Tests for :class:`RiskThresholdCheck` (spec §7.4).
+
+The decision table is small (4 outcomes) but each tier has a real-world
+trigger story behind it, so the tests pin both the boundary behavior and
+the operator-facing remediation text.
+
+Decision recap from spec §7.4:
+
+- env var unset → PASS (RiskConfig default 0.05 applies)
+- unparseable → BLOCK ("config corrupt")
+- ``< 0.01``    → BLOCK
+- ``< 0.02``    → WARN
+- ``>= 0.02``   → PASS (including values above the 0.10 ceiling — the
+                  Pydantic ``le=0.10`` validator catches those at runner
+                  startup; preflight's job is the low end only)
+
+The ``< 0.01`` vs ``< 0.02`` boundary is strict less-than, so 0.01 itself
+falls into the WARN tier (it is not ``< 0.01``, but it is ``< 0.02``).
+The test below pins this explicitly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from robo_trader.preflight import CheckStatus, PreflightContext
+from robo_trader.preflight.risk_threshold_check import (
+    BLOCK_THRESHOLD,
+    ENV_VAR,
+    WARN_THRESHOLD,
+    RiskThresholdCheck,
+)
+
+
+def _ctx(tmp_path: Path, value: str | None) -> PreflightContext:
+    """Build a context with the env var set to ``value`` (or unset if None)."""
+    env = {ENV_VAR: value} if value is not None else {}
+    return PreflightContext.for_test(tmp_path, env=env)
+
+
+class TestMetadata:
+    def test_check_identifier_is_stable(self) -> None:
+        # The name is the JSON output key and the grep target in logs;
+        # changing it is a breaking change for downstream tooling.
+        check = RiskThresholdCheck()
+        assert check.name == "risk_threshold"
+        assert check.description == "Risk thresholds"
+
+    def test_timeout_is_half_a_second(self) -> None:
+        # Pure dict lookup + float parse; sub-second is generous.
+        assert RiskThresholdCheck().timeout_seconds == 0.5
+
+    def test_threshold_constants_match_spec(self) -> None:
+        # If these drift, the spec §7.4 decision table needs updating too.
+        assert BLOCK_THRESHOLD == 0.01
+        assert WARN_THRESHOLD == 0.02
+
+
+class TestUnset:
+    def test_env_var_unset_passes(self, tmp_path: Path) -> None:
+        # The common, healthy case — RiskConfig default (0.05) will apply.
+        result = RiskThresholdCheck().run(_ctx(tmp_path, None))
+        assert result.status is CheckStatus.PASS
+        assert "default" in result.message.lower()
+
+    def test_unset_pass_exposes_thresholds_in_details(self, tmp_path: Path) -> None:
+        # JSON consumers need to know what was checked even on PASS.
+        result = RiskThresholdCheck().run(_ctx(tmp_path, None))
+        assert result.details["env_var"] == ENV_VAR
+        assert result.details["value"] is None
+        assert result.details["warn_threshold"] == WARN_THRESHOLD
+        assert result.details["block_threshold"] == BLOCK_THRESHOLD
+
+
+class TestPassValues:
+    def test_default_value_005_passes(self, tmp_path: Path) -> None:
+        # The post-baadd26 default explicitly set in .env — should be
+        # indistinguishable from "unset" in terms of safety.
+        result = RiskThresholdCheck().run(_ctx(tmp_path, "0.05"))
+        assert result.status is CheckStatus.PASS
+        assert result.details["value"] == 0.05
+
+    def test_warn_boundary_002_passes(self, tmp_path: Path) -> None:
+        # Boundary: spec says `>= 0.02` is PASS. 0.02 itself is healthy.
+        result = RiskThresholdCheck().run(_ctx(tmp_path, "0.02"))
+        assert result.status is CheckStatus.PASS
+
+    def test_above_ceiling_passes_at_preflight(self, tmp_path: Path) -> None:
+        # 0.5 (50%) is way above the RiskConfig le=0.10 ceiling — but
+        # this check intentionally does not duplicate that validation.
+        # The Pydantic validator will reject it when the runner loads;
+        # preflight's role here is the low-end safety net only.
+        result = RiskThresholdCheck().run(_ctx(tmp_path, "0.5"))
+        assert result.status is CheckStatus.PASS
+
+
+class TestWarnTier:
+    def test_value_below_002_warns(self, tmp_path: Path) -> None:
+        # 0.018 — the canonical "tight but defensible" value from spec.
+        result = RiskThresholdCheck().run(_ctx(tmp_path, "0.018"))
+        assert result.status is CheckStatus.WARN
+        assert result.details["value"] == 0.018
+
+    def test_block_boundary_001_warns(self, tmp_path: Path) -> None:
+        # Spec wording is strict: `< 0.01` BLOCKS. So 0.01 itself is NOT
+        # blocked — it falls into the WARN tier (`< 0.02`). Pinning this
+        # explicitly so a future "make it inclusive" refactor surfaces
+        # as a test failure rather than silently changing the contract.
+        result = RiskThresholdCheck().run(_ctx(tmp_path, "0.01"))
+        assert result.status is CheckStatus.WARN
+
+    def test_warn_remediation_mentions_2_percent_floor(self, tmp_path: Path) -> None:
+        # Operator reading the message at 3am needs to know WHY 2% matters
+        # — it's the lesson from 2026-05-22, not an arbitrary number.
+        result = RiskThresholdCheck().run(_ctx(tmp_path, "0.018"))
+        assert "2%" in result.remediation
+        assert "2026-05-22" in result.remediation
+
+    def test_warn_remediation_does_not_mention_force(self, tmp_path: Path) -> None:
+        # WARN doesn't block startup, so --force is irrelevant here.
+        # Mentioning it would confuse the operator.
+        result = RiskThresholdCheck().run(_ctx(tmp_path, "0.018"))
+        assert "--force" not in result.remediation
+
+
+class TestBlockTier:
+    def test_value_below_001_blocks(self, tmp_path: Path) -> None:
+        # 0.005 — well below the BLOCK threshold; almost certainly a typo
+        # (operator meant 0.05 and dropped a zero).
+        result = RiskThresholdCheck().run(_ctx(tmp_path, "0.005"))
+        assert result.status is CheckStatus.BLOCK
+        assert result.details["value"] == 0.005
+
+    def test_negative_value_blocks(self, tmp_path: Path) -> None:
+        # Negative is meaningless for a loss percentage. The RiskConfig
+        # validator would catch this with `gt=0`, but preflight catches
+        # it first via `< 0.01` so the operator sees a clear preflight
+        # message instead of a stack trace at runner start.
+        result = RiskThresholdCheck().run(_ctx(tmp_path, "-0.05"))
+        assert result.status is CheckStatus.BLOCK
+
+    def test_block_remediation_offers_default_and_minimum(self, tmp_path: Path) -> None:
+        # Operator needs a copy-pasteable escape route — either remove
+        # the line (use default 0.05) or set a sensible value (>= 0.02).
+        result = RiskThresholdCheck().run(_ctx(tmp_path, "0.005"))
+        assert "0.05" in result.remediation
+        assert "0.02" in result.remediation
+
+    def test_block_remediation_mentions_force_bypass(self, tmp_path: Path) -> None:
+        # Unlike WARN, BLOCK halts startup. The operator needs the
+        # documented bypass for the "yes, I really mean it" case.
+        result = RiskThresholdCheck().run(_ctx(tmp_path, "0.005"))
+        assert "--force" in result.remediation
+
+
+class TestUnparseable:
+    def test_non_numeric_string_blocks(self, tmp_path: Path) -> None:
+        # Garbage in the env var means we cannot evaluate the threshold;
+        # fail closed (BLOCK) rather than silently treating as 0 or unset.
+        result = RiskThresholdCheck().run(_ctx(tmp_path, "not_a_number"))
+        assert result.status is CheckStatus.BLOCK
+        assert "config corrupt" in result.message.lower() or "corrupt" in result.remediation.lower()
+
+    def test_empty_string_blocks(self, tmp_path: Path) -> None:
+        """Empty string treated as unparseable, NOT as unset.
+
+        Decision: ``RISK_MAX_POSITION_LOSS_PCT=`` in `.env` is a config-
+        authoring bug — the operator clearly intended *something* but left
+        it blank. Treating it as "use default" would silently mask a real
+        misconfiguration. Treating it as a parse failure surfaces it.
+
+        (Justified in test docstring per task #8.)
+        """
+        result = RiskThresholdCheck().run(_ctx(tmp_path, ""))
+        assert result.status is CheckStatus.BLOCK
+        assert result.details.get("parse_error") is True
+
+    def test_unparseable_details_preserve_raw_value(self, tmp_path: Path) -> None:
+        # Downstream tooling (and the operator) should be able to see
+        # exactly what was in the env, not a normalized form.
+        result = RiskThresholdCheck().run(_ctx(tmp_path, "not_a_number"))
+        assert result.details["raw_value"] == "not_a_number"
+        assert result.details["parse_error"] is True

--- a/tests/preflight/test_runner.py
+++ b/tests/preflight/test_runner.py
@@ -1,0 +1,347 @@
+"""Tests for the parallel preflight runner + output formatters.
+
+Covers spec §6.1 (parallelism + timeouts), §6.4 (output format), §10
+(performance budget assumption).
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from robo_trader.preflight.protocol import Check, PreflightContext
+from robo_trader.preflight.result import CheckResult, CheckStatus
+from robo_trader.preflight.runner import (
+    RunReport,
+    format_json,
+    format_plaintext,
+    run_all_checks,
+)
+
+# ---------------------------------------------------------------------------
+# Test doubles — three-line classes since Check is a Protocol
+# ---------------------------------------------------------------------------
+
+
+class _FakeCheck:
+    """Minimal Check implementation. Tests instantiate with the result it
+    should return (or an exception it should raise / a sleep duration)."""
+
+    def __init__(
+        self,
+        name: str,
+        status: CheckStatus = CheckStatus.PASS,
+        message: str = "fake ok",
+        sleep_seconds: float = 0.0,
+        raises: BaseException | None = None,
+        timeout_seconds: float = 1.0,
+        details: dict | None = None,
+    ):
+        self.name = name
+        self.description = name.replace("_", " ").title()
+        self.timeout_seconds = timeout_seconds
+        self._status = status
+        self._message = message
+        self._sleep = sleep_seconds
+        self._raises = raises
+        self._details = details or {}
+
+    def run(self, context: PreflightContext) -> CheckResult:
+        if self._sleep:
+            time.sleep(self._sleep)
+        if self._raises is not None:
+            raise self._raises
+        return CheckResult(
+            name=self.name,
+            status=self._status,
+            message=self._message,
+            details=dict(self._details),
+        )
+
+
+# ---------------------------------------------------------------------------
+# RunReport
+# ---------------------------------------------------------------------------
+
+
+class TestRunReport:
+    def _make(self, results: list[CheckResult]) -> RunReport:
+        now = _dt.datetime.now().astimezone()
+        return RunReport(
+            started_at=now,
+            completed_at=now + _dt.timedelta(milliseconds=42),
+            results=results,
+            context=PreflightContext.for_test(Path("/tmp/x")),
+        )
+
+    def test_duration_ms_computed_from_timestamps(self) -> None:
+        report = self._make([CheckResult(name="x", status=CheckStatus.PASS, message="ok")])
+        assert report.duration_ms == 42
+
+    def test_exit_code_zero_when_all_pass(self) -> None:
+        report = self._make(
+            [
+                CheckResult(name="a", status=CheckStatus.PASS, message="ok"),
+                CheckResult(name="b", status=CheckStatus.PASS, message="ok"),
+            ]
+        )
+        assert report.exit_code == 0
+
+    def test_exit_code_zero_when_warn_but_no_block(self) -> None:
+        # WARN does not block. The plan accepted this — Q11.1 et al.
+        report = self._make(
+            [
+                CheckResult(name="a", status=CheckStatus.WARN, message="meh"),
+                CheckResult(name="b", status=CheckStatus.PASS, message="ok"),
+            ]
+        )
+        assert report.exit_code == 0
+
+    def test_exit_code_one_when_any_block(self) -> None:
+        report = self._make(
+            [
+                CheckResult(name="a", status=CheckStatus.PASS, message="ok"),
+                CheckResult(name="b", status=CheckStatus.BLOCK, message="bad"),
+            ]
+        )
+        assert report.exit_code == 1
+
+    def test_summary_buckets(self) -> None:
+        report = self._make(
+            [
+                CheckResult(name="p1", status=CheckStatus.PASS, message=""),
+                CheckResult(name="p2", status=CheckStatus.PASS, message=""),
+                CheckResult(name="w1", status=CheckStatus.WARN, message=""),
+                CheckResult(name="b1", status=CheckStatus.BLOCK, message=""),
+            ]
+        )
+        assert len(report.passed) == 2
+        assert len(report.warned) == 1
+        assert len(report.blocked) == 1
+
+    def test_to_dict_round_trips_through_json(self) -> None:
+        report = self._make(
+            [
+                CheckResult(
+                    name="x",
+                    status=CheckStatus.BLOCK,
+                    message="bad",
+                    remediation="fix it",
+                    details={"k": 1},
+                    duration_ms=5,
+                )
+            ]
+        )
+        encoded = json.dumps(report.to_dict())
+        decoded = json.loads(encoded)
+        assert decoded["summary"]["blocked"] == 1
+        assert decoded["checks"][0]["status"] == "BLOCK"
+        assert decoded["exit_code"] == 1
+        assert decoded["version"] == 1
+
+
+# ---------------------------------------------------------------------------
+# run_all_checks — execution behavior
+# ---------------------------------------------------------------------------
+
+
+class TestRunAllChecks:
+    @pytest.fixture
+    def context(self, tmp_path: Path) -> PreflightContext:
+        return PreflightContext.for_test(tmp_path)
+
+    def test_runs_every_check_in_registry_order(self, context: PreflightContext) -> None:
+        checks = [
+            _FakeCheck("alpha"),
+            _FakeCheck("bravo"),
+            _FakeCheck("charlie"),
+        ]
+        report = run_all_checks(context, checks=checks)
+        assert [r.name for r in report.results] == ["alpha", "bravo", "charlie"]
+
+    def test_records_per_check_duration(self, context: PreflightContext) -> None:
+        # 50ms sleep — should show up as duration_ms >= ~40 (allowing scheduler slack)
+        checks = [_FakeCheck("slow", sleep_seconds=0.05)]
+        report = run_all_checks(context, checks=checks)
+        assert report.results[0].duration_ms >= 40
+
+    def test_runs_checks_in_parallel(self, context: PreflightContext) -> None:
+        # Three checks each sleeping 100ms. Sequential would take ~300ms;
+        # parallel should be ~100-150ms. Use a generous upper bound to
+        # avoid CI flakiness, but tight enough to prove parallelism.
+        checks = [
+            _FakeCheck("a", sleep_seconds=0.1),
+            _FakeCheck("b", sleep_seconds=0.1),
+            _FakeCheck("c", sleep_seconds=0.1),
+        ]
+        start = time.monotonic()
+        run_all_checks(context, checks=checks, max_workers=3)
+        elapsed = time.monotonic() - start
+        # Sequential would be 300ms; parallel should be well under 250ms.
+        assert elapsed < 0.25, f"expected parallel <0.25s, got {elapsed:.3f}s"
+
+    def test_timeout_becomes_block_not_crash(self, context: PreflightContext) -> None:
+        # Check sleeps longer than its own timeout — runner must
+        # synthesize a BLOCK, not propagate the TimeoutError.
+        checks = [_FakeCheck("slow", sleep_seconds=0.5, timeout_seconds=0.05)]
+        report = run_all_checks(context, checks=checks)
+        assert report.results[0].status is CheckStatus.BLOCK
+        assert "timeout" in report.results[0].message.lower()
+        assert report.results[0].details["timeout_seconds"] == 0.05
+
+    def test_unexpected_exception_becomes_block_with_traceback(
+        self, context: PreflightContext
+    ) -> None:
+        # Check raises ValueError — runner wraps in BLOCK rather than
+        # propagating. Other checks must still run (exception isolation).
+        checks = [
+            _FakeCheck("explodes", raises=ValueError("kaboom")),
+            _FakeCheck("survivor"),
+        ]
+        report = run_all_checks(context, checks=checks)
+        assert report.results[0].status is CheckStatus.BLOCK
+        assert "ValueError" in report.results[0].message
+        assert "kaboom" in report.results[0].message
+        assert report.results[0].details["exception_type"] == "ValueError"
+        # Sibling check still ran
+        assert report.results[1].status is CheckStatus.PASS
+
+    def test_empty_check_list_is_pass(self, context: PreflightContext) -> None:
+        report = run_all_checks(context, checks=[])
+        assert report.exit_code == 0
+        assert report.results == []
+
+    def test_one_block_one_pass_exits_one(self, context: PreflightContext) -> None:
+        checks = [
+            _FakeCheck("ok"),
+            _FakeCheck("bad", status=CheckStatus.BLOCK, message="bad thing"),
+        ]
+        report = run_all_checks(context, checks=checks)
+        assert report.exit_code == 1
+        assert len(report.blocked) == 1
+
+
+# ---------------------------------------------------------------------------
+# format_plaintext
+# ---------------------------------------------------------------------------
+
+
+class TestFormatPlaintext:
+    @pytest.fixture
+    def context(self, tmp_path: Path) -> PreflightContext:
+        return PreflightContext.for_test(tmp_path)
+
+    def test_happy_path_format(self, context: PreflightContext) -> None:
+        checks = [
+            _FakeCheck("kill_switch_state", message="no triggered state"),
+            _FakeCheck("kill_switch_lock", message="no lock file"),
+        ]
+        report = run_all_checks(context, checks=checks)
+        out = format_plaintext(report)
+        assert "Preflight Safety Gate" in out
+        # Badge is in a fixed-width column, so allow >=1 spaces between
+        # badge and name. The brittle exact-spacing assertion ate me once.
+        assert "[PASS]" in out and "kill_switch_state" in out
+        assert "kill_switch_lock" in out
+        assert "2/2 checks passed. Safe to proceed." in out
+
+    def test_block_renders_boxed_remediation(self, context: PreflightContext) -> None:
+        checks = [
+            _FakeCheck(
+                "kill_switch_state",
+                status=CheckStatus.BLOCK,
+                message="triggered=True",
+                details={"trigger_reason": "NVDA loss"},
+            ),
+        ]
+        # Build report manually to force a remediation string
+        report = RunReport(
+            started_at=_dt.datetime.now().astimezone(),
+            completed_at=_dt.datetime.now().astimezone(),
+            results=[
+                CheckResult(
+                    name="kill_switch_state",
+                    status=CheckStatus.BLOCK,
+                    message="triggered=True",
+                    remediation="Kill switch is triggered.\nRun rm data/kill_switch_state.json",
+                )
+            ],
+            context=context,
+        )
+        out = format_plaintext(report)
+        assert "[BLOCK]" in out and "kill_switch_state" in out
+        assert "1/1 checks BLOCKED. Cannot proceed." in out
+        assert "BLOCK #1 — kill_switch_state" in out
+        assert "Kill switch is triggered." in out
+        assert "╔" in out and "╚" in out  # box drawing chars
+
+    def test_warn_renders_after_summary(self, context: PreflightContext) -> None:
+        report = RunReport(
+            started_at=_dt.datetime.now().astimezone(),
+            completed_at=_dt.datetime.now().astimezone(),
+            results=[
+                CheckResult(
+                    name="risk_threshold",
+                    status=CheckStatus.WARN,
+                    message="max_position_loss_pct=0.018 (<0.02)",
+                    remediation="Consider RISK_MAX_POSITION_LOSS_PCT=0.05",
+                )
+            ],
+            context=context,
+        )
+        out = format_plaintext(report)
+        # Allow fixed-width column spacing between badge and name.
+        assert "[WARN]" in out and "risk_threshold" in out
+        assert "1/1 checks passed (1 with warnings). Safe to proceed." in out
+        assert "⚠ WARN — risk_threshold" in out
+        # WARN footer must come AFTER the summary line
+        warn_pos = out.find("⚠ WARN")
+        summary_pos = out.find("Safe to proceed.")
+        assert warn_pos > summary_pos
+
+    def test_verbose_appends_details_block(self, context: PreflightContext) -> None:
+        report = RunReport(
+            started_at=_dt.datetime.now().astimezone(),
+            completed_at=_dt.datetime.now().astimezone(),
+            results=[
+                CheckResult(
+                    name="x",
+                    status=CheckStatus.PASS,
+                    message="ok",
+                    details={"foo": "bar"},
+                )
+            ],
+            context=context,
+        )
+        terse = format_plaintext(report, verbose=False)
+        verbose = format_plaintext(report, verbose=True)
+        assert "--- details ---" not in terse
+        assert "--- details ---" in verbose
+        assert '"foo": "bar"' in verbose
+
+
+# ---------------------------------------------------------------------------
+# format_json
+# ---------------------------------------------------------------------------
+
+
+class TestFormatJson:
+    def test_is_valid_json_with_expected_shape(self, tmp_path: Path) -> None:
+        context = PreflightContext.for_test(tmp_path)
+        checks = [_FakeCheck("a"), _FakeCheck("b", status=CheckStatus.WARN, message="meh")]
+        report = run_all_checks(context, checks=checks)
+        encoded = format_json(report)
+        decoded = json.loads(encoded)
+        assert decoded["version"] == 1
+        assert decoded["summary"] == {
+            "total": 2,
+            "passed": 1,
+            "warned": 1,
+            "blocked": 0,
+        }
+        assert decoded["exit_code"] == 0
+        assert [c["name"] for c in decoded["checks"]] == ["a", "b"]

--- a/tests/preflight/test_runner_enforcement.py
+++ b/tests/preflight/test_runner_enforcement.py
@@ -1,0 +1,212 @@
+"""Tests for ``_enforce_preflight_or_exit`` (Q11.6 server-side enforcement).
+
+The runner refuses to start unless ``data/.preflight_last_ok`` exists and was
+written within the last ``max_age_seconds`` (default 300s). The flag file is
+written by ``scripts/preflight_check.py`` on every clean exit (PASS or
+``--force`` bypass) per Q11.4. The escape hatch ``PREFLIGHT_ENFORCEMENT=off``
+short-circuits the check entirely.
+
+Exit codes (distinct from preflight CLI's 1/2/3):
+- 4 = flag file missing entirely
+- 5 = flag file present but stale
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from robo_trader.runner_async import _enforce_preflight_or_exit
+
+
+def _make_flag(project_root: Path, age_seconds: float = 0.0) -> Path:
+    """Create ``project_root/data/.preflight_last_ok`` with the given age."""
+    (project_root / "data").mkdir(parents=True, exist_ok=True)
+    path = project_root / "data" / ".preflight_last_ok"
+    path.write_text("2026-05-24T12:00:00-04:00\n", encoding="utf-8")
+    if age_seconds > 0:
+        target = time.time() - age_seconds
+        os.utime(path, (target, target))
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# 1. Missing flag → exit 4
+# --------------------------------------------------------------------------- #
+
+
+def test_missing_flag_exits_with_code_4(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    # No flag file at all.
+    with pytest.raises(SystemExit) as exc_info:
+        _enforce_preflight_or_exit(project_root=tmp_path)
+
+    assert exc_info.value.code == 4
+    err = capsys.readouterr().err
+    assert "PREFLIGHT NOT RUN" in err
+    assert "runner refuses to start" in err
+    # Helpful guidance for the operator.
+    assert "START_TRADER.sh" in err
+    assert "PREFLIGHT_ENFORCEMENT=off" in err
+    # Should show the expected path so they know where it would go.
+    assert str(tmp_path / "data" / ".preflight_last_ok") in err
+
+
+# --------------------------------------------------------------------------- #
+# 2. Fresh flag → returns cleanly
+# --------------------------------------------------------------------------- #
+
+
+def test_fresh_flag_returns_cleanly(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _make_flag(tmp_path, age_seconds=0)
+
+    # Should NOT raise SystemExit.
+    _enforce_preflight_or_exit(project_root=tmp_path)
+
+    # No warning / error printed for the happy path.
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert captured.out == ""
+
+
+# --------------------------------------------------------------------------- #
+# 3. Stale flag → exit 5
+# --------------------------------------------------------------------------- #
+
+
+def test_stale_flag_exits_with_code_5(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    # 10 minutes old, default threshold is 5 minutes.
+    _make_flag(tmp_path, age_seconds=600)
+
+    with pytest.raises(SystemExit) as exc_info:
+        _enforce_preflight_or_exit(project_root=tmp_path)
+
+    assert exc_info.value.code == 5
+    err = capsys.readouterr().err
+    assert "PREFLIGHT STALE" in err
+    # Should report how many minutes old and what the threshold is.
+    assert "10 minutes ago" in err
+    assert "threshold 5 min" in err
+    assert "PREFLIGHT_ENFORCEMENT=off" in err
+
+
+# --------------------------------------------------------------------------- #
+# 4. Flag exactly inside the threshold → returns cleanly
+# --------------------------------------------------------------------------- #
+
+
+def test_flag_just_inside_threshold_returns_cleanly(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # 1 second inside the 300s default → fresh.
+    _make_flag(tmp_path, age_seconds=299)
+
+    _enforce_preflight_or_exit(project_root=tmp_path)
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+# --------------------------------------------------------------------------- #
+# 5. PREFLIGHT_ENFORCEMENT=off → bypasses with warning, even when flag missing
+# --------------------------------------------------------------------------- #
+
+
+def test_env_bypass_skips_check_with_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("PREFLIGHT_ENFORCEMENT", "off")
+
+    # No flag file — would normally exit 4. The bypass must override.
+    _enforce_preflight_or_exit(project_root=tmp_path)
+
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "PREFLIGHT_ENFORCEMENT=off" in err
+    assert "bypassed" in err
+
+
+def test_env_bypass_case_insensitive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Be lenient — accept "OFF", "Off", etc.
+    monkeypatch.setenv("PREFLIGHT_ENFORCEMENT", "OFF")
+
+    _enforce_preflight_or_exit(project_root=tmp_path)
+
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+
+
+def test_env_value_other_than_off_does_not_bypass(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Any value other than "off" must still enforce. Guards against typos
+    # like PREFLIGHT_ENFORCEMENT=false or =0 silently disabling the gate.
+    monkeypatch.setenv("PREFLIGHT_ENFORCEMENT", "false")
+
+    with pytest.raises(SystemExit) as exc_info:
+        _enforce_preflight_or_exit(project_root=tmp_path)
+
+    assert exc_info.value.code == 4
+
+
+# --------------------------------------------------------------------------- #
+# 6. Custom max_age_seconds respected
+# --------------------------------------------------------------------------- #
+
+
+def test_custom_max_age_seconds_tighter_threshold(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # 2 minutes old. Default 300s would pass; max_age=60 should fail.
+    _make_flag(tmp_path, age_seconds=120)
+
+    with pytest.raises(SystemExit) as exc_info:
+        _enforce_preflight_or_exit(project_root=tmp_path, max_age_seconds=60)
+
+    assert exc_info.value.code == 5
+    err = capsys.readouterr().err
+    assert "threshold 1 min" in err
+
+
+def test_custom_max_age_seconds_looser_threshold(tmp_path: Path) -> None:
+    # 10 minutes old. Default 300s would fail; max_age=1200 should pass.
+    _make_flag(tmp_path, age_seconds=600)
+
+    _enforce_preflight_or_exit(project_root=tmp_path, max_age_seconds=1200)
+
+
+# --------------------------------------------------------------------------- #
+# 7. Custom project_root respected (the parameter is actually used)
+# --------------------------------------------------------------------------- #
+
+
+def test_custom_project_root_used_for_flag_lookup(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Build flag under a non-default project root and verify the check
+    # reads from that location (not from cwd or the runner's own location).
+    other_root = tmp_path / "some_other_project"
+    other_root.mkdir()
+    _make_flag(other_root, age_seconds=0)
+
+    # Passing other_root: should find the flag.
+    _enforce_preflight_or_exit(project_root=other_root)
+    assert capsys.readouterr().err == ""
+
+    # Passing tmp_path (where no flag exists): should fail with code 4
+    # AND the error message should reference tmp_path's data dir, not
+    # the runner's default location — proving the parameter is honored.
+    with pytest.raises(SystemExit) as exc_info:
+        _enforce_preflight_or_exit(project_root=tmp_path)
+    assert exc_info.value.code == 4
+    err = capsys.readouterr().err
+    assert str(tmp_path / "data" / ".preflight_last_ok") in err

--- a/tests/preflight/test_zombie_connections_check.py
+++ b/tests/preflight/test_zombie_connections_check.py
@@ -1,0 +1,228 @@
+"""Unit tests for ZombieConnectionsCheck (spec §7.6 / §9.1).
+
+Mocks ``subprocess.run`` via the shared ``mock_lsof`` fixture so the
+tests are hermetic — no real lsof, no real Gateway socket needed. The
+sample output strings below are taken from real ``lsof -nP -iTCP:4002
+-sTCP:CLOSE_WAIT`` output on macOS (see CLAUDE.md row 2025-12-06 for
+why this is the canonical command).
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from robo_trader.preflight import CheckStatus
+from robo_trader.preflight.zombie_connections_check import ZombieConnectionsCheck
+
+# Sample lsof outputs ---------------------------------------------------------
+# Header line + N data lines, matching what real `lsof -nP -iTCP:PORT
+# -sTCP:CLOSE_WAIT` prints on macOS when there's at least one match.
+
+_LSOF_HEADER = "COMMAND    PID  USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME"
+_ONE_ZOMBIE = (
+    f"{_LSOF_HEADER}\n"
+    "java     54321 oliver  127u  IPv4 0xabc...   0t0  "
+    "TCP 127.0.0.1:54321->127.0.0.1:4002 (CLOSE_WAIT)"
+)
+_THREE_ZOMBIES = (
+    f"{_LSOF_HEADER}\n"
+    "java     54321 oliver  127u  IPv4 0xabc...   0t0  "
+    "TCP 127.0.0.1:54321->127.0.0.1:4002 (CLOSE_WAIT)\n"
+    "Python3  54322 oliver  128u  IPv4 0xdef...   0t0  "
+    "TCP 127.0.0.1:54323->127.0.0.1:4002 (CLOSE_WAIT)\n"
+    "Python3  54399 oliver  129u  IPv4 0x123...   0t0  "
+    "TCP 127.0.0.1:54324->127.0.0.1:4002 (CLOSE_WAIT)"
+)
+
+
+# -- happy path ---------------------------------------------------------------
+
+
+def test_returns_pass_when_no_close_wait_lines(mock_lsof, preflight_context):
+    """lsof returns 1 + empty stdout when there are no matching sockets.
+
+    This is the overwhelmingly common case — we want PASS without any
+    diagnostic noise in details (just port + count=0).
+    """
+    mock_lsof(returncode=1, stdout="")
+    result = ZombieConnectionsCheck().run(preflight_context)
+    assert result.status is CheckStatus.PASS
+    assert result.details == {"port": 4002, "zombie_count": 0}
+    # No remediation needed on PASS.
+    assert result.remediation == ""
+
+
+# -- block path: zombies present ---------------------------------------------
+
+
+def test_returns_block_when_one_close_wait_line(mock_lsof, preflight_context):
+    """Single zombie → BLOCK with count=1 and the PID in details."""
+    mock_lsof(returncode=0, stdout=_ONE_ZOMBIE)
+    result = ZombieConnectionsCheck().run(preflight_context)
+    assert result.status is CheckStatus.BLOCK
+    assert result.details["zombie_count"] == 1
+    assert result.details["zombie_pids"] == ["54321"]
+    assert result.details["port"] == 4002
+    # Singular wording when count is 1.
+    assert "1 zombie connection " in result.message or result.message.endswith("port 4002")
+
+
+def test_returns_block_when_three_close_wait_lines(mock_lsof, preflight_context):
+    """Multiple zombies → BLOCK with the full PID list in details."""
+    mock_lsof(returncode=0, stdout=_THREE_ZOMBIES)
+    result = ZombieConnectionsCheck().run(preflight_context)
+    assert result.status is CheckStatus.BLOCK
+    assert result.details["zombie_count"] == 3
+    assert result.details["zombie_pids"] == ["54321", "54322", "54399"]
+    assert "3 zombie connections" in result.message
+
+
+def test_header_line_is_not_counted_as_a_zombie(mock_lsof, preflight_context):
+    """Spec edge case: lsof's COMMAND/PID/USER header must NOT inflate count.
+
+    Two real data rows + one header should report count=2, never 3.
+    """
+    two_rows = (
+        f"{_LSOF_HEADER}\n"
+        "java   1111 oliver  127u  IPv4 0x...   0t0  TCP ...:4002 (CLOSE_WAIT)\n"
+        "java   2222 oliver  128u  IPv4 0x...   0t0  TCP ...:4002 (CLOSE_WAIT)"
+    )
+    mock_lsof(returncode=0, stdout=two_rows)
+    result = ZombieConnectionsCheck().run(preflight_context)
+    assert result.status is CheckStatus.BLOCK
+    assert result.details["zombie_count"] == 2
+    assert result.details["zombie_pids"] == ["1111", "2222"]
+
+
+def test_pids_parsed_from_multiline_output(mock_lsof, preflight_context):
+    """details.zombie_pids must be the parsed list from the actual output."""
+    mock_lsof(returncode=0, stdout=_THREE_ZOMBIES)
+    result = ZombieConnectionsCheck().run(preflight_context)
+    # Order preserved from lsof; tests rely on this for grep-friendly logs.
+    assert result.details["zombie_pids"] == ["54321", "54322", "54399"]
+    # PIDs are strings (matching gateway_manager.py's representation, which
+    # treats them as opaque process identifiers — no arithmetic ever done).
+    assert all(isinstance(p, str) for p in result.details["zombie_pids"])
+
+
+# -- failure paths: lsof itself broke ----------------------------------------
+
+
+def test_returns_block_on_subprocess_timeout(mock_lsof, preflight_context):
+    """TimeoutExpired → BLOCK with a message naming the symptom."""
+    mock_lsof(
+        side_effect=subprocess.TimeoutExpired(cmd="lsof", timeout=3),
+    )
+    result = ZombieConnectionsCheck().run(preflight_context)
+    assert result.status is CheckStatus.BLOCK
+    assert "timed out" in result.message.lower()
+    assert result.details["port"] == 4002
+    assert "timeout" in result.details["error"].lower()
+
+
+def test_returns_block_when_lsof_not_installed(mock_lsof, preflight_context):
+    """FileNotFoundError (no lsof binary) → BLOCK that explains what's wrong."""
+    mock_lsof(side_effect=FileNotFoundError(2, "No such file", "lsof"))
+    result = ZombieConnectionsCheck().run(preflight_context)
+    assert result.status is CheckStatus.BLOCK
+    assert "lsof" in result.message.lower()
+    # Remediation must tell the operator how to install lsof.
+    assert "install" in result.remediation.lower()
+
+
+# -- remediation text contracts ----------------------------------------------
+
+
+def test_remediation_includes_both_cleanup_paths(mock_lsof, preflight_context):
+    """Spec §7.6 mandates BOTH the Python-zombie clear path AND Gateway restart.
+
+    Operator should see the cheap fix first, then the escalation.
+    """
+    mock_lsof(returncode=0, stdout=_ONE_ZOMBIE)
+    result = ZombieConnectionsCheck().run(preflight_context)
+    assert "clear-zombies" in result.remediation
+    assert "gateway_manager.py restart" in result.remediation
+    # And the canonical re-entry point.
+    assert "START_TRADER.sh" in result.remediation
+
+
+def test_remediation_includes_port_number(mock_lsof, preflight_context):
+    """Operator-visible message should name the port being inspected."""
+    mock_lsof(returncode=0, stdout=_ONE_ZOMBIE)
+    result = ZombieConnectionsCheck().run(preflight_context)
+    assert "4002" in result.remediation
+
+
+# -- ambiguous lsof exit codes -----------------------------------------------
+
+
+def test_ambiguous_exit_code_with_empty_stdout_passes_with_diagnostic(mock_lsof, preflight_context):
+    """Per task brief: unexpected (returncode, stdout) → PASS but log exit code.
+
+    If lsof exits with something other than 0 (matches) or 1 (no matches)
+    and produces no parseable rows, we don't have evidence of zombies and
+    must not block — but we DO stash the exit code in details for future
+    debugging.
+    """
+    mock_lsof(returncode=99, stdout="")
+    result = ZombieConnectionsCheck().run(preflight_context)
+    assert result.status is CheckStatus.PASS
+    assert result.details["zombie_count"] == 0
+    assert result.details["lsof_exit_code"] == 99
+
+
+# -- target_port plumbing ----------------------------------------------------
+
+
+def test_uses_target_port_from_context(mock_lsof, tmp_path):
+    """Live-trading context (port 4001) must be respected."""
+    from robo_trader.preflight import PreflightContext
+
+    ctx = PreflightContext.for_test(tmp_path, target_port=4001)
+    mock_lsof(returncode=1, stdout="")
+    result = ZombieConnectionsCheck().run(ctx)
+    assert result.status is CheckStatus.PASS
+    assert result.details["port"] == 4001
+    assert "4001" in result.message
+
+
+# -- Check protocol surface --------------------------------------------------
+
+
+def test_check_has_required_protocol_attributes():
+    """name/description/timeout_seconds — the registry depends on these."""
+    check = ZombieConnectionsCheck()
+    assert check.name == "zombie_connections"
+    assert check.description == "Zombie connections"
+    assert check.timeout_seconds == 3.0
+
+
+# -- Sanity: real lsof exit code on macOS ------------------------------------
+
+
+def test_real_lsof_exits_one_when_no_matches():
+    """Documents the lsof exit-code contract this check relies on.
+
+    Regression guard: if a future macOS update makes ``lsof`` exit 0 even
+    when there's nothing to report, our PASS-on-empty-stdout logic still
+    holds, but the ``zombie_count == 0`` invariant would need re-thinking.
+    """
+    # Use a port that's overwhelmingly unlikely to have anything CLOSE_WAIT.
+    result = subprocess.run(
+        ["lsof", "-nP", "-iTCP:59999", "-sTCP:CLOSE_WAIT"],
+        capture_output=True,
+        text=True,
+        timeout=3,
+    )
+    # Either exit 1 (the historical macOS contract) or exit 0 with empty
+    # stdout — both are fine for our check; we just don't want exit 0 with
+    # spurious data.
+    assert (result.returncode == 1 and result.stdout == "") or (
+        result.returncode == 0 and result.stdout.strip() == ""
+    ), f"lsof: rc={result.returncode!r} stdout={result.stdout!r}"
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/tests/test_p1_risk.py
+++ b/tests/test_p1_risk.py
@@ -7,6 +7,7 @@ Tests Kelly sizing, correlation limits, and kill switches
 import asyncio
 import json
 import sys
+import tempfile
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -121,18 +122,22 @@ def test_correlation_limiter():
     return True
 
 
-def test_kill_switches():
+def test_kill_switches(tmp_path):
     """Test automated kill switches"""
     print("\n" + "=" * 50)
     print("Testing Automated Kill Switches")
     print("=" * 50)
 
+    # Isolate state file (and the lock path KillSwitch derives from it) under
+    # tmp_path so triggered state never pollutes the real data/ directory and
+    # blocks the preflight safety gate on the next ./START_TRADER.sh.
     kill_switch = KillSwitch(
         max_daily_loss_pct=0.05,
         max_position_loss_pct=0.02,
         max_consecutive_losses=5,
         max_drawdown_pct=0.10,
         cooldown_minutes=60,
+        state_path=tmp_path / "kill_switch_state.json",
     )
 
     # Test daily loss check
@@ -305,11 +310,12 @@ def main():
 
     # Test kill switches
     try:
-        if test_kill_switches():
-            print("✅ Kill switch tests PASSED")
-        else:
-            print("❌ Kill switch tests FAILED")
-            all_passed = False
+        with tempfile.TemporaryDirectory() as td:
+            if test_kill_switches(Path(td)):
+                print("✅ Kill switch tests PASSED")
+            else:
+                print("❌ Kill switch tests FAILED")
+                all_passed = False
     except Exception as e:
         print(f"❌ Kill switch tests FAILED: {e}")
         all_passed = False


### PR DESCRIPTION
## Summary

Adds a startup safety gate (\`scripts/preflight_check.py\`) that runs BEFORE the trading runner spins up. Six checks in parallel; if any BLOCK, the runner refuses to start and the operator gets a boxed remediation per BLOCK with the exact commands to fix it.

**Built to prevent the 2026-05-22 incident pattern** where a triggered kill switch caused 18 silent failed restarts over 4 hours. With this gate, the same condition surfaces as a clear, actionable message on the first restart attempt.

## ⚠️ Stacked on #72

This PR builds on \`feature/persistent-ibkr-connection-only\` (#72 — persistent IBKR connection). **Merge #72 first**, then this PR's base will need to switch to \`main\`. The two are stacked to keep review surfaces independent.

## What changed

- **New package \`robo_trader/preflight/\`** — six independent \`Check\` classes (kill-switch state, kill-switch lock, equity history freshness, risk threshold, gateway port, zombies), each with its own test module
- \`robo_trader/preflight/runner.py\` — \`ThreadPoolExecutor\` parallel runner with per-check timeouts (timeout → BLOCK, exception → BLOCK with traceback) + plaintext/JSON formatters
- \`scripts/preflight_check.py\` — CLI with \`--json\`, \`--verbose\`, \`--force "<reason>"\` (auditable bypass requiring real-sentence reason, appends JSONL to \`data/preflight_bypass.log\`)
- \`START_TRADER.sh\` — Step 4.5 invokes preflight, case-statement on exit code distinguishes "bypassed via --force" (exit 2, banner) from "blocked" (exit 1, abort)
- \`robo_trader/runner_async.py\` — \`_enforce_preflight_or_exit()\` reads \`data/.preflight_last_ok\` (written by CLI on clean exit). Runner refuses to start if missing (exit 4) or stale >5min (exit 5). Escape hatch via \`PREFLIGHT_ENFORCEMENT=off\` env var (logged at WARNING)
- CLAUDE.md — full operational documentation
- 8 test modules, 150 tests (97 check tests + 18 runner + 25 CLI + 10 runner-enforcement)

## Design decisions worth flagging

1. **Three-tier severity** (PASS/WARN/BLOCK) not flat — lets \`RISK_MAX_POSITION_LOSS_PCT=0.018\` warn but not block, while \`<0.01\` blocks as almost-certainly-typo
2. **No interactive prompts** — at 3am with a watchdog auto-restart there's no human at the keyboard; bypass is via \`--force\` with reason, never \`y/n\`
3. **\`--force\` reason validation** — min 10 chars, denylist filters \`force\`, \`bypass\`, \`idk\`, \`test\` etc. so operators can't paste a placeholder
4. **Prerequisite enforced by the protected thing** — runner reads \`.preflight_last_ok\` itself, so \`python3 -m robo_trader.runner_async\` direct invocation also gets gated, not just \`./START_TRADER.sh\`
5. **AGAINST mirroring H1 keyword-based kill-switch auto-clear at preflight** — H1 auto-clears AFTER \`recover_connection\` proves the connection works; preflight has no such evidence so applying the same keyword check would silently clear real loss-trigger reasons that happen to contain "gateway"/"connection"

## Test plan

- [x] \`.venv/bin/pytest tests/preflight/ --tb=short\` — 150 passed, <1s
- [x] \`.venv/bin/pytest --tb=short\` (full suite) — 881 passed, 3 intentional skips
- [x] \`.venv/bin/black --check\` + \`flake8\` on new code — clean
- [x] \`bash -n START_TRADER.sh\` — syntax clean
- [x] **End-to-end canary** — every BLOCK condition triggered in turn; verified message, exit code, audit log, and \`.preflight_last_ok\` flag behavior. All 8 canary scenarios pass (clean state, kill_switch_state block, kill_switch_lock block, force-with-block exit 2, placeholder reason rejected, WARN tier, BLOCK tier, Q11.6 missing/fresh/stale flag + escape hatch)
- [ ] Soak test in paper trading once stacked PR merges

## Related

- Stacked on #72 (persistent connection)
- Design spec: \`docs/superpowers/specs/2026-05-23-startup-safety-gate-design.md\`
- Plan doc: \`docs/superpowers/plans/2026-05-23-robust-startup-safety-plan.md\`
- 6 spec open questions answered + 4 deferred to Phase 2 (see spec §11)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how production starts (blocks trading on persisted kill switch and Gateway state) and hardens START_TRADER/watchdog behavior; checks are read-only and do not auto-clear risk state, but misconfiguration or bypass misuse could resume trading against real blocks.
> 
> **Overview**
> Adds a **startup preflight safety gate** that runs before the trader and dashboard launch, turning silent restart loops (e.g. persisted kill switch) into immediate, actionable BLOCK messages with remediation text.
> 
> **New `robo_trader/preflight/`** — six parallel checks (kill-switch JSON + lock file, equity-history freshness via trading-day math, `RISK_MAX_POSITION_LOSS_PCT` warn/block tiers, Gateway port LISTEN and CLOSE_WAIT via `lsof` only). **`scripts/preflight_check.py`** exposes plaintext/JSON output, exit codes 0/1/2/3, auditable **`--force "<reason>"`** (JSONL to `data/preflight_bypass.log`), and writes **`data/.preflight_last_ok`** on clean or bypassed runs.
> 
> **`START_TRADER.sh`** wires Step 4.5 with correct exit-code handling under `set -e` (`|| PREFLIGHT_RC=$?`), forwards **`--force=`**, resolves absolute **`lsof`** (fail loud if missing), lengthens Gateway/2FA waits (180s / 240s), and documents preflight in **`CLAUDE.md`**.
> 
> **`runner_async.main()`** calls **`_enforce_preflight_or_exit()`** so direct runner invocation also requires a recent preflight flag (exits 4/5; **`PREFLIGHT_ENFORCEMENT=off`** escape hatch).
> 
> **Test/production isolation:** **`conftest.py`** sets per-session log + **`RT_DB_PATH`** temp DB; DB modules honor **`RT_DB_PATH`**. Watchdog plist PATH adds **`/usr/sbin`**. Design/plan specs under **`docs/superpowers/`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59f39285f76f21fda5dec2c27d6d0cce483391cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->