### PR TITLE
CI: repair secret scan and optional notifications

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -217,8 +217,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
     environment: staging
     steps:
       - uses: actions/checkout@v4
@@ -237,10 +235,24 @@ jobs:
           echo "Running smoke tests against staging"
           # curl https://staging.robo-trader.example.com/health
           
+      - name: Check Slack notification configuration
+        id: staging-slack
+        if: always()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+        run: |
+          if [[ -n "$SLACK_WEBHOOK_URL" ]]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Notify deployment
         # TODO(R2-CFG-H1.4): pin to specific commit SHA
         uses: 8398a7/action-slack@v3
-        if: always() && env.SLACK_WEBHOOK_URL != ''
+        if: always() && steps.staging-slack.outputs.configured == 'true'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         with:
           status: ${{ job.status }}
           text: 'Staging deployment ${{ job.status }}'
@@ -319,8 +331,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
     steps:
       - name: Trigger rollback
         run: |
@@ -330,10 +340,23 @@ jobs:
           # - Restore database backup if needed
           # - Clear caches
           
+      - name: Check Slack notification configuration
+        id: rollback-slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+        run: |
+          if [[ -n "$SLACK_WEBHOOK_URL" ]]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Notify rollback
         # TODO(R2-CFG-H1.4): pin to specific commit SHA
         uses: 8398a7/action-slack@v3
-        if: env.SLACK_WEBHOOK_URL != ''
+        if: steps.rollback-slack.outputs.configured == 'true'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         with:
           status: 'warning'
           text: 'Rollback initiated for failed deployment'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -217,6 +217,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
     environment: staging
     steps:
       - uses: actions/checkout@v4
@@ -238,9 +240,7 @@ jobs:
       - name: Notify deployment
         # TODO(R2-CFG-H1.4): pin to specific commit SHA
         uses: 8398a7/action-slack@v3
-        if: always()
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+        if: always() && env.SLACK_WEBHOOK_URL != ''
         with:
           status: ${{ job.status }}
           text: 'Staging deployment ${{ job.status }}'
@@ -319,6 +319,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
     steps:
       - name: Trigger rollback
         run: |
@@ -331,8 +333,7 @@ jobs:
       - name: Notify rollback
         # TODO(R2-CFG-H1.4): pin to specific commit SHA
         uses: 8398a7/action-slack@v3
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+        if: env.SLACK_WEBHOOK_URL != ''
         with:
           status: 'warning'
           text: 'Rollback initiated for failed deployment'

--- a/.github/workflows/production-ci.yml
+++ b/.github/workflows/production-ci.yml
@@ -44,14 +44,44 @@ jobs:
       with:
         sarif_file: 'trivy-results.sarif'
 
-    - name: Check for hardcoded secrets
+    - name: Check pull request for hardcoded secrets
       # TODO(R2-CFG-H1.4): pin to specific commit SHA
       uses: trufflesecurity/trufflehog@main
-      if: github.event_name == 'push' || github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request'
       with:
         path: ./
-        base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-        head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        base: ${{ github.event.pull_request.base.sha }}
+        head: ${{ github.event.pull_request.head.sha }}
+
+    - name: Check pushed commits for hardcoded secrets
+      # TODO(R2-CFG-H1.4): pin to specific commit SHA
+      uses: trufflesecurity/trufflehog@main
+      if: github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000'
+      with:
+        path: ./
+        base: ${{ github.event.before }}
+        head: ${{ github.sha }}
+
+    - name: Check new ref history for hardcoded secrets
+      # A zero before SHA identifies a newly-created branch or tag. Leaving the
+      # base empty avoids passing that sentinel to git as an invalid revision.
+      # TODO(R2-CFG-H1.4): pin to specific commit SHA
+      uses: trufflesecurity/trufflehog@main
+      if: github.event_name == 'push' && github.event.before == '0000000000000000000000000000000000000000'
+      with:
+        path: ./
+        base: ''
+        head: ${{ github.sha }}
+
+    - name: Check repository history for hardcoded secrets
+      # Empty bounds intentionally request a full-history scan on the weekly run.
+      # TODO(R2-CFG-H1.4): pin to specific commit SHA
+      uses: trufflesecurity/trufflehog@main
+      if: github.event_name == 'schedule'
+      with:
+        path: ./
+        base: ''
+        head: ''
 
   # Comprehensive testing
   test-suite:

--- a/.github/workflows/production-ci.yml
+++ b/.github/workflows/production-ci.yml
@@ -25,6 +25,9 @@ jobs:
       security-events: write
     steps:
     - uses: actions/checkout@v4
+      with:
+        # Secret scanning compares explicit commits and therefore needs history.
+        fetch-depth: 0
 
     - name: Run Trivy security scan
       # TODO(R2-CFG-H1.4): pin to specific commit SHA
@@ -37,17 +40,18 @@ jobs:
         severity: 'CRITICAL,HIGH'
 
     - name: Upload Trivy results to GitHub Security
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: 'trivy-results.sarif'
 
     - name: Check for hardcoded secrets
       # TODO(R2-CFG-H1.4): pin to specific commit SHA
       uses: trufflesecurity/trufflehog@main
+      if: github.event_name == 'push' || github.event_name == 'pull_request'
       with:
         path: ./
-        base: main
-        head: HEAD
+        base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
   # Comprehensive testing
   test-suite:
@@ -265,7 +269,7 @@ jobs:
         output: 'docker-scan-results.sarif'
     
     - name: Upload Docker scan results
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: 'docker-scan-results.sarif'
 

--- a/tests/ci/test_workflow_safety.py
+++ b/tests/ci/test_workflow_safety.py
@@ -78,6 +78,40 @@ def test_mypy_and_supply_chain_debt_are_explicitly_advisory() -> None:
     assert 'safety check -r "$requirements_file" --json' in workflow
 
 
+def test_secret_scan_covers_each_event_with_a_valid_revision_range() -> None:
+    workflow = _workflow("production-ci.yml")
+    zero_sha = "0000000000000000000000000000000000000000"
+
+    def step(name: str) -> str:
+        return workflow.split(f"- name: {name}", maxsplit=1)[1].split(
+            "\n    - name:", maxsplit=1
+        )[0]
+
+    pull_request = step("Check pull request for hardcoded secrets")
+    assert "if: github.event_name == 'pull_request'" in pull_request
+    assert "base: ${{ github.event.pull_request.base.sha }}" in pull_request
+    assert "head: ${{ github.event.pull_request.head.sha }}" in pull_request
+
+    ordinary_push = step("Check pushed commits for hardcoded secrets")
+    assert f"github.event.before != '{zero_sha}'" in ordinary_push
+    assert "base: ${{ github.event.before }}" in ordinary_push
+    assert "head: ${{ github.sha }}" in ordinary_push
+
+    new_ref = step("Check new ref history for hardcoded secrets")
+    assert f"github.event.before == '{zero_sha}'" in new_ref
+    assert "base: ''" in new_ref
+    assert "head: ${{ github.sha }}" in new_ref
+
+    schedule = step("Check repository history for hardcoded secrets")
+    assert "if: github.event_name == 'schedule'" in schedule
+    assert "base: ''" in schedule
+    assert "head: ''" in schedule
+
+    assert workflow.count("uses: trufflesecurity/trufflehog@main") == 4
+    for secret_scan_step in (pull_request, ordinary_push, new_ref, schedule):
+        assert "continue-on-error: true" not in secret_scan_step
+
+
 def test_full_suite_jobs_fail_closed_on_hangs_with_thread_diagnostics() -> None:
     for workflow_name in ("ci.yml", "deploy.yml", "production-ci.yml"):
         workflow = _workflow(workflow_name)

--- a/tests/ci/test_workflow_safety.py
+++ b/tests/ci/test_workflow_safety.py
@@ -83,9 +83,9 @@ def test_secret_scan_covers_each_event_with_a_valid_revision_range() -> None:
     zero_sha = "0000000000000000000000000000000000000000"
 
     def step(name: str) -> str:
-        return workflow.split(f"- name: {name}", maxsplit=1)[1].split(
-            "\n    - name:", maxsplit=1
-        )[0]
+        return workflow.split(f"- name: {name}", maxsplit=1)[1].split("\n    - name:", maxsplit=1)[
+            0
+        ]
 
     pull_request = step("Check pull request for hardcoded secrets")
     assert "if: github.event_name == 'pull_request'" in pull_request


### PR DESCRIPTION
## What changed

- Check out full history before TruffleHog scans.
- Use event-specific hardcoded-secret scan ranges:
  - exact base/head SHAs for pull requests;
  - exact before/head SHAs for ordinary pushes;
  - empty base plus the new head for all-zero-before tag/new-ref pushes;
  - empty base/head for scheduled full-history rescans.
- Upgrade deprecated CodeQL SARIF uploads from v2 to v3.
- Skip Slack notification actions when the optional webhook secret is not configured, while keeping the secret step-scoped.
- Add deterministic workflow-safety regression tests for all trigger shapes and notification scoping.

## Root cause

The production secret scan used `base: main` and `head: HEAD` on a push to `main`, which resolves to the same commit and fails without scanning. Independent review also found that a newly created tag supplies an all-zero before SHA and scheduled runs were skipped. The deploy workflow separately treated an unconfigured optional Slack webhook as a deployment failure.

## Safety and impact

This changes CI workflow behavior only. It does not start the trader, alter trading data, change broker configuration, or weaken secret scanning. Each supported event now receives a complete appropriate scan scope.

## Validation

- Focused workflow tests: 48 passed.
- Dedicated CI workflow safety tests: 17 passed.
- Ruby YAML parser accepted both changed workflows.
- `git diff --check`: pass.
- Two independent review rounds found and the branch fixed secret scope plus tag/schedule scan gaps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions workflows and CI regression tests; no application or trading runtime behavior is affected.
> 
> **Overview**
> **Production CI** fixes broken secret scanning and bumps SARIF uploads. Checkout now uses **`fetch-depth: 0`** so TruffleHog can compare commits. The single **`base: main` / `head: HEAD`** step is replaced by **four event-specific TruffleHog steps** (PR base/head SHAs, push before/SHA, all-zero `before` with empty base, scheduled full history). **CodeQL SARIF upload** moves from **v2 to v3** for filesystem and Docker Trivy results.
> 
> **Deploy workflow** adds a step that detects whether **`SLACK_WEBHOOK`** is set; staging and rollback **Slack notify steps run only when configured**, so missing optional webhooks no longer fail the job.
> 
> **Regression tests** in `test_workflow_safety.py` lock in revision ranges, four TruffleHog invocations, and that secret scans are not advisory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d9f532b1232260512a4e29436bc749d2b9afbc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->