### PR TITLE
Set up Cursor Cloud dev environment (docs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -676,3 +676,45 @@ When Claude makes an error:
 - **NEVER add "Co-Authored-By" or any AI attribution to commit messages**
 - **NEVER mention Claude, AI, or any assistant in commit messages**
 - Write commit messages as if a human wrote them — concise, descriptive, no AI fingerprints
+
+---
+
+## Cursor Cloud specific instructions
+
+The Cursor Cloud VM is **Linux, Python 3.12**, not the macOS dev box the rest of this
+doc assumes. Dependencies are installed by the startup update script into a `.venv`
+(commands: `python3 -m venv .venv` + `pip install -r requirements.txt -r requirements-dev.txt`
++ `pip install -e .` + `pip install feedparser`). Full fresh-machine steps live in
+`DEV_SETUP.md`; only the cloud-specific caveats are captured here.
+
+### What can and cannot run in cloud
+- **`./START_TRADER.sh` and the trading runner (`runner_async`) do NOT work in cloud.**
+  They require a live IBKR Gateway (phone 2FA) plus macOS launchd/IBC. There is no mock
+  market-data feed, so the live trading loop cannot run end-to-end here. Do not launch
+  `START_TRADER.sh` in cloud — it is macOS/IBC/launchd-specific and will block on Gateway.
+- **The dashboard (`app.py`) + WebSocket server ARE the runnable/testable surface.** They
+  read the SQLite DB and open no IBKR connection. Start with `.venv/bin/python app.py`
+  (dashboard on `127.0.0.1:5555`, WebSocket on `127.0.0.1:8765`; the WS server is started
+  by `app.py`'s `__main__`). A red "Runner offline — no updates received" banner is
+  expected in cloud (no runner running); it is not a bug.
+
+### Non-obvious gotchas
+- **`feedparser` is a real runtime dependency missing from `requirements.txt`**
+  (`robo_trader/news_fetcher.py` imports it at module top level). The update script installs
+  it explicitly; keep that line if you touch the update script.
+- **`app.py` calls `load_config()` at import time** and the paper runtime contract is
+  fail-closed. `.env` (created from `.env.example`) must set `IBKR_ACCOUNT` to a `DU`-prefixed
+  paper id that is also listed in `IBKR_APPROVED_ACCOUNTS`, and `DASH_AUTH_ENABLED=false` for
+  headless dev. If `.env` is missing, recreate: `cp .env.example .env` then set
+  `IBKR_ACCOUNT=DU1234567` and `IBKR_APPROVED_ACCOUNTS=DU1234567`.
+- **`tensorflow` is intentionally not installed** on Python 3.12 (no wheel; guarded by
+  `python_version < "3.12"` in `requirements.txt`). ML code degrades gracefully via
+  `NEURAL_NETWORK_AVAILABLE`; this is expected, not a broken install.
+
+### Lint / test / run (from repo root, using the venv)
+- Lint: `.venv/bin/flake8 robo_trader/` and `.venv/bin/black --check robo_trader/`.
+- Tests: `.venv/bin/python -m pytest tests/ --ignore=tests/security -q` then
+  `.venv/bin/python -m pytest tests/security/ -q`. All pass; the ~7 skips are Docker-compose
+  and macOS launchd/`plutil` tests that are correctly skipped on Linux. `conftest.py` isolates
+  the DB via `RT_DB_PATH`, so tests never touch a live `trading_data.db`.
+- Run dashboard: `.venv/bin/python app.py` (see above).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the RoboTrader development environment on the Cursor Cloud VM (Linux, Python 3.12) and documents the cloud-specific caveats for future agents. The only code change is a new `## Cursor Cloud specific instructions` section in `AGENTS.md`/`CLAUDE.md` — no application code was modified.

## What was set up
- Python 3.12 `.venv` with `requirements.txt` + `requirements-dev.txt` + editable install (`pip install -e .`).
- Installed `feedparser`, a genuine runtime dependency missing from `requirements.txt` (`robo_trader/news_fetcher.py` imports it at top level; documented gap in `DEV_SETUP.md`).
- `.env` created from `.env.example` with the fail-closed paper contract satisfied (`IBKR_ACCOUNT=DU…`, `IBKR_APPROVED_ACCOUNTS`, `DASH_AUTH_ENABLED=false`). `.env` is gitignored and not committed.
- Registered a minimal, idempotent startup update script (venv + pip installs + feedparser).

## Verification
| Check | Command | Result |
|---|---|---|
| Lint | `flake8 robo_trader/` / `black --check robo_trader/` | 0 errors / 168 files unchanged |
| Tests (main) | `pytest tests/ --ignore=tests/security -q` | 1285 passed |
| Tests (security) | `pytest tests/security/ -q` | 380 passed, 7 skipped (Docker/macOS-only) |
| Run | `python app.py` → dashboard `:5555` + WebSocket `:8765` | Both listening |

## Hello-world (core paper-trading path)
Drove the real modules end-to-end without an IBKR Gateway: `RiskManager` fixed sizing + `validate_order` → `PaperExecutor` simulated fill (5 bps slippage) → persisted trade/position/account to SQLite. The dashboard then reflected a 13-share AAPL long, cash reduced to $98,049.03, and the BUY trade in trade history.

[robotrader_dashboard_paper_trade_demo.mp4](https://cursor.com/agents/bc-061a429c-8bf6-4ae6-a223-f43e9e89f0d8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frobotrader_dashboard_paper_trade_demo.mp4)

[Dashboard overview](https://cursor.com/agents/bc-061a429c-8bf6-4ae6-a223-f43e9e89f0d8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_overview.webp)
[AAPL position](https://cursor.com/agents/bc-061a429c-8bf6-4ae6-a223-f43e9e89f0d8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_positions_aapl.webp)
[AAPL BUY trade](https://cursor.com/agents/bc-061a429c-8bf6-4ae6-a223-f43e9e89f0d8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_trades_aapl.webp)

## Notes / out of scope
- The trading runner (`runner_async`) and `./START_TRADER.sh` require a live IBKR Gateway + phone 2FA + macOS launchd/IBC, so the live trading loop is not runnable in cloud. The standalone dashboard + WebSocket (reading SQLite) is the runnable/testable dev surface here. The red "Runner offline" banner in the demo is expected.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-061a429c-8bf6-4ae6-a223-f43e9e89f0d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-061a429c-8bf6-4ae6-a223-f43e9e89f0d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

