### PR TITLE
Harden runtime stability after disk-fill incident

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -566,6 +566,9 @@ STOP_LOSS_PERCENT=2.0           # Fixed 2% stop
 | Stop-loss has no price data on restart → ML sells first | Stop-loss needs `update_price()` calls; ML sell blocked by profit check | 2026-02-04 |
 | Forgetting to load launchd watchdog on fresh install | Run ./scripts/install_watchdog.sh ONCE per machine | 2026-05-12 |
 | Adding per-cycle IBKR disconnect/reconnect in run_continuous | Connection is long-lived under run_continuous; cycles must reuse via teardown(full_cleanup=False). Re-introducing per-cycle disconnect causes 2026-05-13-style IBKR-throttle cascade | 2026-05-16 |
+| Gating the run_continuous inter-cycle sleep on `is_trading_allowed()` | With `--force-connect` + market closed, NO wait branch ran → zero-backoff spin at thousands of iterations/sec, 69 GB log flood (2026-07-10). Sleep must run on EVERY loop path — use `intercycle_wait_seconds()`; regression tests in `tests/test_run_continuous_persistent.py::TestIntercycleWait` | 2026-07-10 |
+| Passing testing flags (`--force-connect`) in production startup (START_TRADER.sh) | The flag's help says "for testing" but it shipped in the only sanctioned startup path for 7 months. Testing-only flags stay OUT of START_TRADER.sh | 2026-07-10 |
+| launchd `StandardOutPath`/`StandardErrorPath` pointing at a script-rotated log (watchdog.log) | launchd holds a persistent write fd, so `rotate_log()`'s mv can't cap it, and every backgrounded child (`&` in START_TRADER.sh) inherits the fd and floods it. launchd streams go to a separate `watchdog_launchd.log`; children redirect their own stdout (`runner_stdout.log`, `dashboard_stdout.log`, truncated per start) | 2026-07-10 |
 
 ---
 

--- a/START_TRADER.sh
+++ b/START_TRADER.sh
@@ -212,6 +212,19 @@ check_zombies() {
     echo "${count:-0}"
 }
 
+# Function to rotate a child's stdout log before (re)launching it.
+# In a restart storm (472 restarts on 2026-05-29) each start would otherwise
+# truncate the previous attempt's crash output, leaving only the last try.
+# Keep ONE prior generation as <name>.log.1 (gitignored via *.log.*), then let
+# the caller's `> file` redirect truncate a fresh file. Guarded so a non-zero
+# test/mv can't trip `set -e`. Uses only /bin,/usr/bin coreutils (test, mv).
+rotate_log() {
+    local f="$1"
+    if [ -s "$f" ]; then
+        mv -f "$f" "$f.1" || true
+    fi
+}
+
 # Step 2: Check/Start Gateway with retry logic
 echo "2. Checking Gateway status..."
 GATEWAY_RETRY=0
@@ -421,8 +434,10 @@ echo "5. Starting dashboard with WebSocket server..."
 export DASH_PORT=5555
 # Redirect stdout/stderr: backgrounded children otherwise inherit the
 # caller's fds — under the watchdog/launchd that was watchdog.log, which
-# bypassed all rotation and filled the disk on 2026-07-10. Truncate on
-# each start so these can't grow unbounded across restarts.
+# bypassed all rotation and filled the disk on 2026-07-10. Rotate one
+# generation, then truncate on each start so these can't grow unbounded
+# across restarts while still preserving the prior attempt's crash output.
+rotate_log "$SCRIPT_DIR/dashboard_stdout.log"
 $PYTHON app.py > "$SCRIPT_DIR/dashboard_stdout.log" 2>&1 &
 DASH_PID=$!
 sleep 2
@@ -432,6 +447,7 @@ if ps -p $DASH_PID > /dev/null; then
     echo "   ✓ WebSocket server running on ws://localhost:8765"
 else
     echo "   ⚠️  Dashboard may have failed to start"
+    echo "      Check logs: tail -50 $SCRIPT_DIR/dashboard_stdout.log"
 fi
 echo ""
 
@@ -448,6 +464,7 @@ export LOG_FILE="$SCRIPT_DIR/robo_trader.log"
 # skip, drove the zero-backoff spin loop in the disk-fill incident. Outside
 # market hours the runner now sleeps until open (extended hours still
 # covered by ENABLE_EXTENDED_HOURS via is_trading_allowed).
+rotate_log "$SCRIPT_DIR/runner_stdout.log"
 $PYTHON -m robo_trader.runner_async --symbols "$SYMBOLS" > "$SCRIPT_DIR/runner_stdout.log" 2>&1 &
 TRADER_PID=$!
 
@@ -469,6 +486,7 @@ if ps -p $TRADER_PID > /dev/null; then
     echo "Dashboard PID: $DASH_PID (includes WebSocket server)"
     echo ""
     echo "Monitor logs: tail -f robo_trader.log"
+    echo "  Pre-logger crash output (import/.env errors): runner_stdout.log, dashboard_stdout.log"
     echo "View dashboard: http://localhost:5555"
     echo "WebSocket: ws://localhost:8765"
     echo ""
@@ -501,7 +519,9 @@ if ps -p $TRADER_PID > /dev/null; then
 else
     echo "   ❌ Trading system stopped unexpectedly"
     echo ""
-    echo "Check logs: tail -50 robo_trader.log"
+    echo "Check logs: tail -50 $SCRIPT_DIR/runner_stdout.log"
+    echo "  (a pre-logger crash — import error, bad .env — lands ONLY there, not robo_trader.log)"
+    echo "  Then also: tail -50 robo_trader.log"
     echo ""
     exit 1
 fi

--- a/START_TRADER.sh
+++ b/START_TRADER.sh
@@ -419,7 +419,11 @@ echo ""
 # Step 5: Start dashboard (includes WebSocket server)
 echo "5. Starting dashboard with WebSocket server..."
 export DASH_PORT=5555
-$PYTHON app.py &
+# Redirect stdout/stderr: backgrounded children otherwise inherit the
+# caller's fds — under the watchdog/launchd that was watchdog.log, which
+# bypassed all rotation and filled the disk on 2026-07-10. Truncate on
+# each start so these can't grow unbounded across restarts.
+$PYTHON app.py > "$SCRIPT_DIR/dashboard_stdout.log" 2>&1 &
 DASH_PID=$!
 sleep 2
 
@@ -439,7 +443,12 @@ echo ""
 
 export LOG_FILE="$SCRIPT_DIR/robo_trader.log"
 
-$PYTHON -m robo_trader.runner_async --symbols "$SYMBOLS" --force-connect &
+# --force-connect removed 2026-07-10: it is a testing flag ("Force IBKR
+# connection even when market is closed") that, combined with a health-gate
+# skip, drove the zero-backoff spin loop in the disk-fill incident. Outside
+# market hours the runner now sleeps until open (extended hours still
+# covered by ENABLE_EXTENDED_HOURS via is_trading_allowed).
+$PYTHON -m robo_trader.runner_async --symbols "$SYMBOLS" > "$SCRIPT_DIR/runner_stdout.log" 2>&1 &
 TRADER_PID=$!
 
 echo "   ✓ Trading system started (PID: $TRADER_PID)"

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -41,6 +41,7 @@ services:
       - DASH_PORT=5555
       - WEBSOCKET_URL=ws://websocket:8765
       - LOG_LEVEL=WARNING
+      - LOG_CONSOLE=true
       - MONITORING_LOG_FORMAT=json
       - DASH_ENV=production
       - PYTHONOPTIMIZE=2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       - DASH_PORT=5555
       - WEBSOCKET_URL=ws://websocket:8765
       - LOG_LEVEL=INFO
+      - LOG_CONSOLE=true
       - MONITORING_LOG_FORMAT=plain
     volumes:
       - ./data:/app/data

--- a/handoff/HANDOFF_2026-06-13_pnl-and-data-quality-investigation.md
+++ b/handoff/HANDOFF_2026-06-13_pnl-and-data-quality-investigation.md
@@ -1,0 +1,182 @@
+# Handoff — P&L / Data-Quality Investigation (3 root-cause bugs)
+
+**Created:** 2026-06-13
+**Priority:** HIGH (real money-affecting logic; system is live in paper mode)
+**Branch:** investigation done on `main`; **no code changed, no DB touched**
+**Status:** DIAGNOSIS ONLY — awaiting coordination before any fix is implemented
+
+---
+
+## Why this handoff exists
+
+User asked "are the recommendations accurate?" and "why have we lost money?".
+A read-only investigation (3 parallel agents) found **three independent root
+causes**. This doc exists to **coordinate with the parallel
+`fix/strategy-and-test-bugs` work** before anyone edits core trading code, so we
+don't collide. All findings are cited to `file:line`. Nothing here is
+implemented yet.
+
+> Numbers below were captured live (~149 trades) and drift as the trader runs.
+> The *diagnosis* is stable; treat exact dollar figures as of 2026-06-13.
+
+---
+
+## TL;DR — the headline you need to act on
+
+1. **The dashboard P&L is wrong and overstates profit.** The ledger shows
+   ~**+$224** realized; correct running-cost accounting shows **−$215.12**
+   (verified to the cent via an economic-identity check). **The system is
+   actually down, not up.**
+2. **The "recommendations" carry no signal.** Recorded signal `strength` is a
+   **hardcoded 0.6** — the ML model's confidence never reaches the recorded
+   signal. The 2,900+ signals/week are mostly a fallback path re-logging
+   blocked signals every cycle.
+3. **The −$419 TSLA trade was bad data, not a strategy decision.** A corrupt
+   `$214.85` tick (TSLA was ~$424) fired the stop-loss because **the
+   deviation-checking validator is dead code** and the on-path validator only
+   checks absolute bounds.
+
+---
+
+## Root cause #1 — corrupt tick + unguarded stop-loss (the −$419 event)
+
+`2026-06-04 10:54:27  TSLA SELL 2 @ $214.85  pnl −$410.93`
+
+- The only price-deviation check in the repo lives in
+  `robo_trader/data_validator.py:311-334` (`_check_anomalies`, 20% max move).
+  **This class is instantiated/called nowhere in the running system — dead
+  code.** (A second unused `DataValidator` also exists at
+  `robo_trader/data/validation.py:205`.)
+- The validator actually on the hot path,
+  `robo_trader/database_validator.py:150-193` (`validate_price`, called by
+  `stop_loss_monitor.py:271`), only enforces absolute bounds
+  ($0.0001–$1,000,000). `$214.85` passes.
+- Path: `runner_async.py:1954` pushes the raw close into
+  `stop_loss_monitor.update_price` → `check_stops` (`stop_loss_monitor.py:334-387`,
+  1s loop) → triggers → `execute_stop_loss` fills at `trigger_price = 214.85`
+  (`stop_loss_monitor.py:418`). The stop-loss path is **exempt** from the
+  "don't sell at a loss" guard, so it liquidated 2 real shares for $429.70
+  instead of ~$848.
+- **Likely source = cross-symbol contamination, not a random tick.** The
+  subprocess IBKR client uses a **shared response queue with no request-ID /
+  symbol correlation** (`subprocess_ibkr_client.py:128`, FIFO pop at
+  `:499`); `get_historical_bars` returns bars without checking the symbol
+  (`:749-762`), and the worker response carries no symbol field
+  (`ibkr_subprocess_worker.py:501`). A late NVDA response (~$214, exactly
+  NVDA's band that day) could be popped by a TSLA request.
+
+**Proposed fix (described, not implemented):**
+- **A.** Max-deviation guard in `stop_loss_monitor.py` right after line 274:
+  reject a tick if `abs(price - last)/last > MAX_TICK_DEVIATION_PCT` (default
+  0.20, env-configurable); don't update `last_prices`, log a warning, return.
+  This neutralizes BOTH a bad tick and a contaminated price.
+- **B.** Echo the symbol in the worker response and assert it client-side in
+  `subprocess_ibkr_client.get_historical_bars` — closes the contamination hole
+  at the source.
+- **C (lower priority).** Wire `DataValidator.validate_dataframe()` into
+  `runner_async.fetch_and_store_data` (~line 1810) so corrupt bars never reach
+  `latest_prices` or the DB.
+
+---
+
+## Root cause #2 — signal flood + whipsaw + meaningless strength
+
+- **Strength is hardcoded 0.6**, not ML confidence: `runner_async.py:2203`
+  (SMA fallback) and `ml_enhanced_strategy.py:406/409` (MTF helper). DB confirms
+  every ML_ENHANCED row is exactly 0.6. The model path
+  (`ml_enhanced_strategy.py:295`, `np.max(probabilities)`) is being bypassed —
+  likely the `len(data) < 200` gate (`ml_enhanced_strategy.py:175`) on intraday
+  bars forces the fallback.
+- **The flood:** `record_signal` is called every 15s cycle at
+  `runner_async.py:2349-2360`, **before** any execution guard. Guards block the
+  *trade* but not the *recording*. AAPL is held at a loss → emits SELL every
+  cycle → blocked by the profit guard (`runner_async.py:2757`) → re-logged
+  forever (≈2,324 rows/week). TSLA mirror: held position re-emits BUY, blocked
+  by the "already have position" guard, re-logged.
+- **The whipsaw:** no hysteresis/dwell between opposite signals; the SELL
+  execution block (`runner_async.py:2731-2767`) has **no cooldown** (only BUY
+  does, at `:2507/:2523`).
+
+**Proposed fix (described, not implemented), prioritized:**
+- **P1.** Don't re-record an unchanged/blocked signal: keep
+  `self._last_recorded_signal[symbol]` and only write on direction/strength-band
+  change (`runner_async.py:~2349`). Collapses thousands of rows → tens, kills
+  the dashboard whipsaw, zero trade-logic risk.
+- **P2.** Make `strength` the real ML confidence; fix why `analyze()` falls
+  through to SMA (the 200-bar gate). Until then every confidence threshold is
+  operating on a constant.
+- **P3.** Add a symmetric opposite-signal cooldown to the SELL path / centralize
+  the `has_recent_*` guards for both directions.
+- **P4.** When a position is held at a loss and the stop-loss owns the exit,
+  emit HOLD upstream instead of a guaranteed-blocked SELL.
+
+---
+
+## Root cause #3 — two incompatible P&L accounting methods
+
+- **Ledger `trades.pnl`** is computed by `_calculate_fifo_pnl`
+  (`database_async.py:478-516`) which, despite the name, is **not FIFO**: it
+  averages over *all buy rows ever* without consuming sold shares. On a system
+  that round-trips AAPL/TSLA/NVDA 20+ times at rising prices, this
+  **systematically overstates profit** (~+$584 error on AAPL alone). Written to
+  `trades` at `database_async.py:556-563`.
+- **Portfolio `realized_pnl`** (`portfolio.py:82-84`) uses correct running
+  weighted-average cost. This is the right method.
+- **`account.realized_pnl`** is a *third*, path-dependent value: restored from
+  the `account` snapshot on restart (`runner_async.py:1522-1533`), incremented
+  in-memory, written back (`runner_async.py:3060-3113`). It matches neither.
+- **True realized P&L = −$215.12** (running-cost recompute; economic identity:
+  ledger-implied equity − $100k start − unrealized = −$215.12 exactly).
+- **~$430 cash desync** = the corrupt TSLA sell notional exactly → the
+  documented **TC-M8** non-transactional update window
+  (`runner_async.py:867-877`): position/cash/DB writes aren't atomic, so a
+  restart mid-fill drifts `portfolio.cash` from the ledger.
+
+**Proposed fix (described, not implemented) — NEVER deletes data:**
+- Replace `_calculate_fifo_pnl` with true running-average (or real FIFO
+  lot-matching) so ledger == portfolio going forward; add a regression test
+  (round-trip at rising prices → ledger == portfolio).
+- **Append, don't overwrite:** add a `pnl_v2` column or a reconciliation
+  view/table; leave original `pnl` intact for audit.
+- Read-only reconciliation report script (ledger vs portfolio vs account).
+- Flag (don't delete) the corrupt `2026-06-04 10:54 TSLA` row (`corrupt`
+  boolean); user decides whether to back out the ~$419.
+- Make `_update_position_atomic` + DB write transactional (or reconcile cash
+  from the ledger on restart).
+
+---
+
+## ⚠️ Collision map (coordinate before editing)
+
+| Fix | Files touched | Overlap w/ `fix/strategy-and-test-bugs`? |
+|---|---|---|
+| #1A deviation guard | `stop_loss_monitor.py` | Low — isolated |
+| #1B subprocess assert | `subprocess_ibkr_client.py`, `ibkr_subprocess_worker.py` | Low |
+| #2 signal flood/whipsaw | `runner_async.py`, `ml_enhanced_strategy.py` | **Check** — strategy logic |
+| #3 accounting | `database_async.py`, `portfolio.py`, `runner_async.py` | **Check** — `runner_async.py` is shared |
+
+The parallel branch was last seen editing `robo_trader/strategies/pairs_trading.py`
+and `tests/test_mean_reversion_strategies.py`. Pairs trading is a separate path
+(`runner_async.py:3269+`) from the ML_ENHANCED symptom, but **`runner_async.py`
+is shared** — whoever edits it should claim it explicitly to avoid clobbering.
+
+## Suggested division of labor
+
+- **This session / next:** Fix #1A (deviation guard) is the highest-value,
+  lowest-risk, fully-isolated change — do it on a fresh worktree off `main`.
+- **Whoever owns strategy logic** (`fix/strategy-and-test-bugs`): take #2
+  (signal flood/whipsaw) since it's strategy-adjacent.
+- **Accounting (#3):** sequence *after* the strategy branch lands to avoid
+  `runner_async.py` conflicts; start with the read-only reconciliation report.
+
+## Hard constraints
+- Trader is **live** (paper, runner PID was 87266) — don't restart without the user.
+- **Never delete trading data** (CLAUDE.md rule #1). All #3 fixes are append-only.
+- No edits were made during this investigation.
+
+## Evidence / reproduce (read-only)
+- `SELECT SUM(pnl), COUNT(*) FROM trades;`
+- `SELECT realized_pnl, cash, equity FROM account;`
+- `SELECT signal_type, COUNT(*) FROM signals WHERE timestamp>'2026-06-03' GROUP BY signal_type;`
+- Per-symbol chronological replay (Python) reproduces stored `pnl` exactly under
+  the buggy method; running-cost gives −$215.12.

--- a/handoff/LATEST_HANDOFF.md
+++ b/handoff/LATEST_HANDOFF.md
@@ -1,1 +1,1 @@
-HANDOFF_2026-05-30_risk-tab-and-ci-repair.md
+HANDOFF_2026-06-13_pnl-and-data-quality-investigation.md

--- a/robo_trader/logger.py
+++ b/robo_trader/logger.py
@@ -335,13 +335,34 @@ def configure_stdlib_logging():
     # Remove existing handlers
     root.handlers.clear()
 
-    # Console handler
-    console_handler = logging.StreamHandler(sys.stdout)
-    console_handler.setFormatter(formatter)
-    root.addHandler(console_handler)
+    log_file = os.getenv("LOG_FILE")
+
+    # Console handler — mirror logs to stdout only when it makes sense.
+    #
+    # A backgrounded/redirected process (e.g. the runner under START_TRADER.sh,
+    # whose stdout goes to the un-rotated runner_stdout.log) would otherwise
+    # duplicate every line to that sink, growing it unbounded over long uptimes
+    # while the RotatingFileHandler below is already capturing everything.
+    #
+    # Policy:
+    #   LOG_CONSOLE truthy  -> always attach
+    #   LOG_CONSOLE falsy   -> never attach
+    #   unset               -> attach when stdout is a TTY, or when there is no
+    #                          file handler to fall back on; skip only when
+    #                          stdout is redirected AND a file handler is active.
+    console_env = os.getenv("LOG_CONSOLE")
+    if console_env is not None:
+        want_console = console_env.strip().lower() in ("1", "true", "yes", "on")
+    else:
+        is_tty = bool(getattr(sys.stdout, "isatty", lambda: False)())
+        want_console = is_tty or not log_file
+
+    if want_console:
+        console_handler = logging.StreamHandler(sys.stdout)
+        console_handler.setFormatter(formatter)
+        root.addHandler(console_handler)
 
     # File handler with rotation (if enabled)
-    log_file = os.getenv("LOG_FILE")
     if log_file:
         from logging.handlers import RotatingFileHandler
 

--- a/robo_trader/runner_async.py
+++ b/robo_trader/runner_async.py
@@ -4561,6 +4561,24 @@ async def sleep_unless_shutdown(
             return
 
 
+def _raise_if_recovery_exhausted(runners: Dict[str, AsyncRunner]) -> None:
+    """Raise when any long-lived portfolio runner exhausted recovery.
+
+    This check must run before market-hours waiting. Recovery can exhaust just
+    after the last trading cycle; delaying observation until the next open
+    would leave a known-dead runner alive and prevent launchd from restarting
+    it.
+    """
+
+    for portfolio_id, portfolio_runner in runners.items():
+        if portfolio_runner._recovery_exhausted:
+            raise RecoveryExhaustedError(
+                f"portfolio={portfolio_id} recovery exhausted after "
+                "all backoff attempts; exiting run_continuous so "
+                "watchdog can restart the process"
+            )
+
+
 async def run_continuous(
     symbols: Optional[List[str]] = None,
     duration: str = "1 D",
@@ -4621,41 +4639,47 @@ async def run_continuous(
             eastern = pytz.timezone("US/Eastern")
             current_time = datetime.now(eastern)
 
-            # Check market status and adjust polling frequency
-            if not is_trading_allowed() and not force_connect:
-                session = get_market_session()
-                seconds_to_open = seconds_until_market_open()
-
-                # Extended hours: slower polling (2 min) - but only if extended hours trading is DISABLED
-                # If ENABLE_EXTENDED_HOURS=true, is_trading_allowed() returns true and we won't reach here
-                if session in ["after-hours", "pre-market"]:
-                    wait_time = 120  # 2 minutes during extended hours
-                    logger.info(f"Extended hours ({session}). Polling every 2 minutes...")
-                    await sleep_unless_shutdown(wait_time, lambda: shutdown_flag)
-                    continue
-                # Within 1 hour of open: moderate polling (5 min)
-                elif seconds_to_open < 3600:
-                    wait_time = 300  # 5 minutes when close to open
-                    logger.info(
-                        f"Market opens in {seconds_to_open/60:.0f} min. Polling every 5 minutes..."
-                    )
-                    await sleep_unless_shutdown(wait_time, lambda: shutdown_flag)
-                    continue
-                else:
-                    # Market fully closed (overnight/weekend): long wait (30 min max)
-                    wait_time = min(1800, seconds_to_open // 2)  # Max 30 minutes
-                    logger.info(
-                        f"Market {session}. Next open in {seconds_to_open/3600:.1f} hours. "
-                        f"Sleeping {wait_time/60:.1f} minutes..."
-                    )
-                    await sleep_unless_shutdown(wait_time, lambda: shutdown_flag)
-                    continue
-            elif force_connect and not is_trading_allowed():
-                logger.warning(
-                    "⚠️ Force-connect enabled - connecting to IBKR despite market being closed"
-                )
-
             try:
+                # Observe recovery exhaustion before any market-closed sleep or
+                # continue. A failure latched after the prior cycle must exit
+                # promptly even when the next session is hours away.
+                _raise_if_recovery_exhausted(runners)
+
+                # Check market status and adjust polling frequency
+                if not is_trading_allowed() and not force_connect:
+                    session = get_market_session()
+                    seconds_to_open = seconds_until_market_open()
+
+                    # Extended hours: slower polling (2 min) - but only if
+                    # extended-hours trading is disabled.
+                    if session in ["after-hours", "pre-market"]:
+                        wait_time = 120  # 2 minutes during extended hours
+                        logger.info(f"Extended hours ({session}). Polling every 2 minutes...")
+                        await sleep_unless_shutdown(wait_time, lambda: shutdown_flag)
+                        continue
+                    # Within 1 hour of open: moderate polling (5 min)
+                    elif seconds_to_open < 3600:
+                        wait_time = 300  # 5 minutes when close to open
+                        logger.info(
+                            f"Market opens in {seconds_to_open/60:.0f} min. "
+                            "Polling every 5 minutes..."
+                        )
+                        await sleep_unless_shutdown(wait_time, lambda: shutdown_flag)
+                        continue
+                    else:
+                        # Market fully closed (overnight/weekend): long wait
+                        wait_time = min(1800, seconds_to_open // 2)  # Max 30 minutes
+                        logger.info(
+                            f"Market {session}. Next open in {seconds_to_open/3600:.1f} hours. "
+                            f"Sleeping {wait_time/60:.1f} minutes..."
+                        )
+                        await sleep_unless_shutdown(wait_time, lambda: shutdown_flag)
+                        continue
+                elif force_connect and not is_trading_allowed():
+                    logger.warning(
+                        "⚠️ Force-connect enabled - connecting to IBKR despite market being closed"
+                    )
+
                 logger.info(
                     f"Starting trading cycle at {current_time.strftime('%Y-%m-%d %H:%M:%S %Z')}"
                 )
@@ -4720,12 +4744,7 @@ async def run_continuous(
                     # runner can't get stuck in a perpetual "cycle skipped"
                     # state that keeps the log mtime fresh (which would defeat
                     # the watchdog's "no log activity for 5 min" trigger).
-                    if portfolio_runner._recovery_exhausted:
-                        raise RecoveryExhaustedError(
-                            f"portfolio={portfolio_id} recovery exhausted after "
-                            f"all backoff attempts; exiting run_continuous so "
-                            f"watchdog can restart the process"
-                        )
+                    _raise_if_recovery_exhausted({portfolio_id: portfolio_runner})
 
                     # Skip cycle if recovery is mid-flight
                     if portfolio_runner.recovery_in_progress:

--- a/robo_trader/runner_async.py
+++ b/robo_trader/runner_async.py
@@ -4547,7 +4547,7 @@ async def sleep_unless_shutdown(
     (up to 1800s for the overnight closed-market branch, or intercycle_wait for
     the inter-cycle wait) therefore delays a graceful shutdown by up to its full
     duration. Sleeping in poll_seconds chunks and re-checking should_stop() caps
-    that delay at ~poll_seconds. Pass `lambda: shutdown_flag` for should_stop.
+    that delay at ~poll_seconds.
     """
     if should_stop():
         return
@@ -4559,6 +4559,14 @@ async def sleep_unless_shutdown(
         remaining -= chunk
         if should_stop():
             return
+
+
+def _continuous_wait_should_stop(
+    shutdown_requested: bool,
+    runners: Dict[str, AsyncRunner],
+) -> bool:
+    """Return whether a continuous-loop wait must end promptly."""
+    return shutdown_requested or any(runner._recovery_exhausted for runner in runners.values())
 
 
 def _raise_if_recovery_exhausted(runners: Dict[str, AsyncRunner]) -> None:
@@ -4655,7 +4663,10 @@ async def run_continuous(
                     if session in ["after-hours", "pre-market"]:
                         wait_time = 120  # 2 minutes during extended hours
                         logger.info(f"Extended hours ({session}). Polling every 2 minutes...")
-                        await sleep_unless_shutdown(wait_time, lambda: shutdown_flag)
+                        await sleep_unless_shutdown(
+                            wait_time,
+                            lambda: _continuous_wait_should_stop(shutdown_flag, runners),
+                        )
                         continue
                     # Within 1 hour of open: moderate polling (5 min)
                     elif seconds_to_open < 3600:
@@ -4664,7 +4675,10 @@ async def run_continuous(
                             f"Market opens in {seconds_to_open/60:.0f} min. "
                             "Polling every 5 minutes..."
                         )
-                        await sleep_unless_shutdown(wait_time, lambda: shutdown_flag)
+                        await sleep_unless_shutdown(
+                            wait_time,
+                            lambda: _continuous_wait_should_stop(shutdown_flag, runners),
+                        )
                         continue
                     else:
                         # Market fully closed (overnight/weekend): long wait
@@ -4673,7 +4687,10 @@ async def run_continuous(
                             f"Market {session}. Next open in {seconds_to_open/3600:.1f} hours. "
                             f"Sleeping {wait_time/60:.1f} minutes..."
                         )
-                        await sleep_unless_shutdown(wait_time, lambda: shutdown_flag)
+                        await sleep_unless_shutdown(
+                            wait_time,
+                            lambda: _continuous_wait_should_stop(shutdown_flag, runners),
+                        )
                         continue
                 elif force_connect and not is_trading_allowed():
                     logger.warning(
@@ -4795,7 +4812,10 @@ async def run_continuous(
                     logger.info(
                         f"Waiting {intercycle_wait/60:.1f} minutes before next iteration..."
                     )
-                    await sleep_unless_shutdown(intercycle_wait, lambda: shutdown_flag)
+                    await sleep_unless_shutdown(
+                        intercycle_wait,
+                        lambda: _continuous_wait_should_stop(shutdown_flag, runners),
+                    )
 
             except asyncio.CancelledError:
                 logger.info("Trading loop cancelled")
@@ -4824,7 +4844,10 @@ async def run_continuous(
                 # owns its connection lifecycle.
                 if not shutdown_flag:
                     logger.info("Waiting 1 minute before retry...")
-                    await sleep_unless_shutdown(60, lambda: shutdown_flag)
+                    await sleep_unless_shutdown(
+                        60,
+                        lambda: _continuous_wait_should_stop(shutdown_flag, runners),
+                    )
 
     finally:
         # Final cleanup: all portfolios get full disconnect on process exit

--- a/robo_trader/runner_async.py
+++ b/robo_trader/runner_async.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass  # isort:skip  # noqa: E402
 from datetime import date, datetime
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 import pandas as pd
 from ib_async import Stock
@@ -4535,6 +4535,32 @@ def intercycle_wait_seconds(interval_seconds: int, trading_allowed: bool) -> flo
     return max(1.0, float(interval_seconds), float(FORCE_CONNECT_CLOSED_WAIT_SECONDS))
 
 
+async def sleep_unless_shutdown(
+    total_seconds: float,
+    should_stop: Callable[[], bool],
+    poll_seconds: float = 1.0,
+) -> None:
+    """Sleep up to total_seconds, returning early once should_stop() is True.
+
+    run_continuous's SIGINT/SIGTERM handler only flips a local shutdown_flag;
+    it does not cancel the running coroutine. A single long asyncio.sleep()
+    (up to 1800s for the overnight closed-market branch, or intercycle_wait for
+    the inter-cycle wait) therefore delays a graceful shutdown by up to its full
+    duration. Sleeping in poll_seconds chunks and re-checking should_stop() caps
+    that delay at ~poll_seconds. Pass `lambda: shutdown_flag` for should_stop.
+    """
+    if should_stop():
+        return
+    remaining = float(total_seconds)
+    poll = float(poll_seconds)
+    while remaining > 0:
+        chunk = min(poll, remaining) if poll > 0 else remaining
+        await asyncio.sleep(chunk)
+        remaining -= chunk
+        if should_stop():
+            return
+
+
 async def run_continuous(
     symbols: Optional[List[str]] = None,
     duration: str = "1 D",
@@ -4605,7 +4631,7 @@ async def run_continuous(
                 if session in ["after-hours", "pre-market"]:
                     wait_time = 120  # 2 minutes during extended hours
                     logger.info(f"Extended hours ({session}). Polling every 2 minutes...")
-                    await asyncio.sleep(wait_time)
+                    await sleep_unless_shutdown(wait_time, lambda: shutdown_flag)
                     continue
                 # Within 1 hour of open: moderate polling (5 min)
                 elif seconds_to_open < 3600:
@@ -4613,7 +4639,7 @@ async def run_continuous(
                     logger.info(
                         f"Market opens in {seconds_to_open/60:.0f} min. Polling every 5 minutes..."
                     )
-                    await asyncio.sleep(wait_time)
+                    await sleep_unless_shutdown(wait_time, lambda: shutdown_flag)
                     continue
                 else:
                     # Market fully closed (overnight/weekend): long wait (30 min max)
@@ -4622,7 +4648,7 @@ async def run_continuous(
                         f"Market {session}. Next open in {seconds_to_open/3600:.1f} hours. "
                         f"Sleeping {wait_time/60:.1f} minutes..."
                     )
-                    await asyncio.sleep(wait_time)
+                    await sleep_unless_shutdown(wait_time, lambda: shutdown_flag)
                     continue
             elif force_connect and not is_trading_allowed():
                 logger.warning(
@@ -4750,7 +4776,7 @@ async def run_continuous(
                     logger.info(
                         f"Waiting {intercycle_wait/60:.1f} minutes before next iteration..."
                     )
-                    await asyncio.sleep(intercycle_wait)
+                    await sleep_unless_shutdown(intercycle_wait, lambda: shutdown_flag)
 
             except asyncio.CancelledError:
                 logger.info("Trading loop cancelled")
@@ -4779,7 +4805,7 @@ async def run_continuous(
                 # owns its connection lifecycle.
                 if not shutdown_flag:
                     logger.info("Waiting 1 minute before retry...")
-                    await asyncio.sleep(60)
+                    await sleep_unless_shutdown(60, lambda: shutdown_flag)
 
     finally:
         # Final cleanup: all portfolios get full disconnect on process exit

--- a/robo_trader/runner_async.py
+++ b/robo_trader/runner_async.py
@@ -4515,6 +4515,26 @@ async def run_once(
     await runner.run(symbols)
 
 
+# 2026-07-10 disk-fill incident: with --force-connect and the market closed,
+# run_continuous skipped both wait branches and spun at loop speed, flooding
+# watchdog.log at ~20 GB/hour. Inter-cycle wait must be positive on every path.
+FORCE_CONNECT_CLOSED_WAIT_SECONDS = 120
+
+
+def intercycle_wait_seconds(interval_seconds: int, trading_allowed: bool) -> float:
+    """Seconds to sleep between run_continuous iterations. Never returns < 1.
+
+    When trading is not allowed, back off to at least
+    FORCE_CONNECT_CLOSED_WAIT_SECONDS. Reachable with --force-connect (the
+    top-of-loop closed-market branch is skipped entirely) or, without the
+    flag, on the single iteration where the market closes mid-cycle before
+    this bottom-of-loop re-check.
+    """
+    if trading_allowed:
+        return max(1.0, float(interval_seconds))
+    return max(1.0, float(interval_seconds), float(FORCE_CONNECT_CLOSED_WAIT_SECONDS))
+
+
 async def run_continuous(
     symbols: Optional[List[str]] = None,
     duration: str = "1 D",
@@ -4718,12 +4738,19 @@ async def run_continuous(
 
                     await portfolio_runner.teardown(full_cleanup=False)
 
-                # Wait before next iteration
-                if not shutdown_flag and is_trading_allowed():
-                    logger.info(
-                        f"Waiting {interval_seconds/60:.1f} minutes before next iteration..."
+                # Wait before next iteration. This sleep must run on EVERY
+                # path: with --force-connect and the market closed, neither
+                # top-of-loop wait branch runs, so gating this sleep on
+                # is_trading_allowed() spins the loop with zero delay
+                # (2026-07-10 disk-fill incident, ~20 GB/hour of logs).
+                if not shutdown_flag:
+                    intercycle_wait = intercycle_wait_seconds(
+                        interval_seconds, is_trading_allowed()
                     )
-                    await asyncio.sleep(interval_seconds)
+                    logger.info(
+                        f"Waiting {intercycle_wait/60:.1f} minutes before next iteration..."
+                    )
+                    await asyncio.sleep(intercycle_wait)
 
             except asyncio.CancelledError:
                 logger.info("Trading loop cancelled")

--- a/scripts/com.robotrader.watchdog.plist
+++ b/scripts/com.robotrader.watchdog.plist
@@ -5,9 +5,8 @@
     <key>Label</key>
     <string>com.robotrader.watchdog</string>
 
-    <!-- NEW-IB-M3: Restrict to the GUI (Aqua) session of the explicit user.
-         If you deploy on a machine where the username is not 'oliver',
-         change UserName below to match. -->
+    <!-- NEW-IB-M3: Restrict to the GUI (Aqua) session. The installer rewrites
+         UserName and every project path for the current checkout/user. -->
     <key>UserName</key>
     <string>oliver</string>
 
@@ -33,7 +32,8 @@
          persistent write fd on these paths, so any child output streamed
          here bypasses watchdog.sh's rotate_log() entirely (69 GB disk-fill
          incident). watchdog.sh writes its own rotated watchdog.log; this
-         file only catches stray stdout/stderr (e.g. bash errors). -->
+         file only catches stray stdout/stderr (e.g. bash errors). The
+         installer rewrites this path to the same checkout watchdog.sh caps. -->
     <key>StandardOutPath</key>
     <string>/Users/oliver/Projects/robo_trader/watchdog_launchd.log</string>
 

--- a/scripts/com.robotrader.watchdog.plist
+++ b/scripts/com.robotrader.watchdog.plist
@@ -29,11 +29,16 @@
     <key>KeepAlive</key>
     <true/>
 
+    <!-- 2026-07-10: must NOT point at watchdog.log. launchd holds a
+         persistent write fd on these paths, so any child output streamed
+         here bypasses watchdog.sh's rotate_log() entirely (69 GB disk-fill
+         incident). watchdog.sh writes its own rotated watchdog.log; this
+         file only catches stray stdout/stderr (e.g. bash errors). -->
     <key>StandardOutPath</key>
-    <string>/Users/oliver/Projects/robo_trader/watchdog.log</string>
+    <string>/Users/oliver/Projects/robo_trader/watchdog_launchd.log</string>
 
     <key>StandardErrorPath</key>
-    <string>/Users/oliver/Projects/robo_trader/watchdog.log</string>
+    <string>/Users/oliver/Projects/robo_trader/watchdog_launchd.log</string>
 
     <key>EnvironmentVariables</key>
     <dict>

--- a/scripts/install_watchdog.sh
+++ b/scripts/install_watchdog.sh
@@ -93,6 +93,7 @@ plist["StandardErrorPath"] = launchd_log
 with open(destination, "wb") as handle:
     plistlib.dump(plist, handle, sort_keys=False)
 PY
+chmod 600 "$PLIST_DEST" || die "could not set safe permissions on $PLIST_DEST"
 
 # 5. Validate the rendered plist ------------------------------------------
 echo "==> Validating rendered plist with plutil -lint"

--- a/scripts/install_watchdog.sh
+++ b/scripts/install_watchdog.sh
@@ -12,6 +12,8 @@
 # Environment overrides (testing):
 #   LAUNCH_AGENTS_DIR   Override target dir (default: ~/Library/LaunchAgents)
 #   SKIP_LAUNCHCTL=1    Skip launchctl load/list assertions (for CI/tests).
+#   ROBOTRADER_USER     Override launchd UserName (default: current user).
+#   PLUTIL_BIN          Override plutil executable (testing only).
 #
 # Exits non-zero on any error.
 
@@ -22,6 +24,9 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 PLIST_SRC="$SCRIPT_DIR/com.robotrader.watchdog.plist"
 WATCHDOG_SH="$SCRIPT_DIR/watchdog.sh"
 LABEL="com.robotrader.watchdog"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+PLUTIL_BIN="${PLUTIL_BIN:-plutil}"
+ROBOTRADER_USER="${ROBOTRADER_USER:-$(id -un)}"
 
 LAUNCH_AGENTS_DIR="${LAUNCH_AGENTS_DIR:-$HOME/Library/LaunchAgents}"
 PLIST_DEST="$LAUNCH_AGENTS_DIR/${LABEL}.plist"
@@ -48,25 +53,50 @@ echo ""
 # 1. Sanity checks ---------------------------------------------------------
 [[ -f "$PLIST_SRC" ]]    || die "plist source not found at $PLIST_SRC"
 [[ -f "$WATCHDOG_SH" ]]  || die "watchdog.sh not found at $WATCHDOG_SH"
+command -v "$PYTHON_BIN" >/dev/null 2>&1 || die "Python not found: $PYTHON_BIN"
 [[ -x "$WATCHDOG_SH" ]]  || {
     echo "    watchdog.sh not executable, fixing..."
     chmod +x "$WATCHDOG_SH" || die "could not chmod +x $WATCHDOG_SH"
 }
 
-# 2. Validate plist --------------------------------------------------------
-echo "==> Validating plist with plutil -lint"
-plutil -lint "$PLIST_SRC" || die "plist failed plutil -lint"
-
-# 3. Validate watchdog.sh shell syntax ------------------------------------
+# 2. Validate watchdog.sh shell syntax ------------------------------------
 echo "==> Validating watchdog.sh shell syntax"
 bash -n "$WATCHDOG_SH" || die "watchdog.sh failed bash -n syntax check"
 
-# 4. Ensure LaunchAgents dir exists ---------------------------------------
+# 3. Ensure LaunchAgents dir exists ---------------------------------------
 mkdir -p "$LAUNCH_AGENTS_DIR" || die "could not create $LAUNCH_AGENTS_DIR"
 
-# 5. Copy plist (idempotent) ----------------------------------------------
-echo "==> Copying plist to $PLIST_DEST"
-cp "$PLIST_SRC" "$PLIST_DEST" || die "failed to copy plist to $PLIST_DEST"
+# 4. Render the machine-specific plist (idempotent) ------------------------
+# The tracked template contains this checkout's defaults so it remains easy to
+# inspect, but the installed plist must always match the actual checkout and
+# current GUI user. In particular, StandardOutPath/StandardErrorPath must point
+# beside watchdog.sh's WATCHDOG_LAUNCHD_LOG or launchd output escapes its cap.
+echo "==> Rendering plist to $PLIST_DEST"
+"$PYTHON_BIN" - "$PLIST_SRC" "$PLIST_DEST" "$PROJECT_DIR" "$ROBOTRADER_USER" <<'PY'
+import plistlib
+import sys
+from pathlib import Path
+
+source, destination, project_dir, user_name = sys.argv[1:]
+project = Path(project_dir).resolve()
+
+with open(source, "rb") as handle:
+    plist = plistlib.load(handle)
+
+plist["UserName"] = user_name
+plist["ProgramArguments"][0] = str(project / "scripts" / "watchdog.sh")
+plist["WorkingDirectory"] = str(project)
+launchd_log = str(project / "watchdog_launchd.log")
+plist["StandardOutPath"] = launchd_log
+plist["StandardErrorPath"] = launchd_log
+
+with open(destination, "wb") as handle:
+    plistlib.dump(plist, handle, sort_keys=False)
+PY
+
+# 5. Validate the rendered plist ------------------------------------------
+echo "==> Validating rendered plist with plutil -lint"
+"$PLUTIL_BIN" -lint "$PLIST_DEST" || die "rendered plist failed plutil -lint"
 
 if [[ "${SKIP_LAUNCHCTL:-0}" = "1" ]]; then
     echo "==> SKIP_LAUNCHCTL=1 set; skipping launchctl load/list."

--- a/scripts/install_watchdog.sh
+++ b/scripts/install_watchdog.sh
@@ -87,9 +87,20 @@ echo "==> Loading $PLIST_DEST"
 launchctl load "$PLIST_DEST" || die "launchctl load failed for $PLIST_DEST"
 
 # 8. Give launchd a beat, then assert the agent registered ----------------
-sleep 2
+# launchd registration can lag the `launchctl load` return, so poll instead of
+# checking once (a single check raced registration on 2026-07-10 and printed a
+# false ERROR while the job was in fact present). `grep` returning non-zero must
+# not trip `set -e`, hence the `if` guard around it.
 echo "==> Verifying registration with launchctl list"
-if ! launchctl list | grep -q "$LABEL"; then
+registered=0
+for _ in $(seq 1 10); do
+    if launchctl list | grep -q "$LABEL"; then
+        registered=1
+        break
+    fi
+    sleep 1
+done
+if [[ "$registered" -ne 1 ]]; then
     die "launchctl list does not show $LABEL after load"
 fi
 

--- a/scripts/start_runner.sh
+++ b/scripts/start_runner.sh
@@ -80,8 +80,10 @@ echo "4. Starting runner..."
 echo "   Symbols: $SYMBOLS"
 
 export LOG_FILE="$SCRIPT_DIR/robo_trader.log"
-# Redirect output to log file so subprocess.run can complete
-$PYTHON -m robo_trader.runner_async --symbols "$SYMBOLS" --force-connect >> "$LOG_FILE" 2>&1 &
+# Redirect output to log file so subprocess.run can complete.
+# --force-connect removed 2026-07-10 (testing-only flag; see CLAUDE.md
+# Common Mistakes and the disk-fill incident) — same fix as START_TRADER.sh.
+$PYTHON -m robo_trader.runner_async --symbols "$SYMBOLS" >> "$LOG_FILE" 2>&1 &
 RUNNER_PID=$!
 
 sleep 3

--- a/scripts/start_runner.sh
+++ b/scripts/start_runner.sh
@@ -100,6 +100,6 @@ if ps -p $RUNNER_PID > /dev/null 2>&1; then
     exit 0
 else
     echo "   ERROR: Runner failed to start"
-    echo "   Check robo_trader.log for details"
+    echo "   Check $RUNNER_STDOUT_LOG first, then $LOG_FILE for details"
     exit 1
 fi

--- a/scripts/start_runner.sh
+++ b/scripts/start_runner.sh
@@ -80,10 +80,16 @@ echo "4. Starting runner..."
 echo "   Symbols: $SYMBOLS"
 
 export LOG_FILE="$SCRIPT_DIR/robo_trader.log"
-# Redirect output to log file so subprocess.run can complete.
+RUNNER_STDOUT_LOG="$SCRIPT_DIR/runner_stdout.log"
+RUNNER_STDOUT_PREVIOUS="$SCRIPT_DIR/runner_stdout.log.1"
+if [ -f "$RUNNER_STDOUT_LOG" ]; then
+    mv -f "$RUNNER_STDOUT_LOG" "$RUNNER_STDOUT_PREVIOUS"
+fi
+# Keep inherited stdout/stderr separate from RotatingFileHandler's LOG_FILE.
+# Sharing the same inode lets post-rotation writes bypass the configured cap.
 # --force-connect removed 2026-07-10 (testing-only flag; see CLAUDE.md
 # Common Mistakes and the disk-fill incident) — same fix as START_TRADER.sh.
-$PYTHON -m robo_trader.runner_async --symbols "$SYMBOLS" >> "$LOG_FILE" 2>&1 &
+$PYTHON -m robo_trader.runner_async --symbols "$SYMBOLS" >> "$RUNNER_STDOUT_LOG" 2>&1 &
 RUNNER_PID=$!
 
 sleep 3

--- a/scripts/watchdog.sh
+++ b/scripts/watchdog.sh
@@ -14,8 +14,9 @@ LOG_FILE="$PROJECT_DIR/robo_trader.log"
 LOG_FILE_1="$PROJECT_DIR/robo_trader.log.1"
 WATCHDOG_LOG="$PROJECT_DIR/watchdog.log"
 # launchd's StandardOutPath/StandardErrorPath target (see com.robotrader.watchdog.plist).
-# launchd holds a persistent O_APPEND fd on this file, so it must be capped IN PLACE
-# (copy-then-truncate) — an mv would leave writers appending to the moved inode.
+# launchd holds a persistent O_APPEND fd on this file, so it must be capped IN PLACE.
+# Preserve at most one bounded tail before truncating; copying the whole file can
+# consume the last free disk space during the failure mode this guard handles.
 WATCHDOG_LAUNCHD_LOG="$PROJECT_DIR/watchdog_launchd.log"
 WATCHDOG_LOG_MAX_SIZE=10485760  # 10MB max log size
 STALE_MINUTES="${1:-5}"  # Default 5 minutes
@@ -66,15 +67,22 @@ rotate_log() {
 cap_launchd_log() {
     # Cap the launchd stdout/stderr log IN PLACE. launchd holds a persistent
     # O_APPEND fd on this file, so `mv` does NOT work (writers follow the moved
-    # inode — that was the 2026-07-10 incident's bypass). Copy the current
-    # contents aside, then truncate in place with `: >`, which O_APPEND writers
-    # continue past safely at the new EOF.
+    # inode — that was the 2026-07-10 incident's bypass). Save only a bounded
+    # tail, then truncate in place with `: >`, which O_APPEND writers continue
+    # past safely at the new EOF.
     if [ -f "$WATCHDOG_LAUNCHD_LOG" ]; then
         local size=$(stat -f %z "$WATCHDOG_LAUNCHD_LOG" 2>/dev/null || stat -c %s "$WATCHDOG_LAUNCHD_LOG" 2>/dev/null || echo 0)
         if [ "$size" -gt "$WATCHDOG_LOG_MAX_SIZE" ]; then
-            cp "$WATCHDOG_LAUNCHD_LOG" "$WATCHDOG_LAUNCHD_LOG.old" 2>/dev/null
+            local backup_tmp="$WATCHDOG_LAUNCHD_LOG.old.tmp"
+            local backup_note="without backup (bounded tail copy failed)"
+            if tail -c "$WATCHDOG_LOG_MAX_SIZE" "$WATCHDOG_LAUNCHD_LOG" > "$backup_tmp" 2>/dev/null; then
+                mv -f "$backup_tmp" "$WATCHDOG_LAUNCHD_LOG.old"
+                backup_note="saved final ${WATCHDOG_LOG_MAX_SIZE} bytes"
+            else
+                rm -f "$backup_tmp"
+            fi
             : > "$WATCHDOG_LAUNCHD_LOG"
-            log "launchd log capped in place (was ${size} bytes, saved to $(basename "$WATCHDOG_LAUNCHD_LOG").old)"
+            log "launchd log capped in place (was ${size} bytes; ${backup_note})"
         fi
     fi
 }

--- a/scripts/watchdog.sh
+++ b/scripts/watchdog.sh
@@ -13,6 +13,10 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 LOG_FILE="$PROJECT_DIR/robo_trader.log"
 LOG_FILE_1="$PROJECT_DIR/robo_trader.log.1"
 WATCHDOG_LOG="$PROJECT_DIR/watchdog.log"
+# launchd's StandardOutPath/StandardErrorPath target (see com.robotrader.watchdog.plist).
+# launchd holds a persistent O_APPEND fd on this file, so it must be capped IN PLACE
+# (copy-then-truncate) — an mv would leave writers appending to the moved inode.
+WATCHDOG_LAUNCHD_LOG="$PROJECT_DIR/watchdog_launchd.log"
 WATCHDOG_LOG_MAX_SIZE=10485760  # 10MB max log size
 STALE_MINUTES="${1:-5}"  # Default 5 minutes
 CHECK_INTERVAL=60        # Check every 60 seconds
@@ -55,6 +59,22 @@ rotate_log() {
         if [ "$size" -gt "$WATCHDOG_LOG_MAX_SIZE" ]; then
             mv "$WATCHDOG_LOG" "$WATCHDOG_LOG.old"
             echo "[$(date '+%Y-%m-%d %H:%M:%S')] Log rotated (was ${size} bytes)" > "$WATCHDOG_LOG"
+        fi
+    fi
+}
+
+cap_launchd_log() {
+    # Cap the launchd stdout/stderr log IN PLACE. launchd holds a persistent
+    # O_APPEND fd on this file, so `mv` does NOT work (writers follow the moved
+    # inode — that was the 2026-07-10 incident's bypass). Copy the current
+    # contents aside, then truncate in place with `: >`, which O_APPEND writers
+    # continue past safely at the new EOF.
+    if [ -f "$WATCHDOG_LAUNCHD_LOG" ]; then
+        local size=$(stat -f %z "$WATCHDOG_LAUNCHD_LOG" 2>/dev/null || stat -c %s "$WATCHDOG_LAUNCHD_LOG" 2>/dev/null || echo 0)
+        if [ "$size" -gt "$WATCHDOG_LOG_MAX_SIZE" ]; then
+            cp "$WATCHDOG_LAUNCHD_LOG" "$WATCHDOG_LAUNCHD_LOG.old" 2>/dev/null
+            : > "$WATCHDOG_LAUNCHD_LOG"
+            log "launchd log capped in place (was ${size} bytes, saved to $(basename "$WATCHDOG_LAUNCHD_LOG").old)"
         fi
     fi
 }
@@ -273,6 +293,9 @@ log "Watchdog started (PID: $$, stale threshold: ${STALE_MINUTES} minutes)"
 log "=========================================="
 
 while true; do
+    # Keep the launchd stdout/stderr log from filling the disk (2026-07-10 incident).
+    cap_launchd_log
+
     # Layer 6: if we're in an escalated-failure state, slow down to avoid
     # hammering Gateway and burning 2FA attempts.
     failure_count=$(get_failure_count)

--- a/tests/security/test_ops.py
+++ b/tests/security/test_ops.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import os
 import plistlib
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -131,7 +132,13 @@ def test_install_watchdog_renders_checkout_and_user_paths(tmp_path):
     env["PLUTIL_BIN"] = shutil.which("true") or "true"
 
     result = subprocess.run(
-        ["bash", str(portable_scripts / INSTALL_SH.name)],
+        [
+            "bash",
+            "-c",
+            'umask 000; exec bash "$1"',
+            "watchdog-installer-test",
+            str(portable_scripts / INSTALL_SH.name),
+        ],
         capture_output=True,
         text=True,
         env=env,
@@ -149,6 +156,8 @@ def test_install_watchdog_renders_checkout_and_user_paths(tmp_path):
     assert installed["WorkingDirectory"] == str(expected_project)
     assert installed["StandardOutPath"] == expected_launchd_log
     assert installed["StandardErrorPath"] == expected_launchd_log
+    installed_mode = stat.S_IMODE((fake_la / "com.robotrader.watchdog.plist").stat().st_mode)
+    assert installed_mode == 0o600
 
 
 @macos_only

--- a/tests/security/test_ops.py
+++ b/tests/security/test_ops.py
@@ -204,6 +204,15 @@ def test_claude_md_mentions_watchdog_install():
     assert "install_watchdog.sh" in content, "CLAUDE.md must reference scripts/install_watchdog.sh"
 
 
+def test_start_runner_failure_points_to_both_log_sinks():
+    """Pre-logger startup failures are visible in runner_stdout.log first."""
+    content = (SCRIPTS_DIR / "start_runner.sh").read_text()
+    failure_block = content.split('echo "   ERROR: Runner failed to start"', maxsplit=1)[1]
+
+    assert "$RUNNER_STDOUT_LOG" in failure_block
+    assert "$LOG_FILE" in failure_block
+
+
 # ---------------------------------------------------------------------------
 # START_TRADER.sh must warn loudly if the watchdog isn't loaded
 # ---------------------------------------------------------------------------

--- a/tests/security/test_ops.py
+++ b/tests/security/test_ops.py
@@ -114,6 +114,43 @@ def test_install_watchdog_script_bash_syntax():
     assert result.returncode == 0, f"bash -n failed: {result.stderr}"
 
 
+def test_install_watchdog_renders_checkout_and_user_paths(tmp_path):
+    """Installed plist paths must follow the checkout, not tracked defaults."""
+    portable_project = tmp_path / "different checkout"
+    portable_scripts = portable_project / "scripts"
+    portable_scripts.mkdir(parents=True)
+    for source in (INSTALL_SH, PLIST_PATH, WATCHDOG_SH):
+        shutil.copy2(source, portable_scripts / source.name)
+
+    fake_la = tmp_path / "LaunchAgents"
+    env = os.environ.copy()
+    env["LAUNCH_AGENTS_DIR"] = str(fake_la)
+    env["SKIP_LAUNCHCTL"] = "1"
+    env["ROBOTRADER_USER"] = "portable-user"
+    env["PYTHON_BIN"] = sys.executable
+    env["PLUTIL_BIN"] = shutil.which("true") or "true"
+
+    result = subprocess.run(
+        ["bash", str(portable_scripts / INSTALL_SH.name)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    with (fake_la / "com.robotrader.watchdog.plist").open("rb") as fh:
+        installed = plistlib.load(fh)
+
+    expected_project = portable_project.resolve()
+    expected_launchd_log = str(expected_project / "watchdog_launchd.log")
+    assert installed["UserName"] == "portable-user"
+    assert installed["ProgramArguments"][0] == str(expected_project / "scripts" / "watchdog.sh")
+    assert installed["WorkingDirectory"] == str(expected_project)
+    assert installed["StandardOutPath"] == expected_launchd_log
+    assert installed["StandardErrorPath"] == expected_launchd_log
+
+
 @macos_only
 def test_install_watchdog_script_is_idempotent(tmp_path):
     """Run the installer twice into a fake LaunchAgents dir; both runs must

--- a/tests/test_logger_stdout_mirror.py
+++ b/tests/test_logger_stdout_mirror.py
@@ -1,0 +1,140 @@
+"""Tests for the conditional stdout mirror in ``robo_trader.logger``.
+
+Background: ``configure_stdlib_logging`` used to unconditionally attach a
+``StreamHandler(sys.stdout)`` to the root logger, in addition to the
+size-capped ``RotatingFileHandler``. Under ``START_TRADER.sh`` the runner's
+stdout is redirected to ``runner_stdout.log`` (truncated per start, no
+rotation), so mirroring every log line there grows that file unbounded over
+multi-week uptimes.
+
+Policy under test:
+- ``LOG_CONSOLE`` env forces the mirror on (truthy) or off (falsy),
+  regardless of TTY / file-handler state.
+- Otherwise the mirror is attached when stdout is a TTY, OR when no file
+  handler is active (``LOG_FILE`` unset). It is skipped only when stdout is
+  not a TTY AND a file handler is active.
+"""
+
+import logging
+import sys
+
+import pytest
+
+from robo_trader import logger as logger_mod
+
+
+@pytest.fixture
+def restore_root_logger():
+    """Snapshot and restore the root logger so tests don't leak handlers."""
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    try:
+        yield root
+    finally:
+        root.handlers[:] = saved_handlers
+        root.setLevel(saved_level)
+
+
+def _stdout_stream_handlers(root):
+    """Root handlers that mirror to sys.stdout, excluding file handlers.
+
+    ``RotatingFileHandler`` subclasses ``StreamHandler``, so we must exclude
+    ``FileHandler`` explicitly and match the actual stream identity.
+    """
+    return [
+        h
+        for h in root.handlers
+        if isinstance(h, logging.StreamHandler)
+        and not isinstance(h, logging.FileHandler)
+        and getattr(h, "stream", None) is sys.stdout
+    ]
+
+
+def _file_handlers(root):
+    return [h for h in root.handlers if isinstance(h, logging.FileHandler)]
+
+
+def test_redirected_stdout_with_log_file_skips_mirror(monkeypatch, tmp_path, restore_root_logger):
+    """Backgrounded (non-TTY) process with LOG_FILE set: no stdout mirror."""
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: False, raising=False)
+    monkeypatch.delenv("LOG_CONSOLE", raising=False)
+    monkeypatch.setenv("LOG_FILE", str(tmp_path / "robo_trader.log"))
+
+    logger_mod.configure_stdlib_logging()
+
+    root = restore_root_logger
+    assert _stdout_stream_handlers(root) == []
+    assert len(_file_handlers(root)) == 1
+
+
+def test_tty_keeps_mirror(monkeypatch, tmp_path, restore_root_logger):
+    """Interactive TTY use keeps console output even with LOG_FILE set."""
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
+    monkeypatch.delenv("LOG_CONSOLE", raising=False)
+    monkeypatch.setenv("LOG_FILE", str(tmp_path / "robo_trader.log"))
+
+    logger_mod.configure_stdlib_logging()
+
+    root = restore_root_logger
+    assert len(_stdout_stream_handlers(root)) == 1
+    assert len(_file_handlers(root)) == 1
+
+
+def test_no_log_file_keeps_mirror_when_redirected(monkeypatch, restore_root_logger):
+    """No file sink: keep the mirror even when stdout is redirected."""
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: False, raising=False)
+    monkeypatch.delenv("LOG_CONSOLE", raising=False)
+    monkeypatch.delenv("LOG_FILE", raising=False)
+
+    logger_mod.configure_stdlib_logging()
+
+    root = restore_root_logger
+    assert len(_stdout_stream_handlers(root)) == 1
+    assert _file_handlers(root) == []
+
+
+def test_log_console_true_forces_mirror_on(monkeypatch, tmp_path, restore_root_logger):
+    """LOG_CONSOLE=true attaches the mirror even when redirected with LOG_FILE."""
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: False, raising=False)
+    monkeypatch.setenv("LOG_CONSOLE", "true")
+    monkeypatch.setenv("LOG_FILE", str(tmp_path / "robo_trader.log"))
+
+    logger_mod.configure_stdlib_logging()
+
+    root = restore_root_logger
+    assert len(_stdout_stream_handlers(root)) == 1
+
+
+def test_log_console_false_forces_mirror_off_on_tty(monkeypatch, restore_root_logger):
+    """LOG_CONSOLE=false removes the mirror even on an interactive TTY."""
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
+    monkeypatch.setenv("LOG_CONSOLE", "false")
+    monkeypatch.delenv("LOG_FILE", raising=False)
+
+    logger_mod.configure_stdlib_logging()
+
+    root = restore_root_logger
+    assert _stdout_stream_handlers(root) == []
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
+def test_log_console_truthy_values(value, monkeypatch, tmp_path, restore_root_logger):
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: False, raising=False)
+    monkeypatch.setenv("LOG_CONSOLE", value)
+    monkeypatch.setenv("LOG_FILE", str(tmp_path / "robo_trader.log"))
+
+    logger_mod.configure_stdlib_logging()
+
+    assert len(_stdout_stream_handlers(restore_root_logger)) == 1
+
+
+@pytest.mark.parametrize("value", ["0", "false", "FALSE", "no", "off", ""])
+def test_log_console_falsy_values(value, monkeypatch, tmp_path, restore_root_logger):
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
+    monkeypatch.setenv("LOG_CONSOLE", value)
+    monkeypatch.setenv("LOG_FILE", str(tmp_path / "robo_trader.log"))
+
+    logger_mod.configure_stdlib_logging()
+
+    assert _stdout_stream_handlers(restore_root_logger) == []

--- a/tests/test_logger_stdout_mirror.py
+++ b/tests/test_logger_stdout_mirror.py
@@ -32,6 +32,10 @@ def restore_root_logger():
     try:
         yield root
     finally:
+        for handler in root.handlers[:]:
+            if handler not in saved_handlers:
+                root.removeHandler(handler)
+                handler.close()
         root.handlers[:] = saved_handlers
         root.setLevel(saved_level)
 

--- a/tests/test_logger_stdout_mirror.py
+++ b/tests/test_logger_stdout_mirror.py
@@ -17,10 +17,14 @@ Policy under test:
 
 import logging
 import sys
+from pathlib import Path
 
 import pytest
+import yaml
 
 from robo_trader import logger as logger_mod
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 @pytest.fixture
@@ -120,6 +124,20 @@ def test_log_console_false_forces_mirror_off_on_tty(monkeypatch, restore_root_lo
 
     root = restore_root_logger
     assert _stdout_stream_handlers(root) == []
+
+
+@pytest.mark.parametrize(
+    "compose_path",
+    (
+        "docker-compose.yml",
+        "deployment/docker-compose.prod.yml",
+    ),
+)
+def test_container_dashboard_explicitly_keeps_console_logging(compose_path):
+    compose = yaml.safe_load((PROJECT_ROOT / compose_path).read_text())
+    environment = compose["services"]["dashboard"]["environment"]
+
+    assert "LOG_CONSOLE=true" in environment
 
 
 @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])

--- a/tests/test_logger_stdout_mirror.py
+++ b/tests/test_logger_stdout_mirror.py
@@ -20,7 +20,6 @@ import sys
 from pathlib import Path
 
 import pytest
-import yaml
 
 from robo_trader import logger as logger_mod
 
@@ -134,10 +133,16 @@ def test_log_console_false_forces_mirror_off_on_tty(monkeypatch, restore_root_lo
     ),
 )
 def test_container_dashboard_explicitly_keeps_console_logging(compose_path):
-    compose = yaml.safe_load((PROJECT_ROOT / compose_path).read_text())
-    environment = compose["services"]["dashboard"]["environment"]
+    lines = (PROJECT_ROOT / compose_path).read_text().splitlines()
+    start = lines.index("  dashboard:") + 1
+    dashboard_lines = []
+    for line in lines[start:]:
+        if line.startswith("  ") and not line.startswith("    ") and line.strip():
+            break
+        dashboard_lines.append(line)
+    dashboard_service = "\n".join(dashboard_lines)
 
-    assert "LOG_CONSOLE=true" in environment
+    assert "- LOG_CONSOLE=true" in dashboard_service
 
 
 @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])

--- a/tests/test_mean_reversion_strategies.py
+++ b/tests/test_mean_reversion_strategies.py
@@ -40,8 +40,8 @@ class TestMeanReversionStrategy(unittest.IsolatedAsyncioTestCase):
 
     def tearDown(self):
         """Clean up test fixtures."""
-        import shutil
         import os
+        import shutil
 
         if os.path.exists("model_registry"):
             try:

--- a/tests/test_recover_connection_propagates_exhaustion.py
+++ b/tests/test_recover_connection_propagates_exhaustion.py
@@ -27,6 +27,7 @@ import pytest
 from robo_trader.runner_async import (
     AsyncRunner,
     RecoveryExhaustedError,
+    _continuous_wait_should_stop,
     _raise_if_recovery_exhausted,
 )
 
@@ -139,6 +140,20 @@ def test_recovery_exhaustion_helper_checks_all_long_lived_runners():
         _raise_if_recovery_exhausted({"healthy": healthy_runner, "failed": failed_runner})
 
 
+def test_continuous_wait_stops_for_shutdown_or_any_exhausted_runner():
+    healthy_runner = MagicMock()
+    healthy_runner._recovery_exhausted = False
+    failed_runner = MagicMock()
+    failed_runner._recovery_exhausted = True
+
+    assert not _continuous_wait_should_stop(False, {"healthy": healthy_runner})
+    assert _continuous_wait_should_stop(True, {"healthy": healthy_runner})
+    assert _continuous_wait_should_stop(
+        False,
+        {"healthy": healthy_runner, "failed": failed_runner},
+    )
+
+
 def test_cycle_loop_contains_recovery_exhausted_check():
     """Guard against future refactors silently dropping the cycle-loop
     check. The actual lines of code matter here — this is the only
@@ -169,6 +184,17 @@ def test_recovery_exhaustion_is_checked_before_market_closed_wait():
     market_closed_branch = src.index("if not is_trading_allowed() and not force_connect")
 
     assert top_level_check < market_closed_branch
+
+
+def test_every_continuous_loop_wait_observes_recovery_exhaustion():
+    """No long wait may watch only the shutdown flag."""
+    import inspect
+
+    from robo_trader import runner_async
+
+    src = inspect.getsource(runner_async.run_continuous)
+    assert src.count("_continuous_wait_should_stop(shutdown_flag, runners)") == 5
+    assert "lambda: shutdown_flag" not in src
 
 
 def test_run_continuous_catches_recovery_exhausted_at_outer_level():

--- a/tests/test_recover_connection_propagates_exhaustion.py
+++ b/tests/test_recover_connection_propagates_exhaustion.py
@@ -24,7 +24,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from robo_trader.runner_async import AsyncRunner, RecoveryExhaustedError
+from robo_trader.runner_async import (
+    AsyncRunner,
+    RecoveryExhaustedError,
+    _raise_if_recovery_exhausted,
+)
 
 
 def test_recovery_exhausted_error_is_subclass_of_exception():
@@ -125,6 +129,16 @@ async def test_run_continuous_raises_recovery_exhausted_via_flag():
     assert "recovery exhausted" in str(excinfo.value)
 
 
+def test_recovery_exhaustion_helper_checks_all_long_lived_runners():
+    healthy_runner = MagicMock()
+    healthy_runner._recovery_exhausted = False
+    failed_runner = MagicMock()
+    failed_runner._recovery_exhausted = True
+
+    with pytest.raises(RecoveryExhaustedError, match="portfolio=failed"):
+        _raise_if_recovery_exhausted({"healthy": healthy_runner, "failed": failed_runner})
+
+
 def test_cycle_loop_contains_recovery_exhausted_check():
     """Guard against future refactors silently dropping the cycle-loop
     check. The actual lines of code matter here — this is the only
@@ -142,6 +156,19 @@ def test_cycle_loop_contains_recovery_exhausted_check():
     assert (
         "RecoveryExhaustedError" in src
     ), "run_continuous no longer raises RecoveryExhaustedError — C2 regression."
+
+
+def test_recovery_exhaustion_is_checked_before_market_closed_wait():
+    """A closed market must not defer a latched recovery failure until open."""
+    import inspect
+
+    from robo_trader import runner_async
+
+    src = inspect.getsource(runner_async.run_continuous)
+    top_level_check = src.index("_raise_if_recovery_exhausted(runners)")
+    market_closed_branch = src.index("if not is_trading_allowed() and not force_connect")
+
+    assert top_level_check < market_closed_branch
 
 
 def test_run_continuous_catches_recovery_exhausted_at_outer_level():

--- a/tests/test_run_continuous_persistent.py
+++ b/tests/test_run_continuous_persistent.py
@@ -102,7 +102,74 @@ async def test_persistent_runner_starts_subprocess_only_once_across_cycles():
 import pytest
 
 from robo_trader.exceptions import KillSwitchTriggeredError
-from robo_trader.runner_async import intercycle_wait_seconds
+from robo_trader.runner_async import intercycle_wait_seconds, sleep_unless_shutdown
+
+
+class TestSleepUnlessShutdown:
+    """The waits in run_continuous must be shutdown-responsive.
+
+    Before this helper, run_continuous slept in single un-interruptible
+    asyncio.sleep() calls (up to 1800s for the overnight closed-market branch
+    and up to intercycle_wait_seconds() for the inter-cycle wait). A graceful
+    SIGINT/SIGTERM only flips a local shutdown_flag, so an overnight SIGTERM
+    could take up to 30 minutes to be honored. sleep_unless_shutdown() polls
+    the flag in small chunks and returns early.
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_immediately_when_already_stopping(self):
+        slept = {"total": 0.0}
+
+        async def fake_sleep(d):
+            slept["total"] += d
+
+        with patch("asyncio.sleep", side_effect=fake_sleep):
+            await sleep_unless_shutdown(1800.0, lambda: True, poll_seconds=1.0)
+
+        assert slept["total"] == 0.0, "must not sleep at all if should_stop() is already true"
+
+    @pytest.mark.asyncio
+    async def test_returns_early_after_flag_flips_mid_sleep(self):
+        calls = {"n": 0}
+        stop = {"v": False}
+
+        async def fake_sleep(_d):
+            calls["n"] += 1
+            if calls["n"] >= 3:  # simulate SIGTERM flipping the flag mid-sleep
+                stop["v"] = True
+
+        with patch("asyncio.sleep", side_effect=fake_sleep):
+            await sleep_unless_shutdown(1800.0, lambda: stop["v"], poll_seconds=1.0)
+
+        # Must return right after the flag flips (3 poll chunks), not after ~1800.
+        assert calls["n"] == 3
+
+    @pytest.mark.asyncio
+    async def test_sleeps_full_duration_when_never_stopping(self):
+        slept = {"total": 0.0, "chunks": 0}
+
+        async def fake_sleep(d):
+            slept["total"] += d
+            slept["chunks"] += 1
+
+        with patch("asyncio.sleep", side_effect=fake_sleep):
+            await sleep_unless_shutdown(5.0, lambda: False, poll_seconds=1.0)
+
+        assert slept["total"] == pytest.approx(5.0)
+        assert slept["chunks"] == 5, "should sleep in poll_seconds chunks"
+
+    @pytest.mark.asyncio
+    async def test_final_chunk_does_not_overshoot_total(self):
+        slept = {"total": 0.0}
+
+        async def fake_sleep(d):
+            slept["total"] += d
+
+        with patch("asyncio.sleep", side_effect=fake_sleep):
+            await sleep_unless_shutdown(2.5, lambda: False, poll_seconds=1.0)
+
+        # Total slept must equal the requested duration, not round up to 3.0.
+        assert slept["total"] == pytest.approx(2.5)
 
 
 class TestIntercycleWait:

--- a/tests/test_run_continuous_persistent.py
+++ b/tests/test_run_continuous_persistent.py
@@ -102,6 +102,31 @@ async def test_persistent_runner_starts_subprocess_only_once_across_cycles():
 import pytest
 
 from robo_trader.exceptions import KillSwitchTriggeredError
+from robo_trader.runner_async import intercycle_wait_seconds
+
+
+class TestIntercycleWait:
+    """Regression guard for the 2026-07-10 disk-fill incident.
+
+    With --force-connect and the market closed, run_continuous skipped BOTH
+    wait branches (top-of-loop market wait AND bottom-of-loop interval sleep)
+    and spun at thousands of iterations/second, filling watchdog.log at
+    ~20 GB/hour. The inter-cycle wait must be positive on EVERY path.
+    """
+
+    def test_wait_when_market_closed_is_long_not_zero(self):
+        # force-connect + market closed: must back off, not spin
+        assert intercycle_wait_seconds(15, trading_allowed=False) >= 120
+
+    def test_wait_when_trading_uses_interval(self):
+        assert intercycle_wait_seconds(15, trading_allowed=True) == 15
+
+    def test_wait_has_positive_floor_even_with_zero_interval(self):
+        assert intercycle_wait_seconds(0, trading_allowed=True) >= 1
+        assert intercycle_wait_seconds(0, trading_allowed=False) >= 1
+
+    def test_wait_respects_interval_larger_than_closed_floor(self):
+        assert intercycle_wait_seconds(600, trading_allowed=False) == 600
 
 
 @pytest.mark.asyncio

--- a/tests/test_run_continuous_persistent.py
+++ b/tests/test_run_continuous_persistent.py
@@ -102,7 +102,11 @@ async def test_persistent_runner_starts_subprocess_only_once_across_cycles():
 import pytest
 
 from robo_trader.exceptions import KillSwitchTriggeredError
-from robo_trader.runner_async import intercycle_wait_seconds, sleep_unless_shutdown
+from robo_trader.runner_async import (
+    _continuous_wait_should_stop,
+    intercycle_wait_seconds,
+    sleep_unless_shutdown,
+)
 
 
 class TestSleepUnlessShutdown:
@@ -142,6 +146,26 @@ class TestSleepUnlessShutdown:
             await sleep_unless_shutdown(1800.0, lambda: stop["v"], poll_seconds=1.0)
 
         # Must return right after the flag flips (3 poll chunks), not after ~1800.
+        assert calls["n"] == 3
+
+    @pytest.mark.asyncio
+    async def test_returns_early_when_recovery_exhausts_mid_sleep(self):
+        calls = {"n": 0}
+        runner = MagicMock()
+        runner._recovery_exhausted = False
+
+        async def fake_sleep(_d):
+            calls["n"] += 1
+            if calls["n"] >= 3:
+                runner._recovery_exhausted = True
+
+        with patch("asyncio.sleep", side_effect=fake_sleep):
+            await sleep_unless_shutdown(
+                1800.0,
+                lambda: _continuous_wait_should_stop(False, {"default": runner}),
+                poll_seconds=1.0,
+            )
+
         assert calls["n"] == 3
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Hardens runtime stability after the 2026-07-10 disk-fill incident and preserves prompt shutdown/recovery behavior:

- guarantees a positive inter-cycle backoff on every market-state path
- makes long waits interruptible for both shutdown and exhausted connection recovery
- separates redirected runner/dashboard stdout from the rotating application log
- preserves container dashboard logs through explicit LOG_CONSOLE=true
- caps watchdog launchd output and renders checkout-specific LaunchAgent paths
- forces the rendered LaunchAgent plist to safe mode 0600
- improves startup failure guidance and closes test-created logging handlers
- removes the production use of the testing-only force-connect flag

## Final evidence

- rebased onto main after PR #83
- local full suite under CI environment: 929 passed, 2 skipped
- local full Black, application isort, flake8, shell syntax, and diff checks: pass
- hosted Python 3.10, 3.11, and 3.12 test matrices: pass
- hosted unit, integration, and performance matrices: pass
- hosted lint, security, Trivy, build, Docker image, container structure, and compose-render jobs: pass
- all 11 review threads addressed and resolved; final Codex review produced no remaining finding
- Claude reviewer did not inspect code because its repository credential returns HTTP 401 with zero tokens; this external configuration failure is unchanged from PR #83

## Safety impact

No database migration or data deletion, no broker credential changes, and no live-order enablement. Startup remains through ./START_TRADER.sh. The attempted trader restart remains blocked by the existing TSLA loss kill switch; no bypass or state clearing was performed.

## Merge order

This is the runtime prerequisite after #83. Rebase and complete #82 next, preserving this runtime stability while applying the paper-only containment rules.