### PR TITLE
fix: prevent WebSocket port collision reconnect loops

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -70,6 +70,8 @@ DASH_PORT=5555
 # WebSocket server port
 # Change this if another local service already owns 8765. START_TRADER.sh
 # refuses to kill foreign listeners and verifies the dashboard owns this port.
+# Do not set WEBSOCKET_URL for START_TRADER.sh; that override is reserved for
+# direct/container deployments and supervised startup rejects endpoint drift.
 WEBSOCKET_PORT=8765
 
 # Dashboard authentication (optional)

--- a/.env.template
+++ b/.env.template
@@ -68,6 +68,8 @@ LOG_LEVEL=INFO
 DASH_PORT=5555
 
 # WebSocket server port
+# Change this if another local service already owns 8765. START_TRADER.sh
+# refuses to kill foreign listeners and verifies the dashboard owns this port.
 WEBSOCKET_PORT=8765
 
 # Dashboard authentication (optional)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,6 +322,13 @@ Any code that hard-codes one of these forms will `AttributeError`, the broad `ex
 
 **Don't trust `Connected to WebSocket server` in the runner log.** The `websockets` client logs that BEFORE the server's handshake completes. Look for `WS rejected` warnings on the server side, and for `client_count` increases on `WebSocket client connected` events.
 
+**Don't trust a listener on port 8765 without checking its owner.** Another local
+service can occupy the default port, causing the dashboard to connect to the
+wrong process while RoboTrader's WebSocket thread fails to bind. Check with
+`lsof -nP -iTCP:${WEBSOCKET_PORT:-8765} -sTCP:LISTEN`. Configure one free
+`WEBSOCKET_PORT` in `.env`; the launcher must verify that the dashboard PID owns
+that listener and must never kill an unrelated process.
+
 ---
 
 ## Current Issues Status

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,7 +327,9 @@ service can occupy the default port, causing the dashboard to connect to the
 wrong process while RoboTrader's WebSocket thread fails to bind. Check with
 `lsof -nP -iTCP:${WEBSOCKET_PORT:-8765} -sTCP:LISTEN`. Configure one free
 `WEBSOCKET_PORT` in `.env`; the launcher must verify that the dashboard PID owns
-that listener and must never kill an unrelated process.
+that listener and must never kill an unrelated process. `WEBSOCKET_URL` is for
+direct/container deployments; `START_TRADER.sh` rejects any non-loopback or
+port-mismatched override, then exports its verified local endpoint to the runner.
 
 ---
 

--- a/START_TRADER.sh
+++ b/START_TRADER.sh
@@ -67,11 +67,24 @@ if [ -f "$SCRIPT_DIR/.env" ]; then
     # Read only the startup values we need instead of sourcing arbitrary shell.
     SYMBOLS=$(grep "^SYMBOLS=" "$SCRIPT_DIR/.env" 2>/dev/null | tail -1 | cut -d= -f2- | sed 's/[[:space:]]*#.*$//' | tr -d '"' | tr -d "'" | xargs)
     ENV_IBKR_PORT=$(grep "^IBKR_PORT=" "$SCRIPT_DIR/.env" 2>/dev/null | tail -1 | cut -d= -f2- | sed 's/[[:space:]]*#.*$//' | tr -d '"' | tr -d "'" | xargs)
+    ENV_WEBSOCKET_PORT=$(grep "^WEBSOCKET_PORT=" "$SCRIPT_DIR/.env" 2>/dev/null | tail -1 | cut -d= -f2- | sed 's/[[:space:]]*#.*$//' | tr -d '"' | tr -d "'" | xargs)
 fi
 
 # Fallback default if .env doesn't have SYMBOLS
 SYMBOLS="${SYMBOLS:-AAPL,NVDA,TSLA}"
 PORT="${PORT:-${ENV_IBKR_PORT:-4002}}"
+WEBSOCKET_PORT="${WEBSOCKET_PORT:-${ENV_WEBSOCKET_PORT:-8765}}"
+case "$WEBSOCKET_PORT" in
+    ''|*[!0-9]*)
+        echo "FATAL: WEBSOCKET_PORT must be an integer between 1024 and 65535; got '$WEBSOCKET_PORT'." >&2
+        exit 5
+        ;;
+esac
+if [ "$WEBSOCKET_PORT" -lt 1024 ] || [ "$WEBSOCKET_PORT" -gt 65535 ]; then
+    echo "FATAL: WEBSOCKET_PORT must be between 1024 and 65535; got '$WEBSOCKET_PORT'." >&2
+    exit 5
+fi
+export WEBSOCKET_PORT
 case "$PORT" in
     4002)
         ;;
@@ -661,9 +674,23 @@ stop_processes_gracefully "dashboard" '(^|[/[:space:]])app[.]py([[:space:]]|$)'
 stop_processes_gracefully "websocket_server" "robo_trader[./]websocket_server"
 echo ""
 
+# Never connect the dashboard to an unrelated listener. A foreign service on
+# the configured port previously left Flask alive while its WebSocket thread
+# died in the background, producing an endless reconnect loop.
+if "$LSOF" -nP -iTCP:"$WEBSOCKET_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+    echo "FATAL: WebSocket port $WEBSOCKET_PORT is already owned by another process." >&2
+    "$LSOF" -nP -iTCP:"$WEBSOCKET_PORT" -sTCP:LISTEN >&2 || true
+    echo "Set a free WEBSOCKET_PORT in .env; refusing to kill the foreign process." >&2
+    exit 5
+fi
+
 # Step 5: Start dashboard (includes WebSocket server)
 echo "5. Starting dashboard with WebSocket server..."
 export DASH_PORT=5555
+# Canonical lifecycle ownership requires Flask and the WebSocket listener to
+# remain in this exact PID. Never let an inherited/local .env development mode
+# spawn Werkzeug's reloader parent/child pair under START_TRADER.sh.
+export FLASK_ENV=production
 # Redirect stdout/stderr: backgrounded children otherwise inherit the
 # caller's fds — under the watchdog/launchd that was watchdog.log, which
 # bypassed all rotation and filled the disk on 2026-07-10. Rotate one
@@ -672,14 +699,25 @@ export DASH_PORT=5555
 rotate_log "$SCRIPT_DIR/dashboard_stdout.log"
 $PYTHON app.py > "$SCRIPT_DIR/dashboard_stdout.log" 2>&1 200>&- &
 DASH_PID=$!
-sleep 2
+for _ in $(seq 1 10); do
+    if "$LSOF" -nP -a -p "$DASH_PID" -iTCP:"$WEBSOCKET_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+        break
+    fi
+    if ! ps -p "$DASH_PID" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
 
-if ps -p $DASH_PID > /dev/null; then
+if ps -p "$DASH_PID" >/dev/null 2>&1 && \
+    "$LSOF" -nP -a -p "$DASH_PID" -iTCP:"$WEBSOCKET_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
     echo "   ✓ Dashboard started (PID: $DASH_PID)"
-    echo "   ✓ WebSocket server running on ws://localhost:8765"
+    echo "   ✓ WebSocket server running on ws://localhost:$WEBSOCKET_PORT"
 else
-    echo "   ⚠️  Dashboard may have failed to start"
-    echo "      Check logs: tail -50 $SCRIPT_DIR/dashboard_stdout.log"
+    echo "FATAL: dashboard/WebSocket failed to bind port $WEBSOCKET_PORT." >&2
+    echo "       Check logs: tail -50 $SCRIPT_DIR/dashboard_stdout.log" >&2
+    kill -TERM "$DASH_PID" 2>/dev/null || true
+    exit 5
 fi
 echo ""
 
@@ -720,7 +758,7 @@ if ps -p $TRADER_PID > /dev/null; then
     echo "Monitor logs: tail -f robo_trader.log"
     echo "  Pre-logger crash output (import/.env errors): runner_stdout.log, dashboard_stdout.log"
     echo "View dashboard: http://localhost:5555"
-    echo "WebSocket: ws://localhost:8765"
+    echo "WebSocket: ws://localhost:$WEBSOCKET_PORT"
     echo ""
     echo "To stop gracefully:"
     echo "  pkill -TERM -f 'robo_trader[./]runner_async'"

--- a/START_TRADER.sh
+++ b/START_TRADER.sh
@@ -68,6 +68,7 @@ if [ -f "$SCRIPT_DIR/.env" ]; then
     SYMBOLS=$(grep "^SYMBOLS=" "$SCRIPT_DIR/.env" 2>/dev/null | tail -1 | cut -d= -f2- | sed 's/[[:space:]]*#.*$//' | tr -d '"' | tr -d "'" | xargs)
     ENV_IBKR_PORT=$(grep "^IBKR_PORT=" "$SCRIPT_DIR/.env" 2>/dev/null | tail -1 | cut -d= -f2- | sed 's/[[:space:]]*#.*$//' | tr -d '"' | tr -d "'" | xargs)
     ENV_WEBSOCKET_PORT=$(grep "^WEBSOCKET_PORT=" "$SCRIPT_DIR/.env" 2>/dev/null | tail -1 | cut -d= -f2- | sed 's/[[:space:]]*#.*$//' | tr -d '"' | tr -d "'" | xargs)
+    ENV_WEBSOCKET_URL=$(grep "^WEBSOCKET_URL=" "$SCRIPT_DIR/.env" 2>/dev/null | tail -1 | cut -d= -f2- | sed 's/[[:space:]]*#.*$//' | tr -d '"' | tr -d "'" | xargs)
 fi
 
 # Fallback default if .env doesn't have SYMBOLS
@@ -85,6 +86,25 @@ if [ "$WEBSOCKET_PORT" -lt 1024 ] || [ "$WEBSOCKET_PORT" -gt 65535 ]; then
     exit 5
 fi
 export WEBSOCKET_PORT
+# START_TRADER owns a local server and producer as one supervised lifecycle.
+# Reject conflicting inherited/.env overrides before touching Gateway or any
+# process, then force both children onto the verified local listener. Direct
+# and container launches continue to support remote WEBSOCKET_URL endpoints.
+if [ "${WEBSOCKET_URL+x}" = x ]; then
+    SUPERVISED_WEBSOCKET_URL="$WEBSOCKET_URL"
+else
+    SUPERVISED_WEBSOCKET_URL="${ENV_WEBSOCKET_URL:-}"
+fi
+case "$SUPERVISED_WEBSOCKET_URL" in
+    ""|"ws://localhost:$WEBSOCKET_PORT"|"ws://127.0.0.1:$WEBSOCKET_PORT"|"ws://[::1]:$WEBSOCKET_PORT")
+        ;;
+    *)
+        echo "FATAL: WEBSOCKET_URL conflicts with supervised local WEBSOCKET_PORT." >&2
+        echo "       Remove the override or set it to ws://localhost:$WEBSOCKET_PORT." >&2
+        exit 5
+        ;;
+esac
+export WEBSOCKET_URL="ws://localhost:$WEBSOCKET_PORT"
 case "$PORT" in
     4002)
         ;;

--- a/START_TRADER.sh
+++ b/START_TRADER.sh
@@ -674,16 +674,6 @@ stop_processes_gracefully "dashboard" '(^|[/[:space:]])app[.]py([[:space:]]|$)'
 stop_processes_gracefully "websocket_server" "robo_trader[./]websocket_server"
 echo ""
 
-# Never connect the dashboard to an unrelated listener. A foreign service on
-# the configured port previously left Flask alive while its WebSocket thread
-# died in the background, producing an endless reconnect loop.
-if "$LSOF" -nP -iTCP:"$WEBSOCKET_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
-    echo "FATAL: WebSocket port $WEBSOCKET_PORT is already owned by another process." >&2
-    "$LSOF" -nP -iTCP:"$WEBSOCKET_PORT" -sTCP:LISTEN >&2 || true
-    echo "Set a free WEBSOCKET_PORT in .env; refusing to kill the foreign process." >&2
-    exit 5
-fi
-
 # Step 5: Start dashboard (includes WebSocket server)
 echo "5. Starting dashboard with WebSocket server..."
 export DASH_PORT=5555
@@ -691,6 +681,22 @@ export DASH_PORT=5555
 # remain in this exact PID. Never let an inherited/local .env development mode
 # spawn Werkzeug's reloader parent/child pair under START_TRADER.sh.
 export FLASK_ENV=production
+
+# Never connect to or hide behind an unrelated listener. A foreign service on
+# the WebSocket port previously caused an endless reconnect loop; the same race
+# on the HTTP port could leave the runner active without an accessible dashboard.
+if [ "$DASH_PORT" -eq "$WEBSOCKET_PORT" ]; then
+    echo "FATAL: DASH_PORT and WEBSOCKET_PORT must be different; both are $DASH_PORT." >&2
+    exit 5
+fi
+for SERVICE_PORT in "$DASH_PORT" "$WEBSOCKET_PORT"; do
+    if "$LSOF" -nP -iTCP:"$SERVICE_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+        echo "FATAL: monitoring port $SERVICE_PORT is already owned by another process." >&2
+        "$LSOF" -nP -iTCP:"$SERVICE_PORT" -sTCP:LISTEN >&2 || true
+        echo "Choose free DASH_PORT/WEBSOCKET_PORT values; refusing to kill the foreign process." >&2
+        exit 5
+    fi
+done
 # Redirect stdout/stderr: backgrounded children otherwise inherit the
 # caller's fds — under the watchdog/launchd that was watchdog.log, which
 # bypassed all rotation and filled the disk on 2026-07-10. Rotate one
@@ -700,7 +706,8 @@ rotate_log "$SCRIPT_DIR/dashboard_stdout.log"
 $PYTHON app.py > "$SCRIPT_DIR/dashboard_stdout.log" 2>&1 200>&- &
 DASH_PID=$!
 for _ in $(seq 1 10); do
-    if "$LSOF" -nP -a -p "$DASH_PID" -iTCP:"$WEBSOCKET_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+    if "$LSOF" -nP -a -p "$DASH_PID" -iTCP:"$DASH_PORT" -sTCP:LISTEN >/dev/null 2>&1 && \
+        "$LSOF" -nP -a -p "$DASH_PID" -iTCP:"$WEBSOCKET_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
         break
     fi
     if ! ps -p "$DASH_PID" >/dev/null 2>&1; then
@@ -710,11 +717,12 @@ for _ in $(seq 1 10); do
 done
 
 if ps -p "$DASH_PID" >/dev/null 2>&1 && \
+    "$LSOF" -nP -a -p "$DASH_PID" -iTCP:"$DASH_PORT" -sTCP:LISTEN >/dev/null 2>&1 && \
     "$LSOF" -nP -a -p "$DASH_PID" -iTCP:"$WEBSOCKET_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
     echo "   ✓ Dashboard started (PID: $DASH_PID)"
     echo "   ✓ WebSocket server running on ws://localhost:$WEBSOCKET_PORT"
 else
-    echo "FATAL: dashboard/WebSocket failed to bind port $WEBSOCKET_PORT." >&2
+    echo "FATAL: dashboard PID $DASH_PID failed to own HTTP $DASH_PORT and WebSocket $WEBSOCKET_PORT." >&2
     echo "       Check logs: tail -50 $SCRIPT_DIR/dashboard_stdout.log" >&2
     kill -TERM "$DASH_PID" 2>/dev/null || true
     exit 5

--- a/app.py
+++ b/app.py
@@ -29,6 +29,11 @@ from flask_cors import CORS
 
 load_dotenv()
 
+from robo_trader.websocket_config import (  # noqa: E402
+    get_websocket_port,
+    should_start_websocket_server,
+)
+
 # Multi-process logging fix: the dashboard and the trading runner both emit logs,
 # but logging.handlers.RotatingFileHandler is NOT multi-process safe. Two writers
 # on one file race on rotation — the loser strands its fd on the renamed inode
@@ -4252,7 +4257,8 @@ HTML_TEMPLATE = """
             // The token is injected by the index() view from the env var; it
             // is visible only to authenticated dashboard users.
             var wsAuthToken = {{ ws_auth_token | tojson }};
-            var wsUrl = 'ws://' + window.location.hostname + ':8765';
+            var wsScheme = window.location.protocol === 'https:' ? 'wss://' : 'ws://';
+            var wsUrl = wsScheme + window.location.hostname + ':{{ websocket_port }}';
             if (wsAuthToken) {
                 wsUrl += '?token=' + encodeURIComponent(wsAuthToken);
             }
@@ -4947,6 +4953,7 @@ def index():
     return render_template_string(
         HTML_TEMPLATE,
         ws_auth_token=os.getenv("WS_AUTH_TOKEN", "").strip(),
+        websocket_port=get_websocket_port(),
         runtime_identity=runtime_contract.public_dict(),
     )
 
@@ -8160,14 +8167,6 @@ if __name__ == "__main__":
     # Initialize components
     logger.info("Starting RoboTrader Dashboard...")
 
-    # Start WebSocket server for real-time log streaming
-    from robo_trader.websocket_server import ws_manager
-
-    logger.info("Starting WebSocket server...")
-    ws_manager.start()
-
-    logger.info(f"Dashboard starting on port {os.getenv('DASH_PORT', 5555)}")
-
     # A-1 (branch audit, CRITICAL): the Werkzeug debugger is unauth RCE-as-
     # a-feature, gated only by a guessable PIN. The previous guard refused to
     # start on a non-loopback host but still enabled debug=True on loopback.
@@ -8184,6 +8183,19 @@ if __name__ == "__main__":
             "Refusing to start: FLASK_ENV=development with DASH_HOST=%r is "
             "ambiguous. Set DASH_HOST=127.0.0.1 or unset FLASK_ENV." % _dash_host
         )
+
+    # Start WebSocket server for real-time log streaming. When Werkzeug's
+    # development reloader is active, only its serving child may own the
+    # listener; the supervisory parent deliberately skips this bind.
+    if should_start_websocket_server(use_reloader=_dev_reload):
+        from robo_trader.websocket_server import ws_manager
+
+        logger.info("Starting WebSocket server...")
+        ws_manager.start()
+    else:
+        logger.info("WebSocket bind deferred to Werkzeug reloader child")
+
+    logger.info(f"Dashboard starting on port {os.getenv('DASH_PORT', 5555)}")
 
     # Run Flask app
     # W-H1: bind to loopback by default. Set DASH_HOST=0.0.0.0 to expose on LAN

--- a/robo_trader/websocket_client.py
+++ b/robo_trader/websocket_client.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, Optional
 import websockets
 
 from robo_trader.logger import get_logger
+from robo_trader.websocket_config import get_websocket_client_uri
 
 logger = get_logger(__name__)
 
@@ -21,8 +22,8 @@ logger = get_logger(__name__)
 class WebSocketClient:
     """Client for sending updates to the WebSocket server."""
 
-    def __init__(self, uri: str = "ws://localhost:8765", max_queue_size: int = 1000):
-        self.uri = uri
+    def __init__(self, uri: Optional[str] = None, max_queue_size: int = 1000):
+        self.uri = get_websocket_client_uri() if uri is None else uri
         self.websocket = None
         self.connected = False
         self.message_queue: Queue[Dict[str, Any]] = Queue(maxsize=max_queue_size)

--- a/robo_trader/websocket_client.py
+++ b/robo_trader/websocket_client.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, Optional
 import websockets
 
 from robo_trader.logger import get_logger
-from robo_trader.websocket_config import get_websocket_client_uri
+from robo_trader.websocket_config import get_websocket_client_uri, validate_websocket_uri
 
 logger = get_logger(__name__)
 
@@ -23,7 +23,7 @@ class WebSocketClient:
     """Client for sending updates to the WebSocket server."""
 
     def __init__(self, uri: Optional[str] = None, max_queue_size: int = 1000):
-        self.uri = get_websocket_client_uri() if uri is None else uri
+        self.uri = get_websocket_client_uri() if uri is None else validate_websocket_uri(uri)
         self.websocket = None
         self.connected = False
         self.message_queue: Queue[Dict[str, Any]] = Queue(maxsize=max_queue_size)

--- a/robo_trader/websocket_config.py
+++ b/robo_trader/websocket_config.py
@@ -1,0 +1,63 @@
+"""Validated WebSocket endpoint configuration shared by every local component."""
+
+from __future__ import annotations
+
+import os
+from typing import Mapping, Optional
+
+DEFAULT_WEBSOCKET_PORT = 8765
+
+
+class WebSocketConfigurationError(ValueError):
+    """Raised when the configured WebSocket endpoint is unsafe or ambiguous."""
+
+
+def get_websocket_port(environ: Optional[Mapping[str, str]] = None) -> int:
+    """Return the validated ``WEBSOCKET_PORT`` value.
+
+    Local development and deployment already advertise ``WEBSOCKET_PORT`` in
+    their environment templates. Keeping the parsing here prevents the server,
+    runner client, and dashboard from silently drifting onto different ports.
+    """
+
+    source = os.environ if environ is None else environ
+    raw = (source.get("WEBSOCKET_PORT") or str(DEFAULT_WEBSOCKET_PORT)).strip()
+    try:
+        port = int(raw, 10)
+    except (TypeError, ValueError) as exc:
+        raise WebSocketConfigurationError(
+            f"WEBSOCKET_PORT must be an integer between 1024 and 65535; got {raw!r}"
+        ) from exc
+    if not 1024 <= port <= 65535:
+        raise WebSocketConfigurationError(
+            f"WEBSOCKET_PORT must be between 1024 and 65535; got {port}"
+        )
+    return port
+
+
+def get_websocket_client_uri(environ: Optional[Mapping[str, str]] = None) -> str:
+    """Return the runner producer endpoint, honoring container deployments."""
+
+    source = os.environ if environ is None else environ
+    configured = (source.get("WEBSOCKET_URL") or "").strip()
+    if configured:
+        if not configured.startswith(("ws://", "wss://")):
+            raise WebSocketConfigurationError("WEBSOCKET_URL must use the ws:// or wss:// scheme")
+        return configured
+    return f"ws://localhost:{get_websocket_port(source)}"
+
+
+def should_start_websocket_server(
+    *, use_reloader: bool, environ: Optional[Mapping[str, str]] = None
+) -> bool:
+    """Return whether this process, rather than a reloader parent, owns WS.
+
+    Werkzeug imports and executes the entrypoint once in its supervisory
+    parent and again in the serving child. Binding in both processes turns a
+    healthy development restart into a deterministic address-in-use failure.
+    """
+
+    if not use_reloader:
+        return True
+    source = os.environ if environ is None else environ
+    return source.get("WERKZEUG_RUN_MAIN", "").strip().lower() == "true"

--- a/robo_trader/websocket_config.py
+++ b/robo_trader/websocket_config.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import ipaddress
 import os
+import re
 from typing import Mapping, Optional
+from urllib.parse import urlsplit
 
 DEFAULT_WEBSOCKET_PORT = 8765
 
@@ -22,6 +25,10 @@ def get_websocket_port(environ: Optional[Mapping[str, str]] = None) -> int:
 
     source = os.environ if environ is None else environ
     raw = (source.get("WEBSOCKET_PORT") or str(DEFAULT_WEBSOCKET_PORT)).strip()
+    if not raw.isascii() or not raw.isdecimal():
+        raise WebSocketConfigurationError(
+            f"WEBSOCKET_PORT must be an integer between 1024 and 65535; got {raw!r}"
+        )
     try:
         port = int(raw, 10)
     except (TypeError, ValueError) as exc:
@@ -39,12 +46,59 @@ def get_websocket_client_uri(environ: Optional[Mapping[str, str]] = None) -> str
     """Return the runner producer endpoint, honoring container deployments."""
 
     source = os.environ if environ is None else environ
-    configured = (source.get("WEBSOCKET_URL") or "").strip()
+    configured = source.get("WEBSOCKET_URL") or ""
     if configured:
-        if not configured.startswith(("ws://", "wss://")):
-            raise WebSocketConfigurationError("WEBSOCKET_URL must use the ws:// or wss:// scheme")
-        return configured
+        return validate_websocket_uri(configured)
     return f"ws://localhost:{get_websocket_port(source)}"
+
+
+def validate_websocket_uri(uri: str) -> str:
+    """Validate a complete producer endpoint before its retry loop starts."""
+
+    configured = uri.strip()
+    if configured != uri or any(
+        character.isspace() or ord(character) < 32 or ord(character) == 127 for character in uri
+    ):
+        raise WebSocketConfigurationError("WEBSOCKET_URL must not contain whitespace or controls")
+    try:
+        parsed = urlsplit(configured)
+        port = parsed.port
+    except (UnicodeError, ValueError) as exc:
+        raise WebSocketConfigurationError("WEBSOCKET_URL is malformed") from exc
+
+    if parsed.scheme not in {"ws", "wss"}:
+        raise WebSocketConfigurationError("WEBSOCKET_URL must use the ws:// or wss:// scheme")
+    if not parsed.netloc or not parsed.hostname:
+        raise WebSocketConfigurationError("WEBSOCKET_URL must include a hostname")
+    if parsed.username is not None or parsed.password is not None:
+        raise WebSocketConfigurationError("WEBSOCKET_URL must not contain credentials")
+    if port is not None and not 1 <= port <= 65535:
+        raise WebSocketConfigurationError("WEBSOCKET_URL port must be between 1 and 65535")
+    if parsed.fragment:
+        raise WebSocketConfigurationError("WEBSOCKET_URL must not contain a fragment")
+    _validate_websocket_hostname(parsed.hostname)
+    return configured
+
+
+def _validate_websocket_hostname(hostname: str) -> None:
+    """Accept IP literals and conservative DNS names, including Docker names."""
+
+    try:
+        ipaddress.ip_address(hostname)
+        return
+    except ValueError:
+        pass
+
+    try:
+        ascii_hostname = hostname.encode("idna").decode("ascii").rstrip(".")
+    except UnicodeError as exc:
+        raise WebSocketConfigurationError("WEBSOCKET_URL hostname is invalid") from exc
+    if not ascii_hostname or len(ascii_hostname) > 253:
+        raise WebSocketConfigurationError("WEBSOCKET_URL hostname is invalid")
+
+    label_pattern = re.compile(r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?")
+    if any(not label_pattern.fullmatch(label) for label in ascii_hostname.split(".")):
+        raise WebSocketConfigurationError("WEBSOCKET_URL hostname is invalid")
 
 
 def should_start_websocket_server(

--- a/robo_trader/websocket_server.py
+++ b/robo_trader/websocket_server.py
@@ -17,6 +17,7 @@ import websockets
 from websockets.server import WebSocketServerProtocol
 
 from robo_trader.logger import get_logger
+from robo_trader.websocket_config import get_websocket_port
 
 logger = get_logger(__name__)
 
@@ -141,9 +142,9 @@ class WebSocketManager:
     """Manages WebSocket connections and broadcasts updates."""
 
     # W-H3: bind to loopback by default; override with WS_HOST env var.
-    def __init__(self, host: Optional[str] = None, port: int = 8765):
+    def __init__(self, host: Optional[str] = None, port: Optional[int] = None):
         self.host = host if host is not None else os.getenv("WS_HOST", "127.0.0.1")
-        self.port = port
+        self.port = get_websocket_port() if port is None else port
         self.clients: Set[WebSocketServerProtocol] = set()
         # Producer connections (the runner) are tagged on handshake via the
         # X-WS-Role: producer header. Inbound messages from producers are
@@ -155,6 +156,8 @@ class WebSocketManager:
         self.server = None
         self.loop = None
         self.thread = None
+        self._startup_event = threading.Event()
+        self._startup_error: Optional[BaseException] = None
         # W-M1: optional shared secret for authenticating WS clients via ?token=...
         self.auth_token = os.getenv("WS_AUTH_TOKEN", "")
 
@@ -392,6 +395,8 @@ class WebSocketManager:
 
         # Create server and queue processor tasks
         server = await websockets.serve(self.handle_client, self.host, self.port)
+        self.server = server
+        self._startup_event.set()
 
         # Run both server and queue processor
         await asyncio.gather(server.wait_closed(), self.process_queue())
@@ -404,16 +409,39 @@ class WebSocketManager:
         try:
             self.loop.run_until_complete(self.start_server())
         except Exception as e:
-            logger.error(f"WebSocket server error: {e}")
+            self._startup_error = e
+            self._startup_event.set()
+            logger.exception("WebSocket server failed")
         finally:
+            self._startup_event.set()
             self.loop.close()
 
-    def start(self):
-        """Start the WebSocket server in a background thread."""
+    def start(self, timeout: float = 5.0):
+        """Start the server and fail synchronously if the socket cannot bind."""
         if self.thread is None or not self.thread.is_alive():
+            self._startup_event.clear()
+            self._startup_error = None
+            self.server = None
             self.thread = threading.Thread(target=self.run_in_thread, daemon=True)
             self.thread.start()
-            logger.info("WebSocket server thread started")
+            if not self._startup_event.wait(timeout):
+                raise RuntimeError(
+                    f"WebSocket server did not bind {self.host}:{self.port} "
+                    f"within {timeout:.1f}s"
+                )
+            if self._startup_error is not None:
+                raise RuntimeError(
+                    f"WebSocket server could not bind {self.host}:{self.port}"
+                ) from self._startup_error
+            if self.server is None:
+                raise RuntimeError(
+                    f"WebSocket server exited before binding {self.host}:{self.port}"
+                )
+            logger.info(
+                "WebSocket server thread started",
+                websocket_host=self.host,
+                websocket_port=self.port,
+            )
 
     def stop(self):
         """Stop the WebSocket server."""
@@ -562,7 +590,7 @@ if __name__ == "__main__":
 
     signal.signal(signal.SIGINT, signal_handler)
 
-    print(f"Starting WebSocket server on ws://localhost:8765")
+    print(f"Starting WebSocket server on ws://localhost:{ws_manager.port}")
     print("Press Ctrl+C to stop")
 
     # Run the server

--- a/tests/security/test_web.py
+++ b/tests/security/test_web.py
@@ -10,6 +10,7 @@ and W-R2-L1 (refuse debug=True on non-loopback host).
 import base64
 import hashlib
 import importlib
+import json
 import os
 import sys
 from unittest.mock import MagicMock, patch
@@ -871,9 +872,7 @@ def test_ws_request_headers_shim_handles_v15_api():
 
 
 def test_ws_auth_end_to_end_against_real_library():
-    """Smoke: stand up the real WebSocketManager and connect with a Bearer
-    token. This would have caught the v15 regression at PR time.
-    """
+    """Pin browser auth, producer auth/role, registration, and live relay."""
     import asyncio
 
     import websockets
@@ -885,22 +884,61 @@ def test_ws_auth_end_to_end_against_real_library():
         mgr.auth_token = "test-token-32-chars-aaaaaaaaaaaaa"
         server = await websockets.serve(mgr.handle_client, "127.0.0.1", 18766)
         try:
-            headers = {
+            browser = await websockets.connect(
+                f"ws://127.0.0.1:18766?token={mgr.auth_token}",
+                origin="http://127.0.0.1:5555",
+            )
+            browser_initial = json.loads(await browser.recv())
+            assert browser_initial["status"] == "connected"
+
+            producer_headers = {
                 "Authorization": f"Bearer {mgr.auth_token}",
                 "Origin": "http://127.0.0.1:5555",
+                "X-WS-Role": "producer",
             }
             try:
-                ws = await websockets.connect("ws://127.0.0.1:18766", additional_headers=headers)
+                producer = await websockets.connect(
+                    "ws://127.0.0.1:18766",
+                    additional_headers=producer_headers,
+                )
             except TypeError:
-                ws = await websockets.connect("ws://127.0.0.1:18766", extra_headers=headers)
-            await ws.send('{"type":"subscribe","symbols":["AAPL"]}')
-            await asyncio.sleep(0.2)
-            await ws.close()
+                producer = await websockets.connect(
+                    "ws://127.0.0.1:18766",
+                    extra_headers=producer_headers,
+                )
+            producer_initial = json.loads(await producer.recv())
+            assert producer_initial["status"] == "connected"
+            assert len(mgr.clients) == 2
+            assert len(mgr.producer_clients) == 1
+
+            payload = '{"type":"market_data","symbol":"AAPL","price":123.45}'
+            await producer.send(payload)
+            assert json.loads(await asyncio.wait_for(browser.recv(), timeout=1.0)) == json.loads(
+                payload
+            )
+
+            await producer.close()
+            await browser.close()
         finally:
             server.close()
             await server.wait_closed()
 
     asyncio.run(go())
+
+
+def test_dashboard_uses_configured_websocket_port(monkeypatch):
+    """The browser must use the same validated port as server and runner."""
+
+    app_mod = _reload_app(
+        monkeypatch,
+        DASH_AUTH_ENABLED="false",
+        WEBSOCKET_PORT="18767",
+    )
+    response = app_mod.app.test_client().get("/")
+
+    assert response.status_code == 200
+    assert b"window.location.hostname + ':18767'" in response.data
+    assert b"window.location.protocol === 'https:'" in response.data
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_websocket_port_config.py
+++ b/tests/test_websocket_port_config.py
@@ -1,0 +1,74 @@
+"""Regression tests for the shared WebSocket endpoint and bind failures."""
+
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+
+import pytest
+
+from robo_trader.websocket_client import WebSocketClient
+from robo_trader.websocket_config import (
+    WebSocketConfigurationError,
+    get_websocket_client_uri,
+    get_websocket_port,
+    should_start_websocket_server,
+)
+from robo_trader.websocket_server import WebSocketManager
+
+
+def test_server_and_runner_client_share_configured_port(monkeypatch):
+    monkeypatch.setenv("WEBSOCKET_PORT", "18767")
+    monkeypatch.delenv("WEBSOCKET_URL", raising=False)
+
+    assert get_websocket_port() == 18767
+    assert get_websocket_client_uri() == "ws://localhost:18767"
+    assert WebSocketManager(host="127.0.0.1").port == 18767
+    assert WebSocketClient().uri == "ws://localhost:18767"
+
+
+@pytest.mark.parametrize("value", ["nope", "0", "1023", "65536"])
+def test_invalid_websocket_port_fails_closed(value):
+    with pytest.raises(WebSocketConfigurationError):
+        get_websocket_port({"WEBSOCKET_PORT": value})
+
+
+def test_container_websocket_url_must_use_websocket_scheme():
+    with pytest.raises(WebSocketConfigurationError):
+        get_websocket_client_uri(
+            {"WEBSOCKET_PORT": "18767", "WEBSOCKET_URL": "http://websocket:18767"}
+        )
+
+
+def test_websocket_start_surfaces_foreign_port_collision():
+    blocker = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    blocker.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    blocker.bind(("127.0.0.1", 0))
+    blocker.listen(1)
+    port = blocker.getsockname()[1]
+    manager = WebSocketManager(host="127.0.0.1", port=port)
+
+    try:
+        with pytest.raises(RuntimeError, match="could not bind"):
+            manager.start(timeout=2.0)
+    finally:
+        blocker.close()
+        if manager.thread is not None:
+            manager.thread.join(timeout=2.0)
+
+
+def test_only_werkzeug_serving_child_starts_websocket_with_reloader():
+    assert should_start_websocket_server(use_reloader=False, environ={})
+    assert not should_start_websocket_server(use_reloader=True, environ={})
+    assert should_start_websocket_server(
+        use_reloader=True,
+        environ={"WERKZEUG_RUN_MAIN": "true"},
+    )
+
+
+def test_authoritative_launcher_disables_werkzeug_reloader():
+    launcher = (Path(__file__).resolve().parents[1] / "START_TRADER.sh").read_text()
+    production_export = launcher.index("export FLASK_ENV=production")
+    dashboard_launch = launcher.index("$PYTHON app.py")
+
+    assert production_export < dashboard_launch

--- a/tests/test_websocket_port_config.py
+++ b/tests/test_websocket_port_config.py
@@ -27,7 +27,7 @@ def test_server_and_runner_client_share_configured_port(monkeypatch):
     assert WebSocketClient().uri == "ws://localhost:18767"
 
 
-@pytest.mark.parametrize("value", ["nope", "0", "1023", "65536"])
+@pytest.mark.parametrize("value", ["nope", "+8765", "8_765", "0", "1023", "65536"])
 def test_invalid_websocket_port_fails_closed(value):
     with pytest.raises(WebSocketConfigurationError):
         get_websocket_port({"WEBSOCKET_PORT": value})
@@ -38,6 +38,53 @@ def test_container_websocket_url_must_use_websocket_scheme():
         get_websocket_client_uri(
             {"WEBSOCKET_PORT": "18767", "WEBSOCKET_URL": "http://websocket:18767"}
         )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "ws://",
+        "ws://websocket:notaport",
+        "ws://websocket:0",
+        "ws://websocket:65536",
+        "ws://bad host:8765",
+        "ws://bad_host:8765",
+        "ws://user:secret@websocket:8765",
+        "ws://websocket:8765/#fragment",
+        "ws://[invalid:8765",
+        "ws://websocket:8765/\npath",
+        " ws://websocket:8765",
+        "ws://websocket:8765\x7f",
+    ],
+)
+def test_malformed_websocket_url_fails_before_client_retry_loop(value):
+    with pytest.raises(WebSocketConfigurationError):
+        get_websocket_client_uri({"WEBSOCKET_URL": value})
+
+
+def test_container_websocket_url_accepts_valid_remote_endpoint():
+    assert (
+        get_websocket_client_uri({"WEBSOCKET_URL": "wss://websocket.example:443/events?v=1"})
+        == "wss://websocket.example:443/events?v=1"
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "ws://websocket:8765",
+        "wss://websocket.example/events",
+        "ws://127.0.0.1:8765/events?v=1",
+        "ws://[::1]:8765/events",
+    ],
+)
+def test_container_websocket_url_accepts_valid_authorities(value):
+    assert get_websocket_client_uri({"WEBSOCKET_URL": value}) == value
+
+
+def test_explicit_client_uri_uses_same_validation():
+    with pytest.raises(WebSocketConfigurationError):
+        WebSocketClient(uri="ws://websocket:notaport")
 
 
 def test_websocket_start_surfaces_foreign_port_collision():
@@ -72,6 +119,20 @@ def test_authoritative_launcher_disables_werkzeug_reloader():
     dashboard_launch = launcher.index("$PYTHON app.py")
 
     assert production_export < dashboard_launch
+
+
+def test_authoritative_launcher_forces_producer_to_verified_local_port():
+    launcher = (Path(__file__).resolve().parents[1] / "START_TRADER.sh").read_text()
+    conflict_guard = launcher.index(
+        'echo "FATAL: WEBSOCKET_URL conflicts with supervised local WEBSOCKET_PORT."'
+    )
+    endpoint_export = launcher.index('export WEBSOCKET_URL="ws://localhost:$WEBSOCKET_PORT"')
+    gateway_work = launcher.index('IBC_INI="${SCRIPT_DIR}/config/ibc/config.ini"')
+    dashboard_launch = launcher.index("$PYTHON app.py")
+
+    assert conflict_guard < endpoint_export < gateway_work < dashboard_launch
+    assert '"ws://127.0.0.1:$WEBSOCKET_PORT"' in launcher
+    assert '"ws://[::1]:$WEBSOCKET_PORT"' in launcher
 
 
 def test_launcher_requires_dashboard_pid_to_own_http_and_websocket_ports():

--- a/tests/test_websocket_port_config.py
+++ b/tests/test_websocket_port_config.py
@@ -72,3 +72,15 @@ def test_authoritative_launcher_disables_werkzeug_reloader():
     dashboard_launch = launcher.index("$PYTHON app.py")
 
     assert production_export < dashboard_launch
+
+
+def test_launcher_requires_dashboard_pid_to_own_http_and_websocket_ports():
+    launcher = (Path(__file__).resolve().parents[1] / "START_TRADER.sh").read_text()
+
+    ownership_guard = (
+        '"$LSOF" -nP -a -p "$DASH_PID" '
+        '-iTCP:"$DASH_PORT" -sTCP:LISTEN >/dev/null 2>&1 && \\\n'
+        '    "$LSOF" -nP -a -p "$DASH_PID" '
+        '-iTCP:"$WEBSOCKET_PORT" -sTCP:LISTEN >/dev/null 2>&1'
+    )
+    assert ownership_guard in launcher


### PR DESCRIPTION
## Root cause

A foreign Dopplr daemon owns the hard-coded port 8765. RoboTrader could leave Flask alive after its WebSocket background thread failed to bind, causing the dashboard to reconnect forever to the wrong service.

## Fix

- use one validated `WEBSOCKET_PORT` across server, runner client, browser, and launcher
- surface WebSocket bind failures synchronously so Flask cannot appear healthy without realtime
- refuse to kill foreign listeners and require the exact dashboard PID to own the configured socket
- force canonical launcher production/no-reloader ownership while preserving safe direct dev autoreload
- retain v14/v15+/v16 auth/path shims and strengthen browser-token, producer-role, and relay coverage
- document the port-owner diagnostic in canonical agent guidance

Local machine config selects free port 8766; `.env` remains untracked. No trader or service was manually started.

## Verification

- full suite: 2,251 passed, 5 skipped, 20 warnings
- final focused WebSocket/security/launcher review: 130 passed
- broader security/preflight/launcher matrix: 615 passed, 5 skipped
- two independent reviews: PASS after correcting two Werkzeug reloader findings
- Black, isort, Flake8, mypy for new config module, py_compile, `bash -n`, and `git diff --check`: passed

## Safety

No database, preflight, runner, risk, settlement, position, execution, or order-authority module is changed. Startup still fails closed on existing kill-switch and stale-equity gates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes supervised startup and monitoring port behavior (stricter preflight, fatal on port conflicts) but does not touch trading, risk, or order paths; misconfigured ports will block launch rather than fail silently at runtime.
> 
> **Overview**
> Fixes **endless dashboard reconnect loops** when another process owns the default WebSocket port while Flask still appears healthy after a failed background bind.
> 
> **Shared endpoint config:** New `robo_trader/websocket_config.py` validates `WEBSOCKET_PORT` and optional `WEBSOCKET_URL`; the WebSocket server, runner client, and dashboard UI all read the same values instead of hard-coded `8765`.
> 
> **Fail-closed startup:** `WebSocketManager.start()` now waits for a successful bind and raises if the socket cannot open. `START_TRADER.sh` validates ports early, rejects conflicting `WEBSOCKET_URL` under supervised startup, forces `FLASK_ENV=production` (no Werkzeug reloader double-bind), refuses occupied HTTP/WebSocket ports without killing foreign processes, and **requires the dashboard PID to own both listeners** before continuing.
> 
> **Dashboard/runtime:** Browser WebSocket URL uses the configured port and `ws`/`wss` from the page protocol; WebSocket startup is deferred to the Werkzeug serving child when dev reload is enabled.
> 
> **Tests & docs:** Expanded WebSocket e2e coverage (browser token, producer role, relay) plus new port-config and launcher contract tests; `.env.template` and `CLAUDE.md` document port-owner diagnostics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ace9830c51ccbf486ab890dc68513106cd1a5b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->