### PR TITLE
feat(safety): add fail-closed broker reconciliation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@
 IBKR_HOST=127.0.0.1
 IBKR_PORT=4002              # Supervised IB Gateway paper port
 IBKR_CLIENT_ID=123          # Unique client ID (0-999)
+IBKR_RECONCILIATION_CLIENT_ID=997  # Dedicated read-only diagnostic ID; must differ
 IBKR_ACCOUNT=               # Required expected paper-account identifier
 IBKR_APPROVED_ACCOUNTS=     # Required comma-separated allowlist; must include IBKR_ACCOUNT
 IBKR_ACCOUNT_TYPE=paper     # Containment accepts paper accounts only

--- a/.env.template
+++ b/.env.template
@@ -35,6 +35,8 @@ IBKR_ACCOUNT_TYPE=paper
 
 # IBKR Client ID (must be unique per connection)
 IBKR_CLIENT_ID=1
+# Dedicated read-only reconciliation ID; must differ from IBKR_CLIENT_ID
+IBKR_RECONCILIATION_CLIENT_ID=997
 
 # ============================================
 # RISK MANAGEMENT

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,6 +6,8 @@ All runtime configuration is loaded via environment variables in `robo_trader/co
 - `IBKR_HOST` (default `127.0.0.1`)
 - `IBKR_PORT` (default `7497` for paper)
 - `IBKR_CLIENT_ID` (integer client ID)
+- `IBKR_RECONCILIATION_CLIENT_ID` (dedicated read-only diagnostic ID; must
+  differ from `IBKR_CLIENT_ID`)
 
 ### Trading Mode
 - `TRADING_MODE`:
@@ -26,5 +28,4 @@ All runtime configuration is loaded via environment variables in `robo_trader/co
 
 ### Validation
 On startup, ensure variables are present and parseable. Fail fast with clear messages.
-
 

--- a/robo_trader/clients/ibkr_subprocess_worker.py
+++ b/robo_trader/clients/ibkr_subprocess_worker.py
@@ -348,10 +348,10 @@ async def handle_connect(params: dict) -> dict:
             "error": "Diagnostic worker requires readonly exactly true",
             "error_type": "ValueError",
         }
-    if isinstance(client_id, bool) or not isinstance(client_id, int) or client_id <= 0:
+    if isinstance(client_id, bool) or not isinstance(client_id, int) or client_id < 0:
         return {
             "status": "error",
-            "error": "Diagnostic worker requires a positive client ID",
+            "error": "Diagnostic worker requires a non-negative client ID",
             "error_type": "ValueError",
         }
     if ib is not None and ib.isConnected():

--- a/robo_trader/clients/ibkr_subprocess_worker.py
+++ b/robo_trader/clients/ibkr_subprocess_worker.py
@@ -20,19 +20,21 @@ import sys
 import threading
 import time
 import traceback
-from datetime import datetime, timezone
-from typing import Any, Optional
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal, InvalidOperation
+from typing import Any, Optional, cast
 
 # CRITICAL: Enable real disconnect BEFORE importing ib_async or ibkr_safe
 # This prevents zombie connections when the worker process exits
 os.environ["IBKR_FORCE_DISCONNECT"] = "1"
 
-from ib_async import IB  # noqa: E402
+from ib_async import IB, ExecutionFilter  # noqa: E402
 
 from robo_trader.utils.ibkr_safe import safe_disconnect  # noqa: E402
 
 # Global IB instance
 ib: Optional[IB] = None
+worker_connection_identity: Optional[tuple[str, int, int, bool]] = None
 
 # Global shutdown flag
 shutdown_requested = False
@@ -76,6 +78,24 @@ class ContractIdentityProtocolError(ValueError):
     """Qualified broker identity cannot be trusted for the requested symbol."""
 
 
+class BrokerSnapshotAccountMismatchError(ValueError):
+    """Expected and connected broker account identities do not match."""
+
+
+BROKER_SNAPSHOT_SCHEMA_VERSION = 1
+BROKER_SNAPSHOT_BALANCE_TAGS = frozenset(
+    {
+        "NetLiquidation",
+        "TotalCashValue",
+        "SettledCash",
+        "GrossPositionValue",
+        "RealizedPnL",
+        "UnrealizedPnL",
+    }
+)
+BROKER_SNAPSHOT_REQUIRED_BALANCE_TAGS = frozenset({"NetLiquidation", "TotalCashValue"})
+
+
 def _aware_iso(value: Any) -> str:
     """Serialize a broker timestamp without silently losing timezone identity."""
     if not isinstance(value, datetime):
@@ -83,6 +103,72 @@ def _aware_iso(value: Any) -> str:
     if value.tzinfo is None or value.utcoffset() is None:
         raise ValueError("Broker timestamp is timezone-naive")
     return value.isoformat()
+
+
+def _canonical_decimal(value: Any) -> str:
+    """Return a finite, non-lossy decimal string for reconciliation evidence."""
+    if isinstance(value, bool):
+        raise ValueError("Boolean is not a broker numeric value")
+    try:
+        decimal_value = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise ValueError("Broker numeric value is not decimal") from exc
+    if not decimal_value.is_finite():
+        raise ValueError("Broker numeric value is not finite")
+    if decimal_value == 0:
+        return "0"
+    return format(decimal_value.normalize(), "f")
+
+
+def _required_int(value: Any, field: str, *, allow_zero: bool = False) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field} is not an integer")
+    if value < 0 or (value == 0 and not allow_zero):
+        raise ValueError(f"{field} is not a valid broker identifier")
+    return value
+
+
+def _optional_identifier(value: Any, reason: str) -> tuple[Optional[int], Optional[str]]:
+    try:
+        identifier = _required_int(value, "broker identifier")
+    except ValueError:
+        return None, reason
+    return identifier, None
+
+
+def _optional_decimal(value: Any, reason: str) -> tuple[Optional[str], Optional[str]]:
+    """Represent IBKR unset numeric sentinels explicitly instead of as evidence."""
+    try:
+        canonical = _canonical_decimal(value)
+        decimal_value = Decimal(canonical)
+    except ValueError:
+        return None, reason
+    if abs(decimal_value) >= Decimal("1e307"):
+        return None, reason
+    return canonical, None
+
+
+def _optional_aware_time(value: Any, reason: str) -> tuple[Optional[str], Optional[str]]:
+    try:
+        return _aware_iso(value), None
+    except (TypeError, ValueError):
+        return None, reason
+
+
+async def _qualified_stock_identity(contract: Any) -> dict:
+    qualified = await _qualify_one_contract(contract)
+    requested_symbol = str(getattr(contract, "symbol", "")).strip()
+    _validate_stock_identity(qualified, requested_symbol)
+    return {
+        "con_id": qualified.conId,
+        "symbol": str(qualified.symbol).strip().upper(),
+        "local_symbol": str(qualified.localSymbol).strip().upper(),
+        "security_type": qualified.secType,
+        "currency": qualified.currency,
+        "exchange": qualified.exchange,
+        "primary_exchange": qualified.primaryExchange,
+        "trading_class": qualified.tradingClass,
+    }
 
 
 async def _qualify_one_contract(contract: Any) -> Any:
@@ -239,7 +325,40 @@ async def handle_connect(params: dict) -> dict:
     3. Async polling with asyncio.sleep() for account data
     4. Event-based waiting using ib_async's internal event loop
     """
-    global ib, gateway_api_down, gateway_failure_detail
+    global ib, gateway_api_down, gateway_failure_detail, worker_connection_identity
+
+    host = params.get("host", "127.0.0.1")
+    port = params.get("port", 4002)
+    client_id = params.get("client_id", 1)
+    readonly = params.get("readonly", True)
+    timeout = params.get("timeout", 30.0)
+    if isinstance(port, bool) or port != 4002:
+        return {
+            "status": "error",
+            "error": "Diagnostic worker requires IBKR paper port 4002",
+            "error_type": "ValueError",
+        }
+    if readonly is not True:
+        return {
+            "status": "error",
+            "error": "Diagnostic worker requires readonly exactly true",
+            "error_type": "ValueError",
+        }
+    if isinstance(client_id, bool) or not isinstance(client_id, int) or client_id <= 0:
+        return {
+            "status": "error",
+            "error": "Diagnostic worker requires a positive client ID",
+            "error_type": "ValueError",
+        }
+    if ib is not None and ib.isConnected():
+        return {
+            "status": "error",
+            "error": (
+                "Worker already has an active IBKR connection; "
+                "client must stop/start before reconnecting"
+            ),
+            "error_type": "RuntimeError",
+        }
 
     try:
         if gateway_api_down:
@@ -252,26 +371,14 @@ async def handle_connect(params: dict) -> dict:
             }
 
         if ib is not None:
-            if ib.isConnected():
-                raise RuntimeError(
-                    "Worker already has an active IBKR connection; "
-                    "client must stop/start before reconnecting"
-                )
             safe_disconnect(ib)
             ib = None
 
         # Create new IB instance
         ib = IB()
 
-        # Extract parameters
-        host = params.get("host", "127.0.0.1")
-        port = params.get("port", 4002)
-        client_id = params.get("client_id", 1)
-        readonly = params.get("readonly", True)
-        timeout = params.get("timeout", 30.0)
-
         print(
-            f"DEBUG: Connecting to {host}:{port} client_id={client_id} timeout={timeout}",
+            f"DEBUG: Connecting diagnostic client to {host}:{port} timeout={timeout}",
             file=sys.stderr,
             flush=True,
         )
@@ -376,7 +483,9 @@ async def handle_connect(params: dict) -> dict:
             accounts = ib.managedAccounts()
             if accounts:
                 print(
-                    f"DEBUG: Received accounts after {time.time() - account_wait_start:.2f}s: {accounts}",
+                    "DEBUG: Received managed account set after "
+                    f"{time.time() - account_wait_start:.2f}s "
+                    f"(count={len(accounts)})",
                     file=sys.stderr,
                     flush=True,
                 )
@@ -398,11 +507,12 @@ async def handle_connect(params: dict) -> dict:
         # Connection fully established
         gateway_api_down = False
         gateway_failure_detail = ""
+        worker_connection_identity = (host, port, client_id, readonly)
 
         total_time = time.time() - handshake_start
         print(
             f"DEBUG: Connection fully established in {total_time:.2f}s "
-            f"(serverVersion={server_version}, accounts={accounts})",
+            f"(serverVersion={server_version}, managed_account_count={len(accounts)})",
             file=sys.stderr,
             flush=True,
         )
@@ -423,6 +533,7 @@ async def handle_connect(params: dict) -> dict:
         # Gateway has a bug where disconnect() during/after a failed connection
         # causes the API client to go RED. Let Python's cleanup handle it naturally.
         ib = None
+        worker_connection_identity = None
 
         error_text = str(e).lower()
         if isinstance(e, TimeoutError) or "timeout" in error_text:
@@ -508,9 +619,425 @@ async def handle_get_account_summary() -> dict:
         return {"status": "error", "error": str(e), "error_type": type(e).__name__}
 
 
+async def _position_state_signature(positions: Any, account: str) -> tuple:
+    rows = []
+    for position in positions:
+        if str(getattr(position, "account", "")).strip() != account:
+            raise ValueError("Broker position account is inconsistent")
+        contract = await _qualified_stock_identity(position.contract)
+        rows.append(
+            (
+                contract["con_id"],
+                contract["symbol"],
+                _canonical_decimal(position.position),
+                _canonical_decimal(position.avgCost),
+            )
+        )
+    return tuple(sorted(rows))
+
+
+async def _open_order_evidence(trade: Any, account: str) -> dict:
+    """Build every emitted order term from one broker trade object."""
+    order = trade.order
+    order_status = trade.orderStatus
+    if str(getattr(order, "account", "")).strip() != account:
+        raise ValueError("Broker order account is inconsistent")
+
+    order_id = _required_int(order.orderId, "broker order ID")
+    client_id = _required_int(order.clientId, "order client ID", allow_zero=True)
+    side = str(getattr(order, "action", "")).upper()
+    if side not in {"BUY", "SELL"}:
+        raise ValueError("Broker order side is unsupported")
+    contract_identity = await _qualified_stock_identity(trade.contract)
+
+    unavailable = {}
+    permanent_id, reason = _optional_identifier(order.permId, "IBKR returned no permanent order ID")
+    if reason:
+        unavailable["permanent_id"] = reason
+    limit_price, reason = _optional_decimal(
+        getattr(order, "lmtPrice", None),
+        "not supplied for this order type",
+    )
+    if reason:
+        unavailable["limit_price"] = reason
+    elif limit_price is not None and Decimal(limit_price) <= 0:
+        limit_price = None
+        unavailable["limit_price"] = "order has no positive limit price"
+    stop_price, reason = _optional_decimal(
+        getattr(order, "auxPrice", None),
+        "not supplied for this order type",
+    )
+    if reason:
+        unavailable["stop_price"] = reason
+    elif stop_price is not None and Decimal(stop_price) <= 0:
+        stop_price = None
+        unavailable["stop_price"] = "order has no positive stop price"
+    last_status_at, reason = _optional_aware_time(
+        trade.log[-1].time if getattr(trade, "log", None) else None,
+        "IBKR returned no order status timestamp",
+    )
+    if reason:
+        unavailable["last_status_at"] = reason
+
+    filled_quantity = _canonical_decimal(order_status.filled)
+    total_quantity = _canonical_decimal(order.totalQuantity)
+    remaining_quantity = _canonical_decimal(order_status.remaining)
+    if Decimal(total_quantity) <= 0:
+        raise ValueError("Broker order total quantity is not positive")
+    if Decimal(filled_quantity) < 0 or Decimal(remaining_quantity) < 0:
+        raise ValueError("Broker order quantity evidence is negative")
+    if Decimal(filled_quantity) + Decimal(remaining_quantity) != Decimal(total_quantity):
+        raise ValueError("Broker order quantities are internally inconsistent")
+    avg_fill_price, reason = _optional_decimal(
+        order_status.avgFillPrice,
+        "order has no reported average fill price",
+    )
+    if Decimal(filled_quantity) == 0:
+        avg_fill_price = None
+        reason = "order has no fills"
+    if reason:
+        unavailable["avg_fill_price"] = reason
+
+    return {
+        "account": account,
+        "broker_order_id": order_id,
+        "permanent_id": permanent_id,
+        "client_id": client_id,
+        "contract": contract_identity,
+        "side": side,
+        "status": str(order_status.status),
+        "order_type": str(order.orderType),
+        "time_in_force": str(order.tif),
+        "total_quantity": total_quantity,
+        "filled_quantity": filled_quantity,
+        "remaining_quantity": remaining_quantity,
+        "limit_price": limit_price,
+        "stop_price": stop_price,
+        "avg_fill_price": avg_fill_price,
+        "last_status_at": last_status_at,
+        "unavailable": unavailable,
+    }
+
+
+def _order_evidence_signature(orders: list[dict]) -> tuple[str, ...]:
+    """Freeze every emitted term so any between-read change is detected."""
+    return tuple(
+        sorted(json.dumps(order, sort_keys=True, separators=(",", ":")) for order in orders)
+    )
+
+
+async def _order_state_signature(trades: Any, account: str) -> tuple[str, ...]:
+    return _order_evidence_signature(
+        [await _open_order_evidence(trade, account) for trade in trades]
+    )
+
+
+async def handle_get_broker_snapshot(params: dict) -> dict:
+    """Collect one bounded, read-only broker evidence snapshot.
+
+    The command deliberately uses fresh async request APIs and verifies the
+    connected account before and after collection. It never calls an order,
+    cancellation, or account-mutation API.
+    """
+    try:
+        if (
+            not ib
+            or not ib.isConnected()
+            or worker_connection_identity is None
+            or worker_connection_identity[1] != 4002
+            or worker_connection_identity[2] <= 0
+            or worker_connection_identity[3] is not True
+        ):
+            raise ConnectionError("Broker snapshot requires a connected session")
+        expected_account = str(params.get("expected_account", "")).strip()
+        if not expected_account:
+            raise ValueError("Broker snapshot expected account is missing")
+
+        accounts_before = [
+            str(account).strip() for account in ib.managedAccounts() if str(account).strip()
+        ]
+        if len(accounts_before) != 1:
+            raise BrokerSnapshotAccountMismatchError(
+                "Broker snapshot requires exactly one managed account"
+            )
+        account = accounts_before[0]
+        if account != expected_account:
+            raise BrokerSnapshotAccountMismatchError(
+                "Broker snapshot managed account does not match expectation"
+            )
+
+        broker_time_before = await _request_broker_time()
+        positions = await ib.reqPositionsAsync()
+        initial_position_signature = await _position_state_signature(positions, account)
+        if not ib.isConnected():
+            raise ConnectionError("Broker disconnected during snapshot collection")
+
+        positions_data = []
+        seen_contract_ids: set[int] = set()
+        seen_symbols: set[str] = set()
+        for position in positions:
+            if str(getattr(position, "account", "")).strip() != account:
+                raise ValueError("Broker position account is inconsistent")
+            contract_identity = await _qualified_stock_identity(position.contract)
+            con_id = contract_identity["con_id"]
+            symbol = contract_identity["symbol"]
+            if con_id in seen_contract_ids or symbol in seen_symbols:
+                raise ValueError("Broker snapshot contains duplicate position identity")
+            seen_contract_ids.add(con_id)
+            seen_symbols.add(symbol)
+
+            quantity = _canonical_decimal(position.position)
+            if Decimal(quantity) == 0:
+                raise ValueError("Broker snapshot contains a zero position")
+            avg_cost = _canonical_decimal(position.avgCost)
+            if Decimal(avg_cost) < 0:
+                raise ValueError("Broker snapshot contains a negative average cost")
+
+            positions_data.append(
+                {
+                    "account": account,
+                    "contract": contract_identity,
+                    "quantity": quantity,
+                    "avg_cost": avg_cost,
+                }
+            )
+
+        open_trades = await ib.reqAllOpenOrdersAsync()
+        if not ib.isConnected():
+            raise ConnectionError("Broker disconnected during snapshot collection")
+        open_orders_data = []
+        seen_order_ids: set[tuple[int, int]] = set()
+        for trade in open_trades:
+            order_evidence = await _open_order_evidence(trade, account)
+            order_id = order_evidence["broker_order_id"]
+            client_id = order_evidence["client_id"]
+            order_identity = (client_id, order_id)
+            if order_identity in seen_order_ids:
+                raise ValueError("Broker snapshot contains duplicate order identity")
+            seen_order_ids.add(order_identity)
+            open_orders_data.append(order_evidence)
+        initial_order_signature = _order_evidence_signature(open_orders_data)
+
+        # IBKR's ExecutionFilter carries a lower bound only, serialized to
+        # whole seconds. Derive that exact wire value from authoritative broker
+        # time and expose the identical instant in the snapshot.
+        execution_window_start = broker_time_before.replace(microsecond=0) - timedelta(hours=24)
+        execution_filter_time = execution_window_start.strftime("%Y%m%d %H:%M:%S UTC")
+        execution_filter = ExecutionFilter(
+            acctCode=account,
+            time=execution_filter_time,
+        )
+        fills = await ib.reqExecutionsAsync(execution_filter)
+        # The wire filter has no upper-bound field. Capture a broker-clock
+        # upper bound immediately after the response rather than extending the
+        # evidence window to the much later snapshot retrieval timestamp.
+        execution_window_end = await _request_broker_time()
+        if not ib.isConnected():
+            raise ConnectionError("Broker disconnected during snapshot collection")
+        executions_data = []
+        seen_execution_ids: set[str] = set()
+        for fill in fills:
+            execution = fill.execution
+            execution_id = str(getattr(execution, "execId", "")).strip()
+            if not execution_id or execution_id in seen_execution_ids:
+                raise ValueError("Broker snapshot contains invalid execution identity")
+            seen_execution_ids.add(execution_id)
+            if str(getattr(execution, "acctNumber", "")).strip() != account:
+                raise ValueError("Broker execution account is inconsistent")
+            raw_side = str(getattr(execution, "side", "")).upper()
+            side = {"BOT": "BUY", "SLD": "SELL", "BUY": "BUY", "SELL": "SELL"}.get(raw_side)
+            if side is None:
+                raise ValueError("Broker execution side is unsupported")
+
+            contract_identity = await _qualified_stock_identity(fill.contract)
+            execution_time = getattr(execution, "time", None) or getattr(fill, "time", None)
+            executed_at = _aware_iso(execution_time)
+            unavailable = {}
+            broker_order_id, reason = _optional_identifier(
+                execution.orderId, "IBKR returned no broker order ID"
+            )
+            if reason:
+                unavailable["broker_order_id"] = reason
+            permanent_id, reason = _optional_identifier(
+                execution.permId, "IBKR returned no permanent order ID"
+            )
+            if reason:
+                unavailable["permanent_id"] = reason
+            commission_report = getattr(fill, "commissionReport", None)
+            if commission_report is None:
+                commission = None
+                commission_currency = None
+                realized_pnl = None
+                unavailable.update(
+                    {
+                        "commission": "IBKR returned no commission report",
+                        "commission_currency": "IBKR returned no commission report",
+                        "realized_pnl": "IBKR returned no commission report",
+                    }
+                )
+            else:
+                commission, reason = _optional_decimal(
+                    getattr(commission_report, "commission", None),
+                    "IBKR returned no commission value",
+                )
+                if reason:
+                    unavailable["commission"] = reason
+                commission_currency = (
+                    str(getattr(commission_report, "currency", "")).strip() or None
+                )
+                if commission_currency is None:
+                    unavailable["commission_currency"] = "IBKR returned no commission currency"
+                realized_pnl, reason = _optional_decimal(
+                    getattr(commission_report, "realizedPNL", None),
+                    "IBKR returned no realized PnL",
+                )
+                if reason:
+                    unavailable["realized_pnl"] = reason
+
+            quantity = _canonical_decimal(execution.shares)
+            price = _canonical_decimal(execution.price)
+            average_price = _canonical_decimal(execution.avgPrice)
+            if Decimal(quantity) <= 0 or Decimal(price) <= 0 or Decimal(average_price) <= 0:
+                raise ValueError("Broker execution numeric evidence is not positive")
+
+            executions_data.append(
+                {
+                    "account": account,
+                    "execution_id": execution_id,
+                    "broker_order_id": broker_order_id,
+                    "permanent_id": permanent_id,
+                    "client_id": _required_int(
+                        execution.clientId,
+                        "execution client ID",
+                        allow_zero=True,
+                    ),
+                    "contract": contract_identity,
+                    "side": side,
+                    "quantity": quantity,
+                    "price": price,
+                    "average_price": average_price,
+                    "executed_at": executed_at,
+                    "execution_exchange": str(execution.exchange),
+                    "commission": commission,
+                    "commission_currency": commission_currency,
+                    "realized_pnl": realized_pnl,
+                    "unavailable": unavailable,
+                }
+            )
+
+        await ib.reqAccountSummaryAsync()
+        account_values = ib.accountValues(account)
+        if not ib.isConnected():
+            raise ConnectionError("Broker disconnected during snapshot collection")
+
+        balances = []
+        seen_balances: set[tuple[str, str]] = set()
+        present_tags: set[str] = set()
+        for account_value in account_values:
+            tag = str(getattr(account_value, "tag", ""))
+            if tag not in BROKER_SNAPSHOT_BALANCE_TAGS:
+                continue
+            if str(getattr(account_value, "account", "")).strip() != account:
+                raise ValueError("Broker balance account is inconsistent")
+            currency = str(getattr(account_value, "currency", "")).strip()
+            if not currency:
+                raise ValueError("Broker balance currency is missing")
+            identity = (tag, currency)
+            if identity in seen_balances:
+                raise ValueError("Broker snapshot contains duplicate balance identity")
+            seen_balances.add(identity)
+            present_tags.add(tag)
+            balances.append(
+                {
+                    "tag": tag,
+                    "currency": currency,
+                    "value": _canonical_decimal(account_value.value),
+                }
+            )
+        if not BROKER_SNAPSHOT_REQUIRED_BALANCE_TAGS.issubset(present_tags):
+            raise ValueError("Broker snapshot is missing required balance evidence")
+
+        final_positions = await ib.reqPositionsAsync()
+        final_position_signature = await _position_state_signature(final_positions, account)
+        final_open_trades = await ib.reqAllOpenOrdersAsync()
+        final_order_signature = await _order_state_signature(final_open_trades, account)
+        if (
+            final_position_signature != initial_position_signature
+            or final_order_signature != initial_order_signature
+        ):
+            raise ValueError("Broker critical state changed during snapshot collection")
+
+        broker_time_after = await _request_broker_time()
+        accounts_after = [str(item).strip() for item in ib.managedAccounts() if str(item).strip()]
+        if accounts_after != accounts_before:
+            raise ValueError("Managed account set changed during snapshot collection")
+        if not ib.isConnected():
+            raise ConnectionError("Broker disconnected during snapshot collection")
+
+        positions_data.sort(
+            key=lambda item: (
+                cast(dict[str, Any], item["contract"])["symbol"],
+                cast(dict[str, Any], item["contract"])["con_id"],
+            )
+        )
+        open_orders_data.sort(key=lambda item: (item["client_id"], item["broker_order_id"]))
+        executions_data.sort(key=lambda item: cast(str, item["execution_id"]))
+        balances.sort(key=lambda item: (item["tag"], item["currency"]))
+        retrieved_at = datetime.now(timezone.utc)
+        return {
+            "status": "success",
+            "data": {
+                "snapshot_schema_version": BROKER_SNAPSHOT_SCHEMA_VERSION,
+                "account": account,
+                "broker_time_before": _aware_iso(broker_time_before),
+                "broker_time_after": _aware_iso(broker_time_after),
+                "retrieved_at": retrieved_at.isoformat(),
+                "positions": positions_data,
+                "balances": balances,
+                "open_orders": open_orders_data,
+                "executions": executions_data,
+                "execution_scope": {
+                    "kind": "bounded_execution_filter",
+                    "start_at": execution_window_start.isoformat(),
+                    "end_at": execution_window_end.isoformat(),
+                },
+            },
+        }
+    except BrokerSnapshotAccountMismatchError:
+        return {
+            "status": "error",
+            "error": "Broker snapshot account mismatch",
+            "error_type": "BrokerSnapshotAccountMismatchError",
+        }
+    except TimeoutError:
+        # Preserve the timeout classification so the parent poisons this exact
+        # worker generation and never reuses an ambiguous broker request.
+        return {
+            "status": "error",
+            "error": "Broker snapshot collection timed out",
+            "error_type": "TimeoutError",
+        }
+    except ConnectionError:
+        return {
+            "status": "error",
+            "error": "Broker snapshot collection failed",
+            "error_type": "ConnectionError",
+        }
+    except Exception:
+        # Once collection has started, malformed or internally inconsistent
+        # broker evidence is a transport-integrity failure, not an ordinary
+        # per-request miss. The parent treats this status as ambiguous and
+        # poisons the exact responding generation.
+        return {
+            "status": PROTOCOL_ERROR_STATUS,
+            "error": "Broker snapshot collection failed",
+            "error_type": PROTOCOL_ERROR_TYPE,
+        }
+
+
 async def handle_disconnect() -> dict:
     """Handle disconnect command"""
-    global ib
+    global ib, worker_connection_identity
 
     try:
         if ib:
@@ -518,6 +1045,7 @@ async def handle_disconnect() -> dict:
             print("Disconnecting from IBKR...", file=sys.stderr, flush=True)
             safe_disconnect(ib)
             ib = None
+        worker_connection_identity = None
 
         return {"status": "success", "data": {"disconnected": True}}
 
@@ -690,6 +1218,8 @@ async def handle_command(command: dict) -> dict:
         return await handle_get_positions()
     elif cmd == "get_account_summary":
         return await handle_get_account_summary()
+    elif cmd == "get_broker_snapshot":
+        return await handle_get_broker_snapshot(command.get("params", {}))
     elif cmd == "get_historical_bars":
         return await handle_get_historical_bars(command.get("params", {}))
     elif cmd == "disconnect":

--- a/robo_trader/clients/ibkr_subprocess_worker.py
+++ b/robo_trader/clients/ibkr_subprocess_worker.py
@@ -287,10 +287,14 @@ def _cleanup_on_exit():
     if ib is not None:
         print("atexit: Disconnecting from IBKR...", file=sys.stderr, flush=True)
         try:
-            safe_disconnect(ib)
+            safe_disconnect(
+                ib,
+                context="diagnostic_worker:atexit",
+                log_exception_details=False,
+            )
             print("atexit: Disconnected successfully", file=sys.stderr, flush=True)
-        except Exception as e:
-            print(f"atexit: Disconnect error: {e}", file=sys.stderr, flush=True)
+        except Exception:
+            print("atexit: Disconnect error", file=sys.stderr, flush=True)
         ib = None
 
 
@@ -371,7 +375,11 @@ async def handle_connect(params: dict) -> dict:
             }
 
         if ib is not None:
-            safe_disconnect(ib)
+            safe_disconnect(
+                ib,
+                context="diagnostic_worker:replace_connection",
+                log_exception_details=False,
+            )
             ib = None
 
         # Create new IB instance
@@ -431,17 +439,17 @@ async def handle_connect(params: dict) -> dict:
             except AttributeError:
                 # client.serverVersion() not available yet - handshake incomplete
                 pass
-            except (ConnectionError, OSError) as e:
+            except (ConnectionError, OSError):
                 # Connection-related errors during handshake
                 print(
-                    f"DEBUG: serverVersion() connection error: {e}",
+                    "DEBUG: serverVersion() connection error",
                     file=sys.stderr,
                     flush=True,
                 )
             except Exception as e:
                 # Unexpected error - log but continue polling
                 print(
-                    f"DEBUG: serverVersion() unexpected error ({type(e).__name__}): {e}",
+                    "DEBUG: serverVersion() unexpected error " f"({type(e).__name__})",
                     file=sys.stderr,
                     flush=True,
                 )
@@ -535,19 +543,30 @@ async def handle_connect(params: dict) -> dict:
         ib = None
         worker_connection_identity = None
 
-        error_text = str(e).lower()
-        if isinstance(e, TimeoutError) or "timeout" in error_text:
+        is_timeout = isinstance(e, TimeoutError) or "timeout" in str(e).lower()
+        if is_timeout:
             gateway_api_down = True
             gateway_failure_detail = (
                 "Handshake timed out at "
                 f"{datetime.utcnow().isoformat()}Z. Restart IB Gateway before retrying."
             )
 
+        # Broker/client exceptions can contain account identifiers or other
+        # connection secrets. The diagnostic transport needs only a stable
+        # classification; never serialize the exception text or traceback.
+        if is_timeout:
+            safe_error = "Diagnostic broker connection timed out"
+            safe_error_type = "TimeoutError"
+        elif isinstance(e, (ConnectionError, OSError)):
+            safe_error = "Diagnostic broker connection failed"
+            safe_error_type = "ConnectionError"
+        else:
+            safe_error = "Diagnostic broker connection failed"
+            safe_error_type = "BrokerConnectionError"
         return {
             "status": "error",
-            "error": str(e),
-            "error_type": type(e).__name__,
-            "traceback": traceback.format_exc(),
+            "error": safe_error,
+            "error_type": safe_error_type,
             "requires_restart": gateway_api_down,
             "detail": gateway_failure_detail if gateway_api_down else "",
         }
@@ -827,11 +846,13 @@ async def handle_get_broker_snapshot(params: dict) -> dict:
             acctCode=account,
             time=execution_filter_time,
         )
-        fills = await ib.reqExecutionsAsync(execution_filter)
         # The wire filter has no upper-bound field. Capture a broker-clock
-        # upper bound immediately after the response rather than extending the
-        # evidence window to the much later snapshot retrieval timestamp.
+        # upper bound before issuing the request. A fill can arrive while the
+        # lower-bound-only request is in flight; such a later fill must make
+        # the snapshot fail closed rather than be silently omitted or falsely
+        # claimed as covered by an after-the-fact cutoff.
         execution_window_end = await _request_broker_time()
+        fills = await ib.reqExecutionsAsync(execution_filter)
         if not ib.isConnected():
             raise ConnectionError("Broker disconnected during snapshot collection")
         executions_data = []
@@ -852,6 +873,9 @@ async def handle_get_broker_snapshot(params: dict) -> dict:
             contract_identity = await _qualified_stock_identity(fill.contract)
             execution_time = getattr(execution, "time", None) or getattr(fill, "time", None)
             executed_at = _aware_iso(execution_time)
+            executed_at_value = datetime.fromisoformat(executed_at)
+            if not execution_window_start <= executed_at_value <= execution_window_end:
+                raise ValueError("Broker execution is outside the declared evidence window")
             unavailable = {}
             broker_order_id, reason = _optional_identifier(
                 execution.orderId, "IBKR returned no broker order ID"
@@ -1043,14 +1067,22 @@ async def handle_disconnect() -> dict:
         if ib:
             # Properly disconnect to avoid zombie connections
             print("Disconnecting from IBKR...", file=sys.stderr, flush=True)
-            safe_disconnect(ib)
+            safe_disconnect(
+                ib,
+                context="diagnostic_worker:disconnect",
+                log_exception_details=False,
+            )
             ib = None
         worker_connection_identity = None
 
         return {"status": "success", "data": {"disconnected": True}}
 
-    except Exception as e:
-        return {"status": "error", "error": str(e), "error_type": type(e).__name__}
+    except Exception:
+        return {
+            "status": "error",
+            "error": "Diagnostic broker disconnect failed",
+            "error_type": "BrokerDisconnectionError",
+        }
 
 
 async def handle_ping() -> dict:
@@ -1347,10 +1379,14 @@ async def main():
         if ib is not None:
             print("Disconnecting from IBKR to prevent zombie...", file=sys.stderr, flush=True)
             try:
-                safe_disconnect(ib)
+                safe_disconnect(
+                    ib,
+                    context="diagnostic_worker:shutdown",
+                    log_exception_details=False,
+                )
                 print("Disconnected successfully", file=sys.stderr, flush=True)
-            except Exception as e:
-                print(f"Disconnect error (non-fatal): {e}", file=sys.stderr, flush=True)
+            except Exception:
+                print("Disconnect error (non-fatal)", file=sys.stderr, flush=True)
 
 
 if __name__ == "__main__":

--- a/robo_trader/clients/subprocess_ibkr_client.py
+++ b/robo_trader/clients/subprocess_ibkr_client.py
@@ -1276,8 +1276,8 @@ class SubprocessIBKRClient:
             raise ValueError("Diagnostic client requires IBKR paper port 4002")
         if readonly is not True:
             raise ValueError("Diagnostic client requires readonly exactly true")
-        if isinstance(client_id, bool) or not isinstance(client_id, int) or client_id <= 0:
-            raise ValueError("Diagnostic client requires a positive client ID")
+        if isinstance(client_id, bool) or not isinstance(client_id, int) or client_id < 0:
+            raise ValueError("Diagnostic client requires a non-negative client ID")
         command = {
             "command": "connect",
             "params": {
@@ -1293,7 +1293,7 @@ class SubprocessIBKRClient:
             "Connecting diagnostic IBKR subprocess",
             host=host,
             port=port,
-            client_id_alias="configured-positive-id",
+            client_id_alias="configured-client-id",
         )
 
         # ZOMBIE CONNECTION CHECK: Detect zombies before connection attempt
@@ -1352,7 +1352,7 @@ class SubprocessIBKRClient:
                             "Reusing matching IBKR subprocess connection",
                             host=host,
                             port=port,
-                            client_id_alias="configured-positive-id",
+                            client_id_alias="configured-client-id",
                             readonly=readonly,
                         )
                         return True
@@ -1360,7 +1360,7 @@ class SubprocessIBKRClient:
                         "Cached broker connection was stale; reconnecting worker session",
                         host=host,
                         port=port,
-                        client_id_alias="configured-positive-id",
+                        client_id_alias="configured-client-id",
                     )
                 data = await self._execute_command_unlocked(command, timeout=extended_timeout)
                 connected = data.get("connected", False)

--- a/robo_trader/clients/subprocess_ibkr_client.py
+++ b/robo_trader/clients/subprocess_ibkr_client.py
@@ -81,12 +81,31 @@ _WORKER_ENV_ALLOWLIST = frozenset(
         "WINDIR",
     }
 )
+_LSOF_EXECUTABLE_CANDIDATES: tuple[Path, ...] = (
+    Path("/usr/sbin/lsof"),
+    Path("/usr/bin/lsof"),
+)
 _WORKER_BOOTSTRAP = (
     "import runpy,sys;"
     "root=sys.argv[1];worker=sys.argv[2];"
     "sys.path.insert(0,root);"
     "runpy.run_path(worker,run_name='__main__')"
 )
+
+
+def _trusted_lsof_executable() -> Path:
+    """Return one fixed, non-symlinked system lsof executable or fail closed."""
+    for candidate in _LSOF_EXECUTABLE_CANDIDATES:
+        if not candidate.is_absolute() or candidate.is_symlink():
+            continue
+        try:
+            resolved = candidate.resolve(strict=True)
+        except OSError:
+            continue
+        if resolved != candidate or not resolved.is_file() or not os.access(resolved, os.X_OK):
+            continue
+        return resolved
+    raise IBKRError("Trusted absolute lsof executable is unavailable")
 
 
 def _is_interpreter_path_safe(resolved: Path, project_root: Path) -> bool:
@@ -1420,20 +1439,38 @@ class SubprocessIBKRClient:
             tuple: (zombie_count, error_message)
         """
         try:
-            import subprocess as sp
+            lsof_executable = _trusted_lsof_executable()
+            lsof_env = {
+                name: os.environ[name] for name in _WORKER_ENV_ALLOWLIST if name in os.environ
+            }
 
-            # Use lsof to check for CLOSE_WAIT connections on the port
+            # Use one approved absolute lsof binary with no inherited secrets,
+            # PATH lookup, working directory, or file descriptors.
             result = await asyncio.get_event_loop().run_in_executor(
                 None,
-                lambda: sp.run(
-                    ["lsof", "-nP", f"-iTCP:{port}", "-sTCP:CLOSE_WAIT"],
+                lambda: subprocess.run(
+                    [
+                        str(lsof_executable),
+                        "-nP",
+                        f"-iTCP:{port}",
+                        "-sTCP:CLOSE_WAIT",
+                    ],
                     capture_output=True,
                     text=True,
                     timeout=5,
+                    close_fds=True,
+                    cwd="/",
+                    env=lsof_env,
                 ),
             )
 
-            if not result.stdout.strip():
+            stdout = result.stdout.strip()
+            stderr = result.stderr.strip()
+            if result.returncode == 1 and not stdout and not stderr:
+                return 0, "No zombies detected"
+            if result.returncode != 0 or stderr:
+                raise IBKRError("Trusted lsof zombie check failed")
+            if not stdout:
                 return 0, "No zombies detected"
 
             # Count zombie connections (skip header line)
@@ -1447,18 +1484,14 @@ class SubprocessIBKRClient:
             if zombie_count > 0:
                 error_msg = f"Found {zombie_count} CLOSE_WAIT zombie connection(s) on port {port}"
                 logger.warning("Zombie connections detected", count=zombie_count, port=port)
-                for line in lines:
-                    logger.warning("Zombie connection", connection=line.strip())
                 return zombie_count, error_msg
 
             return 0, "No zombies detected"
 
-        except FileNotFoundError:
-            logger.warning("lsof command not available - cannot check for zombies")
-            return 0, "lsof not available"
-        except Exception as e:
-            logger.warning("Error checking for zombie connections", error=str(e))
-            return 0, f"Error checking zombies: {e}"
+        except IBKRError:
+            raise
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise IBKRError("Trusted lsof zombie check failed") from exc
 
     @property
     def zombies_detected_before_connect(self) -> bool:

--- a/robo_trader/clients/subprocess_ibkr_client.py
+++ b/robo_trader/clients/subprocess_ibkr_client.py
@@ -66,6 +66,28 @@ _INTERPRETER_PREFIX_ALLOWLIST: tuple[Path, ...] = (
     Path("/Library/Frameworks/Python.framework"),
 )
 
+# The diagnostic worker receives broker connection parameters over its
+# request-correlated stdin transport. It does not need the dashboard, model,
+# database, IBC, or shell environment. Keep only non-secret locale settings
+# required for predictable text/time handling.
+_WORKER_ENV_ALLOWLIST = frozenset(
+    {
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "TZ",
+        # Required by CPython on Windows; harmless and non-secret elsewhere.
+        "SYSTEMROOT",
+        "WINDIR",
+    }
+)
+_WORKER_BOOTSTRAP = (
+    "import runpy,sys;"
+    "root=sys.argv[1];worker=sys.argv[2];"
+    "sys.path.insert(0,root);"
+    "runpy.run_path(worker,run_name='__main__')"
+)
+
 
 def _is_interpreter_path_safe(resolved: Path, project_root: Path) -> bool:
     """Return True if a resolved interpreter path is acceptable for exec."""
@@ -463,13 +485,6 @@ class SubprocessIBKRClient:
         if self._generation:
             await self._stop_unlocked()
 
-        # Find worker script
-        worker_script = Path(__file__).parent / "ibkr_subprocess_worker.py"
-        if not worker_script.exists():
-            raise FileNotFoundError(f"Worker script not found: {worker_script}")
-
-        logger.info("Starting IBKR subprocess worker", script=str(worker_script))
-
         # Start subprocess using the same Python interpreter.
         #
         # SECURITY (IB-M1 + NEW-IB-M1.1):
@@ -488,7 +503,19 @@ class SubprocessIBKRClient:
         # - NEW-IB-M1.1: Project root is now found via marker-file probing
         #   (pyproject.toml / START_TRADER.sh) instead of fragile
         #   parents[2] indexing — this stays correct if the file moves.
-        project_root = _find_project_root(Path(__file__))
+        project_root = _find_project_root(Path(__file__)).resolve()
+        worker_script = (
+            project_root / "robo_trader" / "clients" / "ibkr_subprocess_worker.py"
+        ).resolve(strict=True)
+        try:
+            worker_script.relative_to(project_root)
+        except ValueError as exc:
+            raise RuntimeError("IBKR worker script resolves outside the project root") from exc
+        if not worker_script.is_file():
+            raise FileNotFoundError(f"Worker script not found: {worker_script}")
+
+        logger.info("Starting IBKR subprocess worker", script=str(worker_script))
+
         project_venv_python = project_root / ".venv" / "bin" / "python3"
 
         python_exe = None
@@ -588,14 +615,33 @@ class SubprocessIBKRClient:
         generation: Optional[_WorkerGeneration] = None
         try:
             generation_id = uuid.uuid4().hex
-            worker_env = os.environ.copy()
-            worker_env["ROBOTRADER_WORKER_GENERATION_ID"] = generation_id
+            worker_env = {
+                name: os.environ[name] for name in _WORKER_ENV_ALLOWLIST if name in os.environ
+            }
+            worker_env.update(
+                {
+                    "PYTHONIOENCODING": "utf-8",
+                    "PYTHONSAFEPATH": "1",
+                    "PYTHONUNBUFFERED": "1",
+                    "ROBOTRADER_WORKER_GENERATION_ID": generation_id,
+                }
+            )
             # CRITICAL FIX: Use regular subprocess.Popen with threading instead of
             # asyncio.create_subprocess_exec to avoid event loop starvation in
             # busy async environments
-            # CRITICAL FIX 2: Launch as module with -m to ensure robo_trader/__init__.py
+            # Launch the exact resolved project worker under isolated mode.
+            # ``-I`` ignores PYTHONPATH, the user site, and the inherited current
+            # directory. The fixed bootstrap admits only the verified project
+            # root before executing the verified script path.
             self.process = subprocess.Popen(
-                [python_exe, "-m", "robo_trader.clients.ibkr_subprocess_worker"],
+                [
+                    python_exe,
+                    "-I",
+                    "-c",
+                    _WORKER_BOOTSTRAP,
+                    str(project_root),
+                    str(worker_script),
+                ],
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,  # Capture stderr for logging
@@ -603,6 +649,7 @@ class SubprocessIBKRClient:
                 bufsize=1,  # Line buffered
                 close_fds=True,  # Don't inherit file descriptors
                 env=worker_env,
+                cwd=str(project_root),
             )
             generation = _WorkerGeneration(generation_id, self.process)
             generation.debug_log_file = debug_log_file
@@ -893,8 +940,8 @@ class SubprocessIBKRClient:
             ):
                 logger.debug("Sending disconnect command to worker")
                 await self._execute_command_unlocked({"command": "disconnect"}, timeout=5.0)
-        except Exception as e:
-            logger.warning("Disconnect command failed during shutdown", error=str(e))
+        except Exception:
+            logger.warning("Diagnostic broker disconnect failed during worker shutdown")
         finally:
             self._clear_cached_connection_state(generation=generation)
 
@@ -924,8 +971,8 @@ class SubprocessIBKRClient:
                 process.wait()
                 logger.warning("Worker killed via SIGKILL")
 
-            except Exception as e:
-                logger.error("Error during process termination", error=str(e))
+            except Exception:
+                logger.error("Error during diagnostic worker process termination")
                 # Ensure process is dead
                 try:
                     process.kill()
@@ -1098,6 +1145,35 @@ class SubprocessIBKRClient:
                 error_type = response.get("error_type", "IBKRError")
                 detail = response.get("detail") or ""
                 requires_restart = bool(response.get("requires_restart"))
+                if command_name in {"connect", "disconnect"}:
+                    # Treat the worker response as untrusted. Broker connection
+                    # libraries may embed account identifiers or credentials in
+                    # exception text, so neither logs nor raised exceptions may
+                    # reuse the worker's free-form fields.
+                    if command_name == "connect":
+                        allowed_error_types = {
+                            "TimeoutError",
+                            "ConnectionError",
+                            "NotConnectedError",
+                            "GatewayRequiresRestartError",
+                        }
+                        if error_type not in allowed_error_types:
+                            error_type = "BrokerConnectionError"
+                        error_msg = (
+                            "Diagnostic broker connection timed out"
+                            if error_type == "TimeoutError"
+                            else "Diagnostic broker connection failed"
+                        )
+                        detail = (
+                            "Gateway restart required after diagnostic connection failure"
+                            if requires_restart
+                            else ""
+                        )
+                    else:
+                        error_type = "BrokerDisconnectionError"
+                        error_msg = "Diagnostic broker disconnect failed"
+                        detail = ""
+                        requires_restart = False
 
                 logger.error(
                     "Command failed",
@@ -2020,8 +2096,8 @@ class SubprocessIBKRClient:
             logger.info("Disconnecting from IBKR via subprocess")
             try:
                 await self._execute_command_unlocked({"command": "disconnect"}, timeout=5.0)
-            except Exception as e:
-                logger.warning(f"Disconnect command failed, will terminate subprocess: {e}")
+            except Exception:
+                logger.warning("Diagnostic broker disconnect failed; terminating worker subprocess")
             await self._stop_unlocked()
         logger.info("Disconnected from IBKR")
 

--- a/robo_trader/clients/subprocess_ibkr_client.py
+++ b/robo_trader/clients/subprocess_ibkr_client.py
@@ -13,6 +13,7 @@ to avoid event loop starvation in busy async environments.
 
 import asyncio
 import json
+import math
 import os
 import subprocess
 import sys
@@ -23,6 +24,7 @@ import uuid
 from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any, Optional, cast
 
@@ -117,6 +119,12 @@ class IBKRConnectionConflictError(IBKRError):
     pass
 
 
+class BrokerSnapshotAccountMismatchError(IBKRTransportPoisonedError):
+    """Raised without exposing raw IDs when snapshot account identity is wrong."""
+
+    pass
+
+
 class GatewayRequiresRestartError(IBKRError):
     """Raised when the worker detects the Gateway API layer has crashed"""
 
@@ -150,6 +158,20 @@ _INTRADAY_BAR_SIZES = {
     "4 hours",
     "8 hours",
 }
+_BROKER_SNAPSHOT_SCHEMA_VERSION = 1
+_BROKER_SNAPSHOT_BALANCE_TAGS = {
+    "NetLiquidation",
+    "TotalCashValue",
+    "SettledCash",
+    "GrossPositionValue",
+    "RealizedPnL",
+    "UnrealizedPnL",
+}
+_BROKER_SNAPSHOT_REQUIRED_BALANCE_TAGS = {"NetLiquidation", "TotalCashValue"}
+_BROKER_SNAPSHOT_MAX_AGE_SECONDS = 300.0
+_BROKER_SNAPSHOT_MAX_WINDOW_SECONDS = 60.0
+_BROKER_SNAPSHOT_MAX_CLOCK_SKEW_SECONDS = 120.0
+_BROKER_EXECUTION_LOOKBACK_SECONDS = 24 * 60 * 60
 
 
 @dataclass
@@ -201,6 +223,7 @@ class SubprocessIBKRClient:
         self.lock = asyncio.Lock()
         self._lifecycle_lock = asyncio.Lock()
         self._connection_state_lock = threading.Lock()
+        self._debug_log_cleanup_lock = threading.Lock()
         self._connected = False
         self._connection_identity: Optional[tuple[str, int, int, bool]] = None
         self._connection_generation_id: Optional[str] = None
@@ -270,6 +293,84 @@ class SubprocessIBKRClient:
                 self._last_activity,
                 self._gateway_api_down_detail,
             )
+
+    def _cleanup_worker_debug_log(
+        self,
+        generation: Optional[_WorkerGeneration],
+        *,
+        required: bool = False,
+    ) -> None:
+        """Close and unlink one generation's temporary stderr capture.
+
+        References are cleared only for the operation that actually succeeded.
+        A later stop or cleanup call can therefore retry a transient close or
+        unlink failure without losing the remaining handle or path.
+        """
+        failures: list[tuple[str, Exception]] = []
+        with self._debug_log_cleanup_lock:
+            debug_log_file = (
+                generation.debug_log_file if generation is not None else self._debug_log_file
+            )
+            debug_log_path = (
+                generation.debug_log_path if generation is not None else self._debug_log_path
+            )
+
+            close_succeeded = debug_log_file is None
+            if debug_log_file is not None:
+                try:
+                    debug_log_file.close()
+                    close_succeeded = True
+                except Exception as exc:
+                    failures.append(("close", exc))
+
+            unlink_succeeded = not debug_log_path
+            if debug_log_path:
+                try:
+                    os.unlink(debug_log_path)
+                    unlink_succeeded = True
+                except FileNotFoundError:
+                    unlink_succeeded = True
+                except OSError as exc:
+                    failures.append(("remove", exc))
+
+            if close_succeeded:
+                if generation is not None and generation.debug_log_file is debug_log_file:
+                    generation.debug_log_file = None
+                if self._debug_log_file is debug_log_file:
+                    self._debug_log_file = None
+            if unlink_succeeded:
+                if generation is not None and generation.debug_log_path == debug_log_path:
+                    generation.debug_log_path = None
+                if self._debug_log_path == debug_log_path:
+                    self._debug_log_path = None
+
+        for operation, failure_exc in failures:
+            logger.warning(
+                f"Could not {operation} worker debug log",
+                error=str(failure_exc),
+            )
+        if failures and required:
+            operations = " and ".join(operation for operation, _ in failures)
+            raise SubprocessCrashError(
+                f"Could not complete diagnostic worker debug log cleanup ({operations})"
+            ) from failures[0][1]
+
+    def _cleanup_worker_debug_log_with_retry(
+        self,
+        generation: Optional[_WorkerGeneration],
+        *,
+        attempts: int = 2,
+    ) -> None:
+        """Require verified cleanup, retrying transient close/unlink failures."""
+        last_error: Optional[SubprocessCrashError] = None
+        for _ in range(attempts):
+            try:
+                self._cleanup_worker_debug_log(generation, required=True)
+                return
+            except SubprocessCrashError as exc:
+                last_error = exc
+        if last_error is not None:
+            raise last_error
 
     def _record_gateway_failure(
         self,
@@ -476,6 +577,8 @@ class SubprocessIBKRClient:
         try:
             fd, debug_log_path = tempfile.mkstemp(prefix="worker_debug_", suffix=".log")
             debug_log_file = os.fdopen(fd, "w")
+            self._debug_log_file = debug_log_file
+            self._debug_log_path = debug_log_path
             logger.info("Worker debug output will be captured", debug_log=debug_log_path)
         except Exception as e:
             logger.warning("Could not create debug log file", error=str(e))
@@ -502,6 +605,8 @@ class SubprocessIBKRClient:
                 env=worker_env,
             )
             generation = _WorkerGeneration(generation_id, self.process)
+            generation.debug_log_file = debug_log_file
+            generation.debug_log_path = debug_log_path
             with self._connection_state_lock:
                 # Installing a worker is an authoritative disconnected state.
                 # Synchronizing the pointer swap with cached state prevents a
@@ -517,12 +622,6 @@ class SubprocessIBKRClient:
                 pid=self.process.pid,
                 generation_id=generation_id,
             )
-
-            # Store debug log file only after successful subprocess start
-            generation.debug_log_file = debug_log_file
-            generation.debug_log_path = debug_log_path
-            self._debug_log_file = debug_log_file
-            self._debug_log_path = debug_log_path
 
             # Start reader threads to avoid blocking
             self._reader_thread = threading.Thread(
@@ -569,11 +668,6 @@ class SubprocessIBKRClient:
                             stream.close()
                     except Exception:
                         pass
-            if debug_log_file:
-                try:
-                    debug_log_file.close()
-                except Exception:
-                    pass
             if generation:
                 for thread in (generation.stdout_thread, generation.stderr_thread):
                     if thread and thread.is_alive():
@@ -590,7 +684,7 @@ class SubprocessIBKRClient:
                         self._gateway_failure_generation_id = None
             if self.process is process:
                 self.process = None
-            self._debug_log_file = None
+            self._cleanup_worker_debug_log_with_retry(generation)
             raise
 
     def _poison_generation(self, generation: _WorkerGeneration, reason: str) -> None:
@@ -774,11 +868,7 @@ class SubprocessIBKRClient:
                 self._poison_generation(generation, f"stderr reader failure: {e}")
         finally:
             logger.debug("Stderr reader thread exiting")
-            if generation.debug_log_file:
-                try:
-                    generation.debug_log_file.close()
-                except Exception:
-                    pass
+            self._cleanup_worker_debug_log(generation)
 
     async def stop(self) -> None:
         """Serialize shutdown against worker creation and commands."""
@@ -791,6 +881,7 @@ class SubprocessIBKRClient:
         process = generation.process if generation else self.process
         if not process:
             self._clear_cached_connection_state(generation=generation)
+            self._cleanup_worker_debug_log_with_retry(generation)
             return
 
         logger.info("Stopping IBKR subprocess worker", pid=process.pid)
@@ -863,6 +954,7 @@ class SubprocessIBKRClient:
         if (stdout_thread and stdout_thread.is_alive()) or (
             stderr_thread and stderr_thread.is_alive()
         ):
+            self._cleanup_worker_debug_log_with_retry(generation)
             raise SubprocessCrashError(
                 "Worker reader thread did not stop; refusing generation replacement"
             )
@@ -880,16 +972,8 @@ class SubprocessIBKRClient:
                     self._gateway_api_down_detail = None
                     self._gateway_failure_generation_id = None
 
-        # Ensure debug log file is closed (belt-and-suspenders cleanup)
-        debug_log_file = generation.debug_log_file if generation else self._debug_log_file
-        if debug_log_file:
-            try:
-                debug_log_file.close()
-            except Exception:
-                pass
-            if generation:
-                generation.debug_log_file = None
-            self._debug_log_file = None
+        # Ensure the temporary stderr capture never survives its worker.
+        self._cleanup_worker_debug_log_with_retry(generation)
 
         logger.info("IBKR subprocess worker stopped cleanly")
 
@@ -1042,6 +1126,13 @@ class SubprocessIBKRClient:
                         raise IBKRTimeoutRequiresGatewayRestartError(diagnostic)
                     raise IBKRTimeoutError(diagnostic)
 
+                if error_type == "BrokerSnapshotAccountMismatchError":
+                    self._poison_generation(
+                        generation,
+                        "worker-reported broker snapshot account mismatch",
+                    )
+                    raise BrokerSnapshotAccountMismatchError("Broker snapshot account mismatch")
+
                 if requires_restart or error_type == "GatewayRequiresRestartError":
                     message = detail or error_msg
                     gateway_detail = message or "Gateway API layer reported down"
@@ -1086,6 +1177,12 @@ class SubprocessIBKRClient:
             SubprocessCrashError: If subprocess crashes
             IBKRError: If connection fails
         """
+        if isinstance(port, bool) or port != 4002:
+            raise ValueError("Diagnostic client requires IBKR paper port 4002")
+        if readonly is not True:
+            raise ValueError("Diagnostic client requires readonly exactly true")
+        if isinstance(client_id, bool) or not isinstance(client_id, int) or client_id <= 0:
+            raise ValueError("Diagnostic client requires a positive client ID")
         command = {
             "command": "connect",
             "params": {
@@ -1097,7 +1194,12 @@ class SubprocessIBKRClient:
             },
         }
 
-        logger.info("Connecting to IBKR via subprocess", host=host, port=port, client_id=client_id)
+        logger.info(
+            "Connecting diagnostic IBKR subprocess",
+            host=host,
+            port=port,
+            client_id_alias="configured-positive-id",
+        )
 
         # ZOMBIE CONNECTION CHECK: Detect zombies before connection attempt
         # Gateway-owned zombies will block API handshakes
@@ -1155,7 +1257,7 @@ class SubprocessIBKRClient:
                             "Reusing matching IBKR subprocess connection",
                             host=host,
                             port=port,
-                            client_id=client_id,
+                            client_id_alias="configured-positive-id",
                             readonly=readonly,
                         )
                         return True
@@ -1163,7 +1265,7 @@ class SubprocessIBKRClient:
                         "Cached broker connection was stale; reconnecting worker session",
                         host=host,
                         port=port,
-                        client_id=client_id,
+                        client_id_alias="configured-positive-id",
                     )
                 data = await self._execute_command_unlocked(command, timeout=extended_timeout)
                 connected = data.get("connected", False)
@@ -1212,7 +1314,7 @@ class SubprocessIBKRClient:
         logger.info(
             "Connected to IBKR via subprocess",
             connected=connected_state,
-            accounts=accounts,
+            managed_account_count=len(accounts),
             server_version=server_version,
             duration_seconds=f"{time.time() - connection_start:.2f}",
         )
@@ -1301,6 +1403,502 @@ class SubprocessIBKRClient:
         """Get account summary"""
         data = await self._execute_command({"command": "get_account_summary"})
         return data.get("summary", {})
+
+    @staticmethod
+    def _masked_account(account: object) -> str:
+        normalized = str(account or "").strip()
+        return "****" if len(normalized) <= 4 else f"***{normalized[-4:]}"
+
+    @staticmethod
+    def _strict_decimal(value: Any, field: str) -> Decimal:
+        if not isinstance(value, str) or value != value.strip() or not value:
+            raise ValueError(f"{field} must be a canonical decimal string")
+        try:
+            parsed = Decimal(value)
+        except InvalidOperation as exc:
+            raise ValueError(f"{field} must be a canonical decimal string") from exc
+        if not parsed.is_finite():
+            raise ValueError(f"{field} must be finite")
+        canonical = "0" if parsed == 0 else format(parsed.normalize(), "f")
+        if value != canonical:
+            raise ValueError(f"{field} is not canonical")
+        return parsed
+
+    @staticmethod
+    def _strict_timestamp(value: Any, field: str) -> datetime:
+        if not isinstance(value, str):
+            raise ValueError(f"{field} must be an ISO timestamp")
+        try:
+            parsed = datetime.fromisoformat(value)
+        except ValueError as exc:
+            raise ValueError(f"{field} must be an ISO timestamp") from exc
+        if parsed.tzinfo is None or parsed.utcoffset() is None:
+            raise ValueError(f"{field} must be timezone-aware")
+        return parsed
+
+    @staticmethod
+    def _strict_identifier(
+        value: Any,
+        field: str,
+        *,
+        optional: bool = False,
+        allow_zero: bool = False,
+    ) -> Optional[int]:
+        if optional and value is None:
+            return None
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, int)
+            or value < 0
+            or (value == 0 and not allow_zero)
+        ):
+            raise ValueError(f"{field} must be a positive integer")
+        return value
+
+    def _snapshot_fail(
+        self,
+        generation: Optional[_WorkerGeneration],
+        reason: str,
+    ) -> None:
+        if generation:
+            self._poison_generation(generation, reason)
+        raise IBKRTransportPoisonedError(reason)
+
+    def _require_snapshot_generation_binding(
+        self,
+        generation: _WorkerGeneration,
+        *,
+        expected_identity: Optional[tuple[str, int, int, bool]] = None,
+        poison_on_mismatch: bool,
+    ) -> tuple[str, int, int, bool]:
+        """Require one unpoisoned diagnostic session at a snapshot boundary.
+
+        The caller holds ``_lifecycle_lock``.  The nested locks match the
+        transport's global state order so a reader-thread poison and its
+        connection-state clear are observed atomically.
+        """
+        with generation.state_lock:
+            poisoned = generation.poisoned_reason is not None
+            with self._connection_state_lock:
+                identity = self._connection_identity
+                bound = (
+                    self._generation is generation
+                    and self._connected
+                    and identity is not None
+                    and identity[1] == 4002
+                    and identity[2] > 0
+                    and identity[3] is True
+                    and self._connection_generation_id == generation.generation_id
+                    and (expected_identity is None or identity == expected_identity)
+                )
+
+        if poisoned:
+            raise IBKRTransportPoisonedError("Broker snapshot worker generation is poisoned")
+        if not bound:
+            if poison_on_mismatch:
+                self._snapshot_fail(
+                    generation,
+                    "worker generation changed during broker snapshot",
+                )
+            raise IBKRDisconnectedError(
+                "Broker snapshot requires the validated diagnostic connection"
+            )
+        return cast(tuple[str, int, int, bool], identity)
+
+    def _validate_snapshot_contract(self, value: Any) -> tuple[int, str]:
+        expected_keys = {
+            "con_id",
+            "symbol",
+            "local_symbol",
+            "security_type",
+            "currency",
+            "exchange",
+            "primary_exchange",
+            "trading_class",
+        }
+        if not isinstance(value, dict) or set(value) != expected_keys:
+            raise ValueError("broker snapshot contract schema is invalid")
+        con_id = self._strict_identifier(value["con_id"], "contract con_id")
+        symbol = value["symbol"]
+        local_symbol = value["local_symbol"]
+        if (
+            not isinstance(symbol, str)
+            or not symbol
+            or symbol != symbol.strip().upper()
+            or local_symbol != symbol
+        ):
+            raise ValueError("broker snapshot contract alias is unsupported")
+        if value["security_type"] != "STK":
+            raise ValueError("broker snapshot contract is not STK")
+        if value["currency"] != "USD":
+            raise ValueError("broker snapshot contract is not USD")
+        if value["exchange"] != "SMART":
+            raise ValueError("broker snapshot contract exchange is not SMART")
+        for field_name in ("primary_exchange", "trading_class"):
+            if not isinstance(value[field_name], str) or not value[field_name].strip():
+                raise ValueError("broker snapshot contract identity is incomplete")
+        return cast(int, con_id), symbol
+
+    @staticmethod
+    def _validate_unavailable(
+        record: dict,
+        optional_fields: set[str],
+    ) -> dict[str, str]:
+        unavailable = record.get("unavailable")
+        if not isinstance(unavailable, dict) or not set(unavailable).issubset(optional_fields):
+            raise ValueError("broker snapshot unavailable-field schema is invalid")
+        if any(not isinstance(reason, str) or not reason for reason in unavailable.values()):
+            raise ValueError("broker snapshot unavailable reason is invalid")
+        for field_name in optional_fields:
+            if record[field_name] is None and field_name not in unavailable:
+                raise ValueError("broker snapshot silently omitted optional evidence")
+            if record[field_name] is not None and field_name in unavailable:
+                raise ValueError("broker snapshot optional evidence is contradictory")
+        return cast(dict[str, str], unavailable)
+
+    def _validate_broker_snapshot(
+        self,
+        expected_account: str,
+        data: dict,
+        generation: Optional[_WorkerGeneration],
+        max_age_seconds: float,
+    ) -> dict:
+        top_keys = {
+            "snapshot_schema_version",
+            "account",
+            "broker_time_before",
+            "broker_time_after",
+            "retrieved_at",
+            "positions",
+            "balances",
+            "open_orders",
+            "executions",
+            "execution_scope",
+        }
+        try:
+            if set(data) != top_keys:
+                raise ValueError("broker snapshot top-level schema is invalid")
+            if (
+                isinstance(data["snapshot_schema_version"], bool)
+                or data["snapshot_schema_version"] != _BROKER_SNAPSHOT_SCHEMA_VERSION
+            ):
+                raise ValueError("broker snapshot schema version is unsupported")
+
+            account = data["account"]
+            if not isinstance(account, str) or not account:
+                raise ValueError("broker snapshot account identity is malformed")
+            if account != expected_account:
+                reason = "broker snapshot account identity mismatch"
+                if generation:
+                    self._poison_generation(generation, reason)
+                raise BrokerSnapshotAccountMismatchError(
+                    "Broker snapshot account mismatch "
+                    f"(expected={self._masked_account(expected_account)}, "
+                    f"connected={self._masked_account(account)})"
+                )
+
+            broker_before = self._strict_timestamp(data["broker_time_before"], "broker_time_before")
+            broker_after = self._strict_timestamp(data["broker_time_after"], "broker_time_after")
+            retrieved_at = self._strict_timestamp(data["retrieved_at"], "retrieved_at")
+            if broker_after < broker_before:
+                raise ValueError("broker snapshot broker times are reversed")
+            broker_window = (broker_after - broker_before).total_seconds()
+            if (
+                not math.isfinite(broker_window)
+                or broker_window > _BROKER_SNAPSHOT_MAX_WINDOW_SECONDS
+            ):
+                raise ValueError("broker snapshot collection window is unbounded")
+            age = (
+                datetime.now(timezone.utc) - retrieved_at.astimezone(timezone.utc)
+            ).total_seconds()
+            if age < -5 or age > max_age_seconds:
+                raise ValueError("broker snapshot retrieval time is outside freshness bounds")
+            if any(
+                abs((broker_time - retrieved_at).total_seconds())
+                > _BROKER_SNAPSHOT_MAX_CLOCK_SKEW_SECONDS
+                for broker_time in (broker_before, broker_after)
+            ):
+                raise ValueError("broker snapshot clock skew exceeds safety bound")
+
+            positions = data["positions"]
+            if not isinstance(positions, list):
+                raise ValueError("broker snapshot positions are not a list")
+            seen_contract_ids: set[int] = set()
+            seen_symbols: set[str] = set()
+            position_keys = {"account", "contract", "quantity", "avg_cost"}
+            for position in positions:
+                if not isinstance(position, dict) or set(position) != position_keys:
+                    raise ValueError("broker snapshot position schema is invalid")
+                if position["account"] != expected_account:
+                    raise ValueError("broker snapshot position account is inconsistent")
+                con_id, symbol = self._validate_snapshot_contract(position["contract"])
+                if con_id in seen_contract_ids or symbol in seen_symbols:
+                    raise ValueError("broker snapshot position identity is duplicated")
+                seen_contract_ids.add(con_id)
+                seen_symbols.add(symbol)
+                if self._strict_decimal(position["quantity"], "position quantity") == 0:
+                    raise ValueError("broker snapshot position quantity is zero")
+                if self._strict_decimal(position["avg_cost"], "position avg_cost") < 0:
+                    raise ValueError("broker snapshot position average cost is negative")
+
+            balances = data["balances"]
+            if not isinstance(balances, list):
+                raise ValueError("broker snapshot balances are not a list")
+            seen_balances: set[tuple[str, str]] = set()
+            present_tags: set[str] = set()
+            for balance in balances:
+                if not isinstance(balance, dict) or set(balance) != {
+                    "tag",
+                    "currency",
+                    "value",
+                }:
+                    raise ValueError("broker snapshot balance schema is invalid")
+                tag = balance["tag"]
+                currency = balance["currency"]
+                if tag not in _BROKER_SNAPSHOT_BALANCE_TAGS:
+                    raise ValueError("broker snapshot balance tag is not allowed")
+                if not isinstance(currency, str) or not currency:
+                    raise ValueError("broker snapshot balance currency is invalid")
+                identity = (tag, currency)
+                if identity in seen_balances:
+                    raise ValueError("broker snapshot balance identity is duplicated")
+                seen_balances.add(identity)
+                present_tags.add(tag)
+                self._strict_decimal(balance["value"], "balance value")
+            if not _BROKER_SNAPSHOT_REQUIRED_BALANCE_TAGS.issubset(present_tags):
+                raise ValueError("broker snapshot required balances are missing")
+
+            self._validate_snapshot_orders(data["open_orders"], expected_account)
+            execution_scope = data["execution_scope"]
+            if not isinstance(execution_scope, dict) or set(execution_scope) != {
+                "kind",
+                "start_at",
+                "end_at",
+            }:
+                raise ValueError("broker snapshot execution scope schema is invalid")
+            if execution_scope["kind"] != "bounded_execution_filter":
+                raise ValueError("broker snapshot execution scope is unsupported")
+            execution_start = self._strict_timestamp(
+                execution_scope["start_at"], "execution scope start"
+            )
+            execution_end = self._strict_timestamp(execution_scope["end_at"], "execution scope end")
+            expected_execution_start = broker_before.replace(microsecond=0) - timedelta(
+                seconds=_BROKER_EXECUTION_LOOKBACK_SECONDS
+            )
+            if execution_start != expected_execution_start:
+                raise ValueError("broker snapshot execution scope does not match the wire filter")
+            if not broker_before <= execution_end <= broker_after:
+                raise ValueError(
+                    "broker snapshot execution scope end is outside broker collection bounds"
+                )
+            self._validate_snapshot_executions(
+                data["executions"],
+                expected_account,
+                execution_start,
+                execution_end,
+            )
+            return data
+        except BrokerSnapshotAccountMismatchError:
+            raise
+        except (KeyError, TypeError, ValueError) as exc:
+            self._snapshot_fail(generation, str(exc))
+        raise AssertionError("unreachable")
+
+    def _validate_snapshot_orders(self, orders: Any, account: str) -> None:
+        if not isinstance(orders, list):
+            raise ValueError("broker snapshot open orders are not a list")
+        keys = {
+            "account",
+            "broker_order_id",
+            "permanent_id",
+            "client_id",
+            "contract",
+            "side",
+            "status",
+            "order_type",
+            "time_in_force",
+            "total_quantity",
+            "filled_quantity",
+            "remaining_quantity",
+            "limit_price",
+            "stop_price",
+            "avg_fill_price",
+            "last_status_at",
+            "unavailable",
+        }
+        optional = {
+            "permanent_id",
+            "limit_price",
+            "stop_price",
+            "avg_fill_price",
+            "last_status_at",
+        }
+        seen: set[tuple[int, int]] = set()
+        for order in orders:
+            if not isinstance(order, dict) or set(order) != keys:
+                raise ValueError("broker snapshot open-order schema is invalid")
+            self._validate_unavailable(order, optional)
+            if order["account"] != account:
+                raise ValueError("broker snapshot order account is inconsistent")
+            order_id = self._strict_identifier(order["broker_order_id"], "broker order ID")
+            client_id = self._strict_identifier(order["client_id"], "client ID", allow_zero=True)
+            order_identity = (cast(int, client_id), cast(int, order_id))
+            if order_identity in seen:
+                raise ValueError("broker snapshot order identity is duplicated")
+            seen.add(order_identity)
+            self._strict_identifier(order["permanent_id"], "permanent ID", optional=True)
+            self._validate_snapshot_contract(order["contract"])
+            if order["side"] not in {"BUY", "SELL"}:
+                raise ValueError("broker snapshot order side is invalid")
+            for field_name in ("status", "order_type", "time_in_force"):
+                if not isinstance(order[field_name], str) or not order[field_name]:
+                    raise ValueError("broker snapshot order text evidence is missing")
+            total = self._strict_decimal(order["total_quantity"], "order total quantity")
+            filled = self._strict_decimal(order["filled_quantity"], "order filled quantity")
+            remaining = self._strict_decimal(
+                order["remaining_quantity"], "order remaining quantity"
+            )
+            if total <= 0 or filled < 0 or remaining < 0:
+                raise ValueError("broker snapshot order quantities are invalid")
+            if filled + remaining != total:
+                raise ValueError("broker snapshot order quantities are inconsistent")
+            for field_name in ("limit_price", "stop_price", "avg_fill_price"):
+                if order[field_name] is not None:
+                    if self._strict_decimal(order[field_name], field_name) <= 0:
+                        raise ValueError("broker snapshot order price evidence is not positive")
+            if order["last_status_at"] is not None:
+                self._strict_timestamp(order["last_status_at"], "last_status_at")
+
+    def _validate_snapshot_executions(
+        self,
+        executions: Any,
+        account: str,
+        window_start: datetime,
+        window_end: datetime,
+    ) -> None:
+        if not isinstance(executions, list):
+            raise ValueError("broker snapshot executions are not a list")
+        keys = {
+            "account",
+            "execution_id",
+            "broker_order_id",
+            "permanent_id",
+            "client_id",
+            "contract",
+            "side",
+            "quantity",
+            "price",
+            "average_price",
+            "executed_at",
+            "execution_exchange",
+            "commission",
+            "commission_currency",
+            "realized_pnl",
+            "unavailable",
+        }
+        optional = {
+            "broker_order_id",
+            "permanent_id",
+            "commission",
+            "commission_currency",
+            "realized_pnl",
+        }
+        seen: set[str] = set()
+        for execution in executions:
+            if not isinstance(execution, dict) or set(execution) != keys:
+                raise ValueError("broker snapshot execution schema is invalid")
+            self._validate_unavailable(execution, optional)
+            if execution["account"] != account:
+                raise ValueError("broker snapshot execution account is inconsistent")
+            execution_id = execution["execution_id"]
+            if not isinstance(execution_id, str) or not execution_id or execution_id in seen:
+                raise ValueError("broker snapshot execution identity is invalid")
+            seen.add(execution_id)
+            self._strict_identifier(
+                execution["broker_order_id"], "execution order ID", optional=True
+            )
+            self._strict_identifier(
+                execution["permanent_id"], "execution permanent ID", optional=True
+            )
+            self._strict_identifier(execution["client_id"], "execution client ID", allow_zero=True)
+            self._validate_snapshot_contract(execution["contract"])
+            if execution["side"] not in {"BUY", "SELL"}:
+                raise ValueError("broker snapshot execution side is invalid")
+            for field_name in ("quantity", "price", "average_price"):
+                if self._strict_decimal(execution[field_name], field_name) <= 0:
+                    raise ValueError("broker snapshot execution numeric evidence is invalid")
+            executed_at = self._strict_timestamp(execution["executed_at"], "executed_at")
+            if executed_at < window_start or executed_at > window_end:
+                raise ValueError("broker snapshot execution timestamp is outside requested window")
+            if (
+                not isinstance(execution["execution_exchange"], str)
+                or not execution["execution_exchange"]
+            ):
+                raise ValueError("broker snapshot execution exchange is missing")
+            for field_name in ("commission", "realized_pnl"):
+                if execution[field_name] is not None:
+                    self._strict_decimal(execution[field_name], field_name)
+            if execution["commission_currency"] is not None and (
+                not isinstance(execution["commission_currency"], str)
+                or not execution["commission_currency"]
+            ):
+                raise ValueError("broker snapshot commission currency is invalid")
+
+    async def get_broker_snapshot(
+        self,
+        expected_account: str,
+        *,
+        max_age_seconds: float = 30.0,
+    ) -> dict:
+        """Return one strictly validated, read-only broker evidence snapshot."""
+        normalized_account = str(expected_account or "").strip()
+        if not normalized_account:
+            raise ValueError("Expected broker account is required")
+        if (
+            isinstance(max_age_seconds, bool)
+            or not isinstance(max_age_seconds, (int, float))
+            or not math.isfinite(float(max_age_seconds))
+            or max_age_seconds <= 0
+            or max_age_seconds > _BROKER_SNAPSHOT_MAX_AGE_SECONDS
+        ):
+            raise ValueError("Snapshot freshness bound must be finite and at most 300 seconds")
+        async with self._lifecycle_lock:
+            generation = self._generation
+            if generation is None:
+                raise SubprocessCrashError("Subprocess generation is unavailable")
+            try:
+                identity = self._require_snapshot_generation_binding(
+                    generation,
+                    poison_on_mismatch=False,
+                )
+                data = await self._execute_command_unlocked(
+                    {
+                        "command": "get_broker_snapshot",
+                        "params": {"expected_account": normalized_account},
+                    },
+                    timeout=30.0,
+                )
+                self._require_snapshot_generation_binding(
+                    generation,
+                    expected_identity=identity,
+                    poison_on_mismatch=True,
+                )
+                validated = self._validate_broker_snapshot(
+                    normalized_account,
+                    data,
+                    generation,
+                    float(max_age_seconds),
+                )
+                self._require_snapshot_generation_binding(
+                    generation,
+                    expected_identity=identity,
+                    poison_on_mismatch=True,
+                )
+                return validated
+            finally:
+                # Broker evidence must not leave diagnostic stderr artifacts on
+                # disk, whether validation succeeds or fails closed.
+                self._cleanup_worker_debug_log(generation, required=True)
 
     def _validate_historical_response(
         self,

--- a/robo_trader/preflight/equity_history_freshness_check.py
+++ b/robo_trader/preflight/equity_history_freshness_check.py
@@ -110,8 +110,9 @@ class EquityHistoryFreshnessCheck:
                     f"Could not read equity_history from {db_path}. The ledger may be "
                     "locked, corrupted, or schema-mismatched. Inspect that exact file "
                     "with read-only SQLite tooling. If this is a known-good transient "
-                    "(for example, another process is writing), wait and re-run; "
-                    "otherwise use `--force` only after investigating."
+                    "(for example, another process is writing), wait and re-run. "
+                    "Keep startup blocked until the configured ledger can be read; "
+                    "diagnostic evidence does not authorize startup."
                 ),
                 details={"db_path": str(db_path), "error": str(exc)},
             )
@@ -146,8 +147,9 @@ class EquityHistoryFreshnessCheck:
                     f"The most recent equity_history row in {db_path} has a timestamp "
                     "that doesn't match the expected SQLite CURRENT_TIMESTAMP format. "
                     "Inspect the configured ledger and any pending migrations without "
-                    "rewriting history, or use `--force` if you've confirmed positions "
-                    "match IBKR."
+                    "rewriting history. Keep startup blocked; any broker-ledger "
+                    "reconciliation output is evidence only and does not authorize "
+                    "startup."
                 ),
                 details={"db_path": str(db_path), "raw_timestamp": max_ts_raw},
             )
@@ -182,9 +184,11 @@ class EquityHistoryFreshnessCheck:
             remediation=(
                 f"The last equity row in {db_path} is {trading_days_elapsed} trading "
                 "days old. This usually means a prior session died without writing "
-                "a snapshot. Verify positions match IBKR "
-                "(`scripts/reconcile_positions.py`) before resuming, or `--force` "
-                "if you've already confirmed."
+                "a snapshot. Collect evidence with the read-only diagnostic "
+                "`python3 scripts/reconcile_broker_ledger.py --portfolio-id "
+                "<portfolio_id>`. Review the resulting broker-versus-ledger report; "
+                "it does not modify state, clear safety controls, bypass preflight, "
+                "or authorize startup."
             ),
             details=details,
         )

--- a/robo_trader/reconciliation/__init__.py
+++ b/robo_trader/reconciliation/__init__.py
@@ -1,0 +1,15 @@
+"""Non-mutating broker-versus-ledger reconciliation."""
+
+from .broker import BrokerSnapshotProvider, BrokerSnapshotProviderFactory
+from .engine import reconcile
+from .ibkr_adapter import diagnostic_provider_factory
+from .models import BrokerSnapshot, ReconciliationReport
+
+__all__ = [
+    "BrokerSnapshot",
+    "BrokerSnapshotProvider",
+    "BrokerSnapshotProviderFactory",
+    "ReconciliationReport",
+    "diagnostic_provider_factory",
+    "reconcile",
+]

--- a/robo_trader/reconciliation/broker.py
+++ b/robo_trader/reconciliation/broker.py
@@ -1,0 +1,59 @@
+"""Narrow read-only broker boundary for reconciliation."""
+
+from __future__ import annotations
+
+from typing import Awaitable, Protocol, Union, runtime_checkable
+
+from .errors import BrokerEvidenceError
+from .identity import RuntimeSafetyContext
+from .models import BrokerSnapshot
+
+
+@runtime_checkable
+class BrokerSnapshotProvider(Protocol):
+    """Only broker capability made available to the reconciliation engine."""
+
+    async def get_broker_snapshot(
+        self, expected_account: str, *, max_age_seconds: float
+    ) -> BrokerSnapshot:
+        """Call only the dedicated account-validating diagnostic snapshot API."""
+
+    async def close(self) -> None:
+        """Close the diagnostic transport without mutating broker state."""
+
+
+class BrokerSnapshotProviderFactory(Protocol):
+    def __call__(
+        self, runtime: RuntimeSafetyContext
+    ) -> Union[BrokerSnapshotProvider, Awaitable[BrokerSnapshotProvider]]:
+        """Build a provider after all local safety gates have passed."""
+
+
+_ORDER_CAPABILITY_NAMES = frozenset(
+    {
+        "place_order",
+        "placeOrder",
+        "submit_order",
+        "submitOrder",
+        "cancel_order",
+        "cancelOrder",
+        "cancel_all_orders",
+        "cancelAllOrders",
+    }
+)
+
+
+def assert_read_only_provider_surface(provider: object) -> None:
+    exposed = sorted(name for name in _ORDER_CAPABILITY_NAMES if hasattr(provider, name))
+    if exposed:
+        raise BrokerEvidenceError("broker diagnostic provider exposes order capabilities")
+    if not isinstance(provider, BrokerSnapshotProvider):
+        raise BrokerEvidenceError(
+            "broker diagnostic provider does not satisfy the snapshot protocol"
+        )
+
+
+def unavailable_provider_factory(runtime: RuntimeSafetyContext) -> BrokerSnapshotProvider:
+    """Fail closed until the separately owned transport adapter is installed."""
+    del runtime
+    raise BrokerEvidenceError("broker snapshot provider is not configured")

--- a/robo_trader/reconciliation/broker.py
+++ b/robo_trader/reconciliation/broker.py
@@ -39,6 +39,20 @@ _ORDER_CAPABILITY_NAMES = frozenset(
         "cancelOrder",
         "cancel_all_orders",
         "cancelAllOrders",
+        "modify_order",
+        "modifyOrder",
+        "replace_order",
+        "replaceOrder",
+        "cancel_replace_order",
+        "cancelReplaceOrder",
+        "exercise_option",
+        "exerciseOption",
+        "exercise_options",
+        "exerciseOptions",
+        "global_cancel",
+        "globalCancel",
+        "req_global_cancel",
+        "reqGlobalCancel",
     }
 )
 

--- a/robo_trader/reconciliation/cli.py
+++ b/robo_trader/reconciliation/cli.py
@@ -108,9 +108,7 @@ async def run_reconciliation(
             finally:
                 if provider is not None:
                     try:
-                        cleanup_cancelled = await await_cleanup_required(
-                            asyncio.wait_for(provider.close(), timeout=10.0)
-                        )
+                        cleanup_cancelled = await await_cleanup_required(provider.close())
                     except Exception as exc:
                         raise BrokerEvidenceError(
                             "broker diagnostic transport cleanup failed"

--- a/robo_trader/reconciliation/cli.py
+++ b/robo_trader/reconciliation/cli.py
@@ -24,7 +24,7 @@ from .errors import (
     ReconciliationError,
     RuntimeSafetyError,
 )
-from .ibkr_adapter import diagnostic_provider_factory
+from .ibkr_adapter import await_cleanup_required, diagnostic_provider_factory
 from .identity import resolve_environment, validate_runtime_safety
 from .integrity import EvidenceIntegrityGuard, protected_evidence_paths
 from .ledger import ImmutableLedgerReader, validate_portfolio_ids
@@ -75,42 +75,57 @@ async def run_reconciliation(
 ) -> ReconciliationReport:
     """Run all local gates before constructing a broker provider."""
     selected = validate_portfolio_ids(portfolio_ids)
-    resolved_env = resolve_environment(project_root, process_environ)
-    evidence_paths = protected_evidence_paths(project_root, resolved_env)
-    with EvidenceIntegrityGuard(evidence_paths):
-        runtime = validate_runtime_safety(project_root, resolved_env)
-        contract = runtime.runtime_contract
-        reader = ImmutableLedgerReader(project_root, str(contract.database_path))
-        ledger = reader.read(selected)
+    env_path = project_root / ".env"
+    # Guard the path itself before resolving or parsing it. Symlinked .env files
+    # are rejected outright: resolving the target before the guard starts would
+    # leave a race where the link could be swapped and an untracked target parsed.
+    with EvidenceIntegrityGuard((env_path,)) as env_guard:
+        if env_path.is_symlink():
+            raise IntegrityViolation("runtime environment file must not be a symlink")
+        resolved_env = resolve_environment(project_root, process_environ)
+        env_guard.verify_unchanged()
+        evidence_paths = protected_evidence_paths(project_root, resolved_env)
+        with EvidenceIntegrityGuard(evidence_paths):
+            env_guard.verify_unchanged()
+            runtime = validate_runtime_safety(project_root, resolved_env)
+            contract = runtime.runtime_contract
+            reader = ImmutableLedgerReader(project_root, str(contract.database_path))
+            ledger = reader.read(selected)
 
-        provider: Optional[BrokerSnapshotProvider] = None
-        try:
-            provider = await _build_provider(provider_factory, runtime)
-            assert_read_only_provider_surface(provider)
-            snapshot = await asyncio.wait_for(
-                provider.get_broker_snapshot(
-                    runtime.expected_account_for_provider,
-                    max_age_seconds=30.0,
-                ),
-                timeout=60.0,
+            provider: Optional[BrokerSnapshotProvider] = None
+            try:
+                provider = await _build_provider(provider_factory, runtime)
+                assert_read_only_provider_surface(provider)
+                snapshot = await asyncio.wait_for(
+                    provider.get_broker_snapshot(
+                        runtime.expected_account_for_provider,
+                        max_age_seconds=30.0,
+                    ),
+                    timeout=60.0,
+                )
+            except Exception as exc:
+                raise BrokerEvidenceError("broker evidence collection failed") from exc
+            finally:
+                if provider is not None:
+                    try:
+                        cleanup_cancelled = await await_cleanup_required(
+                            asyncio.wait_for(provider.close(), timeout=10.0)
+                        )
+                    except Exception as exc:
+                        raise BrokerEvidenceError(
+                            "broker diagnostic transport cleanup failed"
+                        ) from exc
+                    if cleanup_cancelled:
+                        raise asyncio.CancelledError
+
+            return reconcile(
+                snapshot,
+                ledger,
+                runtime_fingerprint=str(contract.fingerprint),
+                database_identity=str(contract.database_identity),
+                expected_account_alias=runtime.account_alias,
+                now=now or datetime.now(timezone.utc),
             )
-        except Exception as exc:
-            raise BrokerEvidenceError("broker evidence collection failed") from exc
-        finally:
-            if provider is not None:
-                try:
-                    await asyncio.wait_for(provider.close(), timeout=10.0)
-                except Exception as exc:
-                    raise BrokerEvidenceError("broker diagnostic transport cleanup failed") from exc
-
-        return reconcile(
-            snapshot,
-            ledger,
-            runtime_fingerprint=str(contract.fingerprint),
-            database_identity=str(contract.database_identity),
-            expected_account_alias=runtime.account_alias,
-            now=now or datetime.now(timezone.utc),
-        )
 
 
 def _human_output(report: ReconciliationReport) -> str:

--- a/robo_trader/reconciliation/cli.py
+++ b/robo_trader/reconciliation/cli.py
@@ -1,0 +1,217 @@
+"""Report-only orchestration for broker/ledger reconciliation."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import inspect
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Mapping, Optional, Sequence
+
+from .broker import (
+    BrokerSnapshotProvider,
+    BrokerSnapshotProviderFactory,
+    assert_read_only_provider_surface,
+)
+from .engine import reconcile
+from .errors import (
+    BrokerEvidenceError,
+    IntegrityViolation,
+    LedgerSafetyError,
+    ReconciliationError,
+    RuntimeSafetyError,
+)
+from .identity import resolve_environment, validate_runtime_safety
+from .ibkr_adapter import diagnostic_provider_factory
+from .integrity import EvidenceIntegrityGuard, protected_evidence_paths
+from .ledger import ImmutableLedgerReader, validate_portfolio_ids
+from .models import ReconciliationReport
+
+EXIT_CLEAN_QUANTITY_COST = 0
+EXIT_DIFFERENCES = 1
+EXIT_BLOCKED = 2
+EXIT_INTEGRITY_VIOLATION = 3
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Produce non-mutating IBKR paper-account versus local-ledger evidence. "
+            "This command never repairs state or authorizes trader startup."
+        )
+    )
+    parser.add_argument(
+        "--portfolio-id",
+        action="append",
+        required=True,
+        dest="portfolio_ids",
+        help="Explicit local portfolio ID. Repeat to show aggregate evidence.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit stable JSON evidence.")
+    return parser
+
+
+async def _build_provider(
+    factory: BrokerSnapshotProviderFactory, runtime
+) -> BrokerSnapshotProvider:
+    provider_or_awaitable = factory(runtime)
+    if inspect.isawaitable(provider_or_awaitable):
+        provider = await provider_or_awaitable
+    else:
+        provider = provider_or_awaitable
+    return provider
+
+
+async def run_reconciliation(
+    portfolio_ids: Sequence[str],
+    *,
+    project_root: Path,
+    process_environ: Optional[Mapping[str, str]] = None,
+    provider_factory: BrokerSnapshotProviderFactory = diagnostic_provider_factory,
+    now: Optional[datetime] = None,
+) -> ReconciliationReport:
+    """Run all local gates before constructing a broker provider."""
+    selected = validate_portfolio_ids(portfolio_ids)
+    resolved_env = resolve_environment(project_root, process_environ)
+    evidence_paths = protected_evidence_paths(project_root, resolved_env)
+    with EvidenceIntegrityGuard(evidence_paths):
+        runtime = validate_runtime_safety(project_root, resolved_env)
+        contract = runtime.runtime_contract
+        reader = ImmutableLedgerReader(project_root, str(contract.database_path))
+        ledger = reader.read(selected)
+
+        provider: Optional[BrokerSnapshotProvider] = None
+        try:
+            provider = await _build_provider(provider_factory, runtime)
+            assert_read_only_provider_surface(provider)
+            snapshot = await asyncio.wait_for(
+                provider.get_broker_snapshot(
+                    runtime.expected_account_for_provider,
+                    max_age_seconds=30.0,
+                ),
+                timeout=60.0,
+            )
+        except Exception as exc:
+            raise BrokerEvidenceError("broker evidence collection failed") from exc
+        finally:
+            if provider is not None:
+                try:
+                    await asyncio.wait_for(provider.close(), timeout=10.0)
+                except Exception as exc:
+                    raise BrokerEvidenceError("broker diagnostic transport cleanup failed") from exc
+
+        return reconcile(
+            snapshot,
+            ledger,
+            runtime_fingerprint=str(contract.fingerprint),
+            database_identity=str(contract.database_identity),
+            expected_account_alias=runtime.account_alias,
+            now=now or datetime.now(timezone.utc),
+        )
+
+
+def _human_output(report: ReconciliationReport) -> str:
+    lines = [
+        "READ-ONLY BROKER/LEDGER RECONCILIATION",
+        f"status={report.status}",
+        f"account_alias={report.account_alias}",
+        f"portfolios={','.join(report.selected_portfolio_ids)}",
+        "mutated_state=false",
+        "authorizes_startup=false",
+        "This evidence cannot clear a kill switch, repair the ledger, bypass preflight, "
+        "or authorize trader startup.",
+    ]
+    for comparison in report.position_comparisons:
+        reasons = ",".join(comparison.reasons) or "none"
+        lines.append(f"position {comparison.symbol}: {comparison.status}; reasons={reasons}")
+    for blocker in report.blockers:
+        lines.append(f"BLOCKER: {blocker}")
+    for caveat in report.caveats:
+        lines.append(f"CAVEAT: {caveat}")
+    return "\n".join(lines)
+
+
+def _safe_error_payload(error: ReconciliationError) -> dict[str, object]:
+    if isinstance(error, IntegrityViolation):
+        code = "INTEGRITY_VIOLATION"
+    elif isinstance(error, RuntimeSafetyError):
+        code = "RUNTIME_SAFETY_BLOCK"
+    elif isinstance(error, LedgerSafetyError):
+        code = "LEDGER_SAFETY_BLOCK"
+    elif isinstance(error, BrokerEvidenceError):
+        code = "BROKER_EVIDENCE_BLOCK"
+    else:
+        code = "RECONCILIATION_BLOCK"
+    return {
+        "schema_version": 1,
+        "status": "BLOCKED",
+        "error_code": code,
+        "message": str(error),
+        "mutated_state": False,
+        "authorizes_startup": False,
+    }
+
+
+def main(
+    argv: Optional[Sequence[str]] = None,
+    *,
+    project_root: Optional[Path] = None,
+    process_environ: Optional[Mapping[str, str]] = None,
+    provider_factory: BrokerSnapshotProviderFactory = diagnostic_provider_factory,
+    now: Optional[datetime] = None,
+) -> int:
+    args = build_parser().parse_args(argv)
+    root = project_root or Path(__file__).resolve().parents[2]
+    try:
+        report = asyncio.run(
+            run_reconciliation(
+                args.portfolio_ids,
+                project_root=root,
+                process_environ=process_environ,
+                provider_factory=provider_factory,
+                now=now,
+            )
+        )
+    except ReconciliationError as exc:
+        payload = _safe_error_payload(exc)
+        if args.json:
+            print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+        else:
+            print(
+                f"BLOCKED: {payload['message']}\n"
+                "mutated_state=false\n"
+                "authorizes_startup=false",
+                file=sys.stderr,
+            )
+        return EXIT_INTEGRITY_VIOLATION if isinstance(exc, IntegrityViolation) else EXIT_BLOCKED
+    except Exception:
+        payload = {
+            "schema_version": 1,
+            "status": "BLOCKED",
+            "error_code": "UNEXPECTED_FAILURE",
+            "message": "unexpected reconciliation failure",
+            "mutated_state": False,
+            "authorizes_startup": False,
+        }
+        if args.json:
+            print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+        else:
+            print(
+                "BLOCKED: unexpected reconciliation failure\n"
+                "mutated_state=false\nauthorizes_startup=false",
+                file=sys.stderr,
+            )
+        return EXIT_BLOCKED
+
+    if args.json:
+        print(json.dumps(report.public_dict(), sort_keys=True, separators=(",", ":")))
+    else:
+        print(_human_output(report))
+    if report.status == "QUANTITY_COST_COMPARABLE_ONLY":
+        return EXIT_CLEAN_QUANTITY_COST
+    if report.status == "MISMATCH":
+        return EXIT_DIFFERENCES
+    return EXIT_BLOCKED

--- a/robo_trader/reconciliation/cli.py
+++ b/robo_trader/reconciliation/cli.py
@@ -24,8 +24,8 @@ from .errors import (
     ReconciliationError,
     RuntimeSafetyError,
 )
-from .identity import resolve_environment, validate_runtime_safety
 from .ibkr_adapter import diagnostic_provider_factory
+from .identity import resolve_environment, validate_runtime_safety
 from .integrity import EvidenceIntegrityGuard, protected_evidence_paths
 from .ledger import ImmutableLedgerReader, validate_portfolio_ids
 from .models import ReconciliationReport

--- a/robo_trader/reconciliation/engine.py
+++ b/robo_trader/reconciliation/engine.py
@@ -1,0 +1,272 @@
+"""Pure deterministic comparison of broker evidence and immutable ledger data."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+from .errors import BrokerEvidenceError
+from .models import (
+    BrokerSnapshot,
+    LedgerSnapshot,
+    NonComparableEvidence,
+    PositionComparison,
+    ReconciliationReport,
+)
+
+DEFAULT_COST_TOLERANCE = Decimal("0.01")
+DEFAULT_MAX_SNAPSHOT_AGE = timedelta(minutes=2)
+DEFAULT_MAX_COLLECTION_SPAN = timedelta(seconds=30)
+DEFAULT_FUTURE_TOLERANCE = timedelta(seconds=5)
+DEFAULT_MAX_LEDGER_POSITION_AGE = timedelta(minutes=5)
+
+
+def validate_broker_snapshot(
+    snapshot: BrokerSnapshot,
+    *,
+    expected_account_alias: str,
+    now: datetime,
+    max_age: timedelta = DEFAULT_MAX_SNAPSHOT_AGE,
+) -> None:
+    if now.tzinfo is None or now.utcoffset() is None:
+        raise BrokerEvidenceError("reconciliation clock must be timezone-aware")
+    if snapshot.account_alias != expected_account_alias:
+        raise BrokerEvidenceError("broker snapshot account identity does not match runtime")
+    if snapshot.execution_scope.kind != "bounded_execution_filter":
+        raise BrokerEvidenceError("broker recent-execution scope is missing or ambiguous")
+    if snapshot.broker_time_before > snapshot.broker_time_after:
+        raise BrokerEvidenceError("broker snapshot timestamps are reversed")
+    if snapshot.broker_time_after - snapshot.broker_time_before > DEFAULT_MAX_COLLECTION_SPAN:
+        raise BrokerEvidenceError("broker snapshot collection window is too wide")
+    expected_execution_start = snapshot.broker_time_before.replace(microsecond=0) - timedelta(
+        hours=24
+    )
+    if snapshot.execution_scope.start_at != expected_execution_start:
+        raise BrokerEvidenceError("broker execution scope does not match the exact wire filter")
+    if not (
+        snapshot.broker_time_before <= snapshot.execution_scope.end_at <= snapshot.broker_time_after
+    ):
+        raise BrokerEvidenceError("broker execution scope end is outside broker collection bounds")
+    for timestamp in (
+        snapshot.broker_time_before,
+        snapshot.broker_time_after,
+        snapshot.retrieved_at,
+    ):
+        if timestamp > now + DEFAULT_FUTURE_TOLERANCE:
+            raise BrokerEvidenceError("broker snapshot timestamp is in the future")
+        if now - timestamp > max_age:
+            raise BrokerEvidenceError("broker snapshot is stale")
+    if len({item.contract.con_id for item in snapshot.positions}) != len(snapshot.positions):
+        raise BrokerEvidenceError("broker snapshot has duplicate contract identity")
+    if len({item.contract.symbol for item in snapshot.positions}) != len(snapshot.positions):
+        raise BrokerEvidenceError("broker snapshot has duplicate symbol identity")
+    order_identities = {item.identity for item in snapshot.open_orders}
+    if len(order_identities) != len(snapshot.open_orders):
+        raise BrokerEvidenceError("broker snapshot has duplicate open-order identity")
+    execution_ids = {item.execution_id for item in snapshot.recent_executions}
+    if len(execution_ids) != len(snapshot.recent_executions):
+        raise BrokerEvidenceError("broker snapshot has duplicate execution identity")
+    for execution in snapshot.recent_executions:
+        if (
+            execution.executed_at < snapshot.execution_scope.start_at
+            or execution.executed_at > snapshot.execution_scope.end_at
+        ):
+            raise BrokerEvidenceError("broker execution falls outside exact bounded request window")
+
+
+def reconcile(
+    broker: BrokerSnapshot,
+    ledger: LedgerSnapshot,
+    *,
+    runtime_fingerprint: str,
+    database_identity: str,
+    expected_account_alias: str,
+    now: datetime | None = None,
+    cost_tolerance: Decimal = DEFAULT_COST_TOLERANCE,
+) -> ReconciliationReport:
+    generated_at = now or datetime.now(timezone.utc)
+    validate_broker_snapshot(
+        broker, expected_account_alias=expected_account_alias, now=generated_at
+    )
+    broker_by_symbol = {position.contract.symbol: position for position in broker.positions}
+    ledger_by_symbol = {position.symbol: position for position in ledger.aggregated_positions}
+
+    blockers = list(ledger.blockers)
+    caveats = list(ledger.caveats)
+    for position in ledger.positions:
+        identity = f"{position.portfolio_id}:{position.symbol}"
+        if position.timestamp > generated_at + DEFAULT_FUTURE_TOLERANCE:
+            blockers.append(f"LEDGER_POSITION_TIMESTAMP_FUTURE:{identity}")
+        elif generated_at - position.timestamp > DEFAULT_MAX_LEDGER_POSITION_AGE:
+            blockers.append(f"LEDGER_POSITION_PROJECTION_STALE:{identity}")
+    for trade in ledger.recent_trades:
+        if trade.timestamp > generated_at + DEFAULT_FUTURE_TOLERANCE:
+            blockers.append(f"LEDGER_TRADE_TIMESTAMP_FUTURE:{trade.local_trade_id}")
+    comparisons = []
+    for symbol in sorted(set(broker_by_symbol) | set(ledger_by_symbol)):
+        broker_position = broker_by_symbol.get(symbol)
+        ledger_position = ledger_by_symbol.get(symbol)
+        reasons: list[str] = []
+        if broker_position is None:
+            status = "ledger_only"
+            reasons.append("BROKER_POSITION_MISSING")
+        elif ledger_position is None:
+            status = "broker_only"
+            reasons.append("LEDGER_POSITION_MISSING")
+        else:
+            if broker_position.quantity != broker_position.quantity.to_integral_value():
+                blockers.append(f"BROKER_FRACTIONAL_QUANTITY_UNREPRESENTABLE:{symbol}")
+                reasons.append("BROKER_QUANTITY_CANNOT_BE_REPRESENTED_BY_LEDGER_INTEGER_SCHEMA")
+            if broker_position.quantity != ledger_position.quantity:
+                reasons.append("QUANTITY_MISMATCH")
+            if ledger_position.average_cost is None:
+                reasons.append("LEDGER_AGGREGATE_COST_NOT_COMPARABLE")
+            elif abs(broker_position.average_cost - ledger_position.average_cost) > cost_tolerance:
+                reasons.append("AVERAGE_COST_MISMATCH")
+            status = "quantity_cost_match" if not reasons else "quantity_cost_mismatch"
+
+        comparisons.append(
+            PositionComparison(
+                symbol=symbol,
+                status=status,
+                reasons=tuple(reasons),
+                broker_contract=broker_position.contract if broker_position else None,
+                broker_quantity=broker_position.quantity if broker_position else None,
+                ledger_quantity=ledger_position.quantity if ledger_position else None,
+                broker_average_cost=broker_position.average_cost if broker_position else None,
+                ledger_average_cost=ledger_position.average_cost if ledger_position else None,
+                allocations=ledger_position.allocations if ledger_position else (),
+            )
+        )
+
+    open_orders = tuple(
+        NonComparableEvidence(
+            evidence_type="open_order",
+            broker_identifier=f"{order.client_id}:{order.order_id}",
+            symbol=order.contract.symbol,
+            status="not_comparable",
+            reason="LOCAL_LEDGER_HAS_NO_BROKER_ORDER_ID_OR_DURABLE_OPEN_ORDER_TABLE",
+            details={
+                "client_id": order.client_id,
+                "broker_order_id": order.order_id,
+                "permanent_id": order.permanent_id,
+                "contract": order.contract.public_dict(),
+                "side": order.side,
+                "quantity": str(order.quantity),
+                "filled": str(order.filled),
+                "remaining": str(order.remaining),
+                "order_type": order.order_type,
+                "status": order.status,
+                "time_in_force": order.time_in_force,
+                "limit_price": str(order.limit_price) if order.limit_price is not None else None,
+                "auxiliary_price": (
+                    str(order.auxiliary_price) if order.auxiliary_price is not None else None
+                ),
+                "average_fill_price": (
+                    str(order.average_fill_price) if order.average_fill_price is not None else None
+                ),
+                "last_status_at": (
+                    order.last_status_at.isoformat() if order.last_status_at else None
+                ),
+                "unavailable": dict(order.unavailable),
+            },
+        )
+        for order in sorted(
+            broker.open_orders,
+            key=lambda item: (
+                item.client_id,
+                int(item.order_id),
+                item.contract.symbol,
+            ),
+        )
+    )
+    executions = tuple(
+        NonComparableEvidence(
+            evidence_type="recent_execution",
+            broker_identifier=execution.execution_id,
+            symbol=execution.contract.symbol,
+            status="not_comparable",
+            reason="LOCAL_LEDGER_HAS_NO_BROKER_EXECUTION_OR_ORDER_ID",
+            details={
+                "broker_order_id": execution.order_id,
+                "permanent_id": execution.permanent_id,
+                "client_id": execution.client_id,
+                "contract": execution.contract.public_dict(),
+                "side": execution.side,
+                "quantity": str(execution.quantity),
+                "price": str(execution.price),
+                "average_price": (
+                    str(execution.average_price) if execution.average_price is not None else None
+                ),
+                "executed_at": execution.executed_at.isoformat(),
+                "execution_exchange": execution.execution_exchange,
+                "commission": (
+                    str(execution.commission) if execution.commission is not None else None
+                ),
+                "commission_currency": execution.commission_currency,
+                "realized_pnl": (
+                    str(execution.realized_pnl) if execution.realized_pnl is not None else None
+                ),
+                "unavailable": dict(execution.unavailable),
+            },
+        )
+        for execution in sorted(
+            broker.recent_executions,
+            key=lambda item: (
+                item.executed_at,
+                item.contract.symbol,
+                item.execution_id,
+            ),
+        )
+    )
+    local_trade_evidence = tuple(
+        NonComparableEvidence(
+            evidence_type="local_trade",
+            broker_identifier=f"local:{trade.local_trade_id}",
+            symbol=trade.symbol,
+            status="not_comparable",
+            reason="LOCAL_LEDGER_HAS_NO_BROKER_EXECUTION_OR_ORDER_ID",
+            details={
+                "portfolio_id": trade.portfolio_id,
+                "side": trade.side,
+                "quantity": str(trade.quantity),
+                "price": str(trade.price),
+                "timestamp": trade.timestamp.isoformat(),
+            },
+        )
+        for trade in sorted(
+            ledger.recent_trades,
+            key=lambda item: (item.timestamp, item.portfolio_id, item.local_trade_id),
+        )
+    )
+    executions = executions + local_trade_evidence
+    if open_orders:
+        caveats.append("BROKER_OPEN_ORDERS_CANNOT_BE_MATCHED_TO_LOCAL_LEDGER")
+    if executions:
+        caveats.append("BROKER_EXECUTIONS_CANNOT_BE_IDENTITY_MATCHED_TO_LOCAL_TRADES")
+
+    quantity_cost_difference = any(
+        comparison.is_quantity_cost_difference for comparison in comparisons
+    )
+    if blockers:
+        status = "BLOCKED"
+    elif quantity_cost_difference:
+        status = "MISMATCH"
+    else:
+        status = "QUANTITY_COST_COMPARABLE_ONLY"
+
+    return ReconciliationReport(
+        generated_at=generated_at,
+        runtime_fingerprint=runtime_fingerprint,
+        database_identity=database_identity,
+        account_alias=expected_account_alias,
+        selected_portfolio_ids=ledger.selected_portfolio_ids,
+        status=status,
+        blockers=tuple(sorted(set(blockers))),
+        caveats=tuple(sorted(set(caveats))),
+        position_comparisons=tuple(comparisons),
+        open_order_comparisons=open_orders,
+        execution_comparisons=executions,
+        broker_snapshot=broker,
+        ledger_snapshot=ledger,
+    )

--- a/robo_trader/reconciliation/engine.py
+++ b/robo_trader/reconciliation/engine.py
@@ -12,6 +12,7 @@ from .models import (
     NonComparableEvidence,
     PositionComparison,
     ReconciliationReport,
+    canonical_decimal,
 )
 
 DEFAULT_COST_TOLERANCE = Decimal("0.01")
@@ -152,18 +153,24 @@ def reconcile(
                 "permanent_id": order.permanent_id,
                 "contract": order.contract.public_dict(),
                 "side": order.side,
-                "quantity": str(order.quantity),
-                "filled": str(order.filled),
-                "remaining": str(order.remaining),
+                "quantity": canonical_decimal(order.quantity),
+                "filled": canonical_decimal(order.filled),
+                "remaining": canonical_decimal(order.remaining),
                 "order_type": order.order_type,
                 "status": order.status,
                 "time_in_force": order.time_in_force,
-                "limit_price": str(order.limit_price) if order.limit_price is not None else None,
+                "limit_price": (
+                    canonical_decimal(order.limit_price) if order.limit_price is not None else None
+                ),
                 "auxiliary_price": (
-                    str(order.auxiliary_price) if order.auxiliary_price is not None else None
+                    canonical_decimal(order.auxiliary_price)
+                    if order.auxiliary_price is not None
+                    else None
                 ),
                 "average_fill_price": (
-                    str(order.average_fill_price) if order.average_fill_price is not None else None
+                    canonical_decimal(order.average_fill_price)
+                    if order.average_fill_price is not None
+                    else None
                 ),
                 "last_status_at": (
                     order.last_status_at.isoformat() if order.last_status_at else None
@@ -193,19 +200,25 @@ def reconcile(
                 "client_id": execution.client_id,
                 "contract": execution.contract.public_dict(),
                 "side": execution.side,
-                "quantity": str(execution.quantity),
-                "price": str(execution.price),
+                "quantity": canonical_decimal(execution.quantity),
+                "price": canonical_decimal(execution.price),
                 "average_price": (
-                    str(execution.average_price) if execution.average_price is not None else None
+                    canonical_decimal(execution.average_price)
+                    if execution.average_price is not None
+                    else None
                 ),
                 "executed_at": execution.executed_at.isoformat(),
                 "execution_exchange": execution.execution_exchange,
                 "commission": (
-                    str(execution.commission) if execution.commission is not None else None
+                    canonical_decimal(execution.commission)
+                    if execution.commission is not None
+                    else None
                 ),
                 "commission_currency": execution.commission_currency,
                 "realized_pnl": (
-                    str(execution.realized_pnl) if execution.realized_pnl is not None else None
+                    canonical_decimal(execution.realized_pnl)
+                    if execution.realized_pnl is not None
+                    else None
                 ),
                 "unavailable": dict(execution.unavailable),
             },
@@ -229,8 +242,8 @@ def reconcile(
             details={
                 "portfolio_id": trade.portfolio_id,
                 "side": trade.side,
-                "quantity": str(trade.quantity),
-                "price": str(trade.price),
+                "quantity": canonical_decimal(trade.quantity),
+                "price": canonical_decimal(trade.price),
                 "timestamp": trade.timestamp.isoformat(),
             },
         )
@@ -241,6 +254,7 @@ def reconcile(
     )
     executions = executions + local_trade_evidence
     if open_orders:
+        blockers.append("UNMATCHED_ACTIVE_BROKER_OPEN_ORDERS")
         caveats.append("BROKER_OPEN_ORDERS_CANNOT_BE_MATCHED_TO_LOCAL_LEDGER")
     if executions:
         caveats.append("BROKER_EXECUTIONS_CANNOT_BE_IDENTITY_MATCHED_TO_LOCAL_TRADES")
@@ -250,6 +264,8 @@ def reconcile(
     )
     if blockers:
         status = "BLOCKED"
+    elif executions:
+        status = "INCOMPLETE"
     elif quantity_cost_difference:
         status = "MISMATCH"
     else:

--- a/robo_trader/reconciliation/engine.py
+++ b/robo_trader/reconciliation/engine.py
@@ -232,6 +232,12 @@ def reconcile(
             ),
         )
     )
+    execution_scope = broker.execution_scope
+    scoped_local_trades = tuple(
+        trade
+        for trade in ledger.recent_trades
+        if execution_scope.start_at <= trade.timestamp <= execution_scope.end_at
+    )
     local_trade_evidence = tuple(
         NonComparableEvidence(
             evidence_type="local_trade",
@@ -248,7 +254,7 @@ def reconcile(
             },
         )
         for trade in sorted(
-            ledger.recent_trades,
+            scoped_local_trades,
             key=lambda item: (item.timestamp, item.portfolio_id, item.local_trade_id),
         )
     )

--- a/robo_trader/reconciliation/errors.py
+++ b/robo_trader/reconciliation/errors.py
@@ -1,0 +1,21 @@
+"""Fail-closed errors for read-only broker/ledger reconciliation."""
+
+
+class ReconciliationError(Exception):
+    """Base class whose message is safe for operator-facing output."""
+
+
+class RuntimeSafetyError(ReconciliationError):
+    """The paper/read-only runtime identity could not be proven."""
+
+
+class BrokerEvidenceError(ReconciliationError):
+    """The broker snapshot was missing, stale, ambiguous, or malformed."""
+
+
+class LedgerSafetyError(ReconciliationError):
+    """The local ledger could not be proven safe and comparable."""
+
+
+class IntegrityViolation(ReconciliationError):
+    """A protected evidence file changed during reconciliation."""

--- a/robo_trader/reconciliation/ibkr_adapter.py
+++ b/robo_trader/reconciliation/ibkr_adapter.py
@@ -1,0 +1,419 @@
+"""Fail-closed adapter for the dedicated IBKR diagnostic transport."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from decimal import Decimal
+from types import MappingProxyType
+from typing import Any, Mapping, Protocol
+
+from robo_trader.clients.subprocess_ibkr_client import SubprocessIBKRClient
+
+from .errors import BrokerEvidenceError
+from .identity import RuntimeSafetyContext, mask_account_identifier
+from .models import (
+    BrokerExecution,
+    BrokerExecutionScope,
+    BrokerOpenOrder,
+    BrokerPosition,
+    BrokerSnapshot,
+    ContractIdentity,
+)
+
+_TOP_LEVEL_KEYS = frozenset(
+    {
+        "snapshot_schema_version",
+        "account",
+        "broker_time_before",
+        "broker_time_after",
+        "retrieved_at",
+        "positions",
+        "balances",
+        "open_orders",
+        "executions",
+        "execution_scope",
+    }
+)
+_CONTRACT_KEYS = frozenset(
+    {
+        "con_id",
+        "symbol",
+        "local_symbol",
+        "security_type",
+        "currency",
+        "exchange",
+        "primary_exchange",
+        "trading_class",
+    }
+)
+_POSITION_KEYS = frozenset({"account", "contract", "quantity", "avg_cost"})
+_BALANCE_KEYS = frozenset({"tag", "currency", "value"})
+_OPEN_ORDER_KEYS = frozenset(
+    {
+        "account",
+        "broker_order_id",
+        "permanent_id",
+        "client_id",
+        "contract",
+        "side",
+        "status",
+        "order_type",
+        "time_in_force",
+        "total_quantity",
+        "filled_quantity",
+        "remaining_quantity",
+        "limit_price",
+        "stop_price",
+        "avg_fill_price",
+        "last_status_at",
+        "unavailable",
+    }
+)
+_EXECUTION_KEYS = frozenset(
+    {
+        "account",
+        "execution_id",
+        "broker_order_id",
+        "permanent_id",
+        "client_id",
+        "contract",
+        "side",
+        "quantity",
+        "price",
+        "average_price",
+        "executed_at",
+        "execution_exchange",
+        "commission",
+        "commission_currency",
+        "realized_pnl",
+        "unavailable",
+    }
+)
+_EXECUTION_SCOPE_KEYS = frozenset({"kind", "start_at", "end_at"})
+
+
+class DiagnosticTransport(Protocol):
+    """Transport subset available to this adapter."""
+
+    async def start(self) -> None:
+        """Start an isolated diagnostic worker."""
+
+    async def connect(
+        self,
+        host: str,
+        port: int,
+        client_id: int,
+        readonly: bool,
+        timeout: float = 30.0,
+    ) -> bool:
+        """Connect using the already validated diagnostic identity."""
+
+    async def get_broker_snapshot(
+        self, expected_account: str, *, max_age_seconds: float
+    ) -> dict[str, Any]:
+        """Return the transport-v1 diagnostic snapshot."""
+
+    async def stop(self) -> None:
+        """Stop and reap the isolated worker."""
+
+
+def _record(value: object, keys: frozenset[str], label: str) -> Mapping[str, Any]:
+    if not isinstance(value, dict) or set(value) != keys:
+        raise BrokerEvidenceError(f"diagnostic broker {label} schema is invalid")
+    return value
+
+
+def _records(value: object, label: str) -> list[object]:
+    if not isinstance(value, list):
+        raise BrokerEvidenceError(f"diagnostic broker {label} must be a list")
+    return value
+
+
+def _timestamp(value: object, label: str) -> datetime:
+    if not isinstance(value, str):
+        raise BrokerEvidenceError(f"diagnostic broker {label} is invalid")
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise BrokerEvidenceError(f"diagnostic broker {label} is invalid") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise BrokerEvidenceError(f"diagnostic broker {label} is invalid")
+    return parsed
+
+
+def _optional_timestamp(value: object, label: str) -> datetime | None:
+    return None if value is None else _timestamp(value, label)
+
+
+def _decimal(value: object, label: str) -> Decimal:
+    if not isinstance(value, str):
+        raise BrokerEvidenceError(f"diagnostic broker {label} is invalid")
+    try:
+        parsed = Decimal(value)
+    except Exception as exc:
+        raise BrokerEvidenceError(f"diagnostic broker {label} is invalid") from exc
+    if not parsed.is_finite() or str(parsed) != value:
+        raise BrokerEvidenceError(f"diagnostic broker {label} is invalid")
+    return parsed
+
+
+def _optional_decimal(value: object, label: str) -> Decimal | None:
+    return None if value is None else _decimal(value, label)
+
+
+def _optional_identifier(value: object, label: str) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise BrokerEvidenceError(f"diagnostic broker {label} is invalid")
+    return str(value)
+
+
+def _unavailable(value: object) -> Mapping[str, str]:
+    if not isinstance(value, dict) or any(
+        not isinstance(key, str) or not isinstance(reason, str) or not reason
+        for key, reason in value.items()
+    ):
+        raise BrokerEvidenceError("diagnostic broker unavailable evidence is invalid")
+    return MappingProxyType(dict(value))
+
+
+def _contract(value: object) -> ContractIdentity:
+    record = _record(value, _CONTRACT_KEYS, "contract")
+    return ContractIdentity(
+        con_id=record["con_id"],
+        symbol=record["symbol"],
+        local_symbol=record["local_symbol"],
+        security_type=record["security_type"],
+        currency=record["currency"],
+        exchange=record["exchange"],
+        primary_exchange=record["primary_exchange"],
+        trading_class=record["trading_class"],
+    )
+
+
+def _require_account(record: Mapping[str, Any], expected_account: str) -> None:
+    if record["account"] != expected_account:
+        raise BrokerEvidenceError("diagnostic broker account identity is inconsistent")
+
+
+def snapshot_from_transport(
+    payload: object,
+    *,
+    expected_account: str,
+) -> BrokerSnapshot:
+    """Convert one strictly validated transport-v1 payload into evidence models."""
+    if not isinstance(expected_account, str) or not expected_account.strip():
+        raise BrokerEvidenceError("diagnostic broker expected account is unavailable")
+    record = _record(payload, _TOP_LEVEL_KEYS, "snapshot")
+    if record["account"] != expected_account:
+        raise BrokerEvidenceError("diagnostic broker account identity does not match runtime")
+
+    positions = []
+    for raw_position in _records(record["positions"], "positions"):
+        position = _record(raw_position, _POSITION_KEYS, "position")
+        _require_account(position, expected_account)
+        positions.append(
+            BrokerPosition(
+                contract=_contract(position["contract"]),
+                quantity=_decimal(position["quantity"], "position quantity"),
+                average_cost=_decimal(position["avg_cost"], "position average cost"),
+            )
+        )
+
+    balances: dict[str, Decimal] = {}
+    for raw_balance in _records(record["balances"], "balances"):
+        balance = _record(raw_balance, _BALANCE_KEYS, "balance")
+        tag = balance["tag"]
+        currency = balance["currency"]
+        if not isinstance(tag, str) or not isinstance(currency, str):
+            raise BrokerEvidenceError("diagnostic broker balance identity is invalid")
+        identity = f"{tag}:{currency}"
+        if identity in balances:
+            raise BrokerEvidenceError("diagnostic broker balance identity is duplicated")
+        balances[identity] = _decimal(balance["value"], "balance value")
+
+    open_orders = []
+    for raw_order in _records(record["open_orders"], "open orders"):
+        order = _record(raw_order, _OPEN_ORDER_KEYS, "open order")
+        _require_account(order, expected_account)
+        order_id = _optional_identifier(order["broker_order_id"], "order ID")
+        if order_id is None:
+            raise BrokerEvidenceError("diagnostic broker order ID is missing")
+        open_orders.append(
+            BrokerOpenOrder(
+                order_id=order_id,
+                contract=_contract(order["contract"]),
+                side=order["side"],
+                quantity=_decimal(order["total_quantity"], "order quantity"),
+                filled=_decimal(order["filled_quantity"], "order filled quantity"),
+                remaining=_decimal(order["remaining_quantity"], "order remaining quantity"),
+                order_type=order["order_type"],
+                status=order["status"],
+                limit_price=_optional_decimal(order["limit_price"], "order limit price"),
+                auxiliary_price=_optional_decimal(order["stop_price"], "order stop price"),
+                permanent_id=_optional_identifier(order["permanent_id"], "permanent ID"),
+                client_id=order["client_id"],
+                time_in_force=order["time_in_force"],
+                average_fill_price=_optional_decimal(
+                    order["avg_fill_price"], "order average fill price"
+                ),
+                last_status_at=_optional_timestamp(
+                    order["last_status_at"], "order status timestamp"
+                ),
+                unavailable=_unavailable(order["unavailable"]),
+            )
+        )
+
+    executions = []
+    for raw_execution in _records(record["executions"], "executions"):
+        execution = _record(raw_execution, _EXECUTION_KEYS, "execution")
+        _require_account(execution, expected_account)
+        execution_id = execution["execution_id"]
+        if not isinstance(execution_id, str):
+            raise BrokerEvidenceError("diagnostic broker execution ID is invalid")
+        executions.append(
+            BrokerExecution(
+                execution_id=execution_id,
+                order_id=_optional_identifier(execution["broker_order_id"], "execution order ID"),
+                contract=_contract(execution["contract"]),
+                side=execution["side"],
+                quantity=_decimal(execution["quantity"], "execution quantity"),
+                price=_decimal(execution["price"], "execution price"),
+                executed_at=_timestamp(execution["executed_at"], "execution timestamp"),
+                permanent_id=_optional_identifier(
+                    execution["permanent_id"], "execution permanent ID"
+                ),
+                client_id=execution["client_id"],
+                execution_exchange=execution["execution_exchange"],
+                average_price=_optional_decimal(
+                    execution["average_price"], "execution average price"
+                ),
+                commission=_optional_decimal(execution["commission"], "execution commission"),
+                commission_currency=execution["commission_currency"],
+                realized_pnl=_optional_decimal(execution["realized_pnl"], "execution realized PnL"),
+                unavailable=_unavailable(execution["unavailable"]),
+            )
+        )
+
+    execution_scope = _record(record["execution_scope"], _EXECUTION_SCOPE_KEYS, "execution scope")
+    if execution_scope["kind"] != "bounded_execution_filter":
+        raise BrokerEvidenceError("diagnostic broker execution scope is unsupported")
+    scope_start = _timestamp(execution_scope["start_at"], "execution scope start")
+    scope_end = _timestamp(execution_scope["end_at"], "execution scope end")
+    broker_time_before = _timestamp(record["broker_time_before"], "broker time before")
+    broker_time_after = _timestamp(record["broker_time_after"], "broker time after")
+    retrieved_at = _timestamp(record["retrieved_at"], "retrieval timestamp")
+    expected_scope_start = broker_time_before.replace(microsecond=0) - timedelta(hours=24)
+    if scope_start != expected_scope_start:
+        raise BrokerEvidenceError(
+            "diagnostic broker execution scope does not match the wire filter"
+        )
+    if not broker_time_before <= scope_end <= broker_time_after:
+        raise BrokerEvidenceError("diagnostic broker execution scope is inconsistent")
+
+    snapshot = BrokerSnapshot(
+        schema_version=record["snapshot_schema_version"],
+        account_alias=mask_account_identifier(expected_account),
+        broker_time_before=broker_time_before,
+        broker_time_after=broker_time_after,
+        retrieved_at=retrieved_at,
+        execution_scope=BrokerExecutionScope(
+            kind=execution_scope["kind"],
+            start_at=scope_start,
+            end_at=scope_end,
+        ),
+        positions=tuple(positions),
+        open_orders=tuple(open_orders),
+        recent_executions=tuple(executions),
+        balances=MappingProxyType(balances),
+    )
+    return snapshot
+
+
+class IBKRDiagnosticSnapshotProvider:
+    """Expose only snapshot and cleanup capabilities to reconciliation."""
+
+    __slots__ = ("_transport", "_expected_account")
+
+    def __init__(
+        self,
+        transport: DiagnosticTransport,
+        *,
+        expected_account: str,
+    ) -> None:
+        self._transport = transport
+        self._expected_account = expected_account
+
+    async def get_broker_snapshot(
+        self, expected_account: str, *, max_age_seconds: float
+    ) -> BrokerSnapshot:
+        if expected_account != self._expected_account:
+            raise BrokerEvidenceError("diagnostic broker account identity does not match runtime")
+        payload = await self._transport.get_broker_snapshot(
+            expected_account,
+            max_age_seconds=max_age_seconds,
+        )
+        return snapshot_from_transport(payload, expected_account=expected_account)
+
+    async def close(self) -> None:
+        await _stop_transport_required(self._transport)
+
+
+async def _stop_transport_required(
+    transport: DiagnosticTransport,
+    *,
+    attempts: int = 2,
+) -> None:
+    """Require provider cleanup and retry one transient transport failure."""
+    last_error: Exception | None = None
+    for _ in range(attempts):
+        try:
+            await transport.stop()
+            return
+        except Exception as exc:
+            last_error = exc
+    raise BrokerEvidenceError("diagnostic broker transport cleanup failed") from last_error
+
+
+async def build_diagnostic_provider(
+    runtime: RuntimeSafetyContext,
+    *,
+    transport_factory=SubprocessIBKRClient,
+) -> IBKRDiagnosticSnapshotProvider:
+    """Start a dedicated paper/read-only transport or fail closed and reap it."""
+    connection = runtime.diagnostic_connection
+    expected_account = runtime.expected_account_for_provider
+    if not isinstance(expected_account, str) or not expected_account.strip():
+        raise BrokerEvidenceError("diagnostic broker expected account is unavailable")
+    transport = transport_factory()
+    try:
+        await transport.start()
+        connected = await transport.connect(
+            host=connection.host,
+            port=connection.port,
+            client_id=connection.client_id,
+            readonly=connection.readonly,
+            timeout=30.0,
+        )
+        if connected is not True:
+            raise BrokerEvidenceError("diagnostic broker connection was not established")
+    except Exception as exc:
+        try:
+            await _stop_transport_required(transport)
+        except Exception as cleanup_exc:
+            raise BrokerEvidenceError(
+                "diagnostic broker provider initialization cleanup failed"
+            ) from cleanup_exc
+        raise BrokerEvidenceError("diagnostic broker provider initialization failed") from exc
+    return IBKRDiagnosticSnapshotProvider(
+        transport,
+        expected_account=expected_account,
+    )
+
+
+async def diagnostic_provider_factory(
+    runtime: RuntimeSafetyContext,
+) -> IBKRDiagnosticSnapshotProvider:
+    """Production reconciliation provider factory."""
+    return await build_diagnostic_provider(runtime)

--- a/robo_trader/reconciliation/ibkr_adapter.py
+++ b/robo_trader/reconciliation/ibkr_adapter.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta
 from decimal import Decimal
 from types import MappingProxyType
-from typing import Any, Mapping, Protocol
+from typing import Any, Awaitable, Mapping, Protocol
 
 from robo_trader.clients.subprocess_ibkr_client import SubprocessIBKRClient
 
@@ -18,6 +19,7 @@ from .models import (
     BrokerPosition,
     BrokerSnapshot,
     ContractIdentity,
+    canonical_decimal,
 )
 
 _TOP_LEVEL_KEYS = frozenset(
@@ -152,7 +154,7 @@ def _decimal(value: object, label: str) -> Decimal:
         parsed = Decimal(value)
     except Exception as exc:
         raise BrokerEvidenceError(f"diagnostic broker {label} is invalid") from exc
-    if not parsed.is_finite() or str(parsed) != value:
+    if not parsed.is_finite() or canonical_decimal(parsed) != value:
         raise BrokerEvidenceError(f"diagnostic broker {label} is invalid")
     return parsed
 
@@ -376,6 +378,28 @@ async def _stop_transport_required(
     raise BrokerEvidenceError("diagnostic broker transport cleanup failed") from last_error
 
 
+async def await_cleanup_required(cleanup: Awaitable[None]) -> bool:
+    """Finish required cleanup despite caller cancellation.
+
+    Return whether cancellation arrived while cleanup was shielded so the
+    caller can re-raise it only after the transport is known to be reaped.
+    """
+
+    cleanup_task = asyncio.ensure_future(cleanup)
+    cancellation_received = False
+    while not cleanup_task.done():
+        try:
+            await asyncio.shield(cleanup_task)
+        except asyncio.CancelledError:
+            cancellation_received = True
+            continue
+    try:
+        cleanup_task.result()
+    except asyncio.CancelledError as exc:
+        raise BrokerEvidenceError("diagnostic broker cleanup was cancelled internally") from exc
+    return cancellation_received
+
+
 async def build_diagnostic_provider(
     runtime: RuntimeSafetyContext,
     *,
@@ -398,13 +422,19 @@ async def build_diagnostic_provider(
         )
         if connected is not True:
             raise BrokerEvidenceError("diagnostic broker connection was not established")
-    except Exception as exc:
+    except BaseException as exc:
         try:
-            await _stop_transport_required(transport)
+            cleanup_cancelled = await await_cleanup_required(_stop_transport_required(transport))
         except Exception as cleanup_exc:
             raise BrokerEvidenceError(
                 "diagnostic broker provider initialization cleanup failed"
             ) from cleanup_exc
+        if isinstance(exc, asyncio.CancelledError):
+            raise
+        if not isinstance(exc, Exception):
+            raise
+        if cleanup_cancelled:
+            raise asyncio.CancelledError
         raise BrokerEvidenceError("diagnostic broker provider initialization failed") from exc
     return IBKRDiagnosticSnapshotProvider(
         transport,

--- a/robo_trader/reconciliation/identity.py
+++ b/robo_trader/reconciliation/identity.py
@@ -208,16 +208,26 @@ def validate_runtime_safety(
     if getattr(contract, "account_alias", None) != expected_alias:
         raise RuntimeSafetyError("runtime account alias does not match the approved account")
 
-    raw_client_id = str(
-        resolved_env.get(
-            "IBKR_RECONCILIATION_CLIENT_ID",
-            resolved_env.get("IBKR_CLIENT_ID", "997"),
+    raw_client_id = str(resolved_env.get("IBKR_RECONCILIATION_CLIENT_ID", "")).strip()
+    if not raw_client_id:
+        raise RuntimeSafetyError(
+            "IBKR_RECONCILIATION_CLIENT_ID is required for the isolated diagnostic session"
         )
-    ).strip()
     try:
         client_id = int(raw_client_id)
     except ValueError as exc:
         raise RuntimeSafetyError("diagnostic broker client ID must be an integer") from exc
+    raw_trading_client_id = str(resolved_env.get("IBKR_CLIENT_ID", "")).strip()
+    try:
+        trading_client_id = int(raw_trading_client_id)
+    except ValueError as exc:
+        raise RuntimeSafetyError("trading broker client ID must be an integer") from exc
+    if not 1 <= trading_client_id <= 999:
+        raise RuntimeSafetyError("trading broker client ID must be between 1 and 999")
+    if client_id == trading_client_id:
+        raise RuntimeSafetyError(
+            "diagnostic broker client ID must be distinct from the trading client ID"
+        )
     diagnostic_connection = DiagnosticConnectionContract(
         host=str(getattr(contract, "ibkr_host", "127.0.0.1")),
         port=4002,

--- a/robo_trader/reconciliation/identity.py
+++ b/robo_trader/reconciliation/identity.py
@@ -1,0 +1,234 @@
+"""Runtime and IBC identity gates that run before any broker connection."""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import os
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterator, Mapping, Optional, Protocol
+
+from dotenv import dotenv_values
+
+from .errors import RuntimeSafetyError
+
+
+def mask_account_identifier(account: object) -> str:
+    normalized = str(account or "").strip()
+    if len(normalized) <= 4:
+        return "***"
+    return f"***{normalized[-4:]}"
+
+
+def resolve_environment(
+    project_root: Path, process_environ: Optional[Mapping[str, str]] = None
+) -> dict[str, str]:
+    """Read .env without mutating os.environ, then apply process overrides."""
+    values = dotenv_values(project_root / ".env")
+    if any(value is None for value in values.values()):
+        raise RuntimeSafetyError("runtime environment contains malformed entries")
+    resolved = {str(key): str(value) for key, value in values.items() if value is not None}
+    resolved.update(dict(os.environ if process_environ is None else process_environ))
+    return resolved
+
+
+@contextmanager
+def _isolated_application_logging() -> Iterator[None]:
+    """Prevent importing application config from creating or appending a log file."""
+    sentinel = object()
+    prior_log = os.environ.get("LOG_FILE", sentinel)
+    prior_console = os.environ.get("LOG_CONSOLE", sentinel)
+    os.environ["LOG_FILE"] = ""
+    os.environ["LOG_CONSOLE"] = "false"
+    try:
+        yield
+    finally:
+        if prior_log is sentinel:
+            os.environ.pop("LOG_FILE", None)
+        else:
+            os.environ["LOG_FILE"] = str(prior_log)
+        if prior_console is sentinel:
+            os.environ.pop("LOG_CONSOLE", None)
+        else:
+            os.environ["LOG_CONSOLE"] = str(prior_console)
+
+
+@dataclass(frozen=True)
+class RuntimeSafetyContext:
+    """Validated public runtime identity plus a repr-hidden expected account."""
+
+    project_root: Path
+    runtime_contract: "RuntimeContractView"
+    diagnostic_connection: "DiagnosticConnectionContract"
+    ibc_config_hash: str
+    _expected_account: str = field(repr=False)
+
+    @property
+    def account_alias(self) -> str:
+        return mask_account_identifier(self._expected_account)
+
+    @property
+    def expected_account_for_provider(self) -> str:
+        """Return the exact account only for the isolated provider integration."""
+        return self._expected_account
+
+    def verify_managed_accounts(self, accounts: object) -> None:
+        if not isinstance(accounts, (list, tuple)):
+            raise RuntimeSafetyError("broker managed-account evidence is malformed")
+        normalized = [str(value).strip() for value in accounts if str(value).strip()]
+        if len(normalized) != 1 or normalized[0] != self._expected_account:
+            raise RuntimeSafetyError(
+                "broker managed-account identity does not match the approved runtime"
+            )
+
+
+class RuntimeContractView(Protocol):
+    execution_mode: str
+    ibkr_host: str
+    ibkr_port: int
+    ibkr_readonly: bool
+    database_path: str
+    account_alias: Optional[str]
+
+    @property
+    def fingerprint(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def database_identity(self) -> str:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class DiagnosticConnectionContract:
+    """Non-overridable broker safety properties supplied to the adapter."""
+
+    host: str
+    port: int
+    readonly: bool
+    client_id: int
+
+    def __post_init__(self) -> None:
+        normalized_host = self.host.strip().casefold()
+        try:
+            literal_address = ipaddress.ip_address(normalized_host)
+        except ValueError:
+            literal_address = None
+        if normalized_host not in {"localhost", "localhost."} and not (
+            literal_address is not None and literal_address.is_loopback
+        ):
+            raise RuntimeSafetyError(
+                "diagnostic broker host must be a loopback address because "
+                "read-only proof comes from the local IBC configuration"
+            )
+        if self.port != 4002 or self.readonly is not True:
+            raise RuntimeSafetyError(
+                "diagnostic connection must use paper port 4002 and readonly mode"
+            )
+        if isinstance(self.client_id, bool) or not 1 <= self.client_id <= 999:
+            raise RuntimeSafetyError("diagnostic broker client ID must be between 1 and 999")
+
+
+def _read_stable_regular_file(path: Path) -> bytes:
+    if path.is_symlink() or not path.is_file():
+        raise RuntimeSafetyError("IBC safety configuration is missing or not a regular file")
+    before = path.stat()
+    try:
+        content = path.read_bytes()
+    except OSError as exc:
+        raise RuntimeSafetyError("IBC safety configuration cannot be read") from exc
+    after = path.stat()
+    if (
+        before.st_dev,
+        before.st_ino,
+        before.st_size,
+        before.st_mtime_ns,
+    ) != (
+        after.st_dev,
+        after.st_ino,
+        after.st_size,
+        after.st_mtime_ns,
+    ):
+        raise RuntimeSafetyError("IBC safety configuration changed while being validated")
+    return content
+
+
+def validate_ibc_safety_config(path: Path) -> str:
+    """Require exactly one active read-only and paper-mode assignment."""
+    content = _read_stable_regular_file(path)
+    try:
+        text = content.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise RuntimeSafetyError("IBC safety configuration is not valid UTF-8") from exc
+
+    assignments: dict[str, list[str]] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith(("#", ";")) or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        assignments.setdefault(key.strip().casefold(), []).append(value.strip().casefold())
+
+    for key, expected in (("readonlyapi", "yes"), ("tradingmode", "paper")):
+        values = assignments.get(key, [])
+        if values != [expected]:
+            raise RuntimeSafetyError(
+                "IBC safety configuration does not prove one read-only paper session"
+            )
+    return hashlib.sha256(content).hexdigest()
+
+
+def validate_runtime_safety(
+    project_root: Path, resolved_env: Mapping[str, str]
+) -> RuntimeSafetyContext:
+    """Validate the shared runtime contract and independent IBC safety proof."""
+    with _isolated_application_logging():
+        try:
+            from robo_trader.config import load_runtime_contract_from_env
+
+            contract = load_runtime_contract_from_env(resolved_env)
+        except Exception as exc:
+            raise RuntimeSafetyError("paper runtime contract validation failed") from exc
+
+    if (
+        getattr(contract, "execution_mode", None) != "paper"
+        or getattr(contract, "ibkr_port", None) != 4002
+        or getattr(contract, "ibkr_readonly", None) is not True
+    ):
+        raise RuntimeSafetyError(
+            "reconciliation requires the fixed IBKR paper/read-only runtime on port 4002"
+        )
+
+    expected_account = str(resolved_env.get("IBKR_ACCOUNT", "")).strip()
+    if not expected_account:
+        raise RuntimeSafetyError("approved paper account identity is unavailable")
+    expected_alias = mask_account_identifier(expected_account)
+    if getattr(contract, "account_alias", None) != expected_alias:
+        raise RuntimeSafetyError("runtime account alias does not match the approved account")
+
+    raw_client_id = str(
+        resolved_env.get(
+            "IBKR_RECONCILIATION_CLIENT_ID",
+            resolved_env.get("IBKR_CLIENT_ID", "997"),
+        )
+    ).strip()
+    try:
+        client_id = int(raw_client_id)
+    except ValueError as exc:
+        raise RuntimeSafetyError("diagnostic broker client ID must be an integer") from exc
+    diagnostic_connection = DiagnosticConnectionContract(
+        host=str(getattr(contract, "ibkr_host", "127.0.0.1")),
+        port=4002,
+        readonly=True,
+        client_id=client_id,
+    )
+    ibc_hash = validate_ibc_safety_config(project_root / "config" / "ibc" / "config.ini")
+    return RuntimeSafetyContext(
+        project_root=project_root,
+        runtime_contract=contract,
+        diagnostic_connection=diagnostic_connection,
+        ibc_config_hash=ibc_hash,
+        _expected_account=expected_account,
+    )

--- a/robo_trader/reconciliation/identity.py
+++ b/robo_trader/reconciliation/identity.py
@@ -222,8 +222,8 @@ def validate_runtime_safety(
         trading_client_id = int(raw_trading_client_id)
     except ValueError as exc:
         raise RuntimeSafetyError("trading broker client ID must be an integer") from exc
-    if not 1 <= trading_client_id <= 999:
-        raise RuntimeSafetyError("trading broker client ID must be between 1 and 999")
+    if not 0 <= trading_client_id <= 999:
+        raise RuntimeSafetyError("trading broker client ID must be between 0 and 999")
     if client_id == trading_client_id:
         raise RuntimeSafetyError(
             "diagnostic broker client ID must be distinct from the trading client ID"

--- a/robo_trader/reconciliation/integrity.py
+++ b/robo_trader/reconciliation/integrity.py
@@ -1,0 +1,137 @@
+"""Before/after evidence hashing for the non-mutating diagnostic."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Literal, Mapping
+
+from .errors import IntegrityViolation
+
+
+@dataclass(frozen=True)
+class FileFingerprint:
+    state: str
+    size: int
+    sha256: str
+
+
+def _fingerprint(path: Path) -> FileFingerprint:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return FileFingerprint("absent", 0, "")
+    except OSError as exc:
+        raise IntegrityViolation("protected evidence metadata cannot be read") from exc
+
+    if stat.S_ISLNK(metadata.st_mode):
+        try:
+            target = os.readlink(path)
+        except OSError as exc:
+            raise IntegrityViolation("protected evidence symlink cannot be read") from exc
+        return FileFingerprint(
+            "symlink",
+            metadata.st_size,
+            hashlib.sha256(target.encode("utf-8", errors="surrogateescape")).hexdigest(),
+        )
+    if not stat.S_ISREG(metadata.st_mode):
+        return FileFingerprint("other", metadata.st_size, "")
+
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        after = path.stat()
+    except OSError as exc:
+        raise IntegrityViolation("protected evidence file cannot be hashed") from exc
+    if (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+    ) != (
+        after.st_dev,
+        after.st_ino,
+        after.st_size,
+        after.st_mtime_ns,
+    ):
+        raise IntegrityViolation("protected evidence changed while being hashed")
+    return FileFingerprint("regular", metadata.st_size, digest.hexdigest())
+
+
+def protected_evidence_paths(
+    project_root: Path, resolved_env: Mapping[str, str]
+) -> tuple[Path, ...]:
+    db_value = str(resolved_env.get("RT_DB_PATH", "trading_data.db")).strip()
+    db_path = Path(db_value).expanduser()
+    if not db_path.is_absolute():
+        db_path = project_root / db_path
+
+    configured_log = str(resolved_env.get("LOG_FILE", "")).strip()
+    log_paths = [project_root / "robo_trader.log"]
+    if configured_log:
+        configured_path = Path(configured_log).expanduser()
+        if not configured_path.is_absolute():
+            configured_path = project_root / configured_path
+        log_paths.append(configured_path)
+
+    base_paths = [
+        db_path,
+        Path(f"{db_path}-wal"),
+        Path(f"{db_path}-shm"),
+        Path(f"{db_path}-journal"),
+        project_root / "data" / "kill_switch_state.json",
+        project_root / "data" / "kill_switch.lock",
+        project_root / "data" / "preflight_bypass.log",
+        project_root / "data" / ".preflight_last_ok",
+        project_root / ".env",
+        project_root / "config" / "ibc" / "config.ini",
+    ]
+    for log_path in log_paths:
+        base_paths.append(log_path)
+        base_paths.extend(Path(f"{log_path}.{index}") for index in range(1, 6))
+
+    unique: dict[str, Path] = {}
+    for path in base_paths:
+        # Do not resolve symlinks here.  The link itself is protected evidence:
+        # protecting only the current target would allow the configured path to
+        # be swapped during collection.  Protect both identities so target
+        # content changes remain detectable too.
+        absolute = Path(os.path.abspath(os.fspath(path)))
+        unique[str(absolute)] = absolute
+        resolved = absolute.resolve(strict=False)
+        unique[str(resolved)] = resolved
+    return tuple(unique[key] for key in sorted(unique))
+
+
+class EvidenceIntegrityGuard:
+    """Raise if any protected path changes, appears, or disappears."""
+
+    def __init__(self, paths: Iterable[Path]):
+        self.paths = tuple(paths)
+        self.before: dict[Path, FileFingerprint] = {}
+        self.after: dict[Path, FileFingerprint] = {}
+
+    def __enter__(self) -> "EvidenceIntegrityGuard":
+        self.before = {path: _fingerprint(path) for path in self.paths}
+        return self
+
+    def verify_unchanged(self) -> None:
+        self.after = {path: _fingerprint(path) for path in self.paths}
+        if self.after != self.before:
+            raise IntegrityViolation(
+                "protected database, safety, audit, or logging evidence changed"
+            )
+
+    def __exit__(self, exc_type, exc, traceback) -> Literal[False]:
+        try:
+            self.verify_unchanged()
+        except IntegrityViolation as integrity_error:
+            if exc is not None:
+                raise integrity_error from exc
+            raise
+        return False

--- a/robo_trader/reconciliation/ledger.py
+++ b/robo_trader/reconciliation/ledger.py
@@ -46,7 +46,10 @@ _REQUIRED_COLUMNS = {
 
 def validate_portfolio_ids(values: Iterable[str]) -> tuple[str, ...]:
     normalized = tuple(str(value).strip().lower() for value in values)
-    if not normalized or any(not _PORTFOLIO_ID.fullmatch(value) for value in normalized):
+    if not normalized or any(
+        not _PORTFOLIO_ID.fullmatch(value) or _ACCOUNT_FRAGMENT.search(value)
+        for value in normalized
+    ):
         raise LedgerSafetyError("one or more explicit portfolio IDs are invalid")
     if len(normalized) != len(set(normalized)):
         raise LedgerSafetyError("portfolio IDs must be unique")
@@ -194,7 +197,12 @@ class ImmutableLedgerReader:
                 ORDER BY portfolio_id
                 """).fetchall()
             known = tuple(str(row[0]) for row in known_rows)
-            if any(not _PORTFOLIO_ID.fullmatch(value) or value != value.lower() for value in known):
+            if any(
+                not _PORTFOLIO_ID.fullmatch(value)
+                or value != value.lower()
+                or _ACCOUNT_FRAGMENT.search(value)
+                for value in known
+            ):
                 raise LedgerSafetyError("ledger contains ambiguous portfolio identity")
             missing = sorted(set(selected) - set(known))
             if missing:

--- a/robo_trader/reconciliation/ledger.py
+++ b/robo_trader/reconciliation/ledger.py
@@ -68,19 +68,27 @@ def resolve_database_path(project_root: Path, database_path: str) -> Path:
         raise LedgerSafetyError("ledger database is missing") from exc
     if not resolved.is_file():
         raise LedgerSafetyError("ledger database is not a regular file")
+    # A regular SQLite -shm file is a fixed-size WAL index and may remain
+    # nonempty after a clean checkpoint. Only a nonempty WAL or rollback
+    # journal represents unapplied state; the outer integrity guard still
+    # rejects any sidecar that changes during collection.
     sidecars = (
-        ("WAL", Path(f"{resolved}-wal")),
-        ("shared-memory sidecar", Path(f"{resolved}-shm")),
-        ("rollback journal", Path(f"{resolved}-journal")),
+        ("WAL", Path(f"{resolved}-wal"), True),
+        ("shared-memory sidecar", Path(f"{resolved}-shm"), False),
+        ("rollback journal", Path(f"{resolved}-journal"), True),
     )
-    for label, sidecar in sidecars:
+    for label, sidecar, must_be_empty in sidecars:
         try:
             metadata = sidecar.lstat()
         except FileNotFoundError:
             continue
         except OSError as exc:
             raise LedgerSafetyError(f"ledger {label} cannot be inspected") from exc
-        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode) or metadata.st_size:
+        if (
+            stat.S_ISLNK(metadata.st_mode)
+            or not stat.S_ISREG(metadata.st_mode)
+            or (must_be_empty and metadata.st_size)
+        ):
             raise LedgerSafetyError(
                 f"ledger has an ambiguous {label}; immutable reconciliation would be incomplete"
             )

--- a/robo_trader/reconciliation/ledger.py
+++ b/robo_trader/reconciliation/ledger.py
@@ -1,0 +1,372 @@
+"""Immutable SQLite reader for portfolio-scoped reconciliation evidence."""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+import stat
+from collections import defaultdict
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Iterable, Optional
+from urllib.parse import quote
+
+from .errors import LedgerSafetyError
+from .models import (
+    AggregatedLedgerPosition,
+    LedgerPosition,
+    LedgerSnapshot,
+    LedgerTrade,
+)
+
+_PORTFOLIO_ID = re.compile(r"^[a-z0-9_-]{1,64}$")
+_SYMBOL = re.compile(r"^[A-Z]{1,5}(?:\.[A-Z]{1,2})?$")
+_ACCOUNT_FRAGMENT = re.compile(r"(?:DU|U)\d{4,}", re.IGNORECASE)
+_REQUIRED_COLUMNS = {
+    "positions": {
+        "portfolio_id": "TEXT",
+        "symbol": "TEXT",
+        "quantity": "INTEGER",
+        "avg_cost": "REAL",
+        "timestamp": "DATETIME",
+    },
+    "trades": {
+        "id": "INTEGER",
+        "portfolio_id": "TEXT",
+        "symbol": "TEXT",
+        "side": "TEXT",
+        "quantity": "INTEGER",
+        "price": "REAL",
+        "timestamp": "DATETIME",
+    },
+    "account": {"portfolio_id": "TEXT"},
+}
+
+
+def validate_portfolio_ids(values: Iterable[str]) -> tuple[str, ...]:
+    normalized = tuple(str(value).strip().lower() for value in values)
+    if not normalized or any(not _PORTFOLIO_ID.fullmatch(value) for value in normalized):
+        raise LedgerSafetyError("one or more explicit portfolio IDs are invalid")
+    if len(normalized) != len(set(normalized)):
+        raise LedgerSafetyError("portfolio IDs must be unique")
+    return tuple(sorted(normalized))
+
+
+def resolve_database_path(project_root: Path, database_path: str) -> Path:
+    path = Path(database_path).expanduser()
+    if not path.is_absolute():
+        path = project_root / path
+    if path.is_symlink():
+        raise LedgerSafetyError("ledger path must not be a symlink")
+    try:
+        resolved = path.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise LedgerSafetyError("ledger database is missing") from exc
+    if not resolved.is_file():
+        raise LedgerSafetyError("ledger database is not a regular file")
+    sidecars = (
+        ("WAL", Path(f"{resolved}-wal")),
+        ("shared-memory sidecar", Path(f"{resolved}-shm")),
+        ("rollback journal", Path(f"{resolved}-journal")),
+    )
+    for label, sidecar in sidecars:
+        try:
+            metadata = sidecar.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise LedgerSafetyError(f"ledger {label} cannot be inspected") from exc
+        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode) or metadata.st_size:
+            raise LedgerSafetyError(
+                f"ledger has an ambiguous {label}; immutable reconciliation would be incomplete"
+            )
+    return resolved
+
+
+def _authorizer(
+    action: int,
+    argument1: Optional[str],
+    argument2: Optional[str],
+    database: Optional[str],
+    source: Optional[str],
+) -> int:
+    del argument2, database, source
+    allowed = {
+        sqlite3.SQLITE_SELECT,
+        sqlite3.SQLITE_READ,
+        sqlite3.SQLITE_FUNCTION,
+        sqlite3.SQLITE_TRANSACTION,
+    }
+    if action in allowed:
+        return sqlite3.SQLITE_OK
+    if action == sqlite3.SQLITE_PRAGMA and str(argument1).casefold() == "table_info":
+        return sqlite3.SQLITE_OK
+    return sqlite3.SQLITE_DENY
+
+
+def _decimal(value: object, field: str, *, nonnegative: bool = False) -> Decimal:
+    if isinstance(value, bool):
+        raise LedgerSafetyError(f"ledger {field} is not a finite decimal")
+    try:
+        result = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise LedgerSafetyError(f"ledger {field} is not a finite decimal") from exc
+    if not result.is_finite() or (nonnegative and result < 0):
+        raise LedgerSafetyError(f"ledger {field} is not a valid finite decimal")
+    return result
+
+
+def _safe_ledger_text(value: object, field: str, *, max_length: int = 128) -> str:
+    text = str(value)
+    if (
+        not text
+        or len(text) > max_length
+        or any(ord(character) < 32 for character in text)
+        or _ACCOUNT_FRAGMENT.search(text)
+    ):
+        raise LedgerSafetyError(f"ledger {field} contains invalid or sensitive text")
+    return text
+
+
+def _parse_ledger_timestamp(value: object, field: str) -> datetime:
+    """Parse SQLite/ISO timestamps and normalize them to aware UTC values."""
+    text = _safe_ledger_text(value, field)
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise LedgerSafetyError(f"ledger {field} is malformed") from exc
+    # SQLite CURRENT_TIMESTAMP is UTC but omits an offset.
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    try:
+        return parsed.astimezone(timezone.utc)
+    except (OverflowError, ValueError) as exc:
+        raise LedgerSafetyError(f"ledger {field} is malformed") from exc
+
+
+class ImmutableLedgerReader:
+    """Read a stable ledger without invoking any application write path."""
+
+    def __init__(self, project_root: Path, database_path: str):
+        self.path = resolve_database_path(project_root, database_path)
+
+    def _connect(self) -> sqlite3.Connection:
+        encoded = quote(str(self.path), safe="/")
+        uri = f"file:{encoded}?mode=ro&immutable=1"
+        try:
+            connection = sqlite3.connect(uri, uri=True, timeout=1.0, isolation_level=None)
+            connection.row_factory = sqlite3.Row
+            connection.execute("PRAGMA query_only=ON")
+            if connection.execute("PRAGMA query_only").fetchone()[0] != 1:
+                raise LedgerSafetyError("SQLite query-only mode could not be proven")
+            connection.set_authorizer(_authorizer)
+            return connection
+        except sqlite3.Error as exc:
+            raise LedgerSafetyError("immutable ledger connection failed") from exc
+
+    @staticmethod
+    def _validate_schema(connection: sqlite3.Connection) -> None:
+        for table, required in _REQUIRED_COLUMNS.items():
+            try:
+                rows = connection.execute(f'PRAGMA table_info("{table}")').fetchall()
+            except sqlite3.Error as exc:
+                raise LedgerSafetyError("ledger schema cannot be inspected") from exc
+            if not rows:
+                raise LedgerSafetyError("ledger schema is missing required tables")
+            actual = {str(row["name"]): str(row["type"]).upper() for row in rows}
+            for column, expected_type in required.items():
+                if actual.get(column) != expected_type:
+                    raise LedgerSafetyError("ledger schema is not reconciliation-compatible")
+
+    def read(
+        self, portfolio_ids: Iterable[str], *, recent_trade_limit: int = 500
+    ) -> LedgerSnapshot:
+        selected = validate_portfolio_ids(portfolio_ids)
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN")
+            self._validate_schema(connection)
+            known_rows = connection.execute("""
+                SELECT portfolio_id FROM account
+                UNION SELECT portfolio_id FROM positions
+                UNION SELECT portfolio_id FROM trades
+                ORDER BY portfolio_id
+                """).fetchall()
+            known = tuple(str(row[0]) for row in known_rows)
+            if any(not _PORTFOLIO_ID.fullmatch(value) or value != value.lower() for value in known):
+                raise LedgerSafetyError("ledger contains ambiguous portfolio identity")
+            missing = sorted(set(selected) - set(known))
+            if missing:
+                raise LedgerSafetyError("one or more selected portfolios do not exist")
+
+            position_identity_rows = connection.execute("""
+                SELECT portfolio_id, symbol
+                FROM positions
+                ORDER BY portfolio_id, symbol
+                """).fetchall()
+            position_identities: set[tuple[str, str]] = set()
+            for row in position_identity_rows:
+                portfolio_id = str(row["portfolio_id"])
+                raw_symbol = str(row["symbol"]).strip()
+                symbol = raw_symbol.upper()
+                identity = (portfolio_id, symbol)
+                if (
+                    portfolio_id not in known
+                    or portfolio_id != portfolio_id.lower()
+                    or raw_symbol != symbol
+                    or not _SYMBOL.fullmatch(symbol)
+                ):
+                    raise LedgerSafetyError("ledger position identity is malformed")
+                if identity in position_identities:
+                    raise LedgerSafetyError(
+                        "ledger contains duplicate portfolio and symbol positions"
+                    )
+                position_identities.add(identity)
+
+            raw_positions = connection.execute("""
+                SELECT portfolio_id, symbol, quantity, avg_cost, timestamp,
+                       typeof(quantity) AS quantity_type
+                FROM positions
+                WHERE quantity != 0
+                ORDER BY portfolio_id, symbol
+                """).fetchall()
+            positions: list[LedgerPosition] = []
+            for row in raw_positions:
+                portfolio_id = str(row["portfolio_id"])
+                raw_symbol = str(row["symbol"]).strip()
+                symbol = raw_symbol.upper()
+                if (
+                    portfolio_id not in known
+                    or portfolio_id != portfolio_id.lower()
+                    or raw_symbol != symbol
+                    or not _SYMBOL.fullmatch(symbol)
+                ):
+                    raise LedgerSafetyError("ledger position identity is malformed")
+                if row["quantity_type"] != "integer":
+                    raise LedgerSafetyError(
+                        "ledger quantity is fractional despite the INTEGER position schema"
+                    )
+                quantity = _decimal(row["quantity"], "position quantity")
+                average_cost = _decimal(row["avg_cost"], "position average cost", nonnegative=True)
+                positions.append(
+                    LedgerPosition(
+                        portfolio_id=portfolio_id,
+                        symbol=symbol,
+                        quantity=quantity,
+                        average_cost=average_cost,
+                        timestamp=_parse_ledger_timestamp(row["timestamp"], "position timestamp"),
+                    )
+                )
+
+            active = tuple(sorted({position.portfolio_id for position in positions}))
+            blockers: list[str] = []
+            caveats = [
+                "LOCAL_LEDGER_HAS_NO_CONID_EXCHANGE_OR_CURRENCY",
+                "LOCAL_TRADES_HAVE_NO_BROKER_ORDER_OR_EXECUTION_IDS",
+                "BROKER_AND_LOCAL_PAPER_EXECUTOR_ARE_SEPARATE_EXECUTION_DOMAINS",
+            ]
+            unselected_active = sorted(set(active) - set(selected))
+            if unselected_active:
+                blockers.append("UNSELECTED_ACTIVE_PORTFOLIOS")
+            if len(active) > 1:
+                blockers.append("AMBIGUOUS_MULTI_PORTFOLIO_BROKER_ALLOCATION")
+
+            selected_positions = [
+                position for position in positions if position.portfolio_id in selected
+            ]
+            aggregates = self._aggregate(selected_positions, blockers, caveats)
+
+            placeholders = ",".join("?" for _ in selected)
+            trade_rows = connection.execute(
+                f"""
+                SELECT id, portfolio_id, symbol, side, quantity, price, timestamp,
+                       typeof(quantity) AS quantity_type
+                FROM trades
+                WHERE portfolio_id IN ({placeholders})
+                ORDER BY timestamp DESC, id DESC
+                LIMIT ?
+                """,
+                (*selected, recent_trade_limit),
+            ).fetchall()
+            trades = []
+            for row in trade_rows:
+                if row["quantity_type"] != "integer":
+                    raise LedgerSafetyError(
+                        "ledger trade quantity is fractional despite the INTEGER schema"
+                    )
+                raw_symbol = str(row["symbol"]).strip()
+                symbol = raw_symbol.upper()
+                side = str(row["side"]).strip().upper()
+                if raw_symbol != symbol or not _SYMBOL.fullmatch(symbol):
+                    raise LedgerSafetyError("ledger trade symbol is malformed")
+                if side not in {"BUY", "SELL", "BUY_TO_COVER", "SELL_SHORT"}:
+                    raise LedgerSafetyError("ledger trade side is malformed")
+                quantity = _decimal(row["quantity"], "trade quantity")
+                if quantity <= 0:
+                    raise LedgerSafetyError("ledger trade quantity must be positive")
+                trades.append(
+                    LedgerTrade(
+                        local_trade_id=int(row["id"]),
+                        portfolio_id=str(row["portfolio_id"]),
+                        symbol=symbol,
+                        side=side,
+                        quantity=quantity,
+                        price=_decimal(row["price"], "trade price", nonnegative=True),
+                        timestamp=_parse_ledger_timestamp(row["timestamp"], "trade timestamp"),
+                    )
+                )
+            connection.execute("ROLLBACK")
+            return LedgerSnapshot(
+                selected_portfolio_ids=selected,
+                known_portfolio_ids=known,
+                active_portfolio_ids=active,
+                positions=tuple(selected_positions),
+                aggregated_positions=aggregates,
+                recent_trades=tuple(trades),
+                blockers=tuple(sorted(set(blockers))),
+                caveats=tuple(sorted(set(caveats))),
+            )
+        except sqlite3.Error as exc:
+            raise LedgerSafetyError("ledger read failed closed") from exc
+        finally:
+            connection.close()
+
+    @staticmethod
+    def _aggregate(
+        positions: Iterable[LedgerPosition], blockers: list[str], caveats: list[str]
+    ) -> tuple[AggregatedLedgerPosition, ...]:
+        grouped: dict[str, list[LedgerPosition]] = defaultdict(list)
+        for position in positions:
+            grouped[position.symbol].append(position)
+
+        result = []
+        for symbol in sorted(grouped):
+            allocations = tuple(sorted(grouped[symbol], key=lambda item: item.portfolio_id))
+            signs = {1 if item.quantity > 0 else -1 for item in allocations}
+            offsetting = len(signs) > 1
+            total = sum((item.quantity for item in allocations), Decimal("0"))
+            average_cost: Optional[Decimal]
+            if offsetting:
+                blockers.append(f"OFFSETTING_PORTFOLIO_POSITIONS:{symbol}")
+                caveats.append(f"AGGREGATE_COST_UNDEFINED_FOR_OFFSETTING_POSITIONS:{symbol}")
+                average_cost = None
+                if total == 0:
+                    blockers.append(f"NET_ZERO_MASKS_PORTFOLIO_EXPOSURE:{symbol}")
+            else:
+                denominator = sum((abs(item.quantity) for item in allocations), Decimal("0"))
+                numerator = sum(
+                    (abs(item.quantity) * item.average_cost for item in allocations),
+                    Decimal("0"),
+                )
+                average_cost = numerator / denominator
+            result.append(
+                AggregatedLedgerPosition(
+                    symbol=symbol,
+                    quantity=total,
+                    average_cost=average_cost,
+                    allocations=allocations,
+                    has_offsetting_allocations=offsetting,
+                )
+            )
+        return tuple(result)

--- a/robo_trader/reconciliation/ledger.py
+++ b/robo_trader/reconciliation/ledger.py
@@ -286,15 +286,22 @@ class ImmutableLedgerReader:
             aggregates = self._aggregate(selected_positions, blockers, caveats)
 
             placeholders = ",".join("?" for _ in selected)
-            trade_rows = connection.execute(
-                f"""
+            # The only interpolated characters are one parameter marker per
+            # already-validated portfolio ID; every value remains SQL-bound.
+            trade_query = (
+                """
                 SELECT id, portfolio_id, symbol, side, quantity, price, timestamp,
                        typeof(quantity) AS quantity_type
                 FROM trades
-                WHERE portfolio_id IN ({placeholders})
+                WHERE portfolio_id IN ("""
+                + placeholders  # nosec B608
+                + """)
                 ORDER BY timestamp DESC, id DESC
                 LIMIT ?
-                """,
+                """
+            )
+            trade_rows = connection.execute(
+                trade_query,
                 (*selected, recent_trade_limit),
             ).fetchall()
             trades = []

--- a/robo_trader/reconciliation/models.py
+++ b/robo_trader/reconciliation/models.py
@@ -13,6 +13,7 @@ from .errors import BrokerEvidenceError
 
 _SYMBOL = re.compile(r"^[A-Z]{1,5}(?:\.[A-Z]{1,2})?$")
 _TEXT_ID = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+_PORTFOLIO_ID = re.compile(r"^[a-z0-9_-]{1,64}$")
 _ACCOUNT_SHAPED = re.compile(r"^(?:DU|U)\d+$", re.IGNORECASE)
 _ACCOUNT_FRAGMENT = re.compile(r"(?:DU|U)\d{4,}", re.IGNORECASE)
 
@@ -27,6 +28,29 @@ def _safe_text(value: object, field_name: str, *, max_length: int = 128) -> str:
     ):
         raise BrokerEvidenceError(f"{field_name} is invalid or contains sensitive identity")
     return text
+
+
+def _safe_portfolio_id(value: object, field_name: str) -> str:
+    text = str(value).strip()
+    if text != text.lower() or not _PORTFOLIO_ID.fullmatch(text) or _ACCOUNT_FRAGMENT.search(text):
+        raise BrokerEvidenceError(f"{field_name} is invalid or contains sensitive identity")
+    return text
+
+
+def _assert_public_safe(value: object, field_name: str) -> None:
+    """Reject account-shaped text before it can reach a public report."""
+    if isinstance(value, str):
+        if _ACCOUNT_FRAGMENT.search(value):
+            raise BrokerEvidenceError(f"{field_name} contains sensitive identity")
+        return
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            _assert_public_safe(str(key), field_name)
+            _assert_public_safe(nested, field_name)
+        return
+    if isinstance(value, (list, tuple)):
+        for nested in value:
+            _assert_public_safe(nested, field_name)
 
 
 def finite_decimal(value: Any, field_name: str) -> Decimal:
@@ -76,12 +100,14 @@ class ContractIdentity:
             raise BrokerEvidenceError(
                 "broker contract is not an explicitly qualified SMART/USD stock"
             )
-        if not _TEXT_ID.fullmatch(self.primary_exchange.strip()) or not _TEXT_ID.fullmatch(
-            self.trading_class.strip()
-        ):
+        primary_exchange = _safe_text(self.primary_exchange, "broker contract primary exchange")
+        trading_class = _safe_text(self.trading_class, "broker contract trading class")
+        if not _TEXT_ID.fullmatch(primary_exchange) or not _TEXT_ID.fullmatch(trading_class):
             raise BrokerEvidenceError("broker contract identity is incomplete")
         object.__setattr__(self, "symbol", symbol)
         object.__setattr__(self, "local_symbol", symbol)
+        object.__setattr__(self, "primary_exchange", primary_exchange)
+        object.__setattr__(self, "trading_class", trading_class)
 
     def public_dict(self) -> dict[str, object]:
         return {
@@ -205,10 +231,10 @@ class BrokerExecution:
     unavailable: Mapping[str, str] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        if not _TEXT_ID.fullmatch(self.execution_id.strip()) or _ACCOUNT_SHAPED.fullmatch(
-            self.execution_id.strip()
-        ):
+        execution_id = _safe_text(self.execution_id, "broker execution identity")
+        if not _TEXT_ID.fullmatch(execution_id) or _ACCOUNT_SHAPED.fullmatch(execution_id):
             raise BrokerEvidenceError("broker execution identity is incomplete")
+        object.__setattr__(self, "execution_id", execution_id)
         if self.order_id is not None and (not self.order_id.isdigit() or len(self.order_id) > 20):
             raise BrokerEvidenceError("broker execution order identity is invalid")
         quantity = finite_decimal(self.quantity, "broker execution quantity")
@@ -352,6 +378,15 @@ class LedgerPosition:
     def __post_init__(self) -> None:
         object.__setattr__(
             self,
+            "portfolio_id",
+            _safe_portfolio_id(self.portfolio_id, "ledger portfolio identity"),
+        )
+        symbol = self.symbol.strip().upper()
+        if self.symbol != symbol or not _SYMBOL.fullmatch(symbol):
+            raise BrokerEvidenceError("ledger position symbol identity is invalid")
+        object.__setattr__(self, "symbol", symbol)
+        object.__setattr__(
+            self,
             "timestamp",
             aware_datetime(self.timestamp, "ledger position timestamp"),
         )
@@ -379,6 +414,15 @@ class LedgerTrade:
     def __post_init__(self) -> None:
         object.__setattr__(
             self,
+            "portfolio_id",
+            _safe_portfolio_id(self.portfolio_id, "ledger portfolio identity"),
+        )
+        symbol = self.symbol.strip().upper()
+        if self.symbol != symbol or not _SYMBOL.fullmatch(symbol):
+            raise BrokerEvidenceError("ledger trade symbol identity is invalid")
+        object.__setattr__(self, "symbol", symbol)
+        object.__setattr__(
+            self,
             "timestamp",
             aware_datetime(self.timestamp, "ledger trade timestamp"),
         )
@@ -394,6 +438,20 @@ class LedgerSnapshot:
     recent_trades: tuple[LedgerTrade, ...]
     blockers: tuple[str, ...] = ()
     caveats: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "selected_portfolio_ids",
+            "known_portfolio_ids",
+            "active_portfolio_ids",
+        ):
+            values = tuple(
+                _safe_portfolio_id(value, f"ledger {field_name}")
+                for value in getattr(self, field_name)
+            )
+            object.__setattr__(self, field_name, values)
+        _assert_public_safe(self.blockers, "ledger blockers")
+        _assert_public_safe(self.caveats, "ledger caveats")
 
 
 @dataclass(frozen=True)
@@ -423,6 +481,17 @@ class NonComparableEvidence:
     details: Mapping[str, object] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
+        evidence_type = _safe_text(self.evidence_type, "evidence type")
+        broker_identifier = _safe_text(self.broker_identifier, "broker evidence identity")
+        symbol = self.symbol.strip().upper()
+        status = _safe_text(self.status, "evidence status")
+        reason = _safe_text(self.reason, "evidence reason")
+        if not _TEXT_ID.fullmatch(evidence_type) or not _TEXT_ID.fullmatch(broker_identifier):
+            raise BrokerEvidenceError("non-comparable evidence identity is invalid")
+        if self.symbol != symbol or not _SYMBOL.fullmatch(symbol):
+            raise BrokerEvidenceError("non-comparable evidence symbol is invalid")
+        _assert_public_safe(self.details, "non-comparable evidence details")
+
         def freeze(value: object) -> object:
             if isinstance(value, Mapping):
                 return MappingProxyType({str(key): freeze(nested) for key, nested in value.items()})
@@ -433,6 +502,11 @@ class NonComparableEvidence:
         frozen_details = freeze(self.details)
         if not isinstance(frozen_details, Mapping):
             raise BrokerEvidenceError("non-comparable evidence details are invalid")
+        object.__setattr__(self, "evidence_type", evidence_type)
+        object.__setattr__(self, "broker_identifier", broker_identifier)
+        object.__setattr__(self, "symbol", symbol)
+        object.__setattr__(self, "status", status)
+        object.__setattr__(self, "reason", reason)
         object.__setattr__(self, "details", frozen_details)
 
 
@@ -453,6 +527,39 @@ class ReconciliationReport:
     ledger_snapshot: LedgerSnapshot
     mutated_state: bool = False
     authorizes_startup: bool = False
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "generated_at",
+            aware_datetime(self.generated_at, "reconciliation report timestamp"),
+        )
+        runtime_fingerprint = _safe_text(
+            self.runtime_fingerprint, "runtime fingerprint", max_length=256
+        )
+        database_identity = _safe_text(self.database_identity, "database identity", max_length=256)
+        selected_portfolio_ids = tuple(
+            _safe_portfolio_id(value, "selected portfolio identity")
+            for value in self.selected_portfolio_ids
+        )
+        if self.status not in {
+            "BLOCKED",
+            "INCOMPLETE",
+            "MISMATCH",
+            "QUANTITY_COST_COMPARABLE_ONLY",
+        }:
+            raise BrokerEvidenceError("reconciliation report status is invalid")
+        if (
+            not self.account_alias.startswith("***")
+            or len(self.account_alias) > 7
+            or _ACCOUNT_FRAGMENT.search(self.account_alias)
+        ):
+            raise BrokerEvidenceError("reconciliation account alias is not masked")
+        _assert_public_safe(self.blockers, "reconciliation blockers")
+        _assert_public_safe(self.caveats, "reconciliation caveats")
+        object.__setattr__(self, "runtime_fingerprint", runtime_fingerprint)
+        object.__setattr__(self, "database_identity", database_identity)
+        object.__setattr__(self, "selected_portfolio_ids", selected_portfolio_ids)
 
     def public_dict(self) -> dict[str, object]:
         def position_dict(item: PositionComparison) -> dict[str, object]:

--- a/robo_trader/reconciliation/models.py
+++ b/robo_trader/reconciliation/models.py
@@ -1,0 +1,565 @@
+"""Immutable evidence models used by the reconciliation engine."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+from types import MappingProxyType
+from typing import Any, Mapping, Optional, Sequence
+
+from .errors import BrokerEvidenceError
+
+_SYMBOL = re.compile(r"^[A-Z]{1,5}(?:\.[A-Z]{1,2})?$")
+_TEXT_ID = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+_ACCOUNT_SHAPED = re.compile(r"^(?:DU|U)\d+$", re.IGNORECASE)
+_ACCOUNT_FRAGMENT = re.compile(r"(?:DU|U)\d{4,}", re.IGNORECASE)
+
+
+def _safe_text(value: object, field_name: str, *, max_length: int = 128) -> str:
+    text = str(value).strip()
+    if (
+        not text
+        or len(text) > max_length
+        or any(ord(character) < 32 for character in text)
+        or _ACCOUNT_FRAGMENT.search(text)
+    ):
+        raise BrokerEvidenceError(f"{field_name} is invalid or contains sensitive identity")
+    return text
+
+
+def finite_decimal(value: Any, field_name: str) -> Decimal:
+    """Parse a finite Decimal without accepting booleans or binary-float drift."""
+    if isinstance(value, bool):
+        raise BrokerEvidenceError(f"{field_name} must be a finite decimal")
+    try:
+        result = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise BrokerEvidenceError(f"{field_name} must be a finite decimal") from exc
+    if not result.is_finite():
+        raise BrokerEvidenceError(f"{field_name} must be a finite decimal")
+    return result
+
+
+def canonical_decimal(value: Decimal) -> str:
+    """Serialize a Decimal deterministically without exponent notation."""
+    if value == 0:
+        return "0"
+    return format(value.normalize(), "f")
+
+
+def aware_datetime(value: datetime, field_name: str) -> datetime:
+    if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+        raise BrokerEvidenceError(f"{field_name} must be timezone-aware")
+    return value
+
+
+@dataclass(frozen=True)
+class ContractIdentity:
+    con_id: int
+    symbol: str
+    local_symbol: str
+    security_type: str
+    currency: str
+    exchange: str
+    primary_exchange: str
+    trading_class: str
+
+    def __post_init__(self) -> None:
+        if isinstance(self.con_id, bool) or not isinstance(self.con_id, int) or self.con_id <= 0:
+            raise BrokerEvidenceError("broker contract has an invalid conId")
+        symbol = self.symbol.strip().upper()
+        if not _SYMBOL.fullmatch(symbol) or self.local_symbol.strip().upper() != symbol:
+            raise BrokerEvidenceError("broker contract symbol identity is ambiguous")
+        if self.security_type != "STK" or self.currency != "USD" or self.exchange != "SMART":
+            raise BrokerEvidenceError(
+                "broker contract is not an explicitly qualified SMART/USD stock"
+            )
+        if not _TEXT_ID.fullmatch(self.primary_exchange.strip()) or not _TEXT_ID.fullmatch(
+            self.trading_class.strip()
+        ):
+            raise BrokerEvidenceError("broker contract identity is incomplete")
+        object.__setattr__(self, "symbol", symbol)
+        object.__setattr__(self, "local_symbol", symbol)
+
+    def public_dict(self) -> dict[str, object]:
+        return {
+            "con_id": self.con_id,
+            "symbol": self.symbol,
+            "local_symbol": self.local_symbol,
+            "security_type": self.security_type,
+            "currency": self.currency,
+            "exchange": self.exchange,
+            "primary_exchange": self.primary_exchange,
+            "trading_class": self.trading_class,
+        }
+
+
+@dataclass(frozen=True)
+class BrokerPosition:
+    contract: ContractIdentity
+    quantity: Decimal
+    average_cost: Decimal
+
+    def __post_init__(self) -> None:
+        quantity = finite_decimal(self.quantity, "broker position quantity")
+        average_cost = finite_decimal(self.average_cost, "broker position average cost")
+        if quantity == 0:
+            raise BrokerEvidenceError("broker snapshot contains a zero position")
+        if average_cost < 0:
+            raise BrokerEvidenceError("broker position average cost cannot be negative")
+        object.__setattr__(self, "quantity", quantity)
+        object.__setattr__(self, "average_cost", average_cost)
+
+
+@dataclass(frozen=True)
+class BrokerOpenOrder:
+    order_id: str
+    client_id: int
+    contract: ContractIdentity
+    side: str
+    quantity: Decimal
+    filled: Decimal
+    remaining: Decimal
+    order_type: str
+    status: str
+    limit_price: Optional[Decimal] = None
+    auxiliary_price: Optional[Decimal] = None
+    permanent_id: Optional[str] = None
+    time_in_force: Optional[str] = None
+    average_fill_price: Optional[Decimal] = None
+    last_status_at: Optional[datetime] = None
+    unavailable: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.order_id.isdigit() or len(self.order_id) > 20:
+            raise BrokerEvidenceError("broker open order is missing an order ID")
+        side = self.side.strip().upper()
+        if side not in {"BUY", "SELL", "BOT", "SLD"}:
+            raise BrokerEvidenceError("broker open order has an invalid side")
+        quantity = finite_decimal(self.quantity, "broker order quantity")
+        filled = finite_decimal(self.filled, "broker order filled quantity")
+        remaining = finite_decimal(self.remaining, "broker order remaining quantity")
+        if quantity <= 0 or filled < 0 or remaining < 0 or filled + remaining != quantity:
+            raise BrokerEvidenceError("broker open order quantities are inconsistent")
+        for name in ("limit_price", "auxiliary_price", "average_fill_price"):
+            value = getattr(self, name)
+            if value is not None:
+                parsed = finite_decimal(value, f"broker order {name}")
+                if parsed < 0:
+                    raise BrokerEvidenceError(f"broker order {name} cannot be negative")
+                object.__setattr__(self, name, parsed)
+        if self.permanent_id is not None and (
+            not self.permanent_id.isdigit() or len(self.permanent_id) > 20
+        ):
+            raise BrokerEvidenceError("broker open order has an invalid permanent ID")
+        if (
+            isinstance(self.client_id, bool)
+            or not isinstance(self.client_id, int)
+            or self.client_id < 0
+        ):
+            raise BrokerEvidenceError("broker open order has an invalid client ID")
+        if self.last_status_at is not None:
+            object.__setattr__(
+                self,
+                "last_status_at",
+                aware_datetime(self.last_status_at, "broker order status timestamp"),
+            )
+        object.__setattr__(self, "side", side)
+        object.__setattr__(self, "order_type", _safe_text(self.order_type, "broker order type"))
+        object.__setattr__(self, "status", _safe_text(self.status, "broker order status"))
+        if self.time_in_force is not None:
+            object.__setattr__(
+                self,
+                "time_in_force",
+                _safe_text(self.time_in_force, "broker order time in force"),
+            )
+        object.__setattr__(self, "quantity", quantity)
+        object.__setattr__(self, "filled", filled)
+        object.__setattr__(self, "remaining", remaining)
+        object.__setattr__(self, "unavailable", MappingProxyType(dict(self.unavailable)))
+
+    @property
+    def identity(self) -> tuple[int, str]:
+        """IBKR order identity is unique only within its client ID."""
+        return (self.client_id, self.order_id)
+
+
+@dataclass(frozen=True)
+class BrokerExecution:
+    execution_id: str
+    order_id: Optional[str]
+    contract: ContractIdentity
+    side: str
+    quantity: Decimal
+    price: Decimal
+    executed_at: datetime
+    permanent_id: Optional[str] = None
+    client_id: Optional[int] = None
+    execution_exchange: Optional[str] = None
+    average_price: Optional[Decimal] = None
+    commission: Optional[Decimal] = None
+    commission_currency: Optional[str] = None
+    realized_pnl: Optional[Decimal] = None
+    unavailable: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not _TEXT_ID.fullmatch(self.execution_id.strip()) or _ACCOUNT_SHAPED.fullmatch(
+            self.execution_id.strip()
+        ):
+            raise BrokerEvidenceError("broker execution identity is incomplete")
+        if self.order_id is not None and (not self.order_id.isdigit() or len(self.order_id) > 20):
+            raise BrokerEvidenceError("broker execution order identity is invalid")
+        quantity = finite_decimal(self.quantity, "broker execution quantity")
+        price = finite_decimal(self.price, "broker execution price")
+        if quantity <= 0 or price < 0:
+            raise BrokerEvidenceError("broker execution quantity or price is invalid")
+        object.__setattr__(self, "quantity", quantity)
+        object.__setattr__(self, "price", price)
+        side = self.side.strip().upper()
+        if side not in {"BUY", "SELL", "BOT", "SLD"}:
+            raise BrokerEvidenceError("broker execution side is invalid")
+        object.__setattr__(self, "side", side)
+        object.__setattr__(
+            self, "executed_at", aware_datetime(self.executed_at, "broker execution timestamp")
+        )
+        for name in ("average_price", "commission", "realized_pnl"):
+            value = getattr(self, name)
+            if value is not None:
+                object.__setattr__(self, name, finite_decimal(value, f"broker execution {name}"))
+        if self.permanent_id is not None and (
+            not self.permanent_id.isdigit() or len(self.permanent_id) > 20
+        ):
+            raise BrokerEvidenceError("broker execution permanent identity is invalid")
+        if self.client_id is not None and (isinstance(self.client_id, bool) or self.client_id < 0):
+            raise BrokerEvidenceError("broker execution client identity is invalid")
+        if self.execution_exchange is not None:
+            object.__setattr__(
+                self,
+                "execution_exchange",
+                _safe_text(self.execution_exchange, "broker execution exchange"),
+            )
+        if self.commission_currency is not None:
+            object.__setattr__(
+                self,
+                "commission_currency",
+                _safe_text(self.commission_currency, "broker commission currency"),
+            )
+        object.__setattr__(self, "unavailable", MappingProxyType(dict(self.unavailable)))
+
+
+@dataclass(frozen=True)
+class BrokerExecutionScope:
+    """Exact bounded execution request represented by the broker snapshot."""
+
+    kind: str
+    start_at: datetime
+    end_at: datetime
+
+    def __post_init__(self) -> None:
+        if self.kind != "bounded_execution_filter":
+            raise BrokerEvidenceError("broker execution scope is unsupported")
+        object.__setattr__(
+            self,
+            "start_at",
+            aware_datetime(self.start_at, "broker execution scope start"),
+        )
+        object.__setattr__(
+            self,
+            "end_at",
+            aware_datetime(self.end_at, "broker execution scope end"),
+        )
+        if self.end_at <= self.start_at:
+            raise BrokerEvidenceError("broker execution scope is not a positive bounded window")
+        if self.start_at.microsecond != 0:
+            raise BrokerEvidenceError(
+                "broker execution scope start is not the exact whole-second wire filter"
+            )
+        duration_seconds = (self.end_at - self.start_at).total_seconds()
+        # The upper bound is the 60-second snapshot collection limit plus the
+        # sub-second amount discarded by IBKR's whole-second wire format.
+        if duration_seconds < 86400 or duration_seconds >= 86461:
+            raise BrokerEvidenceError("broker execution scope is not the exact bounded window")
+
+    def public_dict(self) -> dict[str, str]:
+        return {
+            "kind": self.kind,
+            "start_at": self.start_at.isoformat(),
+            "end_at": self.end_at.isoformat(),
+        }
+
+
+@dataclass(frozen=True)
+class BrokerSnapshot:
+    schema_version: int
+    account_alias: str
+    broker_time_before: datetime
+    broker_time_after: datetime
+    retrieved_at: datetime
+    execution_scope: BrokerExecutionScope
+    positions: tuple[BrokerPosition, ...] = ()
+    open_orders: tuple[BrokerOpenOrder, ...] = ()
+    recent_executions: tuple[BrokerExecution, ...] = ()
+    balances: Mapping[str, Decimal] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.schema_version != 1:
+            raise BrokerEvidenceError("unsupported broker snapshot schema")
+        if not self.account_alias.startswith("***") or len(self.account_alias) > 7:
+            raise BrokerEvidenceError("broker snapshot account alias is not masked")
+        for name in ("broker_time_before", "broker_time_after", "retrieved_at"):
+            object.__setattr__(self, name, aware_datetime(getattr(self, name), name))
+        object.__setattr__(self, "positions", tuple(self.positions))
+        object.__setattr__(self, "open_orders", tuple(self.open_orders))
+        object.__setattr__(self, "recent_executions", tuple(self.recent_executions))
+        if len({order.identity for order in self.open_orders}) != len(self.open_orders):
+            raise BrokerEvidenceError("broker snapshot has duplicate open-order identity")
+        if len({execution.execution_id for execution in self.recent_executions}) != len(
+            self.recent_executions
+        ):
+            raise BrokerEvidenceError("broker snapshot has duplicate execution identity")
+        if not isinstance(self.execution_scope, BrokerExecutionScope):
+            raise BrokerEvidenceError("broker execution scope evidence is missing")
+        if any(
+            execution.executed_at < self.execution_scope.start_at
+            or execution.executed_at > self.execution_scope.end_at
+            for execution in self.recent_executions
+        ):
+            raise BrokerEvidenceError(
+                "broker snapshot execution falls outside the exact requested scope"
+            )
+        normalized_balances = {
+            _safe_text(key, "broker balance identity"): finite_decimal(
+                value, "broker balance value"
+            )
+            for key, value in self.balances.items()
+        }
+        balance_tags = {key.split(":", 1)[0] for key in normalized_balances}
+        if not {"NetLiquidation", "TotalCashValue"}.issubset(balance_tags):
+            raise BrokerEvidenceError("broker snapshot is missing required account balances")
+        object.__setattr__(self, "balances", MappingProxyType(normalized_balances))
+
+
+@dataclass(frozen=True)
+class LedgerPosition:
+    portfolio_id: str
+    symbol: str
+    quantity: Decimal
+    average_cost: Decimal
+    timestamp: datetime
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "timestamp",
+            aware_datetime(self.timestamp, "ledger position timestamp"),
+        )
+
+
+@dataclass(frozen=True)
+class AggregatedLedgerPosition:
+    symbol: str
+    quantity: Decimal
+    average_cost: Optional[Decimal]
+    allocations: tuple[LedgerPosition, ...]
+    has_offsetting_allocations: bool = False
+
+
+@dataclass(frozen=True)
+class LedgerTrade:
+    local_trade_id: int
+    portfolio_id: str
+    symbol: str
+    side: str
+    quantity: Decimal
+    price: Decimal
+    timestamp: datetime
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "timestamp",
+            aware_datetime(self.timestamp, "ledger trade timestamp"),
+        )
+
+
+@dataclass(frozen=True)
+class LedgerSnapshot:
+    selected_portfolio_ids: tuple[str, ...]
+    known_portfolio_ids: tuple[str, ...]
+    active_portfolio_ids: tuple[str, ...]
+    positions: tuple[LedgerPosition, ...]
+    aggregated_positions: tuple[AggregatedLedgerPosition, ...]
+    recent_trades: tuple[LedgerTrade, ...]
+    blockers: tuple[str, ...] = ()
+    caveats: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class PositionComparison:
+    symbol: str
+    status: str
+    reasons: tuple[str, ...]
+    broker_contract: Optional[ContractIdentity]
+    broker_quantity: Optional[Decimal]
+    ledger_quantity: Optional[Decimal]
+    broker_average_cost: Optional[Decimal]
+    ledger_average_cost: Optional[Decimal]
+    allocations: tuple[LedgerPosition, ...]
+
+    @property
+    def is_quantity_cost_difference(self) -> bool:
+        return self.status not in {"quantity_cost_match"}
+
+
+@dataclass(frozen=True)
+class NonComparableEvidence:
+    evidence_type: str
+    broker_identifier: str
+    symbol: str
+    status: str
+    reason: str
+    details: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        def freeze(value: object) -> object:
+            if isinstance(value, Mapping):
+                return MappingProxyType({str(key): freeze(nested) for key, nested in value.items()})
+            if isinstance(value, (list, tuple)):
+                return tuple(freeze(nested) for nested in value)
+            return value
+
+        frozen_details = freeze(self.details)
+        if not isinstance(frozen_details, Mapping):
+            raise BrokerEvidenceError("non-comparable evidence details are invalid")
+        object.__setattr__(self, "details", frozen_details)
+
+
+@dataclass(frozen=True)
+class ReconciliationReport:
+    generated_at: datetime
+    runtime_fingerprint: str
+    database_identity: str
+    account_alias: str
+    selected_portfolio_ids: tuple[str, ...]
+    status: str
+    blockers: tuple[str, ...]
+    caveats: tuple[str, ...]
+    position_comparisons: tuple[PositionComparison, ...]
+    open_order_comparisons: tuple[NonComparableEvidence, ...]
+    execution_comparisons: tuple[NonComparableEvidence, ...]
+    broker_snapshot: BrokerSnapshot
+    ledger_snapshot: LedgerSnapshot
+    mutated_state: bool = False
+    authorizes_startup: bool = False
+
+    def public_dict(self) -> dict[str, object]:
+        def position_dict(item: PositionComparison) -> dict[str, object]:
+            return {
+                "symbol": item.symbol,
+                "status": item.status,
+                "reasons": list(item.reasons),
+                "broker_contract": (
+                    item.broker_contract.public_dict() if item.broker_contract else None
+                ),
+                "broker_quantity": (
+                    canonical_decimal(item.broker_quantity)
+                    if item.broker_quantity is not None
+                    else None
+                ),
+                "ledger_quantity": (
+                    canonical_decimal(item.ledger_quantity)
+                    if item.ledger_quantity is not None
+                    else None
+                ),
+                "broker_average_cost": (
+                    canonical_decimal(item.broker_average_cost)
+                    if item.broker_average_cost is not None
+                    else None
+                ),
+                "ledger_average_cost": (
+                    canonical_decimal(item.ledger_average_cost)
+                    if item.ledger_average_cost is not None
+                    else None
+                ),
+                "allocations": [
+                    {
+                        "portfolio_id": allocation.portfolio_id,
+                        "quantity": canonical_decimal(allocation.quantity),
+                        "average_cost": canonical_decimal(allocation.average_cost),
+                        "timestamp": allocation.timestamp.isoformat(),
+                    }
+                    for allocation in item.allocations
+                ],
+            }
+
+        def evidence_dict(item: NonComparableEvidence) -> dict[str, object]:
+            def public_value(value: object) -> object:
+                if isinstance(value, Mapping):
+                    return {
+                        str(key): public_value(nested)
+                        for key, nested in sorted(value.items(), key=lambda pair: str(pair[0]))
+                    }
+                if isinstance(value, tuple):
+                    return [public_value(nested) for nested in value]
+                return value
+
+            return {
+                "evidence_type": item.evidence_type,
+                "broker_identifier": item.broker_identifier,
+                "symbol": item.symbol,
+                "status": item.status,
+                "reason": item.reason,
+                "details": public_value(item.details),
+            }
+
+        return {
+            "schema_version": 1,
+            "generated_at": self.generated_at.isoformat(),
+            "runtime_fingerprint": self.runtime_fingerprint,
+            "database_identity": self.database_identity,
+            "account_alias": self.account_alias,
+            "selected_portfolio_ids": list(self.selected_portfolio_ids),
+            "status": self.status,
+            "mutated_state": self.mutated_state,
+            "authorizes_startup": self.authorizes_startup,
+            "blockers": list(self.blockers),
+            "caveats": list(self.caveats),
+            "broker_freshness": {
+                "broker_time_before": self.broker_snapshot.broker_time_before.isoformat(),
+                "broker_time_after": self.broker_snapshot.broker_time_after.isoformat(),
+                "retrieved_at": self.broker_snapshot.retrieved_at.isoformat(),
+                "execution_scope": self.broker_snapshot.execution_scope.public_dict(),
+            },
+            "broker_balances": {
+                key: canonical_decimal(value)
+                for key, value in sorted(self.broker_snapshot.balances.items())
+            },
+            "ledger_scope": {
+                "known_portfolio_ids": list(self.ledger_snapshot.known_portfolio_ids),
+                "active_portfolio_ids": list(self.ledger_snapshot.active_portfolio_ids),
+            },
+            "positions": [position_dict(item) for item in self.position_comparisons],
+            "open_orders": [evidence_dict(item) for item in self.open_order_comparisons],
+            "recent_executions": [evidence_dict(item) for item in self.execution_comparisons],
+            "local_recent_trades": [
+                {
+                    "local_trade_id": trade.local_trade_id,
+                    "portfolio_id": trade.portfolio_id,
+                    "symbol": trade.symbol,
+                    "side": trade.side,
+                    "quantity": canonical_decimal(trade.quantity),
+                    "price": canonical_decimal(trade.price),
+                    "timestamp": trade.timestamp.isoformat(),
+                    "broker_execution_id": None,
+                    "broker_order_id": None,
+                }
+                for trade in self.ledger_snapshot.recent_trades
+            ],
+        }
+
+
+def as_tuple(values: Sequence[Any]) -> tuple[Any, ...]:
+    """Small typed helper for adapters constructing immutable snapshots."""
+    return tuple(values)

--- a/robo_trader/utils/ibkr_safe.py
+++ b/robo_trader/utils/ibkr_safe.py
@@ -42,7 +42,12 @@ def _call_original_disconnect(ib: Any) -> None:
             disconnect_callable()
 
 
-def safe_disconnect(ib: Optional[Any], *, context: str = "") -> bool:
+def safe_disconnect(
+    ib: Optional[Any],
+    *,
+    context: str = "",
+    log_exception_details: bool = True,
+) -> bool:
     """
     Attempt to disconnect from IBKR without crashing the Gateway.
 
@@ -66,7 +71,10 @@ def safe_disconnect(ib: Optional[Any], *, context: str = "") -> bool:
                 logger.debug("safe_disconnect: connection already closed")
                 return False
         except Exception:  # noqa: BLE001
-            logger.debug("safe_disconnect: unable to confirm connection state", exc_info=True)
+            logger.debug(
+                "safe_disconnect: unable to confirm connection state",
+                exc_info=log_exception_details,
+            )
 
     if not _force_disconnect_enabled():
         location = context or "safe_disconnect"
@@ -82,7 +90,10 @@ def safe_disconnect(ib: Optional[Any], *, context: str = "") -> bool:
         logger.info("Forced ib.disconnect() executed in %s", context or "safe_disconnect")
         return True
     except Exception:  # noqa: BLE001
-        logger.warning("ib.disconnect() raised an exception", exc_info=True)
+        logger.warning(
+            "ib.disconnect() raised an exception",
+            exc_info=log_exception_details,
+        )
         return False
 
 

--- a/scripts/reconcile_broker_ledger.py
+++ b/scripts/reconcile_broker_ledger.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Read-only broker/ledger evidence command."""
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:

--- a/scripts/reconcile_broker_ledger.py
+++ b/scripts/reconcile_broker_ledger.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Read-only broker/ledger evidence command."""
+
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from robo_trader.reconciliation.cli import main  # noqa: E402
+
+if __name__ == "__main__":
+    raise SystemExit(main(project_root=PROJECT_ROOT))

--- a/tests/preflight/test_equity_history_freshness_check.py
+++ b/tests/preflight/test_equity_history_freshness_check.py
@@ -274,7 +274,11 @@ class TestStaleRow:
         assert result.status is CheckStatus.BLOCK
         assert result.details["trading_days_elapsed"] == 5
         assert "trading days old" in result.message
-        assert "reconcile_positions.py" in result.remediation
+        assert "scripts/reconcile_broker_ledger.py" in result.remediation
+        assert "--portfolio-id <portfolio_id>" in result.remediation
+        assert "reconcile_positions.py" not in result.remediation
+        assert "--force" not in result.remediation
+        assert "authorize startup" in result.remediation
 
 
 class TestMultiPortfolio:
@@ -317,6 +321,8 @@ class TestSqliteError:
         assert result.status is CheckStatus.BLOCK
         assert "sqlite read error" in result.message
         assert "database is locked" in result.details["error"]
+        assert "--force" not in result.remediation
+        assert "does not authorize startup" in result.remediation
 
 
 class TestMalformedTimestamp:
@@ -331,6 +337,8 @@ class TestMalformedTimestamp:
         result = EquityHistoryFreshnessCheck().run(preflight_context)
         assert result.status is CheckStatus.BLOCK
         assert "could not parse" in result.message
+        assert "--force" not in result.remediation
+        assert "does not authorize startup" in result.remediation
 
 
 class TestCheckMetadata:

--- a/tests/security/test_ibkr_safety.py
+++ b/tests/security/test_ibkr_safety.py
@@ -191,6 +191,81 @@ async def test_subprocess_client_ignores_external_venv(monkeypatch, tmp_path):
     )
 
 
+@pytest.mark.asyncio
+async def test_subprocess_worker_launch_isolated_from_cwd_pythonpath_and_secrets(
+    monkeypatch,
+    tmp_path,
+):
+    """The child executes one verified project script with no parent secrets."""
+    pytest.importorskip("pytest_asyncio")
+
+    from robo_trader.clients import subprocess_ibkr_client as mod
+
+    evil_cwd = tmp_path / "attacker"
+    evil_package = evil_cwd / "robo_trader" / "clients"
+    evil_package.mkdir(parents=True)
+    (evil_cwd / "robo_trader" / "__init__.py").write_text("", encoding="utf-8")
+    (evil_cwd / "robo_trader" / "clients" / "__init__.py").write_text("", encoding="utf-8")
+    (evil_package / "ibkr_subprocess_worker.py").write_text(
+        "raise RuntimeError('hijacked')\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(evil_cwd)
+    monkeypatch.setenv("PYTHONPATH", str(evil_cwd))
+    monkeypatch.setenv("DASHBOARD_PASSWORD_HASH", "dashboard-secret")
+    monkeypatch.setenv("IBKR_PASSWORD", "broker-secret")
+    monkeypatch.setenv("MODEL_SIGNING_KEY", "model-secret")
+    monkeypatch.setenv("DATABASE_URL", "database-secret")
+
+    captured = {}
+
+    def capture_popen(args, *popen_args, **kwargs):
+        captured.update(args=args, popen_args=popen_args, kwargs=kwargs)
+        raise RuntimeError("captured isolated worker launch")
+
+    monkeypatch.setattr(mod.subprocess, "Popen", capture_popen)
+    monkeypatch.setattr(
+        mod,
+        "_INTERPRETER_PREFIX_ALLOWLIST",
+        mod._INTERPRETER_PREFIX_ALLOWLIST + (Path(sys.executable).resolve().parent,),
+    )
+
+    client = mod.SubprocessIBKRClient()
+    with pytest.raises(RuntimeError, match="captured isolated worker launch"):
+        await client.start()
+
+    args = captured["args"]
+    kwargs = captured["kwargs"]
+    project_root = mod._find_project_root(Path(mod.__file__)).resolve()
+    worker_script = (
+        project_root / "robo_trader" / "clients" / "ibkr_subprocess_worker.py"
+    ).resolve()
+
+    assert args[1:4] == ["-I", "-c", mod._WORKER_BOOTSTRAP]
+    assert args[4:] == [str(project_root), str(worker_script)]
+    assert kwargs["cwd"] == str(project_root)
+    assert str(evil_cwd) not in args
+
+    child_env = kwargs["env"]
+    assert "PYTHONPATH" not in child_env
+    assert "VIRTUAL_ENV" not in child_env
+    assert "DASHBOARD_PASSWORD_HASH" not in child_env
+    assert "IBKR_PASSWORD" not in child_env
+    assert "MODEL_SIGNING_KEY" not in child_env
+    assert "DATABASE_URL" not in child_env
+    assert set(child_env) <= (
+        mod._WORKER_ENV_ALLOWLIST
+        | {
+            "PYTHONIOENCODING",
+            "PYTHONSAFEPATH",
+            "PYTHONUNBUFFERED",
+            "ROBOTRADER_WORKER_GENERATION_ID",
+        }
+    )
+    assert child_env["PYTHONSAFEPATH"] == "1"
+    assert child_env["ROBOTRADER_WORKER_GENERATION_ID"]
+
+
 def test_subprocess_client_source_has_relative_to_check():
     """Belt-and-suspenders: the source must contain the relative_to() guard
     that anchors VIRTUAL_ENV to the project root (audit IB-M1)."""

--- a/tests/security/test_ibkr_safety.py
+++ b/tests/security/test_ibkr_safety.py
@@ -266,6 +266,94 @@ async def test_subprocess_worker_launch_isolated_from_cwd_pythonpath_and_secrets
     assert child_env["ROBOTRADER_WORKER_GENERATION_ID"]
 
 
+@pytest.mark.asyncio
+async def test_zombie_check_uses_absolute_lsof_with_secret_free_environment(
+    monkeypatch,
+):
+    from robo_trader.clients import subprocess_ibkr_client as mod
+
+    trusted_lsof = Path("/usr/sbin/lsof")
+    monkeypatch.setattr(mod, "_trusted_lsof_executable", lambda: trusted_lsof)
+    monkeypatch.setenv("PATH", "/attacker-controlled")
+    monkeypatch.setenv("IBKR_PASSWORD", "broker-secret")
+    monkeypatch.setenv("DASHBOARD_PASSWORD_HASH", "dashboard-secret")
+    monkeypatch.setenv("MODEL_SIGNING_KEY", "model-secret")
+
+    captured = {}
+
+    def fake_run(args, **kwargs):
+        captured.update(args=args, kwargs=kwargs)
+        return subprocess.CompletedProcess(args, 1, stdout="", stderr="")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    client = mod.SubprocessIBKRClient()
+    assert await client._check_zombie_connections(4002) == (0, "No zombies detected")
+
+    assert captured["args"][0] == str(trusted_lsof)
+    assert Path(captured["args"][0]).is_absolute()
+    assert captured["kwargs"]["cwd"] == "/"
+    assert captured["kwargs"]["close_fds"] is True
+    child_env = captured["kwargs"]["env"]
+    assert set(child_env) <= mod._WORKER_ENV_ALLOWLIST
+    assert "PATH" not in child_env
+    assert "IBKR_PASSWORD" not in child_env
+    assert "DASHBOARD_PASSWORD_HASH" not in child_env
+    assert "MODEL_SIGNING_KEY" not in child_env
+
+
+@pytest.mark.asyncio
+async def test_zombie_check_never_falls_back_to_path_lookup(monkeypatch, tmp_path):
+    from robo_trader.clients import subprocess_ibkr_client as mod
+
+    attacker_lsof = tmp_path / "lsof"
+    attacker_lsof.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    attacker_lsof.chmod(0o755)
+    monkeypatch.setenv("PATH", str(tmp_path))
+    monkeypatch.setattr(
+        mod,
+        "_LSOF_EXECUTABLE_CANDIDATES",
+        (tmp_path / "missing-approved-lsof",),
+    )
+
+    def unexpected_run(*args, **kwargs):
+        raise AssertionError("PATH-resolved lsof must never execute")
+
+    monkeypatch.setattr(mod.subprocess, "run", unexpected_run)
+
+    client = mod.SubprocessIBKRClient()
+    with pytest.raises(mod.IBKRError, match="Trusted absolute lsof executable is unavailable"):
+        await client._check_zombie_connections(4002)
+
+
+@pytest.mark.asyncio
+async def test_zombie_check_fails_closed_without_exposing_lsof_stderr(monkeypatch):
+    from robo_trader.clients import subprocess_ibkr_client as mod
+
+    raw_secret = "DU1234567 broker-secret"
+    monkeypatch.setattr(
+        mod,
+        "_trusted_lsof_executable",
+        lambda: Path("/usr/sbin/lsof"),
+    )
+    monkeypatch.setattr(
+        mod.subprocess,
+        "run",
+        lambda args, **kwargs: subprocess.CompletedProcess(
+            args,
+            1,
+            stdout="",
+            stderr=raw_secret,
+        ),
+    )
+
+    client = mod.SubprocessIBKRClient()
+    with pytest.raises(mod.IBKRError, match="Trusted lsof zombie check failed") as exc_info:
+        await client._check_zombie_connections(4002)
+
+    assert raw_secret not in str(exc_info.value)
+
+
 def test_subprocess_client_source_has_relative_to_check():
     """Belt-and-suspenders: the source must contain the relative_to() guard
     that anchors VIRTUAL_ENV to the project root (audit IB-M1)."""

--- a/tests/test_broker_snapshot_protocol.py
+++ b/tests/test_broker_snapshot_protocol.py
@@ -770,7 +770,6 @@ def test_worker_exit_cleanup_stderr_redacts_disconnect_exception(monkeypatch, ca
     "kwargs",
     [
         {"port": 4001, "client_id": 7, "readonly": True},
-        {"port": 4002, "client_id": 0, "readonly": True},
         {"port": 4002, "client_id": True, "readonly": True},
         {"port": 4002, "client_id": 7, "readonly": 1},
     ],

--- a/tests/test_broker_snapshot_protocol.py
+++ b/tests/test_broker_snapshot_protocol.py
@@ -1,0 +1,871 @@
+import copy
+import threading
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from robo_trader.clients import ibkr_subprocess_worker as worker
+from robo_trader.clients import subprocess_ibkr_client as client_module
+from robo_trader.clients.subprocess_ibkr_client import (
+    BrokerSnapshotAccountMismatchError,
+    IBKRTransportPoisonedError,
+    SubprocessCrashError,
+    SubprocessIBKRClient,
+    _WorkerGeneration,
+)
+
+ACCOUNT = "DU_TEST_ACCOUNT"
+NOW = datetime.now(timezone.utc)
+
+
+def _contract(symbol="AAPL", con_id=265598):
+    return SimpleNamespace(
+        conId=con_id,
+        symbol=symbol,
+        localSymbol=symbol,
+        secType="STK",
+        currency="USD",
+        exchange="SMART",
+        primaryExchange="NASDAQ",
+        tradingClass="NMS",
+    )
+
+
+class _FakeIB:
+    def __init__(self):
+        self.calls = []
+        self.connected = True
+        self.account_reads = 0
+        self.contract = _contract()
+        self.execution_filters = []
+
+    def isConnected(self):
+        self.calls.append("isConnected")
+        return self.connected
+
+    def managedAccounts(self):
+        self.calls.append("managedAccounts")
+        self.account_reads += 1
+        return [ACCOUNT]
+
+    async def reqCurrentTimeAsync(self):
+        self.calls.append("reqCurrentTimeAsync")
+        return NOW + timedelta(seconds=len(self.calls))
+
+    async def reqPositionsAsync(self):
+        self.calls.append("reqPositionsAsync")
+        return [
+            SimpleNamespace(
+                account=ACCOUNT,
+                contract=self.contract,
+                position="10.5000",
+                avgCost="123.4500",
+            )
+        ]
+
+    async def reqAllOpenOrdersAsync(self):
+        self.calls.append("reqAllOpenOrdersAsync")
+        order = SimpleNamespace(
+            account=ACCOUNT,
+            orderId=101,
+            permId=501,
+            clientId=0,
+            action="BUY",
+            orderType="LMT",
+            tif="DAY",
+            totalQuantity="2",
+            lmtPrice="120.25",
+            auxPrice="1.7976931348623157e+308",
+        )
+        status = SimpleNamespace(
+            status="Submitted",
+            filled="0",
+            remaining="2",
+            avgFillPrice="0",
+        )
+        return [
+            SimpleNamespace(
+                order=order,
+                orderStatus=status,
+                contract=self.contract,
+                log=[SimpleNamespace(time=NOW)],
+            )
+        ]
+
+    async def reqExecutionsAsync(self, execution_filter):
+        self.calls.append("reqExecutionsAsync")
+        self.execution_filters.append(execution_filter)
+        assert execution_filter.acctCode == ACCOUNT
+        assert execution_filter.time.endswith(" UTC")
+        execution = SimpleNamespace(
+            execId="0001.01",
+            orderId=101,
+            permId=501,
+            clientId=0,
+            acctNumber=ACCOUNT,
+            side="BOT",
+            shares="1.25",
+            price="120.25",
+            avgPrice="120.25",
+            time=NOW,
+            exchange="NASDAQ",
+        )
+        return [
+            SimpleNamespace(
+                execution=execution,
+                contract=self.contract,
+                commissionReport=None,
+                time=NOW,
+            )
+        ]
+
+    async def reqAccountSummaryAsync(self):
+        self.calls.append("reqAccountSummaryAsync")
+
+    def accountValues(self, account):
+        self.calls.append("accountValues")
+        assert account == ACCOUNT
+        return [
+            SimpleNamespace(
+                account=ACCOUNT,
+                tag="NetLiquidation",
+                currency="USD",
+                value="100000.00",
+            ),
+            SimpleNamespace(
+                account=ACCOUNT,
+                tag="TotalCashValue",
+                currency="USD",
+                value="25000.500",
+            ),
+            SimpleNamespace(
+                account=ACCOUNT,
+                tag="BuyingPower",
+                currency="USD",
+                value="999999",
+            ),
+        ]
+
+    async def qualifyContractsAsync(self, contract):
+        self.calls.append("qualifyContractsAsync")
+        return [contract]
+
+
+@pytest.fixture
+def fake_ib(monkeypatch):
+    fake = _FakeIB()
+    monkeypatch.setattr(worker, "ib", fake)
+    monkeypatch.setattr(
+        worker,
+        "worker_connection_identity",
+        ("127.0.0.1", 4002, 7, True),
+    )
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_worker_snapshot_is_fresh_atomic_read_only_and_precise(fake_ib):
+    result = await worker.handle_get_broker_snapshot({"expected_account": ACCOUNT})
+
+    assert result["status"] == "success"
+    data = result["data"]
+    assert data["snapshot_schema_version"] == 1
+    assert data["account"] == ACCOUNT
+    assert data["positions"][0]["quantity"] == "10.5"
+    assert data["positions"][0]["avg_cost"] == "123.45"
+    assert {item["tag"] for item in data["balances"]} == {
+        "NetLiquidation",
+        "TotalCashValue",
+    }
+    assert data["open_orders"][0]["stop_price"] is None
+    assert "stop_price" in data["open_orders"][0]["unavailable"]
+    assert data["executions"][0]["commission"] is None
+    assert set(data["executions"][0]["unavailable"]) == {
+        "commission",
+        "commission_currency",
+        "realized_pnl",
+    }
+    assert data["execution_scope"]["kind"] == "bounded_execution_filter"
+    broker_before = datetime.fromisoformat(data["broker_time_before"])
+    broker_after = datetime.fromisoformat(data["broker_time_after"])
+    scope_start = datetime.fromisoformat(data["execution_scope"]["start_at"])
+    scope_end = datetime.fromisoformat(data["execution_scope"]["end_at"])
+    assert scope_start == broker_before.replace(microsecond=0) - timedelta(hours=24)
+    assert fake_ib.execution_filters[0].time == scope_start.strftime("%Y%m%d %H:%M:%S UTC")
+    assert broker_before <= scope_end <= broker_after
+    assert scope_end != datetime.fromisoformat(data["retrieved_at"])
+
+    allowed = {
+        "isConnected",
+        "managedAccounts",
+        "reqCurrentTimeAsync",
+        "reqPositionsAsync",
+        "reqAllOpenOrdersAsync",
+        "reqExecutionsAsync",
+        "reqAccountSummaryAsync",
+        "accountValues",
+        "qualifyContractsAsync",
+    }
+    assert set(fake_ib.calls) <= allowed
+    assert "reqPositionsAsync" in fake_ib.calls
+    assert "reqAllOpenOrdersAsync" in fake_ib.calls
+    assert "reqExecutionsAsync" in fake_ib.calls
+    execution_request_index = fake_ib.calls.index("reqExecutionsAsync")
+    assert fake_ib.calls[execution_request_index + 1] == "reqCurrentTimeAsync"
+    assert not any(
+        token in call.lower()
+        for call in fake_ib.calls
+        for token in ("placeorder", "cancelorder", "exercise", "replaceorder")
+    )
+
+
+@pytest.mark.asyncio
+async def test_worker_snapshot_rechecks_account_and_suppresses_sensitive_errors(
+    fake_ib, monkeypatch
+):
+    def changing_accounts():
+        fake_ib.calls.append("managedAccounts")
+        fake_ib.account_reads += 1
+        return [ACCOUNT] if fake_ib.account_reads == 1 else ["DU_WRONG_ACCOUNT"]
+
+    monkeypatch.setattr(fake_ib, "managedAccounts", changing_accounts)
+    result = await worker.handle_get_broker_snapshot({"expected_account": ACCOUNT})
+
+    assert result == {
+        "status": "error",
+        "error": "Broker snapshot collection failed",
+        "error_type": "ValueError",
+    }
+    assert ACCOUNT not in result["error"]
+    assert "DU_WRONG_ACCOUNT" not in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_worker_wrong_expected_account_performs_zero_data_reads(fake_ib):
+    result = await worker.handle_get_broker_snapshot({"expected_account": "DU_WRONG_ACCOUNT"})
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "ValueError"
+    assert not any(
+        call.startswith("req") or call in {"accountValues", "qualifyContractsAsync"}
+        for call in fake_ib.calls
+    )
+
+
+@pytest.mark.asyncio
+async def test_worker_snapshot_requires_exact_persisted_diagnostic_identity(fake_ib, monkeypatch):
+    monkeypatch.setattr(
+        worker,
+        "worker_connection_identity",
+        ("127.0.0.1", 4001, 7, True),
+    )
+
+    result = await worker.handle_get_broker_snapshot({"expected_account": ACCOUNT})
+
+    assert result["status"] == "error"
+    assert not any(call.startswith("req") for call in fake_ib.calls)
+
+
+@pytest.mark.asyncio
+async def test_worker_rejects_mid_collection_position_mutation(fake_ib, monkeypatch):
+    original = fake_ib.reqPositionsAsync
+    reads = 0
+
+    async def changing_positions():
+        nonlocal reads
+        reads += 1
+        positions = await original()
+        if reads == 2:
+            positions[0].position = "11"
+        return positions
+
+    monkeypatch.setattr(fake_ib, "reqPositionsAsync", changing_positions)
+    result = await worker.handle_get_broker_snapshot({"expected_account": ACCOUNT})
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "ValueError"
+    assert reads == 2
+
+
+def _mutate_avg_fill_price(trade, read_number):
+    trade.orderStatus.filled = "1"
+    trade.orderStatus.remaining = "1"
+    trade.orderStatus.avgFillPrice = "120" if read_number == 1 else "121"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda trade, read: (setattr(trade.order, "lmtPrice", "121.25") if read == 2 else None),
+        lambda trade, read: (setattr(trade.order, "action", "SELL") if read == 2 else None),
+        lambda trade, read: (setattr(trade.order, "orderType", "MKT") if read == 2 else None),
+        lambda trade, read: setattr(trade.order, "tif", "GTC") if read == 2 else None,
+        lambda trade, read: (setattr(trade.order, "permId", 999) if read == 2 else None),
+        lambda trade, read: (setattr(trade.order, "auxPrice", "119") if read == 2 else None),
+        _mutate_avg_fill_price,
+        lambda trade, read: (
+            setattr(trade.log[-1], "time", NOW + timedelta(seconds=1)) if read == 2 else None
+        ),
+        lambda trade, read: (setattr(trade.contract, "conId", 999999) if read == 2 else None),
+        lambda trade, read: (
+            setattr(trade.orderStatus, "status", "PreSubmitted") if read == 2 else None
+        ),
+    ],
+    ids=[
+        "limit-price",
+        "side",
+        "order-type",
+        "time-in-force",
+        "permanent-id",
+        "stop-price",
+        "average-fill-price",
+        "status-timestamp",
+        "contract-identity",
+        "status",
+    ],
+)
+async def test_worker_rejects_any_emitted_order_state_mutation(fake_ib, monkeypatch, mutate):
+    original = fake_ib.reqAllOpenOrdersAsync
+    reads = 0
+
+    async def changing_orders():
+        nonlocal reads
+        reads += 1
+        trades = await original()
+        mutate(trades[0], reads)
+        return trades
+
+    monkeypatch.setattr(fake_ib, "reqAllOpenOrdersAsync", changing_orders)
+
+    result = await worker.handle_get_broker_snapshot({"expected_account": ACCOUNT})
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "ValueError"
+    assert reads == 2
+
+
+@pytest.mark.asyncio
+async def test_worker_rejects_cross_account_execution(fake_ib, monkeypatch):
+    original = fake_ib.reqExecutionsAsync
+
+    async def wrong_execution(execution_filter):
+        fills = await original(execution_filter)
+        fills[0].execution.acctNumber = "DU_WRONG_ACCOUNT"
+        return fills
+
+    monkeypatch.setattr(fake_ib, "reqExecutionsAsync", wrong_execution)
+    result = await worker.handle_get_broker_snapshot({"expected_account": ACCOUNT})
+    assert result["status"] == "error"
+    assert result["error_type"] == "ValueError"
+    assert "DU_WRONG_ACCOUNT" not in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_worker_emits_available_commission_evidence_canonically(fake_ib, monkeypatch):
+    original = fake_ib.reqExecutionsAsync
+
+    async def with_commission(execution_filter):
+        fills = await original(execution_filter)
+        fills[0].commissionReport = SimpleNamespace(
+            commission="1.2300",
+            currency="USD",
+            realizedPNL="-2.500",
+        )
+        return fills
+
+    monkeypatch.setattr(fake_ib, "reqExecutionsAsync", with_commission)
+    result = await worker.handle_get_broker_snapshot({"expected_account": ACCOUNT})
+
+    execution = result["data"]["executions"][0]
+    assert execution["commission"] == "1.23"
+    assert execution["commission_currency"] == "USD"
+    assert execution["realized_pnl"] == "-2.5"
+    assert execution["unavailable"] == {}
+
+
+@pytest.mark.asyncio
+async def test_worker_sorts_open_orders_by_client_then_order_id(fake_ib, monkeypatch):
+    original = fake_ib.reqAllOpenOrdersAsync
+
+    async def multiple_orders():
+        first = (await original())[0]
+        first.order.clientId = 2
+        first.order.orderId = 1
+        second = copy.deepcopy(first)
+        second.order.clientId = 1
+        second.order.orderId = 100
+        second.order.permId = 600
+        return [first, second]
+
+    monkeypatch.setattr(fake_ib, "reqAllOpenOrdersAsync", multiple_orders)
+    result = await worker.handle_get_broker_snapshot({"expected_account": ACCOUNT})
+
+    assert [
+        (item["client_id"], item["broker_order_id"]) for item in result["data"]["open_orders"]
+    ] == [(1, 100), (2, 1)]
+
+
+@pytest.mark.asyncio
+async def test_worker_command_routes_atomic_snapshot(fake_ib):
+    response = await worker.handle_command(
+        {
+            "command": "get_broker_snapshot",
+            "params": {"expected_account": ACCOUNT},
+        }
+    )
+    assert response["status"] == "success"
+    assert response["data"]["account"] == ACCOUNT
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"port": 4001, "readonly": True, "client_id": 7},
+        {"port": 4002, "readonly": 1, "client_id": 7},
+        {"port": 4002, "readonly": True, "client_id": 0},
+        {"port": 4002, "readonly": True, "client_id": True},
+    ],
+)
+async def test_worker_diagnostic_connect_rejects_before_ib_client_creation(monkeypatch, params):
+    factory = Mock()
+    monkeypatch.setattr(worker, "ib", None)
+    monkeypatch.setattr(worker, "IB", factory)
+
+    result = await worker.handle_connect(params)
+
+    assert result["status"] == "error"
+    factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_worker_connect_stderr_masks_managed_account(monkeypatch, capsys):
+    class ConnectIB:
+        def __init__(self):
+            self.client = SimpleNamespace(serverVersion=lambda: 180)
+
+        async def connectAsync(self, **kwargs):
+            return None
+
+        def isConnected(self):
+            return True
+
+        def managedAccounts(self):
+            return [ACCOUNT]
+
+    monkeypatch.setattr(worker, "ib", None)
+    monkeypatch.setattr(worker, "worker_connection_identity", None)
+    monkeypatch.setattr(worker, "gateway_api_down", False)
+    monkeypatch.setattr(worker, "IB", ConnectIB)
+    monkeypatch.setattr(worker.asyncio, "sleep", AsyncMock())
+
+    response = await worker.handle_connect(
+        {
+            "host": "127.0.0.1",
+            "port": 4002,
+            "client_id": 7,
+            "readonly": True,
+            "timeout": 1.0,
+        }
+    )
+
+    assert response["status"] == "success"
+    assert ACCOUNT not in capsys.readouterr().err
+
+
+async def _worker_payload(fake_ib):
+    result = await worker.handle_get_broker_snapshot({"expected_account": ACCOUNT})
+    assert result["status"] == "success"
+    return result["data"]
+
+
+def _connected_client(monkeypatch, payload):
+    client = SubprocessIBKRClient()
+    generation = _WorkerGeneration(
+        generation_id="snapshot-generation",
+        process=SimpleNamespace(poll=lambda: 0),
+    )
+    client._generation = generation
+    with client._connection_state_lock:
+        client._connected = True
+        client._connection_identity = ("127.0.0.1", 4002, 7, True)
+        client._connection_generation_id = generation.generation_id
+    execute = AsyncMock(return_value=payload)
+    monkeypatch.setattr(client, "_execute_command_unlocked", execute)
+    return client, execute
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"port": 4001, "client_id": 7, "readonly": True},
+        {"port": 4002, "client_id": 0, "readonly": True},
+        {"port": 4002, "client_id": True, "readonly": True},
+        {"port": 4002, "client_id": 7, "readonly": 1},
+    ],
+)
+async def test_client_diagnostic_connect_rejects_before_transport(monkeypatch, kwargs):
+    client = SubprocessIBKRClient()
+    zombie_check = AsyncMock()
+    monkeypatch.setattr(client, "_check_zombie_connections", zombie_check)
+
+    with pytest.raises(ValueError, match="Diagnostic client"):
+        await client.connect(**kwargs)
+
+    zombie_check.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_client_connect_logs_never_expose_managed_account(monkeypatch, caplog):
+    client = SubprocessIBKRClient()
+    process = SimpleNamespace(poll=lambda: None)
+    generation = SimpleNamespace(
+        generation_id="log-generation",
+        process=process,
+        state_lock=threading.Lock(),
+        poisoned_reason=None,
+    )
+    client.process = process
+    client._generation = generation
+    monkeypatch.setattr(client, "_check_zombie_connections", AsyncMock(return_value=(0, "none")))
+    monkeypatch.setattr(
+        client,
+        "_execute_command_unlocked",
+        AsyncMock(
+            return_value={
+                "connected": True,
+                "accounts": [ACCOUNT],
+                "server_version": 180,
+            }
+        ),
+    )
+
+    assert await client.connect(port=4002, client_id=7, readonly=True)
+    assert ACCOUNT not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_client_accepts_strict_snapshot(fake_ib, monkeypatch):
+    payload = await _worker_payload(fake_ib)
+    client, execute = _connected_client(monkeypatch, payload)
+
+    snapshot = await client.get_broker_snapshot(ACCOUNT, max_age_seconds=60)
+
+    assert snapshot == payload
+    execute.assert_awaited_once_with(
+        {
+            "command": "get_broker_snapshot",
+            "params": {"expected_account": ACCOUNT},
+        },
+        timeout=30.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_client_snapshot_removes_diagnostic_worker_log(fake_ib, monkeypatch, tmp_path):
+    payload = await _worker_payload(fake_ib)
+    client, _ = _connected_client(monkeypatch, payload)
+    generation = client._generation
+    debug_path = tmp_path / "worker_debug_snapshot.log"
+    debug_path.write_text("diagnostic evidence")
+    debug_file = debug_path.open("a")
+    generation.debug_log_file = debug_file
+    generation.debug_log_path = str(debug_path)
+    client._debug_log_file = debug_file
+    client._debug_log_path = str(debug_path)
+
+    snapshot = await client.get_broker_snapshot(ACCOUNT, max_age_seconds=60)
+
+    assert snapshot == payload
+    assert debug_file.closed
+    assert not debug_path.exists()
+    assert generation.debug_log_file is None
+    assert generation.debug_log_path is None
+    assert client._debug_log_file is None
+    assert client._debug_log_path is None
+
+
+@pytest.mark.asyncio
+async def test_client_failed_snapshot_also_removes_diagnostic_worker_log(
+    fake_ib, monkeypatch, tmp_path
+):
+    payload = await _worker_payload(fake_ib)
+    client, execute = _connected_client(monkeypatch, payload)
+    generation = client._generation
+    debug_path = tmp_path / "worker_debug_failed_snapshot.log"
+    debug_path.write_text("diagnostic evidence")
+    debug_file = debug_path.open("a")
+    generation.debug_log_file = debug_file
+    generation.debug_log_path = str(debug_path)
+    client._debug_log_file = debug_file
+    client._debug_log_path = str(debug_path)
+    execute.side_effect = IBKRTransportPoisonedError("simulated response failure")
+
+    with pytest.raises(IBKRTransportPoisonedError, match="simulated response failure"):
+        await client.get_broker_snapshot(ACCOUNT, max_age_seconds=60)
+
+    assert debug_file.closed
+    assert not debug_path.exists()
+    assert generation.debug_log_file is None
+    assert generation.debug_log_path is None
+    assert client._debug_log_file is None
+    assert client._debug_log_path is None
+
+
+class _CloseFailsOnce:
+    def __init__(self, wrapped):
+        self.wrapped = wrapped
+        self.close_attempts = 0
+
+    @property
+    def closed(self):
+        return self.wrapped.closed
+
+    def close(self):
+        self.close_attempts += 1
+        if self.close_attempts == 1:
+            raise OSError("transient close failure")
+        self.wrapped.close()
+
+
+@pytest.mark.asyncio
+async def test_client_debug_log_close_failure_retains_handle_and_retries(
+    fake_ib, monkeypatch, tmp_path
+):
+    payload = await _worker_payload(fake_ib)
+    client, _ = _connected_client(monkeypatch, payload)
+    generation = client._generation
+    debug_path = tmp_path / "worker_debug_close_retry.log"
+    debug_path.write_text("diagnostic evidence")
+    debug_file = _CloseFailsOnce(debug_path.open("a"))
+    generation.debug_log_file = debug_file
+    generation.debug_log_path = str(debug_path)
+    client._debug_log_file = debug_file
+    client._debug_log_path = str(debug_path)
+
+    with pytest.raises(SubprocessCrashError, match="debug log cleanup"):
+        await client.get_broker_snapshot(ACCOUNT, max_age_seconds=60)
+
+    assert debug_file.close_attempts == 1
+    assert not debug_file.closed
+    assert not debug_path.exists()
+    assert generation.debug_log_file is debug_file
+    assert client._debug_log_file is debug_file
+    assert generation.debug_log_path is None
+    assert client._debug_log_path is None
+
+    client._cleanup_worker_debug_log(generation, required=True)
+
+    assert debug_file.close_attempts == 2
+    assert debug_file.closed
+    assert generation.debug_log_file is None
+    assert client._debug_log_file is None
+
+
+@pytest.mark.asyncio
+async def test_client_debug_log_unlink_failure_retains_path_and_retries(
+    fake_ib, monkeypatch, tmp_path
+):
+    payload = await _worker_payload(fake_ib)
+    client, _ = _connected_client(monkeypatch, payload)
+    generation = client._generation
+    debug_path = tmp_path / "worker_debug_unlink_retry.log"
+    debug_path.write_text("diagnostic evidence")
+    debug_file = debug_path.open("a")
+    generation.debug_log_file = debug_file
+    generation.debug_log_path = str(debug_path)
+    client._debug_log_file = debug_file
+    client._debug_log_path = str(debug_path)
+    real_unlink = client_module.os.unlink
+    unlink_attempts = 0
+
+    def unlink_fails_once(path):
+        nonlocal unlink_attempts
+        unlink_attempts += 1
+        if unlink_attempts == 1:
+            raise OSError("transient unlink failure")
+        real_unlink(path)
+
+    monkeypatch.setattr(client_module.os, "unlink", unlink_fails_once)
+
+    with pytest.raises(SubprocessCrashError, match="debug log cleanup"):
+        await client.get_broker_snapshot(ACCOUNT, max_age_seconds=60)
+
+    assert unlink_attempts == 1
+    assert debug_file.closed
+    assert debug_path.exists()
+    assert generation.debug_log_file is None
+    assert client._debug_log_file is None
+    assert generation.debug_log_path == str(debug_path)
+    assert client._debug_log_path == str(debug_path)
+
+    client._cleanup_worker_debug_log(generation, required=True)
+
+    assert unlink_attempts == 2
+    assert not debug_path.exists()
+    assert generation.debug_log_path is None
+    assert client._debug_log_path is None
+
+
+@pytest.mark.asyncio
+async def test_client_wrong_account_exception_is_masked(fake_ib, monkeypatch):
+    payload = await _worker_payload(fake_ib)
+    client, _ = _connected_client(monkeypatch, payload)
+    monkeypatch.setattr(client, "_poison_generation", Mock())
+
+    with pytest.raises(BrokerSnapshotAccountMismatchError) as exc_info:
+        await client.get_broker_snapshot("DU_EXPECTED_SECRET", max_age_seconds=60)
+
+    message = str(exc_info.value)
+    assert "DU_EXPECTED_SECRET" not in message
+    assert ACCOUNT not in message
+    assert "***CRET" in message
+    assert "***OUNT" in message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("max_age", [float("nan"), float("inf"), 301, 0, True])
+async def test_client_rejects_unbounded_freshness_before_transport(fake_ib, monkeypatch, max_age):
+    payload = await _worker_payload(fake_ib)
+    client, execute = _connected_client(monkeypatch, payload)
+
+    with pytest.raises(ValueError, match="finite and at most"):
+        await client.get_broker_snapshot(ACCOUNT, max_age_seconds=max_age)
+
+    execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_client_generation_swap_during_snapshot_fails_closed(fake_ib, monkeypatch):
+    payload = await _worker_payload(fake_ib)
+    client, execute = _connected_client(monkeypatch, payload)
+    original_generation = client._generation
+    replacement = SimpleNamespace(generation_id="replacement")
+
+    async def swap_generation(*args, **kwargs):
+        client._generation = replacement
+        return payload
+
+    execute.side_effect = swap_generation
+    poison = Mock()
+    monkeypatch.setattr(client, "_poison_generation", poison)
+
+    with pytest.raises(IBKRTransportPoisonedError, match="generation changed"):
+        await client.get_broker_snapshot(ACCOUNT, max_age_seconds=60)
+
+    poison.assert_called_once_with(
+        original_generation, "worker generation changed during broker snapshot"
+    )
+
+
+@pytest.mark.asyncio
+async def test_client_poison_before_snapshot_validation_never_validates(fake_ib, monkeypatch):
+    payload = await _worker_payload(fake_ib)
+    client, execute = _connected_client(monkeypatch, payload)
+    generation = client._generation
+
+    async def poison_after_response(*args, **kwargs):
+        client._poison_generation(generation, "post-response protocol poison")
+        return payload
+
+    execute.side_effect = poison_after_response
+    validate = Mock(wraps=client._validate_broker_snapshot)
+    monkeypatch.setattr(client, "_validate_broker_snapshot", validate)
+
+    with pytest.raises(IBKRTransportPoisonedError, match="generation is poisoned"):
+        await client.get_broker_snapshot(ACCOUNT, max_age_seconds=60)
+
+    validate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_client_poison_after_snapshot_validation_never_returns_data(fake_ib, monkeypatch):
+    payload = await _worker_payload(fake_ib)
+    client, _ = _connected_client(monkeypatch, payload)
+    generation = client._generation
+    original_validate = client._validate_broker_snapshot
+
+    def validate_then_poison(*args, **kwargs):
+        validated = original_validate(*args, **kwargs)
+        client._poison_generation(generation, "post-validation protocol poison")
+        return validated
+
+    monkeypatch.setattr(client, "_validate_broker_snapshot", validate_then_poison)
+
+    with pytest.raises(IBKRTransportPoisonedError, match="generation is poisoned"):
+        await client.get_broker_snapshot(ACCOUNT, max_age_seconds=60)
+
+    assert generation.poisoned_reason == "post-validation protocol poison"
+    assert client.is_connected is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda data: data.update(snapshot_schema_version=2),
+        lambda data: data["positions"][0].update(quantity="10.50"),
+        lambda data: data["positions"][0]["contract"].update(con_id=True),
+        lambda data: data["positions"][0]["contract"].update(local_symbol="AAPL ALIAS"),
+        lambda data: data["positions"].append(copy.deepcopy(data["positions"][0])),
+        lambda data: data.update(retrieved_at=(NOW - timedelta(minutes=5)).isoformat()),
+        lambda data: data.update(
+            broker_time_after=(
+                datetime.fromisoformat(data["broker_time_before"]) + timedelta(minutes=2)
+            ).isoformat()
+        ),
+        lambda data: data.update(
+            broker_time_before=(NOW - timedelta(minutes=10)).isoformat(),
+            broker_time_after=(NOW - timedelta(minutes=9)).isoformat(),
+        ),
+        lambda data: data["open_orders"][0]["unavailable"].pop("stop_price"),
+        lambda data: data["executions"][0]["unavailable"].pop("commission"),
+        lambda data: data["executions"][0].update(executed_at="2026-01-01T00:00:00"),
+        lambda data: data["executions"][0].update(
+            executed_at=(
+                datetime.fromisoformat(data["execution_scope"]["end_at"]) + timedelta(seconds=1)
+            ).isoformat()
+        ),
+        lambda data: data["execution_scope"].update(
+            start_at=(
+                datetime.fromisoformat(data["execution_scope"]["start_at"]) + timedelta(seconds=1)
+            ).isoformat()
+        ),
+        lambda data: data["execution_scope"].update(
+            end_at=(
+                datetime.fromisoformat(data["broker_time_after"]) + timedelta(microseconds=1)
+            ).isoformat()
+        ),
+        lambda data: data["open_orders"][0].update(filled_quantity="1"),
+        lambda data: data["balances"].append(copy.deepcopy(data["balances"][0])),
+        lambda data: data.pop("execution_scope"),
+    ],
+)
+async def test_client_poison_fails_closed_on_malformed_snapshot(fake_ib, monkeypatch, mutation):
+    payload = await _worker_payload(fake_ib)
+    mutation(payload)
+    client, _ = _connected_client(monkeypatch, payload)
+    poison = Mock()
+    monkeypatch.setattr(client, "_poison_generation", poison)
+
+    with pytest.raises(IBKRTransportPoisonedError):
+        await client.get_broker_snapshot(ACCOUNT, max_age_seconds=60)
+
+    poison.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_client_requires_explicit_unavailable_commission_reason(fake_ib, monkeypatch):
+    payload = await _worker_payload(fake_ib)
+    execution = payload["executions"][0]
+    execution["commission"] = None
+    execution["unavailable"] = {}
+    client, _ = _connected_client(monkeypatch, payload)
+    monkeypatch.setattr(client, "_poison_generation", Mock())
+
+    with pytest.raises(IBKRTransportPoisonedError, match="silently omitted"):
+        await client.get_broker_snapshot(ACCOUNT, max_age_seconds=60)

--- a/tests/test_broker_snapshot_protocol.py
+++ b/tests/test_broker_snapshot_protocol.py
@@ -1,4 +1,5 @@
 import copy
+import json
 import threading
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
@@ -10,12 +11,14 @@ from robo_trader.clients import ibkr_subprocess_worker as worker
 from robo_trader.clients import subprocess_ibkr_client as client_module
 from robo_trader.clients.subprocess_ibkr_client import (
     BrokerSnapshotAccountMismatchError,
+    IBKRError,
     IBKRTimeoutError,
     IBKRTransportPoisonedError,
     SubprocessCrashError,
     SubprocessIBKRClient,
     _WorkerGeneration,
 )
+from robo_trader.utils import ibkr_safe
 
 ACCOUNT = "DU_TEST_ACCOUNT"
 NOW = datetime.now(timezone.utc)
@@ -214,7 +217,7 @@ async def test_worker_snapshot_is_fresh_atomic_read_only_and_precise(fake_ib):
     assert "reqAllOpenOrdersAsync" in fake_ib.calls
     assert "reqExecutionsAsync" in fake_ib.calls
     execution_request_index = fake_ib.calls.index("reqExecutionsAsync")
-    assert fake_ib.calls[execution_request_index + 1] == "reqCurrentTimeAsync"
+    assert fake_ib.calls[execution_request_index - 1] == "reqCurrentTimeAsync"
     assert not any(
         token in call.lower()
         for call in fake_ib.calls
@@ -362,6 +365,27 @@ async def test_worker_rejects_cross_account_execution(fake_ib, monkeypatch):
     assert result["status"] == worker.PROTOCOL_ERROR_STATUS
     assert result["error_type"] == worker.PROTOCOL_ERROR_TYPE
     assert "DU_WRONG_ACCOUNT" not in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_worker_rejects_execution_after_pre_request_cutoff(fake_ib, monkeypatch):
+    original = fake_ib.reqExecutionsAsync
+
+    async def execution_after_cutoff(execution_filter):
+        fills = await original(execution_filter)
+        fills[0].execution.time = NOW + timedelta(days=1)
+        fills[0].time = NOW + timedelta(days=1)
+        return fills
+
+    monkeypatch.setattr(fake_ib, "reqExecutionsAsync", execution_after_cutoff)
+
+    result = await worker.handle_get_broker_snapshot({"expected_account": ACCOUNT})
+
+    assert result == {
+        "status": worker.PROTOCOL_ERROR_STATUS,
+        "error": "Broker snapshot collection failed",
+        "error_type": worker.PROTOCOL_ERROR_TYPE,
+    }
 
 
 @pytest.mark.asyncio
@@ -607,6 +631,138 @@ async def test_worker_snapshot_account_mismatch_is_safely_classified_and_poisone
     assert ACCOUNT not in str(exc_info.value)
     assert "DU_EXPECTED_SECRET" not in str(exc_info.value)
     assert generation.poisoned_reason == ("worker-reported broker snapshot account mismatch")
+
+
+@pytest.mark.asyncio
+async def test_diagnostic_connect_failure_is_redacted_at_worker_and_parent(
+    monkeypatch,
+    capsys,
+    caplog,
+):
+    raw_identity = "DU1234567"
+
+    class LeakyConnectIB:
+        async def connectAsync(self, **_kwargs):
+            raise RuntimeError(f"broker rejected account {raw_identity}")
+
+    monkeypatch.setattr(worker, "IB", LeakyConnectIB)
+    monkeypatch.setattr(worker, "ib", None)
+    monkeypatch.setattr(worker, "gateway_api_down", False)
+    monkeypatch.setattr(worker, "gateway_failure_detail", "")
+
+    worker_response = await worker.handle_connect(
+        {
+            "host": "127.0.0.1",
+            "port": 4002,
+            "client_id": 7,
+            "readonly": True,
+            "timeout": 1.0,
+        }
+    )
+
+    serialized = json.dumps(worker_response)
+    assert raw_identity not in serialized
+    assert raw_identity not in capsys.readouterr().err
+    assert "traceback" not in worker_response
+    assert worker_response["error"] == "Diagnostic broker connection failed"
+
+    # Defense in depth: even an older or compromised worker response containing
+    # free-form sensitive text must be sanitized again by the parent.
+    worker_response["error"] = f"broker rejected account {raw_identity}"
+    worker_response["traceback"] = f"trace included {raw_identity}"
+    client, _generation = _transport_response_client(worker_response)
+    with pytest.raises(IBKRError) as exc_info:
+        await client._execute_command_unlocked({"command": "connect"})
+
+    assert raw_identity not in str(exc_info.value)
+    assert raw_identity not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_diagnostic_disconnect_failure_is_redacted_at_worker_and_parent(
+    monkeypatch,
+    capsys,
+    caplog,
+):
+    raw_identity = "DU_DISCONNECT_SECRET"
+
+    class ConnectedIB:
+        pass
+
+    monkeypatch.setattr(worker, "ib", ConnectedIB())
+    monkeypatch.setattr(
+        worker,
+        "safe_disconnect",
+        Mock(side_effect=RuntimeError(f"disconnect account {raw_identity}")),
+    )
+
+    worker_response = await worker.handle_disconnect()
+
+    assert worker_response == {
+        "status": "error",
+        "error": "Diagnostic broker disconnect failed",
+        "error_type": "BrokerDisconnectionError",
+    }
+    assert raw_identity not in json.dumps(worker_response)
+    assert raw_identity not in capsys.readouterr().err
+
+    # Treat disconnect responses as untrusted even if an older or compromised
+    # worker serializes a raw broker exception.
+    worker_response["error"] = f"disconnect account {raw_identity}"
+    worker_response["error_type"] = f"Leaky{raw_identity}"
+    worker_response["detail"] = f"detail {raw_identity}"
+    client, _generation = _transport_response_client(worker_response)
+    with pytest.raises(IBKRError) as exc_info:
+        await client._execute_command_unlocked({"command": "disconnect"})
+
+    assert raw_identity not in str(exc_info.value)
+    assert raw_identity not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_diagnostic_disconnect_real_helper_suppresses_exception_details(
+    monkeypatch,
+    capsys,
+    caplog,
+):
+    raw_identity = "DU123456789"
+
+    class ConnectedIB:
+        def isConnected(self):
+            return True
+
+        def disconnect(self):
+            return None
+
+    def leaky_disconnect(_ib):
+        raise RuntimeError(f"disconnect failed for account {raw_identity}")
+
+    connected_ib = ConnectedIB()
+    monkeypatch.setattr(worker, "ib", connected_ib)
+    monkeypatch.setattr(ibkr_safe, "_call_original_disconnect", leaky_disconnect)
+
+    worker_response = await worker.handle_disconnect()
+
+    assert worker_response == {"status": "success", "data": {"disconnected": True}}
+    assert raw_identity not in capsys.readouterr().err
+    assert raw_identity not in caplog.text
+    assert "ib.disconnect() raised an exception" in caplog.text
+
+
+def test_worker_exit_cleanup_stderr_redacts_disconnect_exception(monkeypatch, capsys):
+    raw_identity = "DU_EXIT_SECRET"
+    monkeypatch.setattr(worker, "ib", object())
+    monkeypatch.setattr(
+        worker,
+        "safe_disconnect",
+        Mock(side_effect=RuntimeError(f"cleanup account {raw_identity}")),
+    )
+
+    worker._cleanup_on_exit()
+
+    stderr = capsys.readouterr().err
+    assert raw_identity not in stderr
+    assert "Disconnect error" in stderr
 
 
 @pytest.mark.asyncio

--- a/tests/test_broker_snapshot_protocol.py
+++ b/tests/test_broker_snapshot_protocol.py
@@ -10,6 +10,7 @@ from robo_trader.clients import ibkr_subprocess_worker as worker
 from robo_trader.clients import subprocess_ibkr_client as client_module
 from robo_trader.clients.subprocess_ibkr_client import (
     BrokerSnapshotAccountMismatchError,
+    IBKRTimeoutError,
     IBKRTransportPoisonedError,
     SubprocessCrashError,
     SubprocessIBKRClient,
@@ -234,9 +235,9 @@ async def test_worker_snapshot_rechecks_account_and_suppresses_sensitive_errors(
     result = await worker.handle_get_broker_snapshot({"expected_account": ACCOUNT})
 
     assert result == {
-        "status": "error",
+        "status": worker.PROTOCOL_ERROR_STATUS,
         "error": "Broker snapshot collection failed",
-        "error_type": "ValueError",
+        "error_type": worker.PROTOCOL_ERROR_TYPE,
     }
     assert ACCOUNT not in result["error"]
     assert "DU_WRONG_ACCOUNT" not in result["error"]
@@ -247,7 +248,7 @@ async def test_worker_wrong_expected_account_performs_zero_data_reads(fake_ib):
     result = await worker.handle_get_broker_snapshot({"expected_account": "DU_WRONG_ACCOUNT"})
 
     assert result["status"] == "error"
-    assert result["error_type"] == "ValueError"
+    assert result["error_type"] == "BrokerSnapshotAccountMismatchError"
     assert not any(
         call.startswith("req") or call in {"accountValues", "qualifyContractsAsync"}
         for call in fake_ib.calls
@@ -284,8 +285,8 @@ async def test_worker_rejects_mid_collection_position_mutation(fake_ib, monkeypa
     monkeypatch.setattr(fake_ib, "reqPositionsAsync", changing_positions)
     result = await worker.handle_get_broker_snapshot({"expected_account": ACCOUNT})
 
-    assert result["status"] == "error"
-    assert result["error_type"] == "ValueError"
+    assert result["status"] == worker.PROTOCOL_ERROR_STATUS
+    assert result["error_type"] == worker.PROTOCOL_ERROR_TYPE
     assert reads == 2
 
 
@@ -342,8 +343,8 @@ async def test_worker_rejects_any_emitted_order_state_mutation(fake_ib, monkeypa
 
     result = await worker.handle_get_broker_snapshot({"expected_account": ACCOUNT})
 
-    assert result["status"] == "error"
-    assert result["error_type"] == "ValueError"
+    assert result["status"] == worker.PROTOCOL_ERROR_STATUS
+    assert result["error_type"] == worker.PROTOCOL_ERROR_TYPE
     assert reads == 2
 
 
@@ -358,8 +359,8 @@ async def test_worker_rejects_cross_account_execution(fake_ib, monkeypatch):
 
     monkeypatch.setattr(fake_ib, "reqExecutionsAsync", wrong_execution)
     result = await worker.handle_get_broker_snapshot({"expected_account": ACCOUNT})
-    assert result["status"] == "error"
-    assert result["error_type"] == "ValueError"
+    assert result["status"] == worker.PROTOCOL_ERROR_STATUS
+    assert result["error_type"] == worker.PROTOCOL_ERROR_TYPE
     assert "DU_WRONG_ACCOUNT" not in result["error"]
 
 
@@ -496,6 +497,116 @@ def _connected_client(monkeypatch, payload):
     execute = AsyncMock(return_value=payload)
     monkeypatch.setattr(client, "_execute_command_unlocked", execute)
     return client, execute
+
+
+def _transport_response_client(response, *, swap_generation=False):
+    """Route one synthetic worker result through the real parent classifier."""
+    client = SubprocessIBKRClient()
+    process = SimpleNamespace(poll=lambda: None)
+    generation = _WorkerGeneration(
+        generation_id="snapshot-transport-generation",
+        process=process,
+    )
+
+    class ImmediateResponseStdin:
+        def write(self, _value):
+            if swap_generation:
+                client._generation = SimpleNamespace(
+                    generation_id="replacement-generation",
+                )
+            with generation.state_lock:
+                pending = next(iter(generation.pending.values()))
+            pending.future.set_result(dict(response))
+
+        def flush(self):
+            return None
+
+    process.stdin = ImmediateResponseStdin()
+    client.process = process
+    client._generation = generation
+    return client, generation
+
+
+@pytest.mark.asyncio
+async def test_worker_snapshot_timeout_preserves_parent_timeout_poison(fake_ib, monkeypatch):
+    async def timeout_positions():
+        raise TimeoutError("snapshot timeout with sensitive diagnostic context")
+
+    monkeypatch.setattr(fake_ib, "reqPositionsAsync", timeout_positions)
+    worker_response = await worker.handle_get_broker_snapshot({"expected_account": ACCOUNT})
+
+    assert worker_response == {
+        "status": "error",
+        "error": "Broker snapshot collection timed out",
+        "error_type": "TimeoutError",
+    }
+    assert ACCOUNT not in worker_response["error"]
+
+    client, generation = _transport_response_client(worker_response)
+    with pytest.raises(IBKRTimeoutError, match="Broker snapshot collection timed out"):
+        await client._execute_command_unlocked({"command": "get_broker_snapshot"})
+
+    assert generation.poisoned_reason is not None
+    assert "worker-reported broker timeout" in generation.poisoned_reason
+    assert "get_broker_snapshot" in generation.poisoned_reason
+
+
+@pytest.mark.asyncio
+async def test_worker_snapshot_protocol_error_poisons_exact_parent_generation(fake_ib, monkeypatch):
+    original = fake_ib.reqPositionsAsync
+    reads = 0
+
+    async def changing_positions():
+        nonlocal reads
+        reads += 1
+        positions = await original()
+        if reads == 2:
+            positions[0].position = "11"
+        return positions
+
+    monkeypatch.setattr(fake_ib, "reqPositionsAsync", changing_positions)
+    worker_response = await worker.handle_get_broker_snapshot({"expected_account": ACCOUNT})
+
+    assert worker_response["status"] == worker.PROTOCOL_ERROR_STATUS
+    assert worker_response["error_type"] == worker.PROTOCOL_ERROR_TYPE
+
+    client, original_generation = _transport_response_client(
+        worker_response,
+        swap_generation=True,
+    )
+    with pytest.raises(IBKRTransportPoisonedError, match="Unknown worker response status"):
+        await client._execute_command_unlocked({"command": "get_broker_snapshot"})
+
+    assert original_generation.poisoned_reason == "unknown response status"
+    assert client._generation.generation_id == "replacement-generation"
+
+
+@pytest.mark.asyncio
+async def test_worker_snapshot_account_mismatch_is_safely_classified_and_poisoned(
+    fake_ib,
+):
+    worker_response = await worker.handle_get_broker_snapshot(
+        {"expected_account": "DU_EXPECTED_SECRET"}
+    )
+
+    assert worker_response == {
+        "status": "error",
+        "error": "Broker snapshot account mismatch",
+        "error_type": "BrokerSnapshotAccountMismatchError",
+    }
+    assert ACCOUNT not in worker_response["error"]
+    assert "DU_EXPECTED_SECRET" not in worker_response["error"]
+
+    client, generation = _transport_response_client(worker_response)
+    with pytest.raises(
+        BrokerSnapshotAccountMismatchError,
+        match="Broker snapshot account mismatch",
+    ) as exc_info:
+        await client._execute_command_unlocked({"command": "get_broker_snapshot"})
+
+    assert ACCOUNT not in str(exc_info.value)
+    assert "DU_EXPECTED_SECRET" not in str(exc_info.value)
+    assert generation.poisoned_reason == ("worker-reported broker snapshot account mismatch")
 
 
 @pytest.mark.asyncio

--- a/tests/test_broker_snapshot_protocol.py
+++ b/tests/test_broker_snapshot_protocol.py
@@ -451,7 +451,6 @@ async def test_worker_command_routes_atomic_snapshot(fake_ib):
     [
         {"port": 4001, "readonly": True, "client_id": 7},
         {"port": 4002, "readonly": 1, "client_id": 7},
-        {"port": 4002, "readonly": True, "client_id": 0},
         {"port": 4002, "readonly": True, "client_id": True},
     ],
 )
@@ -464,6 +463,44 @@ async def test_worker_diagnostic_connect_rejects_before_ib_client_creation(monke
 
     assert result["status"] == "error"
     factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_worker_accepts_existing_zero_client_id(monkeypatch):
+    observed = {}
+
+    class ConnectIB:
+        def __init__(self):
+            self.client = SimpleNamespace(serverVersion=lambda: 180)
+
+        async def connectAsync(self, **kwargs):
+            observed.update(kwargs)
+
+        def isConnected(self):
+            return True
+
+        def managedAccounts(self):
+            return [ACCOUNT]
+
+    monkeypatch.setattr(worker, "ib", None)
+    monkeypatch.setattr(worker, "worker_connection_identity", None)
+    monkeypatch.setattr(worker, "gateway_api_down", False)
+    monkeypatch.setattr(worker, "IB", ConnectIB)
+    monkeypatch.setattr(worker.asyncio, "sleep", AsyncMock())
+
+    response = await worker.handle_connect(
+        {
+            "host": "127.0.0.1",
+            "port": 4002,
+            "client_id": 0,
+            "readonly": True,
+            "timeout": 1.0,
+        }
+    )
+
+    assert response["status"] == "success"
+    assert observed["clientId"] == 0
+    assert response["data"]["client_id"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_ibkr_transport_generation_protocol.py
+++ b/tests/test_ibkr_transport_generation_protocol.py
@@ -904,6 +904,35 @@ async def test_repeated_connect_is_idempotent_and_conflicting_identity_is_reject
 
 
 @pytest.mark.asyncio
+async def test_shared_transport_accepts_existing_zero_client_id():
+    def handler(process, request):
+        assert request["command"] == "connect"
+        assert request["params"]["client_id"] == 0
+        _feed(
+            process,
+            _response(
+                request,
+                data={
+                    "connected": True,
+                    "accounts": ["DU123"],
+                    "client_id": 0,
+                    "server_version": 180,
+                },
+            ),
+        )
+
+    client, _, _ = _attach_client(handler)
+
+    async def no_zombies(port):
+        return 0, "none"
+
+    client._check_zombie_connections = no_zombies
+
+    assert await client.connect(port=4002, client_id=0, readonly=True) is True
+    assert client._connection_identity == ("127.0.0.1", 4002, 0, True)
+
+
+@pytest.mark.asyncio
 async def test_disconnected_ping_drives_health_failure_and_clean_reconnect():
     state = {"connected": False}
     commands = []

--- a/tests/test_ibkr_transport_generation_protocol.py
+++ b/tests/test_ibkr_transport_generation_protocol.py
@@ -183,17 +183,20 @@ async def test_worker_reported_timeout_poisons_exact_generation_for_every_comman
 
 
 @pytest.mark.asyncio
-async def test_worker_reported_gateway_timeout_preserves_both_recovery_signals():
+async def test_worker_reported_gateway_timeout_preserves_both_sanitized_recovery_signals():
+    raw_error = "handshake timeout DU_RAW_ACCOUNT"
+    raw_detail = "restart Gateway DU_RAW_ACCOUNT"
+
     def handler(process, request):
         _feed(
             process,
             _response(
                 request,
                 status="error",
-                error="handshake timeout sentinel",
+                error=raw_error,
                 error_type="TimeoutError",
                 requires_restart=True,
-                detail="restart Gateway diagnostic sentinel",
+                detail=raw_detail,
             ),
         )
 
@@ -201,15 +204,18 @@ async def test_worker_reported_gateway_timeout_preserves_both_recovery_signals()
 
     with pytest.raises(
         IBKRTimeoutRequiresGatewayRestartError,
-        match="restart Gateway diagnostic sentinel",
     ) as caught:
         await client._execute_command({"command": "connect"})
 
     assert isinstance(caught.value, IBKRTimeoutError)
     assert isinstance(caught.value, GatewayRequiresRestartError)
+    assert raw_error not in str(caught.value)
+    assert raw_detail not in str(caught.value)
+    assert "Gateway restart required" in str(caught.value)
     assert generation.poisoned_reason is not None
-    assert "handshake timeout sentinel" in generation.poisoned_reason
-    assert "restart Gateway diagnostic sentinel" in generation.poisoned_reason
+    assert raw_error not in generation.poisoned_reason
+    assert raw_detail not in generation.poisoned_reason
+    assert "Diagnostic broker connection timed out" in generation.poisoned_reason
 
 
 @pytest.mark.asyncio
@@ -1220,7 +1226,11 @@ async def test_worker_refuses_active_connect_and_cleans_stale_instance(monkeypat
     stale = Existing(False)
     disconnected = []
     monkeypatch.setattr(worker, "ib", stale)
-    monkeypatch.setattr(worker, "safe_disconnect", lambda value: disconnected.append(value))
+    monkeypatch.setattr(
+        worker,
+        "safe_disconnect",
+        lambda value, **_kwargs: disconnected.append(value),
+    )
     monkeypatch.setattr(
         worker,
         "IB",

--- a/tests/test_reconciliation_cli.py
+++ b/tests/test_reconciliation_cli.py
@@ -242,13 +242,10 @@ def test_symlinked_env_is_rejected_before_parsing_or_provider_construction(
     assert payload["authorizes_startup"] is False
 
 
-def test_connection_gate_blocks_unsafe_port_readonly_and_zero_client_before_provider(
-    tmp_path, capsys
-):
+def test_connection_gate_blocks_unsafe_port_and_readonly_before_provider(tmp_path, capsys):
     for key, value in (
         ("IBKR_PORT", "4001"),
         ("IBKR_READONLY", "false"),
-        ("IBKR_CLIENT_ID", "0"),
     ):
         project = tmp_path / key.lower()
         _, env = _project(project)

--- a/tests/test_reconciliation_cli.py
+++ b/tests/test_reconciliation_cli.py
@@ -490,6 +490,32 @@ async def test_provider_close_is_shielded_from_cancellation(tmp_path):
     assert provider.closed is True
 
 
+@pytest.mark.asyncio
+async def test_provider_close_has_no_outer_timeout(tmp_path, monkeypatch):
+    """The production transport owns its bounded, multi-stage shutdown."""
+    _, env = _project(tmp_path)
+    observed_timeouts = []
+    real_wait_for = asyncio.wait_for
+
+    async def recording_wait_for(awaitable, *, timeout):
+        observed_timeouts.append(timeout)
+        return await real_wait_for(awaitable, timeout=timeout)
+
+    monkeypatch.setattr(cli_module.asyncio, "wait_for", recording_wait_for)
+    provider = FakeProvider(_broker_snapshot())
+
+    await run_reconciliation(
+        ["default"],
+        project_root=tmp_path,
+        process_environ=env,
+        provider_factory=lambda runtime: provider,
+        now=NOW,
+    )
+
+    assert observed_timeouts == [60.0]
+    assert provider.closed is True
+
+
 def test_provider_error_is_redacted_and_cleanup_runs(tmp_path, capsys):
     _, env = _project(tmp_path)
     provider = FakeProvider(error=RuntimeError(f"credential {RAW_ACCOUNT} secret"))

--- a/tests/test_reconciliation_cli.py
+++ b/tests/test_reconciliation_cli.py
@@ -1,0 +1,343 @@
+import hashlib
+import json
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+
+from robo_trader.reconciliation.cli import (
+    EXIT_BLOCKED,
+    EXIT_CLEAN_QUANTITY_COST,
+    build_parser,
+    main,
+)
+from robo_trader.reconciliation.identity import (
+    mask_account_identifier,
+    validate_runtime_safety,
+)
+from robo_trader.reconciliation.models import (
+    BrokerExecutionScope,
+    BrokerPosition,
+    BrokerSnapshot,
+    ContractIdentity,
+)
+
+NOW = datetime(2026, 7, 23, 15, 0, tzinfo=timezone.utc)
+RAW_ACCOUNT = "DU1234567"
+
+
+def _project(tmp_path: Path, *, valid_ibc: bool = True):
+    (tmp_path / "config" / "ibc").mkdir(parents=True)
+    (tmp_path / "data").mkdir()
+    ibc = "ReadOnlyApi=yes\nTradingMode=paper\n"
+    if not valid_ibc:
+        ibc = "ReadOnlyApi=no\nTradingMode=paper\n"
+    (tmp_path / "config" / "ibc" / "config.ini").write_text(ibc)
+    database = tmp_path / "ledger.db"
+    connection = sqlite3.connect(database)
+    connection.executescript("""
+        CREATE TABLE positions (
+            id INTEGER PRIMARY KEY,
+            portfolio_id TEXT NOT NULL,
+            symbol TEXT NOT NULL,
+            quantity INTEGER NOT NULL,
+            avg_cost REAL NOT NULL,
+            market_price REAL,
+            timestamp DATETIME
+        );
+        CREATE TABLE trades (
+            id INTEGER PRIMARY KEY,
+            portfolio_id TEXT NOT NULL,
+            symbol TEXT NOT NULL,
+            side TEXT NOT NULL,
+            quantity INTEGER NOT NULL,
+            price REAL NOT NULL,
+            timestamp DATETIME
+        );
+        CREATE TABLE account (
+            portfolio_id TEXT PRIMARY KEY,
+            cash REAL NOT NULL,
+            equity REAL NOT NULL
+        );
+        INSERT INTO account VALUES ('default', 1000, 1000);
+        INSERT INTO positions
+        VALUES (1, 'default', 'AAPL', 3, 100, 101, '2026-07-23T14:59:00');
+        """)
+    connection.commit()
+    connection.close()
+    env = {
+        "EXECUTION_MODE": "paper",
+        "ENVIRONMENT": "dev",
+        "IBKR_HOST": "127.0.0.1",
+        "IBKR_PORT": "4002",
+        "IBKR_READONLY": "true",
+        "IBKR_ACCOUNT": RAW_ACCOUNT,
+        "IBKR_APPROVED_ACCOUNTS": RAW_ACCOUNT,
+        "IBKR_ACCOUNT_TYPE": "paper",
+        "RT_DB_PATH": "ledger.db",
+        "RT_STATE_NAMESPACE": "paper",
+        "BUILD_ID": "test-build",
+        "MODEL_ARTIFACT_SET": "test-models",
+        "LOG_FILE": "robo_trader.log",
+    }
+    return database, env
+
+
+def _broker_snapshot() -> BrokerSnapshot:
+    contract = ContractIdentity(
+        con_id=1,
+        symbol="AAPL",
+        local_symbol="AAPL",
+        security_type="STK",
+        currency="USD",
+        exchange="SMART",
+        primary_exchange="NASDAQ",
+        trading_class="AAPL",
+    )
+    return BrokerSnapshot(
+        schema_version=1,
+        account_alias=mask_account_identifier(RAW_ACCOUNT),
+        broker_time_before=NOW - timedelta(seconds=1),
+        broker_time_after=NOW,
+        retrieved_at=NOW,
+        execution_scope=BrokerExecutionScope(
+            kind="bounded_execution_filter",
+            start_at=NOW - timedelta(hours=24, seconds=1),
+            end_at=NOW,
+        ),
+        positions=(BrokerPosition(contract, Decimal("3"), Decimal("100")),),
+        balances={
+            "NetLiquidation:USD": Decimal("1000"),
+            "TotalCashValue:USD": Decimal("500"),
+        },
+    )
+
+
+class FakeProvider:
+    def __init__(self, snapshot=None, error=None):
+        self.snapshot = snapshot
+        self.error = error
+        self.snapshot_calls = 0
+        self.expected_accounts = []
+        self.closed = False
+
+    async def get_broker_snapshot(self, expected_account, *, max_age_seconds):
+        self.snapshot_calls += 1
+        self.expected_accounts.append(expected_account)
+        assert max_age_seconds == 30.0
+        if self.error:
+            raise self.error
+        return self.snapshot
+
+    async def close(self):
+        self.closed = True
+
+
+def test_runtime_context_repr_and_validation_never_expose_raw_account(tmp_path):
+    _, env = _project(tmp_path)
+    context = validate_runtime_safety(tmp_path, env)
+    assert RAW_ACCOUNT not in repr(context)
+    assert context.account_alias == "***4567"
+    context.verify_managed_accounts([RAW_ACCOUNT])
+
+    try:
+        context.verify_managed_accounts(["DU9999999"])
+    except Exception as exc:
+        assert RAW_ACCOUNT not in str(exc)
+
+
+def test_invalid_ibc_blocks_before_provider_construction(tmp_path, capsys):
+    _, env = _project(tmp_path, valid_ibc=False)
+    constructed = []
+
+    def factory(runtime):
+        constructed.append(runtime)
+        return FakeProvider(_broker_snapshot())
+
+    result = main(
+        ["--portfolio-id", "default", "--json"],
+        project_root=tmp_path,
+        process_environ=env,
+        provider_factory=factory,
+        now=NOW,
+    )
+
+    assert result == EXIT_BLOCKED
+    assert constructed == []
+    output = capsys.readouterr().out
+    assert RAW_ACCOUNT not in output
+    payload = json.loads(output)
+    assert payload["mutated_state"] is False
+    assert payload["authorizes_startup"] is False
+
+
+def test_connection_gate_blocks_unsafe_port_readonly_and_zero_client_before_provider(
+    tmp_path, capsys
+):
+    for key, value in (
+        ("IBKR_PORT", "4001"),
+        ("IBKR_READONLY", "false"),
+        ("IBKR_CLIENT_ID", "0"),
+    ):
+        project = tmp_path / key.lower()
+        _, env = _project(project)
+        env[key] = value
+        constructed = []
+
+        result = main(
+            ["--portfolio-id", "default", "--json"],
+            project_root=project,
+            process_environ=env,
+            provider_factory=lambda runtime: constructed.append(runtime),
+            now=NOW,
+        )
+
+        assert result == EXIT_BLOCKED
+        assert constructed == []
+        assert RAW_ACCOUNT not in capsys.readouterr().out
+
+
+def test_connection_gate_rejects_non_loopback_host_before_provider(tmp_path, capsys):
+    for index, host in enumerate(("192.0.2.10", "gateway.internal", "0.0.0.0")):
+        project = tmp_path / f"remote-{index}"
+        _, env = _project(project)
+        env["IBKR_HOST"] = host
+        constructed = []
+
+        result = main(
+            ["--portfolio-id", "default", "--json"],
+            project_root=project,
+            process_environ=env,
+            provider_factory=lambda runtime: constructed.append(runtime),
+            now=NOW,
+        )
+
+        assert result == EXIT_BLOCKED
+        assert constructed == []
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["error_code"] == "RUNTIME_SAFETY_BLOCK"
+        assert "loopback" in payload["message"]
+
+
+def test_connection_gate_accepts_named_ipv4_and_ipv6_loopback(tmp_path):
+    for index, host in enumerate(("localhost", "127.0.0.1", "127.9.8.7", "::1")):
+        project = tmp_path / f"loopback-{index}"
+        _, env = _project(project)
+        env["IBKR_HOST"] = host
+
+        context = validate_runtime_safety(project, env)
+
+        assert context.diagnostic_connection.host == host
+
+
+def test_cli_does_not_expose_broker_or_mutation_overrides():
+    option_strings = {
+        option for action in build_parser()._actions for option in action.option_strings
+    }
+    assert option_strings == {"-h", "--help", "--portfolio-id", "--json"}
+
+
+def test_duplicate_ibc_safety_assignments_fail_closed_without_account_leak(tmp_path):
+    _, env = _project(tmp_path)
+    config = tmp_path / "config" / "ibc" / "config.ini"
+    config.write_text("ReadOnlyApi=yes\nReadOnlyApi=yes\nTradingMode=paper\n")
+
+    try:
+        validate_runtime_safety(tmp_path, env)
+    except Exception as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("ambiguous IBC configuration was accepted")
+
+    assert RAW_ACCOUNT not in message
+    assert "read-only paper session" in message
+
+
+def test_success_is_non_mutating_masks_account_and_closes_provider(tmp_path, capsys):
+    database, env = _project(tmp_path)
+    before = hashlib.sha256(database.read_bytes()).hexdigest()
+    provider = FakeProvider(_broker_snapshot())
+
+    result = main(
+        ["--portfolio-id", "default", "--json"],
+        project_root=tmp_path,
+        process_environ=env,
+        provider_factory=lambda runtime: provider,
+        now=NOW,
+    )
+
+    assert result == EXIT_CLEAN_QUANTITY_COST
+    assert provider.snapshot_calls == 1
+    assert provider.expected_accounts == [RAW_ACCOUNT]
+    assert provider.closed is True
+    assert hashlib.sha256(database.read_bytes()).hexdigest() == before
+    assert not (tmp_path / "robo_trader.log").exists()
+    output = capsys.readouterr().out
+    assert RAW_ACCOUNT not in output
+    payload = json.loads(output)
+    assert payload["account_alias"] == "***4567"
+    assert payload["mutated_state"] is False
+    assert payload["authorizes_startup"] is False
+    assert payload["status"] == "QUANTITY_COST_COMPARABLE_ONLY"
+
+
+def test_provider_error_is_redacted_and_cleanup_runs(tmp_path, capsys):
+    _, env = _project(tmp_path)
+    provider = FakeProvider(error=RuntimeError(f"credential {RAW_ACCOUNT} secret"))
+
+    result = main(
+        ["--portfolio-id", "default", "--json"],
+        project_root=tmp_path,
+        process_environ=env,
+        provider_factory=lambda runtime: provider,
+        now=NOW,
+    )
+
+    assert result == EXIT_BLOCKED
+    assert provider.closed is True
+    output = capsys.readouterr().out
+    assert RAW_ACCOUNT not in output
+    assert "credential" not in output
+    assert json.loads(output)["error_code"] == "BROKER_EVIDENCE_BLOCK"
+
+
+def test_provider_with_order_capability_is_rejected_without_calling_it(tmp_path, capsys):
+    _, env = _project(tmp_path)
+
+    class UnsafeProvider(FakeProvider):
+        def place_order(self):
+            raise AssertionError("must never be called")
+
+    provider = UnsafeProvider(_broker_snapshot())
+    result = main(
+        ["--portfolio-id", "default", "--json"],
+        project_root=tmp_path,
+        process_environ=env,
+        provider_factory=lambda runtime: provider,
+        now=NOW,
+    )
+
+    assert result == EXIT_BLOCKED
+    assert provider.snapshot_calls == 0
+    assert provider.closed is True
+    assert json.loads(capsys.readouterr().out)["error_code"] == "BROKER_EVIDENCE_BLOCK"
+
+
+def test_provider_supplied_reconciliation_error_is_also_redacted(tmp_path, capsys):
+    from robo_trader.reconciliation.errors import BrokerEvidenceError
+
+    _, env = _project(tmp_path)
+    provider = FakeProvider(error=BrokerEvidenceError(f"account={RAW_ACCOUNT}"))
+
+    result = main(
+        ["--portfolio-id", "default", "--json"],
+        project_root=tmp_path,
+        process_environ=env,
+        provider_factory=lambda runtime: provider,
+        now=NOW,
+    )
+
+    assert result == EXIT_BLOCKED
+    output = capsys.readouterr().out
+    assert RAW_ACCOUNT not in output
+    assert "account=" not in output

--- a/tests/test_reconciliation_cli.py
+++ b/tests/test_reconciliation_cli.py
@@ -1,22 +1,31 @@
+import asyncio
 import hashlib
 import json
 import sqlite3
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 
+import pytest
+
+from robo_trader.reconciliation import cli as cli_module
 from robo_trader.reconciliation.cli import (
     EXIT_BLOCKED,
     EXIT_CLEAN_QUANTITY_COST,
+    EXIT_INTEGRITY_VIOLATION,
     build_parser,
     main,
+    run_reconciliation,
 )
 from robo_trader.reconciliation.identity import (
     mask_account_identifier,
     validate_runtime_safety,
 )
 from robo_trader.reconciliation.models import (
+    BrokerExecution,
     BrokerExecutionScope,
+    BrokerOpenOrder,
     BrokerPosition,
     BrokerSnapshot,
     ContractIdentity,
@@ -71,6 +80,8 @@ def _project(tmp_path: Path, *, valid_ibc: bool = True):
         "IBKR_HOST": "127.0.0.1",
         "IBKR_PORT": "4002",
         "IBKR_READONLY": "true",
+        "IBKR_CLIENT_ID": "7",
+        "IBKR_RECONCILIATION_CLIENT_ID": "997",
         "IBKR_ACCOUNT": RAW_ACCOUNT,
         "IBKR_APPROVED_ACCOUNTS": RAW_ACCOUNT,
         "IBKR_ACCOUNT_TYPE": "paper",
@@ -167,6 +178,66 @@ def test_invalid_ibc_blocks_before_provider_construction(tmp_path, capsys):
     output = capsys.readouterr().out
     assert RAW_ACCOUNT not in output
     payload = json.loads(output)
+    assert payload["mutated_state"] is False
+    assert payload["authorizes_startup"] is False
+
+
+def test_env_change_during_resolution_blocks_before_provider(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    _, env = _project(tmp_path)
+    constructed = []
+    real_resolve = cli_module.resolve_environment
+
+    def resolve_then_replace(project_root, process_environ):
+        resolved = real_resolve(project_root, process_environ)
+        (project_root / ".env").write_text("RT_DB_PATH=other.db\n")
+        return resolved
+
+    monkeypatch.setattr(cli_module, "resolve_environment", resolve_then_replace)
+    result = main(
+        ["--portfolio-id", "default", "--json"],
+        project_root=tmp_path,
+        process_environ=env,
+        provider_factory=lambda runtime: constructed.append(runtime),
+        now=NOW,
+    )
+
+    assert result == EXIT_INTEGRITY_VIOLATION
+    assert constructed == []
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error_code"] == "INTEGRITY_VIOLATION"
+    assert payload["mutated_state"] is False
+    assert payload["authorizes_startup"] is False
+
+
+def test_symlinked_env_is_rejected_before_parsing_or_provider_construction(
+    tmp_path,
+    capsys,
+):
+    _, env = _project(tmp_path)
+    raw_target = tmp_path / f"environment-{RAW_ACCOUNT}"
+    raw_target.write_text("RT_DB_PATH=other.db\n")
+    (tmp_path / ".env").symlink_to(raw_target)
+    constructed = []
+
+    result = main(
+        ["--portfolio-id", "default", "--json"],
+        project_root=tmp_path,
+        process_environ=env,
+        provider_factory=lambda runtime: constructed.append(runtime),
+        now=NOW,
+    )
+
+    assert result == EXIT_INTEGRITY_VIOLATION
+    assert constructed == []
+    output = capsys.readouterr().out
+    assert RAW_ACCOUNT not in output
+    payload = json.loads(output)
+    assert payload["error_code"] == "INTEGRITY_VIOLATION"
+    assert payload["message"] == "runtime environment file must not be a symlink"
     assert payload["mutated_state"] is False
     assert payload["authorizes_startup"] is False
 
@@ -281,6 +352,144 @@ def test_success_is_non_mutating_masks_account_and_closes_provider(tmp_path, cap
     assert payload["status"] == "QUANTITY_COST_COMPARABLE_ONLY"
 
 
+@pytest.mark.parametrize(
+    ("evidence_kind", "expected_status"),
+    [("open_order", "BLOCKED"), ("recent_execution", "INCOMPLETE")],
+)
+def test_unmatched_broker_activity_never_returns_success(
+    tmp_path,
+    capsys,
+    evidence_kind,
+    expected_status,
+):
+    _, env = _project(tmp_path)
+    snapshot = _broker_snapshot()
+    contract = snapshot.positions[0].contract
+    if evidence_kind == "open_order":
+        snapshot = replace(
+            snapshot,
+            open_orders=(
+                BrokerOpenOrder(
+                    order_id="101",
+                    client_id=7,
+                    contract=contract,
+                    side="BUY",
+                    quantity=Decimal("1"),
+                    filled=Decimal("0"),
+                    remaining=Decimal("1"),
+                    order_type="LMT",
+                    status="Submitted",
+                    limit_price=Decimal("99"),
+                    time_in_force="DAY",
+                    last_status_at=NOW,
+                ),
+            ),
+        )
+    else:
+        snapshot = replace(
+            snapshot,
+            recent_executions=(
+                BrokerExecution(
+                    execution_id="exec-101",
+                    order_id="101",
+                    contract=contract,
+                    side="BUY",
+                    quantity=Decimal("1"),
+                    price=Decimal("99"),
+                    executed_at=NOW - timedelta(minutes=1),
+                    client_id=7,
+                    execution_exchange="NASDAQ",
+                ),
+            ),
+        )
+
+    result = main(
+        ["--portfolio-id", "default", "--json"],
+        project_root=tmp_path,
+        process_environ=env,
+        provider_factory=lambda runtime: FakeProvider(snapshot),
+        now=NOW,
+    )
+
+    assert result == EXIT_BLOCKED
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == expected_status
+    assert payload["authorizes_startup"] is False
+
+
+@pytest.mark.asyncio
+async def test_snapshot_cancellation_closes_provider_before_propagating(tmp_path):
+    _, env = _project(tmp_path)
+    snapshot_started = asyncio.Event()
+    closed = asyncio.Event()
+
+    class CancellableProvider(FakeProvider):
+        async def get_broker_snapshot(self, expected_account, *, max_age_seconds):
+            del expected_account, max_age_seconds
+            snapshot_started.set()
+            await asyncio.Event().wait()
+
+        async def close(self):
+            self.closed = True
+            closed.set()
+
+    provider = CancellableProvider(_broker_snapshot())
+    task = asyncio.create_task(
+        run_reconciliation(
+            ["default"],
+            project_root=tmp_path,
+            process_environ=env,
+            provider_factory=lambda runtime: provider,
+            now=NOW,
+        )
+    )
+    await snapshot_started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert closed.is_set()
+    assert provider.closed is True
+
+
+@pytest.mark.asyncio
+async def test_provider_close_is_shielded_from_cancellation(tmp_path):
+    _, env = _project(tmp_path)
+    close_started = asyncio.Event()
+    release_close = asyncio.Event()
+    close_finished = asyncio.Event()
+
+    class SlowCloseProvider(FakeProvider):
+        async def close(self):
+            close_started.set()
+            await release_close.wait()
+            self.closed = True
+            close_finished.set()
+
+    provider = SlowCloseProvider(_broker_snapshot())
+    task = asyncio.create_task(
+        run_reconciliation(
+            ["default"],
+            project_root=tmp_path,
+            process_environ=env,
+            provider_factory=lambda runtime: provider,
+            now=NOW,
+        )
+    )
+    await close_started.wait()
+    task.cancel()
+    await asyncio.sleep(0)
+    assert not task.done()
+
+    release_close.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert close_finished.is_set()
+    assert provider.closed is True
+
+
 def test_provider_error_is_redacted_and_cleanup_runs(tmp_path, capsys):
     _, env = _project(tmp_path)
     provider = FakeProvider(error=RuntimeError(f"credential {RAW_ACCOUNT} secret"))
@@ -301,14 +510,38 @@ def test_provider_error_is_redacted_and_cleanup_runs(tmp_path, capsys):
     assert json.loads(output)["error_code"] == "BROKER_EVIDENCE_BLOCK"
 
 
-def test_provider_with_order_capability_is_rejected_without_calling_it(tmp_path, capsys):
+@pytest.mark.parametrize(
+    "capability",
+    [
+        "place_order",
+        "cancel_order",
+        "modify_order",
+        "replace_order",
+        "exercise_options",
+        "globalCancel",
+        "req_global_cancel",
+        "reqGlobalCancel",
+    ],
+)
+def test_provider_with_order_capability_is_rejected_without_calling_it(
+    tmp_path,
+    capsys,
+    capability,
+):
     _, env = _project(tmp_path)
+    env.update(
+        {
+            "IBKR_CLIENT_ID": "1",
+            "IBKR_RECONCILIATION_CLIENT_ID": "71",
+        }
+    )
 
-    class UnsafeProvider(FakeProvider):
-        def place_order(self):
-            raise AssertionError("must never be called")
+    provider = FakeProvider(_broker_snapshot())
 
-    provider = UnsafeProvider(_broker_snapshot())
+    def forbidden_capability():
+        raise AssertionError("must never be called")
+
+    setattr(provider, capability, forbidden_capability)
     result = main(
         ["--portfolio-id", "default", "--json"],
         project_root=tmp_path,

--- a/tests/test_reconciliation_engine.py
+++ b/tests/test_reconciliation_engine.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
@@ -257,6 +258,8 @@ def test_open_orders_and_executions_are_deterministically_non_comparable():
         now=NOW,
     )
 
+    assert report.status == "BLOCKED"
+    assert "UNMATCHED_ACTIVE_BROKER_OPEN_ORDERS" in report.blockers
     assert report.open_order_comparisons[0].status == "not_comparable"
     assert "NO_BROKER_ORDER_ID" in report.open_order_comparisons[0].reason
     assert report.execution_comparisons[0].status == "not_comparable"
@@ -291,6 +294,136 @@ def test_open_orders_and_executions_are_deterministically_non_comparable():
         "start_at": (NOW - timedelta(hours=24, seconds=1)).isoformat(),
         "end_at": NOW.isoformat(),
     }
+
+
+def test_public_report_serializes_all_evidence_decimals_without_exponents():
+    small = Decimal("0.00000001")
+    contract = _contract("AAPL", 1)
+    order = BrokerOpenOrder(
+        order_id="20",
+        client_id=7,
+        contract=contract,
+        side="BUY",
+        quantity=Decimal("0.00000002"),
+        filled=small,
+        remaining=small,
+        order_type="LMT",
+        status="Submitted",
+        limit_price=small,
+        auxiliary_price=small,
+        average_fill_price=small,
+    )
+    execution = BrokerExecution(
+        execution_id="exec-1",
+        order_id="19",
+        contract=contract,
+        side="BOT",
+        quantity=small,
+        price=small,
+        average_price=small,
+        commission=small,
+        commission_currency="USD",
+        realized_pnl=small,
+        executed_at=NOW - timedelta(seconds=5),
+    )
+    trade = LedgerTrade(
+        local_trade_id=42,
+        portfolio_id="default",
+        symbol="AAPL",
+        side="BUY",
+        quantity=small,
+        price=small,
+        timestamp=NOW - timedelta(seconds=5),
+    )
+
+    report = reconcile(
+        _snapshot(orders=(order,), executions=(execution,)),
+        _ledger(trades=(trade,)),
+        runtime_fingerprint="runtime",
+        database_identity="paper:db",
+        expected_account_alias="***4567",
+        now=NOW,
+    )
+    public_json = json.dumps(report.public_dict(), sort_keys=True)
+
+    assert "1E-8" not in public_json
+    assert "2E-8" not in public_json
+    assert "0.00000001" in public_json
+    assert "0.00000002" in public_json
+
+
+def test_uncorrelated_broker_execution_is_incomplete_even_when_positions_match():
+    execution = BrokerExecution(
+        execution_id="exec-1",
+        order_id="19",
+        contract=_contract("AAPL", 1),
+        side="BOT",
+        quantity=Decimal("3"),
+        price=Decimal("100"),
+        executed_at=NOW - timedelta(seconds=5),
+    )
+    report = reconcile(
+        _snapshot(
+            BrokerPosition(_contract("AAPL", 1), Decimal("3"), Decimal("100")),
+            executions=(execution,),
+        ),
+        _ledger(_local("AAPL", "3", "100")),
+        runtime_fingerprint="runtime",
+        database_identity="paper:db",
+        expected_account_alias="***4567",
+        now=NOW,
+    )
+
+    assert report.status == "INCOMPLETE"
+    assert report.status != "QUANTITY_COST_COMPARABLE_ONLY"
+    assert "BROKER_EXECUTIONS_CANNOT_BE_IDENTITY_MATCHED_TO_LOCAL_TRADES" in report.caveats
+
+
+def test_uncorrelated_local_trade_is_incomplete_even_without_broker_execution():
+    trade = LedgerTrade(
+        local_trade_id=42,
+        portfolio_id="default",
+        symbol="AAPL",
+        side="BUY",
+        quantity=Decimal("3"),
+        price=Decimal("100"),
+        timestamp=NOW - timedelta(seconds=5),
+    )
+    report = reconcile(
+        _snapshot(),
+        _ledger(trades=(trade,)),
+        runtime_fingerprint="runtime",
+        database_identity="paper:db",
+        expected_account_alias="***4567",
+        now=NOW,
+    )
+
+    assert report.status == "INCOMPLETE"
+    assert report.status != "QUANTITY_COST_COMPARABLE_ONLY"
+    assert report.execution_comparisons[0].evidence_type == "local_trade"
+
+
+def test_public_report_rejects_account_fragments_in_metadata_and_execution_evidence():
+    with pytest.raises(BrokerEvidenceError, match="sensitive identity"):
+        reconcile(
+            _snapshot(),
+            _ledger(),
+            runtime_fingerprint="runtime-DU1234567",
+            database_identity="paper:db",
+            expected_account_alias="***4567",
+            now=NOW,
+        )
+
+    with pytest.raises(BrokerEvidenceError, match="sensitive identity"):
+        BrokerExecution(
+            execution_id="exec-DU1234567-fill",
+            order_id="19",
+            contract=_contract("AAPL", 1),
+            side="BOT",
+            quantity=Decimal("3"),
+            price=Decimal("100"),
+            executed_at=NOW - timedelta(seconds=5),
+        )
 
 
 def test_duplicate_order_identity_is_rejected_even_when_contracts_differ():

--- a/tests/test_reconciliation_engine.py
+++ b/tests/test_reconciliation_engine.py
@@ -403,6 +403,30 @@ def test_uncorrelated_local_trade_is_incomplete_even_without_broker_execution():
     assert report.execution_comparisons[0].evidence_type == "local_trade"
 
 
+def test_local_trade_before_broker_execution_window_is_not_compared():
+    historical_trade = LedgerTrade(
+        local_trade_id=42,
+        portfolio_id="default",
+        symbol="AAPL",
+        side="BUY",
+        quantity=Decimal("3"),
+        price=Decimal("100"),
+        timestamp=NOW - timedelta(hours=25),
+    )
+    report = reconcile(
+        _snapshot(),
+        _ledger(trades=(historical_trade,)),
+        runtime_fingerprint="runtime",
+        database_identity="paper:db",
+        expected_account_alias="***4567",
+        now=NOW,
+    )
+
+    assert report.status == "QUANTITY_COST_COMPARABLE_ONLY"
+    assert report.execution_comparisons == ()
+    assert "BROKER_EXECUTIONS_CANNOT_BE_IDENTITY_MATCHED_TO_LOCAL_TRADES" not in report.caveats
+
+
 def test_public_report_rejects_account_fragments_in_metadata_and_execution_evidence():
     with pytest.raises(BrokerEvidenceError, match="sensitive identity"):
         reconcile(

--- a/tests/test_reconciliation_engine.py
+++ b/tests/test_reconciliation_engine.py
@@ -1,0 +1,452 @@
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+from robo_trader.reconciliation.engine import reconcile
+from robo_trader.reconciliation.errors import BrokerEvidenceError
+from robo_trader.reconciliation.models import (
+    AggregatedLedgerPosition,
+    BrokerExecution,
+    BrokerExecutionScope,
+    BrokerOpenOrder,
+    BrokerPosition,
+    BrokerSnapshot,
+    ContractIdentity,
+    LedgerPosition,
+    LedgerSnapshot,
+    LedgerTrade,
+)
+
+NOW = datetime(2026, 7, 23, 15, 0, tzinfo=timezone.utc)
+
+
+def _contract(symbol: str, con_id: int) -> ContractIdentity:
+    return ContractIdentity(
+        con_id=con_id,
+        symbol=symbol,
+        local_symbol=symbol,
+        security_type="STK",
+        currency="USD",
+        exchange="SMART",
+        primary_exchange="NASDAQ",
+        trading_class=symbol,
+    )
+
+
+def _snapshot(*positions, orders=(), executions=(), age_seconds=0) -> BrokerSnapshot:
+    at = NOW - timedelta(seconds=age_seconds)
+    return BrokerSnapshot(
+        schema_version=1,
+        account_alias="***4567",
+        broker_time_before=at - timedelta(seconds=1),
+        broker_time_after=at,
+        retrieved_at=at,
+        execution_scope=BrokerExecutionScope(
+            kind="bounded_execution_filter",
+            start_at=at - timedelta(hours=24, seconds=1),
+            end_at=at,
+        ),
+        positions=positions,
+        open_orders=orders,
+        recent_executions=executions,
+        balances={
+            "NetLiquidation:USD": Decimal("1000"),
+            "TotalCashValue:USD": Decimal("500"),
+        },
+    )
+
+
+def _ledger(*positions, blockers=(), trades=()) -> LedgerSnapshot:
+    aggregated = []
+    for position in positions:
+        aggregated.append(
+            AggregatedLedgerPosition(
+                symbol=position.symbol,
+                quantity=position.quantity,
+                average_cost=position.average_cost,
+                allocations=(position,),
+            )
+        )
+    return LedgerSnapshot(
+        selected_portfolio_ids=("default",),
+        known_portfolio_ids=("default",),
+        active_portfolio_ids=("default",) if positions else (),
+        positions=positions,
+        aggregated_positions=tuple(aggregated),
+        recent_trades=trades,
+        blockers=blockers,
+        caveats=("LOCAL_LEDGER_HAS_NO_CONID_EXCHANGE_OR_CURRENCY",),
+    )
+
+
+def _local(symbol: str, quantity: str, cost: str) -> LedgerPosition:
+    return LedgerPosition(
+        portfolio_id="default",
+        symbol=symbol,
+        quantity=Decimal(quantity),
+        average_cost=Decimal(cost),
+        timestamp=NOW - timedelta(minutes=1),
+    )
+
+
+def test_position_diff_is_deterministic_for_match_broker_only_ledger_only_qty_and_cost():
+    broker = _snapshot(
+        BrokerPosition(_contract("AAPL", 1), Decimal("3"), Decimal("100.00")),
+        BrokerPosition(_contract("MSFT", 2), Decimal("4"), Decimal("50.00")),
+        BrokerPosition(_contract("TSLA", 3), Decimal("2"), Decimal("200.00")),
+    )
+    ledger = _ledger(
+        _local("AAPL", "3", "100.009"),
+        _local("GOOG", "1", "90"),
+        _local("MSFT", "5", "50"),
+        _local("TSLA", "2", "201"),
+    )
+
+    report = reconcile(
+        broker,
+        ledger,
+        runtime_fingerprint="runtime",
+        database_identity="paper:db",
+        expected_account_alias="***4567",
+        now=NOW,
+    )
+
+    assert [item.symbol for item in report.position_comparisons] == [
+        "AAPL",
+        "GOOG",
+        "MSFT",
+        "TSLA",
+    ]
+    assert [item.status for item in report.position_comparisons] == [
+        "quantity_cost_match",
+        "ledger_only",
+        "quantity_cost_mismatch",
+        "quantity_cost_mismatch",
+    ]
+    assert report.status == "MISMATCH"
+    assert report.mutated_state is False
+    assert report.authorizes_startup is False
+
+
+def test_fractional_broker_quantity_is_a_schema_blocker():
+    report = reconcile(
+        _snapshot(BrokerPosition(_contract("AAPL", 1), Decimal("1.5"), Decimal("10"))),
+        _ledger(_local("AAPL", "1", "10")),
+        runtime_fingerprint="runtime",
+        database_identity="paper:db",
+        expected_account_alias="***4567",
+        now=NOW,
+    )
+    assert report.status == "BLOCKED"
+    assert "BROKER_FRACTIONAL_QUANTITY_UNREPRESENTABLE:AAPL" in report.blockers
+
+
+def test_stale_ledger_projection_cannot_report_comparable_only():
+    stale = LedgerPosition(
+        portfolio_id="default",
+        symbol="AAPL",
+        quantity=Decimal("3"),
+        average_cost=Decimal("100"),
+        timestamp=NOW - timedelta(minutes=6),
+    )
+    report = reconcile(
+        _snapshot(BrokerPosition(_contract("AAPL", 1), Decimal("3"), Decimal("100"))),
+        _ledger(stale),
+        runtime_fingerprint="runtime",
+        database_identity="paper:db",
+        expected_account_alias="***4567",
+        now=NOW,
+    )
+
+    assert report.status == "BLOCKED"
+    assert "LEDGER_POSITION_PROJECTION_STALE:default:AAPL" in report.blockers
+
+
+def test_future_ledger_position_timestamp_blocks_comparable_only_report():
+    future = LedgerPosition(
+        portfolio_id="default",
+        symbol="AAPL",
+        quantity=Decimal("3"),
+        average_cost=Decimal("100"),
+        timestamp=NOW + timedelta(seconds=6),
+    )
+    report = reconcile(
+        _snapshot(BrokerPosition(_contract("AAPL", 1), Decimal("3"), Decimal("100"))),
+        _ledger(future),
+        runtime_fingerprint="runtime",
+        database_identity="paper:db",
+        expected_account_alias="***4567",
+        now=NOW,
+    )
+
+    assert report.status == "BLOCKED"
+    assert report.status != "QUANTITY_COST_COMPARABLE_ONLY"
+    assert "LEDGER_POSITION_TIMESTAMP_FUTURE:default:AAPL" in report.blockers
+
+
+def test_future_ledger_trade_timestamp_blocks_comparable_only_report():
+    future_trade = LedgerTrade(
+        local_trade_id=42,
+        portfolio_id="default",
+        symbol="AAPL",
+        side="BUY",
+        quantity=Decimal("3"),
+        price=Decimal("100"),
+        timestamp=NOW + timedelta(seconds=6),
+    )
+    report = reconcile(
+        _snapshot(),
+        _ledger(trades=(future_trade,)),
+        runtime_fingerprint="runtime",
+        database_identity="paper:db",
+        expected_account_alias="***4567",
+        now=NOW,
+    )
+
+    assert report.status == "BLOCKED"
+    assert report.status != "QUANTITY_COST_COMPARABLE_ONLY"
+    assert "LEDGER_TRADE_TIMESTAMP_FUTURE:42" in report.blockers
+
+
+def test_open_orders_and_executions_are_deterministically_non_comparable():
+    contract = _contract("AAPL", 1)
+    order = BrokerOpenOrder(
+        order_id="20",
+        client_id=7,
+        contract=contract,
+        side="BUY",
+        quantity=Decimal("3"),
+        filled=Decimal("1"),
+        remaining=Decimal("2"),
+        order_type="LMT",
+        status="Submitted",
+        limit_price=Decimal("99"),
+        permanent_id="501",
+        unavailable={"stop_price": "not supplied for this order type"},
+    )
+    same_order_id_other_client = BrokerOpenOrder(
+        order_id="20",
+        client_id=8,
+        contract=contract,
+        side="SELL",
+        quantity=Decimal("1"),
+        filled=Decimal("0"),
+        remaining=Decimal("1"),
+        order_type="STP",
+        status="Submitted",
+        auxiliary_price=Decimal("90"),
+        permanent_id="502",
+        unavailable={"limit_price": "not supplied for this order type"},
+    )
+    execution = BrokerExecution(
+        execution_id="exec-1",
+        order_id="19",
+        contract=contract,
+        side="BOT",
+        quantity=Decimal("2"),
+        price=Decimal("98"),
+        executed_at=NOW - timedelta(seconds=5),
+    )
+    report = reconcile(
+        _snapshot(orders=(same_order_id_other_client, order), executions=(execution,)),
+        _ledger(),
+        runtime_fingerprint="runtime",
+        database_identity="paper:db",
+        expected_account_alias="***4567",
+        now=NOW,
+    )
+
+    assert report.open_order_comparisons[0].status == "not_comparable"
+    assert "NO_BROKER_ORDER_ID" in report.open_order_comparisons[0].reason
+    assert report.execution_comparisons[0].status == "not_comparable"
+    assert "NO_BROKER_EXECUTION" in report.execution_comparisons[0].reason
+    public = report.public_dict()
+    assert [item["broker_identifier"] for item in public["open_orders"]] == [
+        "7:20",
+        "8:20",
+    ]
+    first_order = public["open_orders"][0]
+    assert first_order["details"]["client_id"] == 7
+    assert first_order["details"]["broker_order_id"] == "20"
+    assert first_order["details"]["permanent_id"] == "501"
+    assert first_order["details"]["contract"] == {
+        "con_id": 1,
+        "currency": "USD",
+        "exchange": "SMART",
+        "local_symbol": "AAPL",
+        "primary_exchange": "NASDAQ",
+        "security_type": "STK",
+        "symbol": "AAPL",
+        "trading_class": "AAPL",
+    }
+    assert first_order["details"]["unavailable"] == {
+        "stop_price": "not supplied for this order type"
+    }
+    with pytest.raises(TypeError):
+        report.open_order_comparisons[0].details["contract"]["symbol"] = "MSFT"
+    assert public["recent_executions"][0]["broker_identifier"] == "exec-1"
+    assert public["broker_freshness"]["execution_scope"] == {
+        "kind": "bounded_execution_filter",
+        "start_at": (NOW - timedelta(hours=24, seconds=1)).isoformat(),
+        "end_at": NOW.isoformat(),
+    }
+
+
+def test_duplicate_order_identity_is_rejected_even_when_contracts_differ():
+    first = BrokerOpenOrder(
+        order_id="20",
+        client_id=7,
+        contract=_contract("AAPL", 1),
+        side="BUY",
+        quantity=Decimal("1"),
+        filled=Decimal("0"),
+        remaining=Decimal("1"),
+        order_type="MKT",
+        status="Submitted",
+    )
+    duplicate_identity = BrokerOpenOrder(
+        order_id="20",
+        client_id=7,
+        contract=_contract("MSFT", 2),
+        side="SELL",
+        quantity=Decimal("1"),
+        filled=Decimal("0"),
+        remaining=Decimal("1"),
+        order_type="MKT",
+        status="Submitted",
+    )
+
+    with pytest.raises(BrokerEvidenceError, match="duplicate open-order identity"):
+        _snapshot(orders=(first, duplicate_identity))
+
+
+@pytest.mark.parametrize(
+    "snapshot,expected",
+    [
+        (_snapshot(age_seconds=121), "stale"),
+        (
+            BrokerSnapshot(
+                schema_version=1,
+                account_alias="***4567",
+                broker_time_before=NOW,
+                broker_time_after=NOW - timedelta(seconds=1),
+                retrieved_at=NOW,
+                execution_scope=BrokerExecutionScope(
+                    kind="bounded_execution_filter",
+                    start_at=NOW - timedelta(hours=24),
+                    end_at=NOW,
+                ),
+                balances={
+                    "NetLiquidation:USD": Decimal("1000"),
+                    "TotalCashValue:USD": Decimal("500"),
+                },
+            ),
+            "reversed",
+        ),
+        (
+            BrokerSnapshot(
+                schema_version=1,
+                account_alias="***4567",
+                broker_time_before=NOW,
+                broker_time_after=NOW,
+                retrieved_at=NOW + timedelta(seconds=6),
+                execution_scope=BrokerExecutionScope(
+                    kind="bounded_execution_filter",
+                    start_at=NOW - timedelta(hours=24),
+                    end_at=NOW,
+                ),
+                balances={
+                    "NetLiquidation:USD": Decimal("1000"),
+                    "TotalCashValue:USD": Decimal("500"),
+                },
+            ),
+            "future",
+        ),
+    ],
+)
+def test_stale_reversed_and_future_broker_evidence_fails_closed(snapshot, expected):
+    with pytest.raises(BrokerEvidenceError, match=expected):
+        reconcile(
+            snapshot,
+            _ledger(),
+            runtime_fingerprint="runtime",
+            database_identity="paper:db",
+            expected_account_alias="***4567",
+            now=NOW,
+        )
+
+
+def test_exact_execution_scope_can_end_before_snapshot_retrieval() -> None:
+    broker_before = NOW - timedelta(seconds=10)
+    snapshot = BrokerSnapshot(
+        schema_version=1,
+        account_alias="***4567",
+        broker_time_before=broker_before,
+        broker_time_after=NOW,
+        retrieved_at=NOW,
+        execution_scope=BrokerExecutionScope(
+            kind="bounded_execution_filter",
+            start_at=broker_before - timedelta(hours=24),
+            end_at=NOW - timedelta(seconds=5),
+        ),
+        balances={
+            "NetLiquidation:USD": Decimal("1000"),
+            "TotalCashValue:USD": Decimal("500"),
+        },
+    )
+
+    report = reconcile(
+        snapshot,
+        _ledger(),
+        runtime_fingerprint="runtime",
+        database_identity="paper:db",
+        expected_account_alias="***4567",
+        now=NOW,
+    )
+
+    assert report.broker_snapshot.execution_scope.end_at == NOW - timedelta(seconds=5)
+    assert report.broker_snapshot.retrieved_at == NOW
+
+
+def test_execution_scope_start_must_exactly_match_wire_filter() -> None:
+    broker_before = NOW - timedelta(seconds=10)
+    snapshot = BrokerSnapshot(
+        schema_version=1,
+        account_alias="***4567",
+        broker_time_before=broker_before,
+        broker_time_after=NOW,
+        retrieved_at=NOW,
+        execution_scope=BrokerExecutionScope(
+            kind="bounded_execution_filter",
+            start_at=broker_before - timedelta(hours=24) + timedelta(seconds=1),
+            end_at=NOW - timedelta(seconds=5),
+        ),
+        balances={
+            "NetLiquidation:USD": Decimal("1000"),
+            "TotalCashValue:USD": Decimal("500"),
+        },
+    )
+
+    with pytest.raises(BrokerEvidenceError, match="exact wire filter"):
+        reconcile(
+            snapshot,
+            _ledger(),
+            runtime_fingerprint="runtime",
+            database_identity="paper:db",
+            expected_account_alias="***4567",
+            now=NOW,
+        )
+
+
+def test_account_mismatch_fails_without_exposing_expected_identity():
+    with pytest.raises(BrokerEvidenceError) as exc_info:
+        reconcile(
+            _snapshot(),
+            _ledger(),
+            runtime_fingerprint="runtime",
+            database_identity="paper:db",
+            expected_account_alias="***9999",
+            now=NOW,
+        )
+    assert "DU1234567" not in str(exc_info.value)

--- a/tests/test_reconciliation_ibkr_adapter.py
+++ b/tests/test_reconciliation_ibkr_adapter.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from types import MappingProxyType, SimpleNamespace
@@ -147,6 +148,18 @@ def test_transport_payload_maps_to_immutable_reconciliation_models():
         snapshot.open_orders[0].unavailable["stop_price"] = "changed"
 
 
+def test_adapter_accepts_worker_canonical_small_fixed_point_and_rejects_exponent():
+    payload = _payload()
+    payload["positions"][0]["quantity"] = "0.00000001"
+
+    snapshot = snapshot_from_transport(payload, expected_account=ACCOUNT)
+    assert snapshot.positions[0].quantity == Decimal("0.00000001")
+
+    payload["positions"][0]["quantity"] = "1E-8"
+    with pytest.raises(BrokerEvidenceError):
+        snapshot_from_transport(payload, expected_account=ACCOUNT)
+
+
 @pytest.mark.parametrize(
     "mutate",
     [
@@ -283,6 +296,54 @@ async def test_factory_reaps_worker_when_connect_raises():
         await build_diagnostic_provider(_runtime(), transport_factory=lambda: transport)
 
     assert ACCOUNT not in str(exc_info.value)
+    transport.stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel_phase", ["start", "connect"])
+async def test_factory_cancellation_reaps_worker_and_propagates(cancel_phase):
+    transport = SimpleNamespace(
+        start=AsyncMock(),
+        connect=AsyncMock(return_value=True),
+        stop=AsyncMock(),
+    )
+    getattr(transport, cancel_phase).side_effect = asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        await build_diagnostic_provider(_runtime(), transport_factory=lambda: transport)
+
+    transport.stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_factory_cleanup_is_shielded_from_repeated_cancellation():
+    cleanup_started = asyncio.Event()
+    release_cleanup = asyncio.Event()
+    cleanup_finished = asyncio.Event()
+
+    async def stop():
+        cleanup_started.set()
+        await release_cleanup.wait()
+        cleanup_finished.set()
+
+    transport = SimpleNamespace(
+        start=AsyncMock(side_effect=asyncio.CancelledError),
+        connect=AsyncMock(return_value=True),
+        stop=AsyncMock(side_effect=stop),
+    )
+    task = asyncio.create_task(
+        build_diagnostic_provider(_runtime(), transport_factory=lambda: transport)
+    )
+    await cleanup_started.wait()
+    task.cancel()
+    await asyncio.sleep(0)
+    assert not task.done()
+
+    release_cleanup.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert cleanup_finished.is_set()
     transport.stop.assert_awaited_once()
 
 

--- a/tests/test_reconciliation_ibkr_adapter.py
+++ b/tests/test_reconciliation_ibkr_adapter.py
@@ -1,0 +1,386 @@
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from types import MappingProxyType, SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from robo_trader.clients import subprocess_ibkr_client as client_module
+from robo_trader.clients.subprocess_ibkr_client import SubprocessIBKRClient
+from robo_trader.reconciliation.broker import assert_read_only_provider_surface
+from robo_trader.reconciliation.errors import BrokerEvidenceError
+from robo_trader.reconciliation.ibkr_adapter import (
+    IBKRDiagnosticSnapshotProvider,
+    build_diagnostic_provider,
+    snapshot_from_transport,
+)
+
+ACCOUNT = "DU_TEST_4567"
+NOW = datetime.now(timezone.utc).replace(microsecond=0)
+
+
+def _contract():
+    return {
+        "con_id": 265598,
+        "symbol": "AAPL",
+        "local_symbol": "AAPL",
+        "security_type": "STK",
+        "currency": "USD",
+        "exchange": "SMART",
+        "primary_exchange": "NASDAQ",
+        "trading_class": "NMS",
+    }
+
+
+def _payload():
+    return {
+        "snapshot_schema_version": 1,
+        "account": ACCOUNT,
+        "broker_time_before": (NOW - timedelta(seconds=2)).isoformat(),
+        "broker_time_after": NOW.isoformat(),
+        "retrieved_at": NOW.isoformat(),
+        "positions": [
+            {
+                "account": ACCOUNT,
+                "contract": _contract(),
+                "quantity": "10.5",
+                "avg_cost": "123.45",
+            }
+        ],
+        "balances": [
+            {"tag": "NetLiquidation", "currency": "USD", "value": "100000"},
+            {"tag": "TotalCashValue", "currency": "USD", "value": "25000.5"},
+        ],
+        "open_orders": [
+            {
+                "account": ACCOUNT,
+                "broker_order_id": 101,
+                "permanent_id": 501,
+                "client_id": 7,
+                "contract": _contract(),
+                "side": "BUY",
+                "status": "Submitted",
+                "order_type": "LMT",
+                "time_in_force": "DAY",
+                "total_quantity": "2",
+                "filled_quantity": "0",
+                "remaining_quantity": "2",
+                "limit_price": "120.25",
+                "stop_price": None,
+                "avg_fill_price": None,
+                "last_status_at": NOW.isoformat(),
+                "unavailable": {
+                    "stop_price": "not supplied for this order type",
+                    "avg_fill_price": "order has no fills",
+                },
+            }
+        ],
+        "executions": [
+            {
+                "account": ACCOUNT,
+                "execution_id": "0001.01",
+                "broker_order_id": 101,
+                "permanent_id": 501,
+                "client_id": 7,
+                "contract": _contract(),
+                "side": "BUY",
+                "quantity": "1.25",
+                "price": "120.25",
+                "average_price": "120.25",
+                "executed_at": (NOW - timedelta(minutes=1)).isoformat(),
+                "execution_exchange": "NASDAQ",
+                "commission": None,
+                "commission_currency": None,
+                "realized_pnl": None,
+                "unavailable": {
+                    "commission": "not returned by the bounded execution request",
+                    "commission_currency": "not returned by the bounded execution request",
+                    "realized_pnl": "not returned by the bounded execution request",
+                },
+            }
+        ],
+        "execution_scope": {
+            "kind": "bounded_execution_filter",
+            "start_at": (NOW - timedelta(hours=24, seconds=2)).isoformat(),
+            "end_at": NOW.isoformat(),
+        },
+    }
+
+
+def test_transport_payload_maps_to_immutable_reconciliation_models():
+    snapshot = snapshot_from_transport(_payload(), expected_account=ACCOUNT)
+
+    assert snapshot.account_alias == "***4567"
+    assert snapshot.execution_scope.public_dict() == {
+        "kind": "bounded_execution_filter",
+        "start_at": (NOW - timedelta(hours=24, seconds=2)).isoformat(),
+        "end_at": NOW.isoformat(),
+    }
+    assert snapshot.positions[0].quantity == Decimal("10.5")
+    assert snapshot.positions[0].average_cost == Decimal("123.45")
+    assert snapshot.balances == {
+        "NetLiquidation:USD": Decimal("100000"),
+        "TotalCashValue:USD": Decimal("25000.5"),
+    }
+    assert isinstance(snapshot.balances, MappingProxyType)
+    assert snapshot.open_orders[0].order_id == "101"
+    assert snapshot.open_orders[0].identity == (7, "101")
+    assert snapshot.open_orders[0].permanent_id == "501"
+    assert snapshot.open_orders[0].contract.public_dict() == _contract()
+    assert snapshot.open_orders[0].auxiliary_price is None
+    assert snapshot.open_orders[0].unavailable == {
+        "stop_price": "not supplied for this order type",
+        "avg_fill_price": "order has no fills",
+    }
+    assert isinstance(snapshot.open_orders[0].unavailable, MappingProxyType)
+    assert snapshot.recent_executions[0].execution_id == "0001.01"
+    assert snapshot.recent_executions[0].commission is None
+    assert snapshot.recent_executions[0].unavailable == {
+        "commission": "not returned by the bounded execution request",
+        "commission_currency": "not returned by the bounded execution request",
+        "realized_pnl": "not returned by the bounded execution request",
+    }
+
+    with pytest.raises(TypeError):
+        snapshot.balances["BuyingPower:USD"] = Decimal("1")
+    with pytest.raises(TypeError):
+        snapshot.open_orders[0].unavailable["stop_price"] = "changed"
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda payload: payload.update(account="DU_OTHER_0000"),
+        lambda payload: payload.update(extra="drift"),
+        lambda payload: payload["positions"][0].update(extra="drift"),
+        lambda payload: payload["balances"].append(payload["balances"][0].copy()),
+        lambda payload: payload["execution_scope"].update(kind="unbounded"),
+        lambda payload: payload["execution_scope"].update(
+            start_at=(NOW - timedelta(days=2)).isoformat()
+        ),
+        lambda payload: payload["execution_scope"].update(
+            start_at=(NOW - timedelta(hours=24, seconds=1)).isoformat()
+        ),
+        lambda payload: payload["execution_scope"].update(
+            end_at=(NOW + timedelta(microseconds=1)).isoformat()
+        ),
+        lambda payload: payload["executions"][0].update(
+            executed_at=(NOW + timedelta(microseconds=1)).isoformat()
+        ),
+        lambda payload: payload["open_orders"][0].update(total_quantity=2),
+    ],
+)
+def test_adapter_rejects_identity_schema_scope_and_type_drift(mutate):
+    payload = _payload()
+    mutate(payload)
+
+    with pytest.raises(BrokerEvidenceError):
+        snapshot_from_transport(payload, expected_account=ACCOUNT)
+
+
+@pytest.mark.asyncio
+async def test_provider_exposes_only_snapshot_protocol_and_converts_payload():
+    transport = SimpleNamespace(
+        get_broker_snapshot=AsyncMock(return_value=_payload()),
+        stop=AsyncMock(),
+    )
+    provider = IBKRDiagnosticSnapshotProvider(transport, expected_account=ACCOUNT)
+
+    assert_read_only_provider_surface(provider)
+    snapshot = await provider.get_broker_snapshot(ACCOUNT, max_age_seconds=30.0)
+    assert snapshot.account_alias == "***4567"
+    transport.get_broker_snapshot.assert_awaited_once_with(ACCOUNT, max_age_seconds=30.0)
+
+    await provider.close()
+    transport.stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_provider_close_retries_transient_transport_cleanup_failure():
+    transport = SimpleNamespace(
+        get_broker_snapshot=AsyncMock(return_value=_payload()),
+        stop=AsyncMock(side_effect=[RuntimeError("transient cleanup failure"), None]),
+    )
+    provider = IBKRDiagnosticSnapshotProvider(transport, expected_account=ACCOUNT)
+
+    await provider.close()
+
+    assert transport.stop.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_provider_rejects_changed_expected_account_without_transport_call():
+    transport = SimpleNamespace(
+        get_broker_snapshot=AsyncMock(return_value=_payload()),
+        stop=AsyncMock(),
+    )
+    provider = IBKRDiagnosticSnapshotProvider(transport, expected_account=ACCOUNT)
+
+    with pytest.raises(BrokerEvidenceError, match="does not match runtime"):
+        await provider.get_broker_snapshot("DU_OTHER_0000", max_age_seconds=30.0)
+
+    transport.get_broker_snapshot.assert_not_awaited()
+
+
+def _runtime():
+    return SimpleNamespace(
+        diagnostic_connection=SimpleNamespace(
+            host="127.0.0.1",
+            port=4002,
+            client_id=997,
+            readonly=True,
+        ),
+        expected_account_for_provider=ACCOUNT,
+    )
+
+
+@pytest.mark.asyncio
+async def test_factory_uses_only_validated_diagnostic_connection_identity():
+    transport = SimpleNamespace(
+        start=AsyncMock(),
+        connect=AsyncMock(return_value=True),
+        get_broker_snapshot=AsyncMock(return_value=_payload()),
+        stop=AsyncMock(),
+    )
+
+    provider = await build_diagnostic_provider(_runtime(), transport_factory=lambda: transport)
+
+    transport.start.assert_awaited_once()
+    transport.connect.assert_awaited_once_with(
+        host="127.0.0.1",
+        port=4002,
+        client_id=997,
+        readonly=True,
+        timeout=30.0,
+    )
+    assert_read_only_provider_surface(provider)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("connect_result", [False, None])
+async def test_factory_fails_closed_and_reaps_unconnected_worker(connect_result):
+    transport = SimpleNamespace(
+        start=AsyncMock(),
+        connect=AsyncMock(return_value=connect_result),
+        stop=AsyncMock(),
+    )
+
+    with pytest.raises(BrokerEvidenceError, match="initialization failed"):
+        await build_diagnostic_provider(_runtime(), transport_factory=lambda: transport)
+
+    transport.stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_factory_reaps_worker_when_connect_raises():
+    transport = SimpleNamespace(
+        start=AsyncMock(),
+        connect=AsyncMock(side_effect=RuntimeError(f"secret {ACCOUNT}")),
+        stop=AsyncMock(),
+    )
+
+    with pytest.raises(BrokerEvidenceError) as exc_info:
+        await build_diagnostic_provider(_runtime(), transport_factory=lambda: transport)
+
+    assert ACCOUNT not in str(exc_info.value)
+    transport.stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_factory_connect_failure_retries_transient_debug_log_unlink(monkeypatch, tmp_path):
+    transport = SubprocessIBKRClient()
+    transport.start = AsyncMock()
+    transport.connect = AsyncMock(side_effect=RuntimeError("simulated connect failure"))
+    debug_path = tmp_path / "provider_init_unlink_retry.log"
+    debug_path.write_text("diagnostic evidence")
+    debug_file = debug_path.open("a")
+    transport._debug_log_file = debug_file
+    transport._debug_log_path = str(debug_path)
+    real_unlink = client_module.os.unlink
+    unlink_attempts = 0
+
+    def unlink_fails_once(path):
+        nonlocal unlink_attempts
+        unlink_attempts += 1
+        if unlink_attempts == 1:
+            raise OSError("transient unlink failure")
+        real_unlink(path)
+
+    monkeypatch.setattr(client_module.os, "unlink", unlink_fails_once)
+
+    with pytest.raises(BrokerEvidenceError, match="provider initialization failed"):
+        await build_diagnostic_provider(_runtime(), transport_factory=lambda: transport)
+
+    assert unlink_attempts == 2
+    assert debug_file.closed
+    assert not debug_path.exists()
+    assert transport._debug_log_file is None
+    assert transport._debug_log_path is None
+
+
+class _ProviderCloseFailsOnce:
+    def __init__(self, wrapped):
+        self.wrapped = wrapped
+        self.attempts = 0
+
+    @property
+    def closed(self):
+        return self.wrapped.closed
+
+    def close(self):
+        self.attempts += 1
+        if self.attempts == 1:
+            raise OSError("transient close failure")
+        self.wrapped.close()
+
+
+@pytest.mark.asyncio
+async def test_factory_connect_failure_retries_transient_debug_log_close(tmp_path):
+    transport = SubprocessIBKRClient()
+    transport.start = AsyncMock()
+    transport.connect = AsyncMock(side_effect=RuntimeError("simulated connect failure"))
+    debug_path = tmp_path / "provider_init_close_retry.log"
+    debug_path.write_text("diagnostic evidence")
+    debug_file = _ProviderCloseFailsOnce(debug_path.open("a"))
+    transport._debug_log_file = debug_file
+    transport._debug_log_path = str(debug_path)
+
+    with pytest.raises(BrokerEvidenceError, match="provider initialization failed"):
+        await build_diagnostic_provider(_runtime(), transport_factory=lambda: transport)
+
+    assert debug_file.attempts == 2
+    assert debug_file.closed
+    assert not debug_path.exists()
+    assert transport._debug_log_file is None
+    assert transport._debug_log_path is None
+
+
+@pytest.mark.asyncio
+async def test_factory_surfaces_persistent_initialization_cleanup_failure():
+    transport = SimpleNamespace(
+        start=AsyncMock(),
+        connect=AsyncMock(side_effect=RuntimeError("simulated connect failure")),
+        stop=AsyncMock(side_effect=RuntimeError("persistent cleanup failure")),
+    )
+
+    with pytest.raises(BrokerEvidenceError, match="initialization cleanup failed"):
+        await build_diagnostic_provider(_runtime(), transport_factory=lambda: transport)
+
+    assert transport.stop.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_factory_rejects_missing_account_before_constructing_transport():
+    runtime = _runtime()
+    runtime.expected_account_for_provider = ""
+    constructed = False
+
+    def transport_factory():
+        nonlocal constructed
+        constructed = True
+        raise AssertionError("must not construct transport")
+
+    with pytest.raises(BrokerEvidenceError, match="account is unavailable"):
+        await build_diagnostic_provider(runtime, transport_factory=transport_factory)
+
+    assert constructed is False

--- a/tests/test_reconciliation_identity.py
+++ b/tests/test_reconciliation_identity.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from robo_trader.reconciliation.errors import RuntimeSafetyError
+from robo_trader.reconciliation.identity import validate_runtime_safety
+
+
+def _project(tmp_path: Path) -> None:
+    config = tmp_path / "config" / "ibc"
+    config.mkdir(parents=True)
+    (config / "config.ini").write_text("ReadOnlyApi=yes\nTradingMode=paper\n")
+
+
+def _environment(**overrides: str) -> dict[str, str]:
+    environment = {
+        "IBKR_ACCOUNT": "DU1234567",
+        "IBKR_CLIENT_ID": "7",
+        "IBKR_RECONCILIATION_CLIENT_ID": "997",
+    }
+    environment.update(overrides)
+    return environment
+
+
+@pytest.fixture
+def runtime_contract(monkeypatch):
+    contract = SimpleNamespace(
+        execution_mode="paper",
+        ibkr_host="127.0.0.1",
+        ibkr_port=4002,
+        ibkr_readonly=True,
+        account_alias="***4567",
+        fingerprint="runtime",
+        database_identity="paper:db",
+    )
+    monkeypatch.setattr(
+        "robo_trader.config.load_runtime_contract_from_env",
+        lambda environment: contract,
+    )
+    return contract
+
+
+def test_reconciliation_client_id_is_dedicated_required_configuration(tmp_path, runtime_contract):
+    del runtime_contract
+    _project(tmp_path)
+    environment = _environment()
+    environment.pop("IBKR_RECONCILIATION_CLIENT_ID")
+
+    with pytest.raises(RuntimeSafetyError, match="IBKR_RECONCILIATION_CLIENT_ID is required"):
+        validate_runtime_safety(tmp_path, environment)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"IBKR_RECONCILIATION_CLIENT_ID": "0"}, "between 1 and 999"),
+        ({"IBKR_RECONCILIATION_CLIENT_ID": "7"}, "distinct"),
+        ({"IBKR_RECONCILIATION_CLIENT_ID": "not-an-integer"}, "must be an integer"),
+        ({"IBKR_CLIENT_ID": "0"}, "trading broker client ID must be between"),
+    ],
+)
+def test_reconciliation_client_id_must_be_positive_and_distinct(
+    tmp_path, runtime_contract, overrides, message
+):
+    del runtime_contract
+    _project(tmp_path)
+
+    with pytest.raises(RuntimeSafetyError, match=message):
+        validate_runtime_safety(tmp_path, _environment(**overrides))

--- a/tests/test_reconciliation_identity.py
+++ b/tests/test_reconciliation_identity.py
@@ -57,7 +57,6 @@ def test_reconciliation_client_id_is_dedicated_required_configuration(tmp_path, 
         ({"IBKR_RECONCILIATION_CLIENT_ID": "0"}, "between 1 and 999"),
         ({"IBKR_RECONCILIATION_CLIENT_ID": "7"}, "distinct"),
         ({"IBKR_RECONCILIATION_CLIENT_ID": "not-an-integer"}, "must be an integer"),
-        ({"IBKR_CLIENT_ID": "0"}, "trading broker client ID must be between"),
     ],
 )
 def test_reconciliation_client_id_must_be_positive_and_distinct(
@@ -68,3 +67,15 @@ def test_reconciliation_client_id_must_be_positive_and_distinct(
 
     with pytest.raises(RuntimeSafetyError, match=message):
         validate_runtime_safety(tmp_path, _environment(**overrides))
+
+
+def test_reconciliation_allows_existing_zero_trading_client_id(tmp_path, runtime_contract):
+    del runtime_contract
+    _project(tmp_path)
+
+    context = validate_runtime_safety(
+        tmp_path,
+        _environment(IBKR_CLIENT_ID="0"),
+    )
+
+    assert context.diagnostic_connection.client_id == 997

--- a/tests/test_reconciliation_ledger.py
+++ b/tests/test_reconciliation_ledger.py
@@ -1,0 +1,251 @@
+import hashlib
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from robo_trader.reconciliation.errors import IntegrityViolation, LedgerSafetyError
+from robo_trader.reconciliation.integrity import (
+    EvidenceIntegrityGuard,
+    protected_evidence_paths,
+)
+from robo_trader.reconciliation.ledger import ImmutableLedgerReader
+
+
+def _create_ledger(path: Path) -> None:
+    connection = sqlite3.connect(path)
+    connection.executescript("""
+        CREATE TABLE positions (
+            id INTEGER PRIMARY KEY,
+            portfolio_id TEXT NOT NULL,
+            symbol TEXT NOT NULL,
+            quantity INTEGER NOT NULL,
+            avg_cost REAL NOT NULL,
+            market_price REAL,
+            timestamp DATETIME
+        );
+        CREATE TABLE trades (
+            id INTEGER PRIMARY KEY,
+            portfolio_id TEXT NOT NULL,
+            symbol TEXT NOT NULL,
+            side TEXT NOT NULL,
+            quantity INTEGER NOT NULL,
+            price REAL NOT NULL,
+            timestamp DATETIME
+        );
+        CREATE TABLE account (
+            portfolio_id TEXT PRIMARY KEY,
+            cash REAL NOT NULL,
+            equity REAL NOT NULL
+        );
+        """)
+    connection.execute("INSERT INTO account VALUES ('default', 1000, 1000)")
+    connection.commit()
+    connection.close()
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_immutable_reader_does_not_modify_ledger(tmp_path):
+    database = tmp_path / "ledger.db"
+    _create_ledger(database)
+    connection = sqlite3.connect(database)
+    connection.execute(
+        "INSERT INTO positions VALUES (1, 'default', 'AAPL', 3, 100.25, 101, '2026-01-01')"
+    )
+    connection.execute(
+        "INSERT INTO trades VALUES (1, 'default', 'AAPL', 'BUY', 3, 100.25, '2026-01-01')"
+    )
+    connection.commit()
+    connection.close()
+    before = _sha256(database)
+
+    snapshot = ImmutableLedgerReader(tmp_path, "ledger.db").read(["default"])
+
+    assert _sha256(database) == before
+    assert not Path(f"{database}-wal").exists()
+    assert snapshot.active_portfolio_ids == ("default",)
+    assert snapshot.aggregated_positions[0].quantity == 3
+    assert snapshot.aggregated_positions[0].average_cost == pytest.approx(100.25)
+    assert snapshot.recent_trades[0].local_trade_id == 1
+
+
+def test_reader_connection_authorizer_denies_writes_and_attach(tmp_path):
+    database = tmp_path / "ledger.db"
+    _create_ledger(database)
+    reader = ImmutableLedgerReader(tmp_path, "ledger.db")
+    connection = reader._connect()
+    try:
+        with pytest.raises(sqlite3.DatabaseError, match="not authorized"):
+            connection.execute("DELETE FROM positions")
+        with pytest.raises(sqlite3.DatabaseError, match="not authorized"):
+            connection.execute("ATTACH DATABASE ':memory:' AS extra")
+    finally:
+        connection.close()
+
+
+@pytest.mark.parametrize(
+    ("suffix", "expected"),
+    [
+        ("-wal", "WAL"),
+        ("-shm", "shared-memory"),
+        ("-journal", "rollback journal"),
+    ],
+)
+def test_reader_rejects_symlink_and_nonempty_sqlite_sidecars(tmp_path, suffix, expected):
+    database = tmp_path / "ledger.db"
+    _create_ledger(database)
+    Path(f"{database}{suffix}").write_bytes(b"uncommitted")
+    with pytest.raises(LedgerSafetyError, match=expected):
+        ImmutableLedgerReader(tmp_path, "ledger.db")
+
+
+def test_reader_rejects_symlink_database(tmp_path):
+    database = tmp_path / "ledger.db"
+    _create_ledger(database)
+    symlink = tmp_path / "linked.db"
+    symlink.symlink_to(database)
+    with pytest.raises(LedgerSafetyError, match="symlink"):
+        ImmutableLedgerReader(tmp_path, "linked.db")
+
+
+def test_reader_rejects_duplicate_portfolio_symbol_before_aggregation(tmp_path):
+    database = tmp_path / "ledger.db"
+    _create_ledger(database)
+    connection = sqlite3.connect(database)
+    connection.executemany(
+        "INSERT INTO positions VALUES (?, 'default', 'AAPL', ?, 100, 100, ?)",
+        [
+            (1, 2, "2026-07-23T14:59:00"),
+            (2, 0, "2026-07-23T14:59:01"),
+        ],
+    )
+    connection.commit()
+    connection.close()
+
+    with pytest.raises(LedgerSafetyError, match="duplicate portfolio and symbol"):
+        ImmutableLedgerReader(tmp_path, "ledger.db").read(["default"])
+
+
+@pytest.mark.parametrize("table", ["positions", "trades"])
+def test_reader_rejects_malformed_ledger_timestamps(tmp_path, table):
+    database = tmp_path / "ledger.db"
+    _create_ledger(database)
+    connection = sqlite3.connect(database)
+    if table == "positions":
+        connection.execute(
+            "INSERT INTO positions VALUES " "(1, 'default', 'AAPL', 3, 100, 100, 'not-a-timestamp')"
+        )
+    else:
+        connection.execute(
+            "INSERT INTO trades VALUES " "(1, 'default', 'AAPL', 'BUY', 3, 100, 'not-a-timestamp')"
+        )
+    connection.commit()
+    connection.close()
+
+    with pytest.raises(LedgerSafetyError, match=f"{table[:-1]} timestamp is malformed"):
+        ImmutableLedgerReader(tmp_path, "ledger.db").read(["default"])
+
+
+def test_reader_rejects_fractional_value_in_integer_quantity_schema(tmp_path):
+    database = tmp_path / "ledger.db"
+    _create_ledger(database)
+    connection = sqlite3.connect(database)
+    connection.execute(
+        "INSERT INTO positions VALUES (1, 'default', 'AAPL', 1.5, 100, 100, '2026-01-01')"
+    )
+    connection.commit()
+    connection.close()
+
+    with pytest.raises(LedgerSafetyError, match="fractional"):
+        ImmutableLedgerReader(tmp_path, "ledger.db").read(["default"])
+
+
+def test_multi_portfolio_aggregate_is_blocked_and_offsetting_net_zero_is_flagged(tmp_path):
+    database = tmp_path / "ledger.db"
+    _create_ledger(database)
+    connection = sqlite3.connect(database)
+    connection.execute("INSERT INTO account VALUES ('other', 1000, 1000)")
+    connection.executemany(
+        "INSERT INTO positions VALUES (?, ?, ?, ?, ?, ?, ?)",
+        [
+            (1, "default", "AAPL", 10, 100, 100, "2026-01-01"),
+            (2, "other", "AAPL", -10, 110, 110, "2026-01-01"),
+        ],
+    )
+    connection.commit()
+    connection.close()
+
+    snapshot = ImmutableLedgerReader(tmp_path, "ledger.db").read(["default", "other"])
+
+    assert snapshot.aggregated_positions[0].quantity == 0
+    assert snapshot.aggregated_positions[0].average_cost is None
+    assert "AMBIGUOUS_MULTI_PORTFOLIO_BROKER_ALLOCATION" in snapshot.blockers
+    assert "OFFSETTING_PORTFOLIO_POSITIONS:AAPL" in snapshot.blockers
+    assert "NET_ZERO_MASKS_PORTFOLIO_EXPOSURE:AAPL" in snapshot.blockers
+
+
+def test_unselected_active_portfolio_fails_closed_in_report_evidence(tmp_path):
+    database = tmp_path / "ledger.db"
+    _create_ledger(database)
+    connection = sqlite3.connect(database)
+    connection.execute("INSERT INTO account VALUES ('other', 1000, 1000)")
+    connection.execute("INSERT INTO positions VALUES (1, 'other', 'MSFT', 2, 50, 50, '2026-01-01')")
+    connection.commit()
+    connection.close()
+
+    snapshot = ImmutableLedgerReader(tmp_path, "ledger.db").read(["default"])
+
+    assert "UNSELECTED_ACTIVE_PORTFOLIOS" in snapshot.blockers
+    assert snapshot.aggregated_positions == ()
+
+
+def test_reader_rejects_missing_schema_and_unknown_portfolio(tmp_path):
+    database = tmp_path / "ledger.db"
+    sqlite3.connect(database).close()
+    with pytest.raises(LedgerSafetyError, match="schema"):
+        ImmutableLedgerReader(tmp_path, "ledger.db").read(["default"])
+
+    database.unlink()
+    _create_ledger(database)
+    with pytest.raises(LedgerSafetyError, match="do not exist"):
+        ImmutableLedgerReader(tmp_path, "ledger.db").read(["unknown"])
+
+
+def test_evidence_guard_detects_content_appearance_and_disappearance(tmp_path):
+    evidence = tmp_path / "evidence"
+    evidence.write_bytes(b"before")
+    with pytest.raises(IntegrityViolation):
+        with EvidenceIntegrityGuard([evidence]):
+            evidence.write_bytes(b"after")
+
+    absent = tmp_path / "absent"
+    with pytest.raises(IntegrityViolation):
+        with EvidenceIntegrityGuard([absent]):
+            absent.write_bytes(b"appeared")
+
+    with pytest.raises(IntegrityViolation):
+        with EvidenceIntegrityGuard([evidence]):
+            os.unlink(evidence)
+
+
+def test_protected_paths_preserve_symlink_identity_and_include_rollback_journal(tmp_path):
+    target = tmp_path / "first.db"
+    target.write_bytes(b"same")
+    alternate = tmp_path / "second.db"
+    alternate.write_bytes(b"same")
+    configured = tmp_path / "configured.db"
+    configured.symlink_to(target)
+
+    paths = protected_evidence_paths(tmp_path, {"RT_DB_PATH": "configured.db"})
+
+    assert configured in paths
+    assert target in paths
+    assert Path(f"{configured}-journal") in paths
+    with pytest.raises(IntegrityViolation):
+        with EvidenceIntegrityGuard(paths):
+            configured.unlink()
+            configured.symlink_to(alternate)

--- a/tests/test_reconciliation_ledger.py
+++ b/tests/test_reconciliation_ledger.py
@@ -10,7 +10,10 @@ from robo_trader.reconciliation.integrity import (
     EvidenceIntegrityGuard,
     protected_evidence_paths,
 )
-from robo_trader.reconciliation.ledger import ImmutableLedgerReader
+from robo_trader.reconciliation.ledger import (
+    ImmutableLedgerReader,
+    validate_portfolio_ids,
+)
 
 
 def _create_ledger(path: Path) -> None:
@@ -213,6 +216,21 @@ def test_reader_rejects_missing_schema_and_unknown_portfolio(tmp_path):
     _create_ledger(database)
     with pytest.raises(LedgerSafetyError, match="do not exist"):
         ImmutableLedgerReader(tmp_path, "ledger.db").read(["unknown"])
+
+
+def test_portfolio_identity_rejects_account_shaped_selected_and_stored_values(tmp_path):
+    with pytest.raises(LedgerSafetyError, match="portfolio IDs are invalid"):
+        validate_portfolio_ids(["du1234567"])
+
+    database = tmp_path / "ledger.db"
+    _create_ledger(database)
+    connection = sqlite3.connect(database)
+    connection.execute("INSERT INTO account VALUES ('desk-du1234567', 1000, 1000)")
+    connection.commit()
+    connection.close()
+
+    with pytest.raises(LedgerSafetyError, match="ambiguous portfolio identity"):
+        ImmutableLedgerReader(tmp_path, "ledger.db").read(["default"])
 
 
 def test_evidence_guard_detects_content_appearance_and_disappearance(tmp_path):

--- a/tests/test_reconciliation_ledger.py
+++ b/tests/test_reconciliation_ledger.py
@@ -94,16 +94,65 @@ def test_reader_connection_authorizer_denies_writes_and_attach(tmp_path):
     ("suffix", "expected"),
     [
         ("-wal", "WAL"),
-        ("-shm", "shared-memory"),
         ("-journal", "rollback journal"),
     ],
 )
-def test_reader_rejects_symlink_and_nonempty_sqlite_sidecars(tmp_path, suffix, expected):
+def test_reader_rejects_nonempty_unapplied_sqlite_sidecars(tmp_path, suffix, expected):
     database = tmp_path / "ledger.db"
     _create_ledger(database)
     Path(f"{database}{suffix}").write_bytes(b"uncommitted")
     with pytest.raises(LedgerSafetyError, match=expected):
         ImmutableLedgerReader(tmp_path, "ledger.db")
+
+
+def test_reader_accepts_regular_nonempty_shm_when_wal_is_empty(tmp_path):
+    database = tmp_path / "ledger.db"
+    _create_ledger(database)
+    Path(f"{database}-wal").write_bytes(b"")
+    Path(f"{database}-shm").write_bytes(bytes(32 * 1024))
+
+    snapshot = ImmutableLedgerReader(tmp_path, "ledger.db").read(["default"])
+
+    assert snapshot.selected_portfolio_ids == ("default",)
+
+
+@pytest.mark.parametrize(
+    ("suffix", "expected"),
+    [
+        ("-wal", "WAL"),
+        ("-shm", "shared-memory"),
+        ("-journal", "rollback journal"),
+    ],
+)
+def test_reader_rejects_symlinked_sqlite_sidecars(tmp_path, suffix, expected):
+    database = tmp_path / "ledger.db"
+    _create_ledger(database)
+    Path(f"{database}{suffix}").symlink_to(database)
+
+    with pytest.raises(LedgerSafetyError, match=expected):
+        ImmutableLedgerReader(tmp_path, "ledger.db")
+
+
+def test_reader_rejects_nonregular_shm_sidecar(tmp_path):
+    database = tmp_path / "ledger.db"
+    _create_ledger(database)
+    Path(f"{database}-shm").mkdir()
+
+    with pytest.raises(LedgerSafetyError, match="shared-memory"):
+        ImmutableLedgerReader(tmp_path, "ledger.db")
+
+
+def test_integrity_guard_rejects_accepted_nonempty_shm_mutation(tmp_path):
+    database = tmp_path / "configured.db"
+    _create_ledger(database)
+    shm = Path(f"{database}-shm")
+    shm.write_bytes(bytes(32 * 1024))
+    paths = protected_evidence_paths(tmp_path, {"RT_DB_PATH": "configured.db"})
+
+    with pytest.raises(IntegrityViolation):
+        with EvidenceIntegrityGuard(paths):
+            ImmutableLedgerReader(tmp_path, "configured.db").read(["default"])
+            shm.write_bytes(b"changed")
 
 
 def test_reader_rejects_symlink_database(tmp_path):


### PR DESCRIPTION
## Summary

Implements remediation PR 1B as a diagnostic-only, fail-closed reconciliation path.

- captures bounded broker positions, balances, active open orders, and recent executions through an isolated subprocess
- requires paper Gateway port 4002, IBKR readonly proof, IBC paper-mode proof, account-alias agreement, and a dedicated reconciliation client ID distinct from the runner
- denies every discovered mutating/cancel/replace/exercise capability
- reads a protected local-ledger snapshot without changing the database
- reports unmatched active orders as BLOCKED and uncorrelated executions/trades as INCOMPLETE
- sanitizes account/credential-shaped data, tracebacks, public evidence, and worker diagnostics
- rejects symlinked or concurrently changed environment/evidence inputs
- never authorizes startup and never corrects positions, orders, balances, or history

Closes #88

## Safety properties

- No order placement, modification, cancellation, exercise, global cancel, or account mutation
- No live port, no live-mode fallback, and no generic client-ID fallback
- No inherited secret-bearing child environment or import-path trust
- Cancellation-safe transport cleanup with sanitized disconnect failures
- Fixed-point decimal serialization and deterministic, schema-versioned output
- Diagnostic nonzero exits for blocked, incomplete, config, broker, ledger, and integrity failures

## Verification

- Full repository: 1,564 passed, 5 skipped, 20 warnings.
- Focused safety/reconciliation and transport gates: 314 passed in the final strict review; 151 passed for the final client-ID boundary set.
- Independent exact-tree reviews: final strict whole-PR PASS plus focused cleanup and client-ID PASS results; no concrete blockers.
- Black, isort, Flake8, compile/static diff checks: clean
- Narrow mypy: four inherited Optional subprocess-pipe findings remain in `subprocess_ibkr_client.py`; no new reconciliation findings

No broker connection, runtime start, production-data mutation, kill-switch change, or bypass was performed while developing or reviewing this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches IBKR connection/subprocess security and broker evidence handling, but scope is read-only paper diagnostics with fail-closed validation and no trading or startup authorization paths.
> 
> **Overview**
> Introduces a **read-only broker/ledger reconciliation** path: operators run diagnostic evidence collection that compares IBKR paper positions (and related broker state) to the local SQLite ledger **without mutating** either side or clearing safety controls.
> 
> **Configuration** adds required `IBKR_RECONCILIATION_CLIENT_ID` (must differ from `IBKR_CLIENT_ID`). Preflight copy for stale equity now points at `scripts/reconcile_broker_ledger.py` instead of implying `--force` authorizes startup.
> 
> **IBKR diagnostic subprocess** gains `get_broker_snapshot` (bounded positions, balances, open orders, 24h executions) with strict paper port 4002 / readonly-only connect, account checks, fail-closed on mid-snapshot drift, and **sanitized** connect/disconnect errors (no tracebacks or broker exception text). The parent client validates snapshot schema, exposes `get_broker_snapshot`, hardens worker launch (`-I`, minimal env, verified script path), trusted `lsof` zombie checks, and debug-log cleanup.
> 
> **New `robo_trader/reconciliation/`** package wires runtime/IBC gates, immutable ledger reads, integrity hashing of protected files, pure compare engine, IBKR adapter, and CLI with JSON/human output and exit codes; reports always set `mutated_state=false` and `authorizes_startup=false`.
> 
> **Minor:** `safe_disconnect` gains optional `log_exception_details` for quieter diagnostic shutdowns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae133c054721ea8ca656594053594e0ae43649d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
