### PR TITLE
docs(remediation): record PR1A merge evidence

### DIFF
--- a/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
+++ b/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
@@ -8,15 +8,14 @@ Target: safe supervised paper operation first, then remote read-only access, the
 
 Current execution baseline (2026-07-23): `main` includes the truthful Phase 0
 CI gates from PR #83 (`7f5de0a`) and runtime-stability fixes from PR #81
-(`b7e5005`). PR #82 completed PR 1 and merged as `393f533`. PR #80 is
-superseded and must not be merged or cherry-picked; its independent findings
-are assigned to later scoped PRs in
-`docs/branch_analysis/PR80_DISPOSITION_2026-07-23.md`. PR 1A is now the next
-gate because a read-only incident reconstruction proved that an uncorrelated
-timed-out broker response can be relabeled as another symbol and reach stop
-logic. PR 1B then supplies the non-mutating broker-versus-ledger evidence
-required for the later Gate A decision. Neither PR 1A nor PR 1B authorizes a
-restart.
+(`b7e5005`). PR #82 completed PR 1 and merged as `393f533`. PR #87 completed
+PR 1A and merged as `4cafb782cbf43ff4397f1b89b42d5f657eceea8e`,
+closing the incident-driven broker-correlation and protected-runtime gate.
+PR #80 is superseded and must not be merged or cherry-picked; its independent
+findings are assigned to later scoped PRs in
+`docs/branch_analysis/PR80_DISPOSITION_2026-07-23.md`. PR 1B is next and must
+supply the non-mutating broker-versus-ledger evidence required for the later
+Gate A decision. Gate A remains closed and the trader remains stopped.
 
 ## 1. Purpose
 
@@ -1118,13 +1117,18 @@ Update after each merge.
   mapped one-to-one to PR 1 / PR #82, PR 6, or PR 11 in the branch disposition
   record. Separate branch requirements, rather than review threads, are
   retained for PRs 8 and 10.
-- PR 1A: Not started. Added as an incident-driven prerequisite after read-only
-  evidence showed that a timed-out IBKR historical-data response could shift
-  later FIFO responses across symbols and feed a mislabeled quote into loss and
-  stop logic. Historical persistence also uses integer RangeIndex values and
-  overwrites prior cycles. The current kill switch, lock, and database evidence
-  must remain intact. Restart is prohibited until correlation, contract
-  validation, and timestamp persistence are complete.
+- PR 1A: PR #87 merged on 2026-07-23 as
+  `4cafb782cbf43ff4397f1b89b42d5f657eceea8e` from exact reviewed head
+  `aa62b3e20dbd88096aa78a5875a8dc48e298f7ee`. Local focused validation
+  passed 371 tests with 2 skipped; the local full suite passed 1,396 tests with
+  5 skipped and 20 warnings. All repository-owned hosted checks were green,
+  Codex exact-head review was clean, and the independent challenger returned
+  PASS. The external Claude run `30047548445` provided no validation: its
+  revoked OAuth credential failed with HTTP 401 after using zero tokens and
+  incurring zero cost. PR 1A closes the incident-driven broker-correlation,
+  event-time, transport-poisoning, stop-protection, and fail-closed lifecycle
+  scope. It does not authorize a restart. Gate A remains closed, the trader
+  remains stopped, and PR 1B read-only reconciliation is next.
 - PR 1B: Not started. A strictly read-only, account-verified broker-versus-ledger
   diagnostic is required because the current preflight points to a nonexistent
   command and the legacy position-sync utility is deliberately quarantined.

--- a/output/pdf/robo_trader_remediation_and_launch_plan.pdf
+++ b/output/pdf/robo_trader_remediation_and_launch_plan.pdf
@@ -2031,7 +2031,7 @@ endobj
 endobj
 297 0 obj
 <<
-/Author (RoboTrader project) /CreationDate (D:20260723125134-04'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260723125134-04'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (RoboTrader project) /CreationDate (D:20260723180917-04'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260723180917-04'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (Ordered safety remediation and launch gates) /Title (RoboTrader Remediation and Launch Plan) /Trapped /False
 >>
 endobj
@@ -2707,24 +2707,24 @@ Gb"/h?$"^Z'Sc)P($@@>/rF4g=MAU@VDjoG6MLZ&<f%aLU9Yrcbl7B#16A3;j3gL]/PUsn`.sK#q],Dp
 endobj
 426 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2807
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2804
 >>
 stream
-Gau0E_/A!u'#"/m$J8!`=/&8`Unf$t+\lVR`WV.Mem^95Jem%&H;(W4->?V8rV1fk9hOup''%V6!(E^*m]KVkYNhASo'nB;T1Me"0rOVM!t%LS?W&TO`\d]\^Wb$<SpAfT`/eNk:%@+_9&;*)-_lL#Ilm6Gg7/ll"aGbKdDQub.AnTf]ccaG1V,U<_GLl`=<a9Rj%2MmGVg:.!L_IUp'o`N[*-CM(WJ;XELuYA5#(i<1G@n^]XcT$4Z=RML9>)?;^H1T$PGm#+%0$QCV%YVnIs1IT_[L@p]nuP:G3-O.ImGY2RjBr2!7>cFJt+69BKWKs3[*68W"%Es#9H#*IkrHO.@"WNkZQMmSc7@-G4%(njZs4+qhin"ODE>JC,EOk(V@mp;&]V/nlVH=jb[]S?B$ZDpse3^TiPRs)n7ao93aM8merTs)u*%5?YKi;q*:`_l=I[Q)T(&96L8BQf-@GMi!C?5<?'-k>iHtU@U.([7pBc^mfNJ^<*3SiP)8SkXOM^>Xi.HFJF!uT2\6Z"6WZ>jX">EhGc?I\u(1WFsh,T=\E85_bqei1B!V??'-U7=\=&U2,G]!<NIY_7dePNW_0B#]O,Hsi!_tQU.]86^O?%PWD9JbKb9-b0;9$2[SkZOeb.Glo)A4BlI4#>r:8=W0-br\&,jUh'RG%Ng="n2)d;G7ea*20$@-"5."S@SBIZT*p+`Y+6s89'9QX.^VFbSdQU]l;9l!T.01,MK@jKfaRtqNdh>f[5Ddfl4<Jd%g-$XO:hjRnSaNSp,!:;Y=Zcs:IF)`N1ZEgKQ8XWna`*%)ra"Q(RAYp#]\:RSs0Q1^e>-Vgd*T"W)9f9l[.kE4>fT,$3o<4-/fR!qFnf#e6^G-@>.@#ai@&QR;V6]9)!#F:qLCd1nejfUp'/3h8"]KaYdef.0+,tINmeJY'R)Ru>I/9MUBJ^Y5UVH;e:EbPBo$%GH%I=hb3jEQ3J4O0B?-/[tUY25A*i4pQHNpb8S&[j0^.&YW2Og5SU2EZ`>d/%M%/H@7L#<e_;H4rf&G5J&2IKfUXZ2gG4jaG\b)"iJbF0Xh:NI`59EB>E,fa>d)S*d1E$:M)C$W3=KDff7>I-QQKkc-VG=lcB"jC$mk42Cm"*'klRdYW^3uhg&7Usah1?)7RlK,=tO\mr^3BX.ULI7E%Q'khFM55p<`$)\=k4Xmu<WE>o,a"[(b"?*($c_1%)e>/m/<>6G(2TsTZVU(q"1(XU[Q`>+[Tf!S.rr^p8Etpq6)JA6RGAL*003VC.HlG__6Mi4Bo3n2AG+9_]glA(qtC$,c%^dFd?4"ug%U+DjV_pSK;G2U<fK"jh/,_>W=)i%F.Zb;kgf%R/cAqd/h_[g[Q,Z&PI2gcn8M.+>^H'G31bl.A`8+&k?;OT($<W6fl`@PmJAY]-`N9*peGVbnZ,e3O'ft3UT3&L8F]IYlbF9FAlWh$LS4(3WZ?Yb.fbF-:lB[[*_3DGoPWpV)SH^(/QWEW:tl<aF"?Qb.V_7V_2%5uHgMflY@cs8l0$dB#2*2IEYN*pLi%(Q[P6F$00t6jI0&_2?HqWgda,>36Jaarn]aVm(2S>5Dfm(k2:k.`p?IejZ'>2>&#[n.14R(2F3R2k]s=VRgTsqn\N\-lIWp):mem-=QJ@Ak6%ArdPNa[.D7q(1ZW@5PIT"4/1@D49648te.+`u7%OfG@_j:^6%9^H1K)<\K%@R@0:/u(q$LJr3)PD%s:f1SmcQ>H-5iEDtV/%@mR7&Egaf=eDI\/QNkn/.3pqkqcimBsaWH3sSV(B_H%nG1>2'hE6.+5T$qU`/5rNW2T>L^k'3`P16//U%@<NO81CWlQ+i,0D!1PFgaPdJm=5ga6!]o4V8jR%$eB[TD'7mS5f"F\&SZR*X^$!"c-6e8>%5kH"WU*M,n8E%!9[InD>mE7h&hEu'+:iuDn^Chi$3OMi%cd`Q?<B:jaH>.dNmia$$?ik@R](?W$ITTk=/E?Ij5P;T(k2&km.*UXaR%Mr"S:^RM[XtV>P(t<i1)t.*U$A<bVAc/NPE/b1G*:)8`fW?BVMZX7;TQ5#'m\/c*S_HJjC!c4;Q(!t2,qO:125R/8^hfu>28[19ih"/fdQ'"bE!i15)j[RUo+&(dMHfH">JUJ9BSF&EDalb#'B!s[4H.H_])`;R'PP\*S4/f_>RaKTW]"kZ0RG*U*A'?Cdg<:Zfd$[%(&YIZ)lba9\kpc^#6:"DWl^6R/Ns1Le]/-?h_+=o.Adu/>EQbJ,lur/2E3TAYjob6Vf"E$#Pg\XAN>m$U>YT(*"fW0m]%#_*=m!SG+dU''[Dqhimn&go#gd#3<&ZHOEdM,TV8q@I41j,B2T;)U-e*)Z+:k-Ze%Ygo;kG@jsfTQK\kMW*F)OF0%<kJ%-BCJ*#YofZQF]Q:B\=PLZ?<D0re4fY52Hjk<($fNVAS@6+<a@6Q]2p\:Raq*cge.\8=MkI/nZiRWn8m6P)%&kfp/^>"SA>b`XS*CA!<k^J!E74@@=3ZS[Ol"Ps*(Rs0fP<bnlG(cJu6KKeqM-O4tp7jfbI1<`kp#nUU3&f/LA8Z[cgN>lVc=Dpc+gH+@DQl1+o>Fp6G"XQaR3gHi,bGX`QP],c_p7$r@d=4ISU4Vs>(8[XE`Xihl1<$XLR[2S8XE+WD"?mSJlm(V.N`i*m22>!erI+7]X^4G+ldTScp0$fl!VZ0\8r^5(fjkJ<&o`>5S3N+`SM]FU@nLbiW!<2#Q@<iig1Pm?PZpj*Xn]H8"$%N(L4@Z!>TDI-MqRFW[`bPrfm/b!C&=GE!6mJ(EN]r!W7I(BR%-.?%1Q"e(Oa%O45I.~>endstream
+Gau0EgMYb:&q0LU'X079Y!hk*MUDq,_00Dp`WV.Mem_tf">-o.opB8G:"$<OoC71-8R7jk`&P1;6l%5OWp<X7WJ`lZn^"PFEDCU1UU+;jnpHn&jGfZAbs'K-Z]hR?c=@X"iKTi=r_+["9YDS>6b<*\`!L.#;GcT9)2c;P)3$&BE9oXBG]TG'm>2MO?9![q+<$:bO.;=SNC&]MiWOS@mO4WnETdO8RcQM)n1U+TI%[Gpk4>,"kdd9&O[qhu17*h1[F,58,,#OA.H2XZB;0W@ZTi-s:HncLGj'7$+Ij#C4f%">PgZ'>.?^AWZ8J%5/Uu0U=@aA!M>n+UfcEB;j,\g!s+tfEZDS[W4==U7?GMF<Y=$5I]+LWYI"9TbB^,`O$223abJkB%e0H,Hgt6\l73s`i8G[`!]Dd'=7RKE8r9br<#<Vg*oJ[Yu:dt-;h\D5&iiG^^7J0PVD45d=2AodRTa'\o]V:+YnS)`[:=hGsO%B>r#B`ILQq19u<;62/]5*&Xcun..eFPekXm"7k7BLSjXD0IkRB"l'WeX*E]jn)*OUPMS4JLPDV>(bj]Zan<'>EGY!6V-@i*'*8E=A^1)@"#D"eGGPOnap8Xu4Tgs'B93=JYP%ilCY4'VtLgNDa[YREe<O&uO\CP-L6\+qL8W5]NYO<@k4]iFS8sOG8ThpC^>6oURhV=<kI6)rR3<T(2nTUMCabJmmgV)[2d`/ua`.#,tMBK[!n_R]<5Of//g5la3@1.?.I@9,6@+jC_A5KnCYVPQdZ_mO]%kYhBTm&)>NdK.moD<GGAr=KMnM7,h:Q/hO:Yl7dUBNiTLs&Klc\U(H"h;UsInc,BSOrp'4Re*Y]PlI3d,]**0FjLAR1$b!X.&+sFnDN+lD,q+D^/p&hlRi8L4r=8(=T[d#Z9I:-L+n+)'YlqslD3TT;.H'4S[T<B^=$!6I`i=W/SBVKS&s@MJfI=GBo0AeZQ5mN7W2atHYae4Jo`SuShNkO1O01D^K;7u%K'l!U3qE2e\D!bZjDR'.#@*k6!a_#.b6).3.<2X7`F6,`b9nb/Ytf5mEp-FcRP!J=35*EoYj04B/YRa=1?;phR5RVnM5h.HLaGtA5QMYI;k0uf]p@joq[4WhLTYB83M,AP[3=0(bC[2E0J\=nG%HNaA)3M1d#VsCc2Nu.>n-;k?HEr=J5'g:7:$=S2QjBpFDZDb47#^1\Zt<0)0$,pFdi"a1)u9\%o:m<_]d7NU?9\q6m.$k2FLX#h!M$<!l,rM-$!BGA'k9o.86W..-")RY[,E\%fLuq=ArpL$spAMDUY>^3V?;"Xbm`Z5V;OPijrPpODii,a`\BKMiJlB#G'd437ch.8W9`#=oHjJgYG9/C[XJg2Y:5]&%!US?.V0bEhHEY,l4?L0mg.:D,H,T!g`f?A(PBLI4MpQU0hZee]$u92Q,V']G/=Og72KVl.'QXjM%%9>L>+3ct;QLO(_1rm:A(QH`CU*^=1f_HS]G)n!0t3Wk'."'`US*%W%8;<Y]h!#jP/bh%FC$1KuGqljr*kIl!k/U0h[->f:hk3B0<AcQUN'6ouc26!qH`BU=)57%JcW41CqkC*ss2CNZ,A0P`piHW,*A&_*W(b\$.P!]l^/hTFuOka1".+`CRXn]j\n(2U<pD[B*Jg8I6<\LdsIf2kq.<;*pdLr)),Ik1Alk%B"FYc2HnZYoJPq]pOco'5T4r;_KdhhgbeJ:K?udq`jUH9hhWD[&Q'XH)U[gfM\0(+'nqXoX*\o39,!Wj6,>.L#R3>oGO'VC,@qH$&76k\G\MJ$5T\6D*^.oF[9^+W%^j@\."sBeiiaSALolH,H*kE5us*li_fd]$GfmmcAXA9<ug[_(kONMW@]uXj9Z5mr`:>P?Sf?;6tG]6U`'=K(6.Q$FdV%g@C3eEArjM)$B_Y.-\a`]t$.-mq25*-1AQt`:M#t1jBRRs#B6&B9D,WOlN4T<5=-@XEjL>dB>fmOt]HEg@V8NhQ7J?Z/MN]RAh#:SUKR'U*POnW<.NcrSUmk4,&elXY8`;L5@LLJ/jnmH3m5/4C%)$j6qVLl=DWm]q*)-R"OEQ5Hg,-#4m1Y#I`?:2.5R`E3qKVWe]tLWY)8DRHhf?bt-u5<ik$nD7_cT>`j<[X_M;0p5LtNYXLMd.K`TY<Ug:uN7L^k1n0M"M`^o5PL[?Ok.?%Yq*CfHa,tP;eW_.CqSI-!d"l^s@j]be_!7YYG7Ec[=%c]KY_P0CDH533h0>*,#TDJ/V?$HR`Y7+pW"gd;?-$mhB/)JSk]/t,'1\j@HPTO=AXd#q=ogSS61%BqF=%9S,/'3;db8tAG:Le7!\YZ]/KF@U,A2:"5d6r['"3I:aKCi-YKR0CNI)$C'uCg$b1>Jme5ae@R5D0bIg5\>eFuF\POQD=4S4h(#Lhm>F7<%][2UZV^k(fe0\`JVfNn*sQJ2o3<aG569-FqS9WsgRAZGROU#'nbiH@KdPOi!d06b'4)KcQ:Mu>rKleralqhB8If,^T;DH6@bAalIIH#t%pi3fHQMf*(+-l)u-DHEqPDV]9ChWkP;CoMV7hsH0o>b`Wh*Q"3"Z2&[=&#!^pcKS_):6$MTIC61o[g+`.\Ro]<1SOB"cpTK<0Y9aq-@Lk^@I;Ek/Ssf4#B@<:Fmc+C!cc4Q`BR^KphnZ_"1q:_`oKT'j-a%bbshO:iHo]eaY.hr^(TaTNO!QL@(U-&9]KulPbrZRrkkl,oVb:"YI=1B4b?4?=]@TQ41cdskH%s&UNCR"i\JNmb+O/\^p8YCPN'=L@#JI$7RNG^+:EiVJ"tZl_q)/4iM2V:",>qCWr~>endstream
 endobj
 427 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2465
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2490
 >>
 stream
-Gau0E9lK&]'#"0De1K@5`??O*+*7%$A9WPD]S[KG@=b(?[\SpT2Q+0$>=!`9^1pQ1]jm1?=b?anO[Kqb?<=gd<K8KG^W=0e"jr)?^&'gaBM>H97<&mfl50<0])$^fbi;in/1?nG17qLLLaKHJ6Haj`"UR=sQ'=\HLM"XZLgqn_R>+!a4hT,*f;i:7Nfkhb9P2au(/YX(B5nQHfj<XJ;<phiAsrjd.BNsP1\iJq3BOSRVX2Wi9>/n,,;NtH.1;OmiKPrdPSsEDl8%2CD(`uGdHV6GrLMbo@NNi(-Bht8Hp..Q>>[u`c:F(WFIDU>4F,(VF=Xe_Al$YN$i"i3cb0/&QnN0iaG#O+>"fM\?:,j%N#+2[INEZ''B&*1)8i#d^V^r5]L.m551[`pda;6#RB'6^E)U%'Tut6%U$FHIB)g)[DdAhbT"#QD-PB.k)*SI8nnN=NBb=%O;\SWLC*tHI]s=A+)'53.WCs,r8]jpSS2<k!J?\]GB((NQRn[)d6N?k&LIP-3ab`sn:DcPK:'K>Cbk0L'K5BOn&JR>\rW[m[=#\=Qn#PQpVpEQ%mejCu!fC_C/QJ<?<,(A@%`>P9^O)*D$m8^Lo&1f6'+S\me@%8!janYoP5)X4esX5\@`XO,RbrhTQYB:`:Ep&DX>>"a/@@EbCWolEk=:rk:7IHE#18nch[R9EoHd+(TYTtAfm6pASP![3D=eiH.a8]p+R6(#+N&+pLn%k@7W+LFOaO7;Kb5G3<4R+6ZiP`<Wa)@Jo7t2DbQdM?&W<OD%C+4N--7UfWQ6M%G.6&>A;la#96(s.l"Vfu]:km]q,!2Bo5gZjgA\j]#"H:7=%7(J[G<jsJm,<+pH:7+#N9XLgM9.3=CiL_K0h)bVf$$@Wpce;?P<^%o1A,:J$+2H*Ia4"S]Z#Z%gplY(jQDS8!$k*f"%T9mmR(P3s]WmWc$<.3mRD46S)t?Z'OT?RH4:l<N;RML#YNCWheAq70.gNDrsC&%j%OVPMF;%Fpd1f@%)-aUDsFsno`Cb/PN`S%LCY*\%HjcE]4j.34YtML]dLOIc,<;Vh)VPUO'(n?M#GS'KuDr%8"CICH9o$j8$7Hd9f72]5J/@,?U2p&JE8)0S:ja3*9BXJBRuUF?nR4[VFAK#P>lrE_J":Id$:]l0M(H`r-0bG2J5YWt//(Ld3:VI]\l8XAVm_`s0DG,k"_[b>`)+;9/8aURq*Jh:[3le2LNbSk+"CK$7-rc;SU;LV+;^QI"EFNHBMp]G(#H2a?YZ%W/#G$H+lZ_-l:cfgFbJ&73sHqcNIu+0MM;017hRXV8pE2V"'$0QEps5k$4[K/."dcVV[lYc76M7g"VMh.4^r_@T*d:r7FN,RZdf*UJB<OZmVBF_#g1*.i.834F-q?3H=4hjR$X\nig)A1O(JNCo$>_R17(D2hEp5M+KDB-`.uJqE)=F).H7\sio?Qju^>PPI'&7q;CqcHqnR2pQDQ3:I(FW!8ge9I'e)^p\PVf<2.02=es^=k]E9rAF6o.dl+D/Zu'LgL_qPG]"N<-a%U[XB-iV->`lL)l`Ch:>>Q5"qcj@m7sSQ!A0u7V7P-j>C,9MTBW`F;Z2/\>5R)8QCZ[tCE^rG302)B(=g&^lLC^.lBCqq9P!mLP=W'LedGaBI7'#'PJ2^sWsmVf*Lcj=.'#oU$ioiqRT*G@Vk/neI8!s)2D&bWW:8GU?9\q7^_N#J5aE9-?5p]mQ(e7/^-=dRVE0p%mj^-imC*[b`4-D.,#;"_5$%)aU-P;(4OE?:n*!q][.:`"*f!'(c_HCjeg-naZJs6SF:U,![:X_%Eafqm.%s\5H.uToMB7$sUg;%2prke`f<.WUD[hWF)*UkIc+Rri$VQdtpXH:1%VnC<*_$p6Dp2auD;bZ9:AfqlH&sMr;0[!Ml.<11_f'EV%*&gR\[F(,m1(F"g=h\F(MfRO4>_91NBjP=)';_+9rG.e>RhBCPl$+0PE-P*;o-nS6k8mN'QQ:1lRh8XXoghTP)#]hAjb;I,aA8eph9FH:jrBFB=pth7n!kaaRZId6&e.D[^Mr9Am:RKi3b=?q3/c[E`2(US5f8=@h.d7JS/GB[=\h%JOs9X]Yh#Yh@%^s0U'JD7G=rMO*9DeUmB#+`["*j].Pn/-#kkNpu5l[I-;hj!+Zd2Im4?04B/!:8`c`'$aA0Gorh2habqbl,`c.lE(dsAPCBq#GSEG&LVf1+oE<4[N4rX;+73AWqAHXJ"p7gn)d(;+b2+.[!!VG*7=#&Z18laq`B7:GGqk+DG])F(=1(Q1QRI]9<t]HXr<R^Vfq!%YI.B%pOnnli:)Kb43ou2;NJi"$]X)-*G.R=0`'O#)B$'u+^GYZlhtc>b\3uI?%JgFulW91M?obCXq>6J69@<6bdB6\Mm1d;/_`H+?R4$b*-3(N*;d/fHpg:Gn*`+m2%[27^7];iRCf`EJ9X7jWH$&sH8DQE'^X:N\IfV3raqO~>endstream
+Gau0E?#ScE&Ua>VkdOe0Mb?\?OS6rrEQJ:Vi91m5*Wd<Nj@G^qae<?<gH+E9Vg:m2G1IjG=c3HbPsdL-CT=G9LB75G(V%4o61ek[++=\JR*o_:60O$0qLuYdY3rL+H'nBSK"O*Mk&^)/_(;!D[/@t0(X_8C8Pt"R.#AQi%&omJp:VS4][,io.rR<TU)5%c8K9&XH/URdUO^S^$MP"@V0$/*aIC/U.^5MthgLsbJeh\:lhP7of6V!r-4MP<+YtEZV+VG47_abV9QtTJMt4'YqL_guj5iK5O*c2Z=YqLT4`uB];+^Aq8<HVgRIA6[]?>]g<bs'.cbf\iq"2a*h"$)b?ddrVGFuWDE>&$\S[`h#T*Pij?3J96"<F("lmMSTS,V;nI%#?&nNI>!k-fEpDY1&)F]%8+Q=ObUC:R?m3XeG`92jg`P3#`0p_<N3<Do]q=Q_FaD<S\G7[,dEc3V2A@5$o:.&diV<[%c^W^KMjS9ZbcqAub`^,RJ$0Do2iK,j[PK4iSR&I,FMefd"AAq>;ae.S,%bbNLD0s[lp/Zd1$8=*GYb8PX?mL.j8R5"NCV8\?#iP!r:9"S)+;5R#6`i]>uKd:6/!*5u9Y$7mL5)u`uo$8T8IsaHtUtRQqrMrMuH+aOlmMC<W^osf.jm)Tjo&e-IV.Y#?hQHrKN<SDn/jZMEW@@K<WS>/mOfJm5=o.jV1EFXPBPl8-0s3c3aYjNU(h.pWb9.",Pg]I^m(Q0,C4@-V!.Yu*db7TCdJ(JIVL<lUBiAeg1=R^u_=WMVf8%(.W<j9k"/N&%=%9+9>$;kn#>1i'iY#5!,EUln-q#CaVSTB4f-Ht<D%VGINRS1"Al@_7PtjPGh96)l`Xn%DZQFnR1%Zd2.G(Q?.2-m6f"tsVPS6]i287Pi>,6A;8]P=0(<k+M3Y(#02&bUbg6Iei>]"[BD':L_PWK,4dA*Z1U:8a-]!9E/N"$,rPYSg+Sl@pFZbIgm'(\]X:4KDeP7G@LkYC5"fgga0,`Fj]p(PBGiGM7,f89:#FqiNlS%@!dlIa_O%C'T.`EJuDAWlk]X&RV%(X<PJ^]<.B.IcP*G;0m@Idec)S`EiF\5Pp'<WEu23%.8t:0cWI8ILaM<"/sLj'(<N;0b<n[6M@'4U=4IVg`/;UXNVa=@`&40>=lPE.06]qAJuu$?iDlZ1]6YkDI<!%3=KC2jqug;3j^S/@`dn:6f%"XDK5ujo7+W5TAHXc!'7[?<C)_b=]2bg\``6cU;/%N'JKZh$C7^0SR[U@UeDHUT@pkJoX(6&?[;STJBZIj,Q*h7V?<r)pZ$UqqeDm1,fCo'cSnU&_Kmid@;uSJ1^6''cU<EnaT@:-sZ\+.04`BKiJ\u0aqZhNUpZk#mWb`]rc,]WTZ:t>UQ/hLbdY#bp*bP<*.McI%!A&Tr0:KStB96i'@`c>.a3t!C_QWZK67<?Hc:_H<SmU$TSE>\oR)ToQE5%@<-8U7)K9WQR\S<;g&d.Z'A#57]"$/iO']8D1b`<4u_%uB-`G(JqN0YHu%[+qMRhZ#fj%48Nt,2BS:<h$q#ERWG?A[#G'coeY;YtKqn\TD!*a!;cc\A%A"Fd9=rZO^UCjE`P%bC`AJBFgJ10Z!*.:_M:X)XX`GpSP;WK79iUpYmqpiKUPM[km7sQS:HCb=Qg.?Gmc94OI&>AI9D'qhe(Sg)=E\/kIg]u!j#lnY/ZSVcf)DM'lAKiB9OnZc8L->mlO5E9Gs`'r8QS7B<<d2l%aFqYP1@ta"+Yc^-<6B1WKX+.+-Uc*D+bfMC-"R;S%"HrY@rXN)N\Nb"g<pDN(Qr4'gJ:]H;gBVV[o&\r:\kJ7:PNgINhQ`dOnVhB;,B%(`rHoeou3fB3KRc:f!jc8+VXBf#XU>ZJsBWF:U0Mhlo5%/RgWQ&><-"Grr/g7h6Z"H.Qc733uA7^$@E@HdgtoL,[USo,ufe_Nq#]HYSV-%`a7*4H(gJ?^St/["T#-G2c:+aeM`Ob`d+;c`iHn#(Cdf@5r-Qc*crSkg!"&UTL*>IBh?``^=eplNq*%[,WA<YjKpTSBJ_MMK42cJ+<nUA1H7.PK;_^6(rU;FL/qKgioE(;t;?$d?ljV$0ABO4pJ_,Pb0)6)':5kPG3UWAGarL5trK9[]u$$Am;]kd'YW/q6S*Yi2"X/S5f8=@h%^?JQ$$.[=\k&L.Peb]Z7;[hAO^<0PBQ4W#56\a11Rk;G5K10bF\9f/'`r,jsh'=1es69:\HQJ;dt$+3&j;`X;?#X*fkQ!O[g<rsE=@?M&>Q+4K^nL-)2pmV(k(F.KT&(\9GH+*PY^9/RjQT"qmE/3lpOBm#lGm+md).%a[EUc6XIK=^&6bXkg\MD6B>F.:abV+iSoZRkNk-jQgY]a.qOfpunS]^%=i_#"!ePJuae8U9#Ze)KsY5-JKJG.Mco`51r&1*f'X3Rb4sNVs7E&d0gGGUk2G4+?P?b44,U^[FS#'Wm*,?2'+Q42oN1Nt4:\Y:t^6rWf9CgaW~>endstream
 endobj
 428 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 605
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 674
 >>
 stream
-Gatm7h/8]9'Y``Z^<>rB%Ls>smA+SXSWm]uJ.!`]-Y$*8/48./muX>\dOF!/9h66Xkkhb6;SM5NhK6QF)RBqeEfPGTR>W'X*T#Di6R&PC9[s3=i_`\e$^m9$L"443.-qTP-2AXIWYB`=%]W'R/0<\#^*Fnl93!Z6<Yfs0+nBoH.uCK%QrflTS6u[MZ3#0hHEoIYW_(Q('U,,XQ,!'9cn,F&W2%r-BY8t@/ai8V2-VW6G-=_l7K%OqIg45h,0Nr>BjN#dlCPjDOD]!MZQm=)b7?/sL/=GWJ*)--aY+1qAMK1A9@C`SV8ZZ,6=$:NknRS9j8t]!Of(<QOd<X.k0J9MA>4J2=buE@CNf?[ie#R@2;]ej*$4<jDbX^c)]j0NmmEmoZL/s^)XDT!U@5egRh97l+W>.lo>AiVC;knlhZG;CjhD!D?OZ!%pjWF@^r:LE%QO*`&WIaeU=4"XmBdFL,@HB;NHR@AJ+S.gq7#q)h&#\m/7c[^Tb#Xg:*%?*+'9H7UZ26<*9*8X^tMm/%YnN?CPj>TmpaWQRqk0WO7:r;e\/aG$G<3`Qql/9f<r*=mtV57dG[em4h6k`_baQSgiMpTIKHNd(Gu~>endstream
+Gatm8gJ6NX'R\5.bTjf/iluUQ/%'f!dWV*%0ZhG>WFH1RJZdL`mn%\R"U(b07>`*5RPQa4:*a;_jF"-mi(Jd1D\@)AWeF,8MWu0gX6;#GAQm%*&u+H`/0U<7.2EfPh]n9B-F1]<ItJpq7%0i;QH)>S\'G8n,*=EeQ8:p,jCob\dRB:1&q1L6?$W)`JB9U0jJY-%PC/6b:5"oWTD4qXh1_oBC<0mZ*Aq"(m4=K=E3;Z7Dm;(?IR&%4lJk;4#bGgh,frYPlZ351W[E;Y8N!EkRN;<'Q+pG#%A>n9s2k8qd4],.17slDMrOR1Tu9kI,C?<[nek^+irLcV6lt]ZH!Kj4=?J&H,8%nCRAEI:XsSLPlY4stG>/0CV9S31(UR2og3J@RGN3:n_5Z=uYH8^;J@:eD:G.G./>)4RQc0p:bP4L.mXa95J.rG1I8,/uOe=qPdBsJ>n6t[1k6!S?lWp0ig:4CRE4n&FZ\*-M"DnR^^)FDWk#Fd+nu[YfQOUJ-ILee$E:>q0#0aVZ#hn]1UJl>8AifED#ad/1XfV**=*:G@'j-Lj$iC2UZK%$eCoLM&3X6;1@;9?HN,Q.83PD4O>&@r?_`Of__@Eu[_5j$D2%J1@E;$tB]tb0L4OVMNJ!>@g>A&o,)():dKdR?&A/hg36Z&*;1'EF4!>#W=$3~>endstream
 endobj
 429 0 obj
 <<
@@ -2910,17 +2910,17 @@ Garo=;/b23'SYHC/'_Y6,npalB9/7f^%<JmkZ_DMbu1`'ADjPhZld%u05ZnE&H]lc3p5;e$?00X5+;TJ
 endobj
 455 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2751
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2934
 >>
 stream
-Gau0Emr.2V')eE:U8670ZZk@&#@NqpPiO1'd:W,n)=GC6,HVlr%D=JSl#&jJh&h-Mg;]5r&=+lpBI9uuWp3TtH<'YAjPs%or_;NCQX`(k%O_TsS5IZ)H8N@4cf;@P1N1p(rVhVc+asiTjGea>%f:AJj-eMseQG3:!,!_Ja'Pr>F6X9`0,SN.F8Bq>7:FOb^dJkIH>u2V08t8VJFrIBIY/u3`lt+E70=IS&Pr%CT8"?4a;](\+7@<D3S#C>RdT9BVFjrj(*nd%DFIPN1V1aunH4c#Vt&Y(r#PCB0_C+;_19CI^OnVQOSW3TO`nnl?^'@:nis]!;b9i9a8Wi8TJlf%`UCD\adc;m2^o+Zj=C@]_"S)ki:a-O7h[)8^kEGV/t/J(GIj;ZBac2R.V#<(k5;(Q_6CCk+#I[B#(DN#?MMBYjMfkIN4d535B>'L]h!jB,Vh>*.?N;pe5PTP$39b""7Y.Fk8q6d:]3Ges6BKtT%)=L\#(7^MkU^Z];WK&n89S3`7M21aQgpnBF;Nsl0b/B15otT.A?7)*tGl2g^PM)qS>UFIbf?Z/^F3loL8BI95e0e30^u1i8$0?RQbTNFB)F#QX++?7-2RoBq_AhO-MK#9kA9c.OVLfqgSS4WU'e`"/u^^eD$.s2?$<*_]X263q"M2OqiF1=i/PBCdk*IlUT@ZCjC,,-6ahJ<2hD]PU5Pg]`B^<0f&-H<TZS!(Aqr$r%$IKic%dJV2!cRg8*`GAM0.$%Ok=kgS*q<4NLrd/torcf*eu/<EM93?pTRl9]e@'F^`6fL]2Abb:VL`UP`d+WHG5HN09T&*_[6&7mE9c\!4M0^=.DB>MC%D&UC=ESa!GKcM/S/.ucFUXin(DS46S6ZKH?M::/=jk?4eI!k;qsXB(1r2f]o&!+RMCYnD=&Z:q8Zpp!lCFf0B^O"u!2"AUG3Vu.iK;?^qTLdki(/Sdo%Z)_oZ.+'$Z\[a8m7i+]cd"d?/Q!?$J$lD>^ZjQ5h11)g9Mq4Y/Q/..0Z0!"r8^--LV'&$hPuXbZVNCU_C-GOHO(r0DROO5YjW`Ce0<T,J,H3B'8L\bmT1c^DZb8ane\ng[PuQ1d\cO\:E`GeY._g)Kf6a(EO+7$^^)2A!mFR8'5(C,T\GEkqFf'34>mQ6C#aj3GR=-$:8^-EuAl<CI0Th3jN,7NIAtkY:9h;jk>Y[]hNT)*W%k>o;Au.%*RkpS!<=T+HAtM-p5%p/kk/!PO<3gp#SWt7Uq;[maF'7EbT.YZkGF@)(hK#/5R487#N*=*5b%.eQEg/m/2(]6AIcbHGgM0$N`b+7WK\_uN;V4lk1QaAC+5qJkeoZ%]j(R(uf=K/]#3=>Of=fgCKO[([+U:(8FctJ&d&N*X#bNlGnnsVWXofOVBE`G,nW??bj^>$^&(k1/S4'r!%9P]UgFfa7'F$u[Ub"?uc?Bp6+j2Zp!Uer>EL4R/U=B>73j_9[nuff3(O"sd<"mM,2e.SCV1,B%@*C0Qh6cU>jE.gU#NmsoP?X;Has%Sq#%bB9UK60?S5j-EEMKGm![hE'dsE$Zi^3bsZ]pI"f!i`2T@XMQ$r%k//57sV^jLa<5l,_j.a"JiF,sI^@HkkOrIS-r_fNpp2lL";fE?kC9cu;m<TkHPBk8>N"R&Rr\Yql[:Y=89aq_4S[L+3nI8!Xu0Nr9f!LoB@-;6!6du'nkn.3aKe0%s1C;9H>ds-714[5kQqd6="n+&a[jqFIiTKnWRdH[JO)?3YE11?K\q:5s:Xs^\6a(:B)VMF)ncqsr^XBW.C;#nP8^[/_D7AOWW&F'0GU9e3pA=EARE;7QW_H>mJ,$0V1JM7h]$C]$MEa3W^k%Fie2-7d(\cY"20^JQ&d1+ME"P[BLT+*2*b0EqRH`q5.0"2u"MK]4bDfXIgT**,U^<a^52.#;q<Q=-^.pj[\UG!&q>K>"AL4)1f+;m-nF1N]UDl-RUKi[pYK$0["K,'9e)#/k-&#.qMd#o?_FYVY)r^5!qrVleO+3s#f8,<sbFQ2ZLF.1\(F@);_11e'HFp2RZmb6DX12S*W2iALK[p6b&@tYtj1n:Kqh-Br,hpqo."4A]9CgD!cn:H/pG8g_3-cgLDTrdV?qW@XHmH99Ud3V8K=jJI,DHoI_aW],<R9WErNf1rX7#9KF8dMqHVcq\k]YN@&9!F;_@1ZA,T04'D^kTX.AEn#m+2fmAjUEL,M1rU*[::7C/!bMJG?TPCDXKA#eP%SSK"'%]..5SpV-Xc8J&5DdS%s;\Cnm?`+/7oF]lY"KL;Y8q;\M)slG3hMCKYQ`p#_!cBPAtASS.H&+L!_14@ec3Wqdj*p>Ei,j@9I-*<g@nGAI'dYr`r=cL/kog!0Dq9!!C(d4cC$8\dC6*7\#Vin:-$o9ujWA\&uu;dd3Ree6lcZ$NW>9"+V!;gL8oQE06Y^Qj\s1AE8B6HU[BGj@2N=hoN2Qa]H2\p1_UW3Z)+-etRS<tjGXGTXk)%p?4i;/OQACm_LG\1d'_DDn'!)-48kgVoJ4&/RJ%\8O*l<OUb#QRuLdG/3_#C(?@QCgYkcr4,$Sg"RWG-@Eh#6_N<)2,LgS)X'tLMN.c2IW&o:SMrBT)H?/R:gs9>TYgJGT__00ndhl@D[,;F[:Qu\C2aT[@!Ln;esesB9qMDbHk`O3IlC3+knARc*X/SC^Pm@;eXAZ&W6nJ8U@?u([AH_".e&Kc'c^E1hMs'FC1B>U.Q@X_khT9sd0Vahi2DnbI^b:\52eg?]Xgteg&D(I<T]h~>endstream
+Gau0EgMYb:&q0LU'X1[^ZRaJ:M56:^a.&J'OI>dqg4oh5$sI1?l7k^Wh5"lsp>bmH2ao/37;IsD+L+@t<H[SIl80/PJ3Tb+[oa<WS^[Cq+b^NQ.gcqSU%nq>2a@1]k3#;O9P<GLplXb#cb_Z"VKDdcR6RPFZ\G>#m\+Hcq+3ngR\kWXVRt/3h44:\'M_SoLpJq[6Lp<g9;WlsjVduN6R[STFR$mqc.@b!rd-mj#;l$NNp"r8]4gA2PZ#u<>g$$%::1OfVPF`sDi,98eY;kjk.fCCD]Jb-q':jq4ASn5ZJuFt`('$5/Oep39t_j$i8q^q-'j_Rl%/e_+[KW9R>jG85Dh=r/f7J%`Q20jr.#lb?f2DBER@11-FD`"Oc:^^kt8EX/WE%A94^/`5BHh3q_V+Bm_^48@2`[dkXT!*Nr<ddM4#I?lGqKO^Gi"Q,`)k'8IFO%/bN$<VZK-^>QB>grjbNP$tsr4pE,#14H`l\F)Up(2c7*#^PVfV#d7:G83D@sSiY\O.p<#DCV%*S^Z;Xe>7q8b"]=OgR2<j7nWf+'r5[kKCKWMHAKZ`r^\7BkLJsU6dML*^B_m!1Vu*>iC[%6^/6&a_/T%lEnl)`N)H.M;3gGUs:4lsNoMd0rlpN<J2YFFfmYu^YbU<mlR*KISLL`j2:6mSU1gBK$Y,62d1g<.lBF@\$]MkYC$Buj,"A)3)@>l`bkULYS2B2WQM>g+QgYq:h]os@VpL]bL=)VkOgeLD.<d,5RYnjf(T?pe]YJTI^g5p&1\^]hp$(7'[CGOYA'+YcQcc%OZi(b6A/16ac93"tkXCQ<dL,aSW\HTa54H8dOkkSuJXcSRq8):bADYrOQ5=F!mdi%r3D:o_kU\dN'k:R6;g?5.#Wmtkcgp@if<e\I*2/\f^@k$Y@05;<//:&-1>cYL(A9@j4[^ZJE/p^Nar"(Q]"r@\=UZd"U*MhZ&bBCR50c\)ZCY<en>p($D'HDS"j?7"gJh_A.;8G-=ep!)Q@eA=/\),,bf^OQA&8V%l.1D>MeL=Ir;TO6l1p<mp=3_YQ<_?k5fnagpM_!QAQ;X+#U(t7%hFk7jX.tZ-Wek;>.]HkcocBZ,[eJ%0\+8-gq=@HrfCRm;jqmW5^\rKKbIa7EMp$=b?!"%lhF<$kd=AW/aR%Z;8n(S_ZBAB9J;#OBDr_aBYnG:oBgU5oeT*)GE"jsN\lEn?R=!ImZWY17gXe-`jmKIaUE;>8#P7/Kj\iC40O6&SRe,,];:i+iFhYHgmb_U'*V:r8=d&"WoUJd&n?4<ECl94.O@Cf@6d2/[)qA6/TiOP6fGS,l/YWqbX1_+>N8Q(.^)("br:&ROi=Ol0Y-n\Yaqm.Q:bT\/3u=S[G7s0d[96p;D7:X8We@CcU2K?$1+KXGR`iZ?U&^IR6Z)^n],On:..<N*[asMg8ieOBK-D.1*B;"!H\dK>jV>Wtn)BPj.>NOBWt!u]kRJ9I>(a.6\q@1_9an5\XVn]gorWk!200#hAop6_B<lGroXs<6GuWImCeB7+W7(&O[Gp0+XK(\"2eG["E$oJjAoC18I$4QRgr[CtkZcP!ceG,o$nX`/9MMku_7TfRJGNA?2/VBahW(cXZF%lpo7C(HiRqb.44H/+C]_P_,r@J]<To)7d`U@>&\p=7kJDp$+/%4&asF?#NXR*O5F/<;(aCr^JA]GN'?1X*ZKEVCqua9!298gZg@%3)4J,tX&qmElIn5QF\$rXtD\0<C$T++a,<sm/j.D2p(>S"p^C:R3lcGpGEHT>J[tim'_4q?CYT;O0N<16:HT:elMC?Xr($0EM0fdNQZ7LVVcbC\i(lNdoe>c>=&>hs#d3c.%*Of:<29*G?RP!P$dfH%KQu9\9oH*6,_gO7(h[Ltjb0F4ZB@#mIO%0b&`EIi<LYPW!B50N!YOce=K/^:jQ*E@1b.GUhF>J%!k]jU]kW[j)TFBV\ZFhNQ0=KHML?@V'_,]'oJV<#<L;BkL5ocCmB!Yu[Z]i7BDu0oN2G9XEb:X!-Q9AQA-&&95=WS<9.Z#\RSRkg2aCgDV.]69-c"%uoaQ7WS*]FXrJ$GKqr=""'+2ga:!SBQK>+mdn!tc`:(9rgME`(tE0M@,@E\YhFWQ<7,a^m<PX%XQFA1&P$[K'6jZld5;*\#+6hT@QC$.2LHNqtK7ES@PQ9_BqJHRsf?M/X*&p'4&V@;:->$8=Z43SQMZ[3l6@(L'H]-QiXsBic;"cEc+VWCua:K1i.U;`=8+cR%/JB\[di-kA8Q_5?*e+^JC/g`0bXIXD7f9t;;J8N'<6,WSUo/887h1KbeFqmGO!`!ie#l(8c>Aj)f$VHI05\JlF?S_nd[hM4MD36/BSX!PbI$KTSICj86H)OMZm"WnjJYCo)ohH=ModN3'j9;fiXA@Jkbb8M:R'u:*P"`MjV0lZ7JPqZLUnURp/KmT!SINV)i[#ul2KU=D91o4Ci!m"TJrkM!8!R:2W\,(n5`c^S53%<D2G=DgBlYbZ(2ER>LGi-s.Wuonp37YT(#N%J=oI56Idc:PG`SjbkD/]=OHFFR4NkaAS?shBdaJI.Q4b)sX7MVK55%F\n.A2Sr;[>uq.97h!m.bCCj.YFV/G:Fn\)^%*j.linYZKm\[^(ReC:.=*[oTaf_f?ElOlQVZki/kb(?N^*7WKm6LR%#\GZdl#\JGcq>KU,$=>TQ*!9ZE8?cPfSXP'Xif.1?lTE/,/@0NW/ieMrrP:PDkj3bl/Yar&-\+33mgYMZ,;^rQ1ChlOta6+4ZZ>#I<HY9cGrFb!mU1L(F3p%-Tkf$k@m7feIW;'5_`j`S+&*iZ'nXfuM49ecPk:[!RDu(>:9cjNg4XDqW%P"#4+/ng/TVfP`JJq6I"/tQ`T]5I[5`MY5!EB%H:gs!*TLRDV!,D3E:p]qn0TDBj!E'as##f\;Y<<b%p0@V2B92cD_aJ/;",`ol`;~>endstream
 endobj
 456 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 391
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 420
 >>
 stream
-Gau1(92EGZ&;9NO'm&FZ[U)03N_$s^6DaIu`AF8&2$npYKZ&ql$&,g\EWTD7at%8AR9bP@LPL4W!@IoC1Bo@_>Hf9'0ZIf<O+K.IV9M;/.Tltu=aO^74VqZ!,&14TJ)IFV@o1!&8aJXu93_eOMQKMag,n=4A<]$=dEY2?o#f*I``^_"Th9e+Tg[HNb/s=*p86)/'A?QQ/Z*)Z(5pfsRMrF`0TOKPljf4jXS3=p&Is-a)tHHIati.Qr,0:q5*YH5/RreMeB:q#)jE9Tik0qf)u>n85[XNhi1F:^AsJHFIll[&9@t9OCFOOaFIL=;FP7)*7`nL&e0O^H,b`>`8NH$DZhbp/2!t&T(JT[_0",%gCk7)5Ek24R<,:a587d9D"n<'uFK)t~>endstream
+Gau1(92!/f'SZ;Q/'cQJS^*d=i_iT37;A?hS$@gXdNf_U,5C2h`7fuEU!OFnO<K#7I.n7AI&MNj9&SK7GY'"arrCJP_iJcqfaHhsG/C'58N`.=4=0*b6$C5W_)n]*./j<]*7l)TN"qlLchAEgN%7K>7YGe_3s+$^BgZR2/EYBTaoZ&^<u/N/IFP5]dM5BbmJ7f6omQ4sO;AA3U+Gk<BP2IA:urOJ[qbJinN9dkn5&O$?2ZXnQBEVP[?,9Q^c4Fmc*/W`5,bOX#F`&b:Q32uJ?itgRlI'PJ(OEBgDuK@M>htQEBjS;9D4nfZiqI_Z@S$?TuBRE$5YA+r08P#\6C8U>kORdhjR^'oGOgt(9_Rgg*5D[rbH(DG:9L,H661&-S(N'b\E!kLR$`<b+o9K>,(b"AcB";qZ?^9"I9~>endstream
 endobj
 457 0 obj
 <<
@@ -3372,43 +3372,43 @@ xref
 0000142742 00000 n 
 0000144259 00000 n 
 0000145587 00000 n 
-0000148487 00000 n 
-0000151045 00000 n 
-0000151742 00000 n 
-0000154166 00000 n 
-0000156579 00000 n 
-0000159409 00000 n 
-0000161937 00000 n 
-0000164475 00000 n 
-0000166672 00000 n 
-0000168925 00000 n 
-0000171127 00000 n 
-0000173244 00000 n 
-0000174726 00000 n 
-0000177070 00000 n 
-0000179394 00000 n 
-0000180753 00000 n 
-0000183226 00000 n 
-0000185626 00000 n 
-0000188040 00000 n 
-0000189407 00000 n 
-0000191797 00000 n 
-0000194005 00000 n 
-0000195974 00000 n 
-0000198162 00000 n 
-0000199900 00000 n 
-0000201874 00000 n 
-0000202999 00000 n 
-0000205563 00000 n 
-0000206142 00000 n 
-0000208986 00000 n 
-0000209469 00000 n 
-0000210588 00000 n 
-0000211541 00000 n 
+0000148484 00000 n 
+0000151067 00000 n 
+0000151833 00000 n 
+0000154257 00000 n 
+0000156670 00000 n 
+0000159500 00000 n 
+0000162028 00000 n 
+0000164566 00000 n 
+0000166763 00000 n 
+0000169016 00000 n 
+0000171218 00000 n 
+0000173335 00000 n 
+0000174817 00000 n 
+0000177161 00000 n 
+0000179485 00000 n 
+0000180844 00000 n 
+0000183317 00000 n 
+0000185717 00000 n 
+0000188131 00000 n 
+0000189498 00000 n 
+0000191888 00000 n 
+0000194096 00000 n 
+0000196065 00000 n 
+0000198253 00000 n 
+0000199991 00000 n 
+0000201965 00000 n 
+0000203090 00000 n 
+0000205654 00000 n 
+0000206233 00000 n 
+0000209260 00000 n 
+0000209772 00000 n 
+0000210891 00000 n 
+0000211844 00000 n 
 trailer
 <<
 /ID 
-[<95d4c18ae93b81ea87f80e17ca3f67c4><95d4c18ae93b81ea87f80e17ca3f67c4>]
+[<ed180a656094c18823d17dffa50857f1><ed180a656094c18823d17dffa50857f1>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 297 0 R
@@ -3416,5 +3416,5 @@ trailer
 /Size 460
 >>
 startxref
-212880
+213183
 %%EOF


### PR DESCRIPTION
## Summary
- records PR #87 / PR1A as merged at `4cafb782cbf43ff4397f1b89b42d5f657eceea8e`
- captures exact-head local, hosted CI, independent challenger, and Codex review evidence
- documents the external Claude revoked-token outage as no validation
- keeps Gate A closed, the trader stopped, and PR1B next
- regenerates and verifies the 39-page remediation PDF

## Validation
- changed files limited to canonical Markdown plan and generated PDF
- PDF has 39 nonblank rendered pages; cover, TOC, headers, footers, and PR1A evidence page visually inspected
- exact evidence assertions passed
- `git diff --check` clean

This is evidence-only documentation and does not change runtime, broker access, safety state, credentials, or trading data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and generated PDF only; no runtime, broker, safety state, or trading behavior changes.
> 
> **Overview**
> Updates the canonical remediation plan to reflect **PR #87 (PR 1A)** as merged at `4cafb782cbf43ff4397f1b89b42d5f657eceea8e`, replacing the prior “PR 1A not started / next gate” wording in the execution baseline and progress register.
> 
> The new register text captures merge validation (local focused and full test counts, green hosted CI, Codex and challenger PASS) and notes the external Claude review run as **no validation** due to a revoked OAuth credential (HTTP 401). It explicitly states that PR 1A closes the incident-driven broker-correlation scope but **does not authorize restart**—**Gate A stays closed**, the trader stays stopped, and **PR 1B** is next.
> 
> Regenerates `output/pdf/robo_trader_remediation_and_launch_plan.pdf` so the published 39-page plan matches the updated Markdown (metadata timestamps and embedded content streams only; no application code).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9eb265fb95c3301a805da40b0fb9d8d8aa7df64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->