### PR TITLE
Fix timezone-naive daily-P&L window and negative-capital guard in get_risk_status

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,7 +14,7 @@ import signal
 import subprocess
 import threading
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from functools import wraps
 from pathlib import Path
@@ -7483,8 +7483,10 @@ def get_risk_status():
         if risk_state_file.exists():
             with open(risk_state_file) as f:
                 risk_state = json.load(f)
-        # Guard against zero/missing capital (division-by-zero protection downstream)
-        if not risk_state.get("current_capital"):
+        # Guard against zero/missing/negative capital (division-by-zero and
+        # negative-leverage protection downstream); mirror get_kelly_parameters.
+        capital = risk_state.get("current_capital")
+        if not isinstance(capital, (int, float)) or capital <= 0:
             risk_state["current_capital"] = 100000
 
         # Get real data from database
@@ -7515,13 +7517,22 @@ def get_risk_status():
             else:
                 break
 
-        # Calculate daily loss
-        today_trades = [
-            t
-            for t in trades
-            if t.get("timestamp")
-            and datetime.fromisoformat(t["timestamp"]).date() == datetime.now().date()
-        ]
+        # Calculate daily loss. Trade timestamps are stored as naive-UTC strings
+        # (SQLite CURRENT_TIMESTAMP), so attach UTC and convert to ET before
+        # comparing dates -- otherwise extended-hours trades after 8 PM ET land
+        # on the wrong calendar day (mirrors the ET handling near line 6058).
+        from zoneinfo import ZoneInfo
+
+        et_tz = ZoneInfo("America/New_York")
+        today_et = datetime.now(et_tz).date()
+        today_trades = []
+        for t in trades:
+            if not t.get("timestamp"):
+                continue
+            ts = datetime.fromisoformat(t["timestamp"].replace(" ", "T"))
+            ts_utc = ts if ts.tzinfo else ts.replace(tzinfo=timezone.utc)
+            if ts_utc.astimezone(et_tz).date() == today_et:
+                today_trades.append(t)
         daily_pnl = sum((t.get("pnl") or 0) for t in today_trades)
         daily_loss_pct = (
             abs(daily_pnl / risk_state.get("current_capital", 100000)) if daily_pnl < 0 else 0

--- a/tests/test_get_risk_status_tz.py
+++ b/tests/test_get_risk_status_tz.py
@@ -1,0 +1,84 @@
+"""Regression tests for the get_risk_status daily-P&L timezone bug.
+
+Per docs/dashboard_risk_tab_backend_followup.md section 4: get_risk_status
+filtered "today" trades with a naive .date() comparison,
+datetime.fromisoformat(ts).date() == datetime.now().date().
+
+Trade timestamps are stored as naive-UTC strings (SQLite CURRENT_TIMESTAMP),
+so a trade after 8 PM ET -- e.g. 21:30 ET, stored as the next UTC calendar
+day -- was attributed to the wrong day and dropped from the current ET day's
+daily_pnl, skewing daily_loss_pct and the kill-switch threshold.
+
+These tests hit the real /api/risk/status route with a patched trade reader
+and a frozen ET clock, so they exercise the production filter (not a copy),
+are deterministic regardless of when/where they run, and fail if the fix is
+reverted.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+from zoneinfo import ZoneInfo
+
+import pytest
+
+ET = ZoneInfo("America/New_York")
+# Frozen "now" = 2026-06-24 21:30 ET (extended hours). In UTC this is
+# 2026-06-25 01:30, i.e. the NEXT calendar day -- the exact condition that
+# broke the old naive comparison.
+FROZEN_ET_NOW = datetime(2026, 6, 24, 21, 30, tzinfo=ET)
+
+
+class _FrozenDateTime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return FROZEN_ET_NOW.astimezone(tz) if tz else FROZEN_ET_NOW.replace(tzinfo=None)
+
+
+@pytest.fixture
+def client():
+    # config.py requires IBKR_* at import; dummy values, the route is tested
+    # with a mocked reader and never connects.
+    env = {
+        "DASH_AUTH_ENABLED": "false",
+        "ADVANCED_RISK_ENABLED": "true",
+        "IBKR_HOST": "127.0.0.1",
+        "IBKR_PORT": "7497",
+        "IBKR_CLIENT_ID": "1",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        from app import app
+
+        app.config["TESTING"] = True
+        with app.test_client() as c:
+            yield c
+
+
+def _reader(trades):
+    reader = MagicMock()
+    reader.get_recent_trades.return_value = trades
+    reader.get_positions.return_value = []
+    return patch("sync_db_reader.SyncDatabaseReader", MagicMock(return_value=reader))
+
+
+def _daily_pnl(client, trades):
+    with _reader(trades), patch("app.datetime", _FrozenDateTime):
+        resp = client.get("/api/risk/status")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data.get("error") is None
+    return data["risk_metrics"]["daily_pnl"]
+
+
+def test_after_8pm_et_trade_counts_today(client):
+    # 2026-06-25 01:30 UTC == 2026-06-24 21:30 ET: same ET day as frozen now.
+    trade = {"timestamp": "2026-06-25 01:30:00", "pnl": -150.0, "symbol": "AAA"}
+    assert _daily_pnl(client, [trade]) == -150.0
+
+
+def test_prior_et_day_trade_excluded_today(client):
+    # 2026-06-23 16:00 UTC == 2026-06-23 12:00 ET: a different ET day.
+    trade = {"timestamp": "2026-06-23 16:00:00", "pnl": -150.0, "symbol": "AAA"}
+    assert _daily_pnl(client, [trade]) == 0.0


### PR DESCRIPTION
## Summary

`get_risk_status` had two latent bugs in its daily-risk math, both tracked in
`docs/dashboard_risk_tab_backend_followup.md` §4 (from the PR #76 review). Scoped to
`get_risk_status`; the cross-endpoint `portfolio_id` scoping item from §4 is left for its own change.

## Fixes

### 1. Timezone-naive daily-P&L window
The "today's trades" filter compared **naive dates**:
`datetime.fromisoformat(t["timestamp"]).date() == datetime.now().date()`.

Trade timestamps are stored as **naive-UTC** strings: `record_trade` omits the column, so SQLite
fills it via `DEFAULT CURRENT_TIMESTAMP` (`'YYYY-MM-DD HH:MM:SS'`, UTC, no offset). So
`fromisoformat(...).date()` is the **UTC** date while `datetime.now().date()` is the **server-local**
date. An extended-hours trade after 8 PM ET (stored on the next UTC day, e.g. `21:30 ET` is `01:30 UTC`)
was attributed to the wrong day and **dropped from `daily_pnl`**, understating `daily_loss_pct` and the
kill-switch threshold.

Fix: attach UTC to the stored timestamp, convert to `America/New_York`, then compare ET dates on both
sides, mirroring the ET handling already used in the portfolio-summary block (~line 6058). Uses stdlib
**`zoneinfo`** (already used elsewhere in `app.py`), so no new dependency.

### 2. Falsy-only negative-capital guard
`if not risk_state.get("current_capital")` caught `0`/`None`/missing but **not a negative** value
(negatives are truthy), which then flows into the leverage and daily-loss divisions and yields
**negative leverage**. Tightened to a type-check plus `<= 0`, mirroring the more defensive guard in
`get_kelly_parameters`.

## Tests

Adds `tests/test_get_risk_status_tz.py`, which hits `/api/risk/status` with a patched trade reader and a
**frozen ET clock**, so it exercises the real route filter (not a copy) and is deterministic regardless
of when or where it runs. The after-8 PM-ET case **fails before this fix and passes after**; a
prior-ET-day case guards against over-counting.

## Verification (local)

- `black --check --line-length 100 app.py tests/test_get_risk_status_tz.py`: clean
- `flake8 app.py tests/test_get_risk_status_tz.py`: clean
- `pytest tests/test_get_risk_status_tz.py`: 2 passed
- `pytest tests/`: 883 passed, 2 skipped (Python 3.12). The single failure,
  `test_ops.py::test_watchdog_plist_paths_exist`, asserts the committed plist's machine-specific
  `/Users/oliver/...` watchdog path, so it only passes on your checkout; unrelated to this change.

## Notes

- Surgical: `app.py` +21/-10 plus one new test file; no whole-file reformat (`black --check .` has
  pre-existing failures on unrelated `app.py` lines).
- The test sets dummy `IBKR_*` env so it can import `app` in isolation (it never connects; the reader is
  mocked).
- The same tz-naive pattern exists in `microstructure_metrics` (~line 7314); left out of scope since §4
  only lists `get_risk_status`.
- The optional `max_drawdown` label relabel from §4 is not included (kept this PR code-only); happy to
  add it or split it into its own change.
