### PR TITLE
Fix: bound broker reconciliation snapshot requests

### DIFF
--- a/robo_trader/clients/ibkr_subprocess_worker.py
+++ b/robo_trader/clients/ibkr_subprocess_worker.py
@@ -162,6 +162,7 @@ BROKER_SNAPSHOT_BALANCE_TAGS = frozenset(
 )
 BROKER_SNAPSHOT_REQUIRED_BALANCE_TAGS = frozenset({"NetLiquidation", "TotalCashValue"})
 BROKER_SNAPSHOT_STAGE_TIMEOUT_SECONDS = 5.0
+BROKER_SNAPSHOT_ACCOUNT_SUMMARY_TAGS = ",".join(sorted(BROKER_SNAPSHOT_BALANCE_TAGS))
 BROKER_SNAPSHOT_REQUEST_STAGES = frozenset(
     {
         "broker_time_before",
@@ -196,6 +197,56 @@ async def _await_broker_snapshot_stage(stage: str, request: Any) -> Any:
         )
     except (asyncio.TimeoutError, TimeoutError) as exc:
         raise BrokerSnapshotStageTimeout(stage) from exc
+
+
+async def _request_fresh_broker_account_summary(account: str) -> list[Any]:
+    """Return only values produced by one fresh, cancelled summary request."""
+    if ib is None:
+        raise ConnectionError("Not connected to IBKR")
+    client = getattr(ib, "client", None)
+    wrapper = getattr(ib, "wrapper", None)
+    summary_cache = getattr(wrapper, "acctSummary", None)
+    get_request_id = getattr(client, "getReqId", None)
+    request_summary = getattr(client, "reqAccountSummary", None)
+    cancel_summary = getattr(client, "cancelAccountSummary", None)
+    start_request = getattr(wrapper, "startReq", None)
+    if (
+        not isinstance(summary_cache, dict)
+        or not callable(get_request_id)
+        or not callable(request_summary)
+        or not callable(cancel_summary)
+        or not callable(start_request)
+    ):
+        raise RuntimeError("IBKR client has no fresh account-summary API")
+
+    # accountSummaryAsync() skips broker I/O whenever this cache is nonempty.
+    # Remove only the expected account's prior values before issuing a request
+    # whose request ID and subscription lifetime are owned by this coroutine.
+    for key, value in list(summary_cache.items()):
+        if str(getattr(value, "account", "")).strip() == account:
+            summary_cache.pop(key, None)
+
+    request_id = get_request_id()
+    request = start_request(request_id)
+    request_started = False
+    try:
+        request_summary(
+            request_id,
+            "All",
+            BROKER_SNAPSHOT_ACCOUNT_SUMMARY_TAGS,
+        )
+        request_started = True
+        await request
+    finally:
+        if request_started:
+            cancel_summary(request_id)
+
+    return [
+        value
+        for value in summary_cache.values()
+        if str(getattr(value, "account", "")).strip() == account
+        and str(getattr(value, "tag", "")) in BROKER_SNAPSHOT_BALANCE_TAGS
+    ]
 
 
 def _aware_iso(value: Any) -> str:
@@ -1077,7 +1128,7 @@ async def handle_get_broker_snapshot(params: dict) -> dict:
             )
 
         account_values = await _await_broker_snapshot_stage(
-            "account_summary", ib.accountSummaryAsync(account)
+            "account_summary", _request_fresh_broker_account_summary(account)
         )
         if not ib.isConnected():
             raise ConnectionError("Broker disconnected during snapshot collection")

--- a/robo_trader/clients/ibkr_subprocess_worker.py
+++ b/robo_trader/clients/ibkr_subprocess_worker.py
@@ -24,7 +24,7 @@ import time
 import traceback
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal, InvalidOperation
-from typing import Any, Optional, cast
+from typing import Any, NamedTuple, Optional, cast
 
 # CRITICAL: Enable real disconnect BEFORE importing ib_async or ibkr_safe
 # This prevents zombie connections when the worker process exits
@@ -112,6 +112,15 @@ class BrokerSnapshotStageTimeout(TimeoutError):
     def __init__(self, stage: str):
         self.stage = stage
         super().__init__(f"Broker snapshot stage timed out: {stage}")
+
+
+class _RequestScopedAccountSummaryValue(NamedTuple):
+    """One account-summary callback attributed to an exact IBKR request ID."""
+
+    account: str
+    tag: str
+    value: str
+    currency: str
 
 
 BROKER_SNAPSHOT_SCHEMA_VERSION = 1
@@ -205,47 +214,111 @@ async def _request_fresh_broker_account_summary(account: str) -> list[Any]:
         raise ConnectionError("Not connected to IBKR")
     client = getattr(ib, "client", None)
     wrapper = getattr(ib, "wrapper", None)
-    summary_cache = getattr(wrapper, "acctSummary", None)
     get_request_id = getattr(client, "getReqId", None)
     request_summary = getattr(client, "reqAccountSummary", None)
     cancel_summary = getattr(client, "cancelAccountSummary", None)
     start_request = getattr(wrapper, "startReq", None)
+    end_request = getattr(wrapper, "_endReq", None)
+    account_summary_callback = getattr(wrapper, "accountSummary", None)
+    wrapper_namespace = getattr(wrapper, "__dict__", None)
     if (
-        not isinstance(summary_cache, dict)
-        or not callable(get_request_id)
+        not callable(get_request_id)
         or not callable(request_summary)
         or not callable(cancel_summary)
         or not callable(start_request)
+        or not callable(end_request)
+        or not callable(account_summary_callback)
+        or not isinstance(wrapper_namespace, dict)
     ):
         raise RuntimeError("IBKR client has no fresh account-summary API")
 
-    # accountSummaryAsync() skips broker I/O whenever this cache is nonempty.
-    # Remove only the expected account's prior values before issuing a request
-    # whose request ID and subscription lifetime are owned by this coroutine.
-    for key, value in list(summary_cache.items()):
-        if str(getattr(value, "account", "")).strip() == account:
-            summary_cache.pop(key, None)
-
     request_id = get_request_id()
-    request = start_request(request_id)
+    if isinstance(request_id, bool) or not isinstance(request_id, int) or request_id < 0:
+        raise RuntimeError("IBKR client returned an invalid account-summary request ID")
+
+    missing = object()
+    previous_instance_callback = wrapper_namespace.get("accountSummary", missing)
+    captured: dict[tuple[str, str, str], _RequestScopedAccountSummaryValue] = {}
+    callback_failed = False
+
+    def capture_owned_account_summary(
+        callback_request_id: int,
+        callback_account: str,
+        tag: str,
+        value: str,
+        currency: str,
+    ) -> None:
+        nonlocal callback_failed
+        try:
+            result = account_summary_callback(
+                callback_request_id,
+                callback_account,
+                tag,
+                value,
+                currency,
+            )
+            if inspect.isawaitable(result):
+                if inspect.iscoroutine(result):
+                    result.close()
+                callback_failed = True
+                return
+        except Exception:
+            callback_failed = True
+            raise
+        if type(callback_request_id) is not int or callback_request_id != request_id:
+            return
+        owned_value = _RequestScopedAccountSummaryValue(
+            account=str(callback_account).strip(),
+            tag=str(tag),
+            value=str(value),
+            currency=str(currency).strip(),
+        )
+        captured[(owned_value.account, owned_value.tag, owned_value.currency)] = owned_value
+
+    request: Any = None
+    callback_overridden = False
+    request_registered = False
     request_started = False
     try:
+        setattr(wrapper, "accountSummary", capture_owned_account_summary)
+        callback_overridden = True
+        if getattr(wrapper, "accountSummary", None) is not capture_owned_account_summary:
+            raise RuntimeError("IBKR account-summary callback cannot be scoped")
+        request = start_request(request_id)
+        request_registered = True
+        # Treat the subscription as possibly live before the synchronous send:
+        # a partial transport write must still trigger a cancellation attempt.
+        request_started = True
         request_summary(
             request_id,
             "All",
             BROKER_SNAPSHOT_ACCOUNT_SUMMARY_TAGS,
         )
-        request_started = True
         await request
     finally:
-        if request_started:
-            cancel_summary(request_id)
+        try:
+            if request_started:
+                cancel_summary(request_id)
+        finally:
+            try:
+                if request_registered:
+                    if not request.done():
+                        request.cancel()
+                    end_request(request_id)
+            finally:
+                if callback_overridden:
+                    if previous_instance_callback is missing:
+                        delattr(wrapper, "accountSummary")
+                    else:
+                        setattr(wrapper, "accountSummary", previous_instance_callback)
+
+    if callback_failed:
+        raise RuntimeError("IBKR account-summary callback provenance cannot be proven")
 
     return [
         value
-        for value in summary_cache.values()
-        if str(getattr(value, "account", "")).strip() == account
-        and str(getattr(value, "tag", "")) in BROKER_SNAPSHOT_BALANCE_TAGS
+        for value in captured.values()
+        if value.account == account and value.tag in BROKER_SNAPSHOT_BALANCE_TAGS
     ]
 
 

--- a/robo_trader/clients/ibkr_subprocess_worker.py
+++ b/robo_trader/clients/ibkr_subprocess_worker.py
@@ -106,6 +106,14 @@ class BrokerSnapshotAccountMismatchError(ValueError):
     """Expected and connected broker account identities do not match."""
 
 
+class BrokerSnapshotStageTimeout(TimeoutError):
+    """One allowlisted broker snapshot stage exceeded its local deadline."""
+
+    def __init__(self, stage: str):
+        self.stage = stage
+        super().__init__(f"Broker snapshot stage timed out: {stage}")
+
+
 BROKER_SNAPSHOT_SCHEMA_VERSION = 1
 BROKER_SAFETY_SNAPSHOT_SCHEMA_VERSION = 1
 BROKER_CONTRACT_SAFETY_SNAPSHOT_SCHEMA_VERSION = 1
@@ -153,6 +161,41 @@ BROKER_SNAPSHOT_BALANCE_TAGS = frozenset(
     }
 )
 BROKER_SNAPSHOT_REQUIRED_BALANCE_TAGS = frozenset({"NetLiquidation", "TotalCashValue"})
+BROKER_SNAPSHOT_STAGE_TIMEOUT_SECONDS = 5.0
+BROKER_SNAPSHOT_REQUEST_STAGES = frozenset(
+    {
+        "broker_time_before",
+        "positions_initial",
+        "positions_initial_identity",
+        "position_identity",
+        "open_orders_initial",
+        "open_order_identity",
+        "broker_time_execution_cutoff",
+        "executions",
+        "execution_identity",
+        "account_summary",
+        "positions_final",
+        "positions_final_identity",
+        "open_orders_final",
+        "open_orders_final_identity",
+        "broker_time_after",
+    }
+)
+
+
+async def _await_broker_snapshot_stage(stage: str, request: Any) -> Any:
+    """Bound one broker await and expose only its allowlisted stage on timeout."""
+    if stage not in BROKER_SNAPSHOT_REQUEST_STAGES:
+        if inspect.iscoroutine(request):
+            request.close()
+        raise ValueError("Broker snapshot stage is not allowlisted")
+    try:
+        return await asyncio.wait_for(
+            request,
+            timeout=BROKER_SNAPSHOT_STAGE_TIMEOUT_SECONDS,
+        )
+    except (asyncio.TimeoutError, TimeoutError) as exc:
+        raise BrokerSnapshotStageTimeout(stage) from exc
 
 
 def _aware_iso(value: Any) -> str:
@@ -853,9 +896,13 @@ async def handle_get_broker_snapshot(params: dict) -> dict:
                 "Broker snapshot managed account does not match expectation"
             )
 
-        broker_time_before = await _request_broker_time()
-        positions = await ib.reqPositionsAsync()
-        initial_position_signature = await _position_state_signature(positions, account)
+        broker_time_before = await _await_broker_snapshot_stage(
+            "broker_time_before", _request_broker_time()
+        )
+        positions = await _await_broker_snapshot_stage("positions_initial", ib.reqPositionsAsync())
+        initial_position_signature = await _await_broker_snapshot_stage(
+            "positions_initial_identity", _position_state_signature(positions, account)
+        )
         if not ib.isConnected():
             raise ConnectionError("Broker disconnected during snapshot collection")
 
@@ -865,7 +912,9 @@ async def handle_get_broker_snapshot(params: dict) -> dict:
         for position in positions:
             if str(getattr(position, "account", "")).strip() != account:
                 raise ValueError("Broker position account is inconsistent")
-            contract_identity = await _qualified_stock_identity(position.contract)
+            contract_identity = await _await_broker_snapshot_stage(
+                "position_identity", _qualified_stock_identity(position.contract)
+            )
             con_id = contract_identity["con_id"]
             symbol = contract_identity["symbol"]
             if con_id in seen_contract_ids or symbol in seen_symbols:
@@ -889,13 +938,17 @@ async def handle_get_broker_snapshot(params: dict) -> dict:
                 }
             )
 
-        open_trades = await ib.reqAllOpenOrdersAsync()
+        open_trades = await _await_broker_snapshot_stage(
+            "open_orders_initial", ib.reqAllOpenOrdersAsync()
+        )
         if not ib.isConnected():
             raise ConnectionError("Broker disconnected during snapshot collection")
         open_orders_data = []
         seen_order_ids: set[tuple[int, int]] = set()
         for trade in open_trades:
-            order_evidence = await _open_order_evidence(trade, account)
+            order_evidence = await _await_broker_snapshot_stage(
+                "open_order_identity", _open_order_evidence(trade, account)
+            )
             order_id = order_evidence["broker_order_id"]
             client_id = order_evidence["client_id"]
             order_identity = (client_id, order_id)
@@ -919,8 +972,12 @@ async def handle_get_broker_snapshot(params: dict) -> dict:
         # lower-bound-only request is in flight; such a later fill must make
         # the snapshot fail closed rather than be silently omitted or falsely
         # claimed as covered by an after-the-fact cutoff.
-        execution_window_end = await _request_broker_time()
-        fills = await ib.reqExecutionsAsync(execution_filter)
+        execution_window_end = await _await_broker_snapshot_stage(
+            "broker_time_execution_cutoff", _request_broker_time()
+        )
+        fills = await _await_broker_snapshot_stage(
+            "executions", ib.reqExecutionsAsync(execution_filter)
+        )
         if not ib.isConnected():
             raise ConnectionError("Broker disconnected during snapshot collection")
         executions_data = []
@@ -938,7 +995,9 @@ async def handle_get_broker_snapshot(params: dict) -> dict:
             if side is None:
                 raise ValueError("Broker execution side is unsupported")
 
-            contract_identity = await _qualified_stock_identity(fill.contract)
+            contract_identity = await _await_broker_snapshot_stage(
+                "execution_identity", _qualified_stock_identity(fill.contract)
+            )
             execution_time = getattr(execution, "time", None) or getattr(fill, "time", None)
             executed_at = _aware_iso(execution_time)
             executed_at_value = datetime.fromisoformat(executed_at)
@@ -1017,8 +1076,9 @@ async def handle_get_broker_snapshot(params: dict) -> dict:
                 }
             )
 
-        await ib.reqAccountSummaryAsync()
-        account_values = ib.accountValues(account)
+        account_values = await _await_broker_snapshot_stage(
+            "account_summary", ib.accountSummaryAsync(account)
+        )
         if not ib.isConnected():
             raise ConnectionError("Broker disconnected during snapshot collection")
 
@@ -1049,17 +1109,27 @@ async def handle_get_broker_snapshot(params: dict) -> dict:
         if not BROKER_SNAPSHOT_REQUIRED_BALANCE_TAGS.issubset(present_tags):
             raise ValueError("Broker snapshot is missing required balance evidence")
 
-        final_positions = await ib.reqPositionsAsync()
-        final_position_signature = await _position_state_signature(final_positions, account)
-        final_open_trades = await ib.reqAllOpenOrdersAsync()
-        final_order_signature = await _order_state_signature(final_open_trades, account)
+        final_positions = await _await_broker_snapshot_stage(
+            "positions_final", ib.reqPositionsAsync()
+        )
+        final_position_signature = await _await_broker_snapshot_stage(
+            "positions_final_identity", _position_state_signature(final_positions, account)
+        )
+        final_open_trades = await _await_broker_snapshot_stage(
+            "open_orders_final", ib.reqAllOpenOrdersAsync()
+        )
+        final_order_signature = await _await_broker_snapshot_stage(
+            "open_orders_final_identity", _order_state_signature(final_open_trades, account)
+        )
         if (
             final_position_signature != initial_position_signature
             or final_order_signature != initial_order_signature
         ):
             raise ValueError("Broker critical state changed during snapshot collection")
 
-        broker_time_after = await _request_broker_time()
+        broker_time_after = await _await_broker_snapshot_stage(
+            "broker_time_after", _request_broker_time()
+        )
         accounts_after = [str(item).strip() for item in ib.managedAccounts() if str(item).strip()]
         if accounts_after != accounts_before:
             raise ValueError("Managed account set changed during snapshot collection")
@@ -1100,6 +1170,13 @@ async def handle_get_broker_snapshot(params: dict) -> dict:
             "status": "error",
             "error": "Broker snapshot account mismatch",
             "error_type": "BrokerSnapshotAccountMismatchError",
+        }
+    except BrokerSnapshotStageTimeout as exc:
+        return {
+            "status": "error",
+            "error": "Broker snapshot collection timed out",
+            "error_type": "TimeoutError",
+            "detail": f"Broker snapshot stage timed out: {exc.stage}",
         }
     except TimeoutError:
         # Preserve the timeout classification so the parent poisons this exact

--- a/tests/test_broker_snapshot_protocol.py
+++ b/tests/test_broker_snapshot_protocol.py
@@ -1,3 +1,4 @@
+import asyncio
 import copy
 import json
 import threading
@@ -128,11 +129,8 @@ class _FakeIB:
             )
         ]
 
-    async def reqAccountSummaryAsync(self):
-        self.calls.append("reqAccountSummaryAsync")
-
-    def accountValues(self, account):
-        self.calls.append("accountValues")
+    async def accountSummaryAsync(self, account):
+        self.calls.append("accountSummaryAsync")
         assert account == ACCOUNT
         return [
             SimpleNamespace(
@@ -146,6 +144,30 @@ class _FakeIB:
                 tag="TotalCashValue",
                 currency="USD",
                 value="25000.500",
+            ),
+            SimpleNamespace(
+                account=ACCOUNT,
+                tag="BuyingPower",
+                currency="USD",
+                value="999999",
+            ),
+        ]
+
+    def accountValues(self, account):
+        self.calls.append("accountValues")
+        assert account == ACCOUNT
+        return [
+            SimpleNamespace(
+                account=ACCOUNT,
+                tag="NetLiquidation",
+                currency="USD",
+                value="1.00",
+            ),
+            SimpleNamespace(
+                account=ACCOUNT,
+                tag="TotalCashValue",
+                currency="USD",
+                value="2.00",
             ),
             SimpleNamespace(
                 account=ACCOUNT,
@@ -211,14 +233,15 @@ async def test_worker_snapshot_is_fresh_atomic_read_only_and_precise(fake_ib):
         "reqPositionsAsync",
         "reqAllOpenOrdersAsync",
         "reqExecutionsAsync",
-        "reqAccountSummaryAsync",
-        "accountValues",
+        "accountSummaryAsync",
         "qualifyContractsAsync",
     }
     assert set(fake_ib.calls) <= allowed
     assert "reqPositionsAsync" in fake_ib.calls
     assert "reqAllOpenOrdersAsync" in fake_ib.calls
     assert "reqExecutionsAsync" in fake_ib.calls
+    assert "accountSummaryAsync" in fake_ib.calls
+    assert "accountValues" not in fake_ib.calls
     execution_request_index = fake_ib.calls.index("reqExecutionsAsync")
     assert fake_ib.calls[execution_request_index - 1] == "reqCurrentTimeAsync"
     assert not any(
@@ -256,7 +279,8 @@ async def test_worker_wrong_expected_account_performs_zero_data_reads(fake_ib):
     assert result["status"] == "error"
     assert result["error_type"] == "BrokerSnapshotAccountMismatchError"
     assert not any(
-        call.startswith("req") or call in {"accountValues", "qualifyContractsAsync"}
+        call.startswith("req")
+        or call in {"accountSummaryAsync", "accountValues", "qualifyContractsAsync"}
         for call in fake_ib.calls
     )
 
@@ -603,8 +627,10 @@ async def test_worker_snapshot_timeout_preserves_parent_timeout_poison(fake_ib, 
         "status": "error",
         "error": "Broker snapshot collection timed out",
         "error_type": "TimeoutError",
+        "detail": "Broker snapshot stage timed out: positions_initial",
     }
     assert ACCOUNT not in worker_response["error"]
+    assert "sensitive diagnostic context" not in json.dumps(worker_response)
 
     client, generation = _transport_response_client(worker_response)
     with pytest.raises(IBKRTimeoutError, match="Broker snapshot collection timed out"):
@@ -613,6 +639,59 @@ async def test_worker_snapshot_timeout_preserves_parent_timeout_poison(fake_ib, 
     assert generation.poisoned_reason is not None
     assert "worker-reported broker timeout" in generation.poisoned_reason
     assert "get_broker_snapshot" in generation.poisoned_reason
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stage", sorted(worker.BROKER_SNAPSHOT_REQUEST_STAGES))
+async def test_worker_snapshot_stage_deadlines_are_bounded_and_sanitized(stage, monkeypatch):
+    sensitive_detail = "DU_SECRET_ACCOUNT raw broker exception"
+
+    async def never_finishes():
+        await asyncio.Future()
+        raise AssertionError(sensitive_detail)
+
+    monkeypatch.setattr(worker, "BROKER_SNAPSHOT_STAGE_TIMEOUT_SECONDS", 0.001)
+
+    with pytest.raises(worker.BrokerSnapshotStageTimeout) as exc_info:
+        await worker._await_broker_snapshot_stage(stage, never_finishes())
+
+    assert exc_info.value.stage == stage
+    assert str(exc_info.value) == f"Broker snapshot stage timed out: {stage}"
+    assert sensitive_detail not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_worker_snapshot_routes_every_broker_await_through_stage_deadline(
+    fake_ib, monkeypatch
+):
+    observed = []
+
+    async def record_stage(stage, request):
+        observed.append(stage)
+        return await request
+
+    monkeypatch.setattr(worker, "_await_broker_snapshot_stage", record_stage)
+
+    result = await worker.handle_get_broker_snapshot({"expected_account": ACCOUNT})
+
+    assert result["status"] == "success"
+    assert observed == [
+        "broker_time_before",
+        "positions_initial",
+        "positions_initial_identity",
+        "position_identity",
+        "open_orders_initial",
+        "open_order_identity",
+        "broker_time_execution_cutoff",
+        "executions",
+        "execution_identity",
+        "account_summary",
+        "positions_final",
+        "positions_final_identity",
+        "open_orders_final",
+        "open_orders_final_identity",
+        "broker_time_after",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_broker_snapshot_protocol.py
+++ b/tests/test_broker_snapshot_protocol.py
@@ -71,6 +71,21 @@ class _FakeAccountSummaryWrapper:
         self.pending[request_id] = future
         return future
 
+    def _endReq(self, request_id):
+        future = self.pending.pop(request_id, None)
+        if future is not None and not future.done():
+            future.set_result(None)
+
+    def accountSummary(self, request_id, account, tag, value, currency):
+        key = (account, tag, currency)
+        self.acctSummary[key] = SimpleNamespace(
+            request_id=request_id,
+            account=account,
+            tag=tag,
+            currency=currency,
+            value=value,
+        )
+
 
 class _FakeAccountSummaryClient:
     def __init__(self, owner):
@@ -93,14 +108,38 @@ class _FakeAccountSummaryClient:
             len(self.owner.account_summary_batches) - 1,
         )
         for value in self.owner.account_summary_batches[batch_index]:
-            key = (value.account, value.tag, value.currency)
-            self.owner.wrapper.acctSummary[key] = value
-        self.owner.wrapper.pending.pop(request_id).set_result(None)
+            if self.owner.account_summary_bypasses_scoped_callback:
+                _FakeAccountSummaryWrapper.accountSummary(
+                    self.owner.wrapper,
+                    request_id,
+                    value.account,
+                    value.tag,
+                    value.value,
+                    value.currency,
+                )
+            else:
+                self.owner.wrapper.accountSummary(
+                    request_id,
+                    value.account,
+                    value.tag,
+                    value.value,
+                    value.currency,
+                )
+        for foreign_request_id, value in self.owner.foreign_account_summary_callbacks:
+            self.owner.wrapper.accountSummary(
+                foreign_request_id,
+                value.account,
+                value.tag,
+                value.value,
+                value.currency,
+            )
+        self.owner.wrapper._endReq(request_id)
 
     def cancelAccountSummary(self, request_id):
         self.owner.calls.append("cancelAccountSummary")
         self.cancelled_request_ids.append(request_id)
-        self.owner.wrapper.pending.pop(request_id, None)
+        if self.owner.account_summary_cancel_raises:
+            raise RuntimeError("raw cancellation failure with sensitive context")
 
 
 class _FakeIB:
@@ -113,6 +152,9 @@ class _FakeIB:
         self.account_summary_batches = [_account_summary_values()]
         self.account_summary_requests = []
         self.account_summary_hangs = False
+        self.account_summary_bypasses_scoped_callback = False
+        self.account_summary_cancel_raises = False
+        self.foreign_account_summary_callbacks = []
         self.wrapper = _FakeAccountSummaryWrapper()
         self.client = _FakeAccountSummaryClient(self)
 
@@ -344,6 +386,43 @@ async def test_worker_repeated_snapshot_forces_fresh_account_summary(fake_ib):
     assert second_balances[("TotalCashValue", "USD")] == "26000"
     assert len(fake_ib.account_summary_requests) == 2
     assert fake_ib.client.cancelled_request_ids == [1, 2]
+    assert "accountSummary" not in fake_ib.wrapper.__dict__
+
+
+@pytest.mark.asyncio
+async def test_worker_account_summary_ignores_foreign_request_cache_interleaving(fake_ib):
+    fake_ib.account_summary_batches = [
+        _account_summary_values("101000.00", "26000.00"),
+    ]
+    fake_ib.foreign_account_summary_callbacks = [
+        (999, value) for value in _account_summary_values("1.00", "2.00")
+    ]
+
+    result = await worker.handle_get_broker_snapshot({"expected_account": ACCOUNT})
+
+    assert result["status"] == "success"
+    balances = {(row["tag"], row["currency"]): row["value"] for row in result["data"]["balances"]}
+    assert balances[("NetLiquidation", "USD")] == "101000"
+    assert balances[("TotalCashValue", "USD")] == "26000"
+    assert fake_ib.wrapper.acctSummary[(ACCOUNT, "NetLiquidation", "USD")].value == "1.00"
+    assert fake_ib.wrapper.acctSummary[(ACCOUNT, "TotalCashValue", "USD")].value == "2.00"
+    assert "accountSummary" not in fake_ib.wrapper.__dict__
+
+
+@pytest.mark.asyncio
+async def test_worker_account_summary_fails_closed_without_owned_callback_provenance(fake_ib):
+    fake_ib.account_summary_bypasses_scoped_callback = True
+
+    result = await worker.handle_get_broker_snapshot({"expected_account": ACCOUNT})
+
+    assert result == {
+        "status": worker.PROTOCOL_ERROR_STATUS,
+        "error": "Broker snapshot collection failed",
+        "error_type": worker.PROTOCOL_ERROR_TYPE,
+    }
+    assert fake_ib.wrapper.acctSummary
+    assert fake_ib.client.cancelled_request_ids == [1]
+    assert "accountSummary" not in fake_ib.wrapper.__dict__
 
 
 @pytest.mark.asyncio
@@ -737,6 +816,41 @@ async def test_worker_account_summary_timeout_cancels_subscription_and_is_saniti
     }
     assert fake_ib.client.cancelled_request_ids == [1]
     assert fake_ib.wrapper.pending == {}
+    assert "accountSummary" not in fake_ib.wrapper.__dict__
+
+
+@pytest.mark.asyncio
+async def test_worker_account_summary_cancellation_restores_callback_and_subscription(fake_ib):
+    fake_ib.account_summary_hangs = True
+
+    task = asyncio.create_task(worker._request_fresh_broker_account_summary(ACCOUNT))
+    while not fake_ib.account_summary_requests:
+        await asyncio.sleep(0)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert fake_ib.client.cancelled_request_ids == [1]
+    assert fake_ib.wrapper.pending == {}
+    assert "accountSummary" not in fake_ib.wrapper.__dict__
+
+
+@pytest.mark.asyncio
+async def test_worker_account_summary_cancel_failure_still_cleans_request_and_callback(fake_ib):
+    fake_ib.account_summary_cancel_raises = True
+
+    result = await worker.handle_get_broker_snapshot({"expected_account": ACCOUNT})
+
+    assert result == {
+        "status": worker.PROTOCOL_ERROR_STATUS,
+        "error": "Broker snapshot collection failed",
+        "error_type": worker.PROTOCOL_ERROR_TYPE,
+    }
+    assert fake_ib.client.cancelled_request_ids == [1]
+    assert fake_ib.wrapper.pending == {}
+    assert "accountSummary" not in fake_ib.wrapper.__dict__
+    assert "sensitive context" not in json.dumps(result)
 
 
 @pytest.mark.asyncio

--- a/tests/test_broker_snapshot_protocol.py
+++ b/tests/test_broker_snapshot_protocol.py
@@ -38,6 +38,71 @@ def _contract(symbol="AAPL", con_id=265598):
     )
 
 
+def _account_summary_values(net_liquidation="100000.00", total_cash="25000.500"):
+    return [
+        SimpleNamespace(
+            account=ACCOUNT,
+            tag="NetLiquidation",
+            currency="USD",
+            value=net_liquidation,
+        ),
+        SimpleNamespace(
+            account=ACCOUNT,
+            tag="TotalCashValue",
+            currency="USD",
+            value=total_cash,
+        ),
+        SimpleNamespace(
+            account=ACCOUNT,
+            tag="BuyingPower",
+            currency="USD",
+            value="999999",
+        ),
+    ]
+
+
+class _FakeAccountSummaryWrapper:
+    def __init__(self):
+        self.acctSummary = {}
+        self.pending = {}
+
+    def startReq(self, request_id):
+        future = asyncio.get_running_loop().create_future()
+        self.pending[request_id] = future
+        return future
+
+
+class _FakeAccountSummaryClient:
+    def __init__(self, owner):
+        self.owner = owner
+        self.next_request_id = 1
+        self.cancelled_request_ids = []
+
+    def getReqId(self):
+        request_id = self.next_request_id
+        self.next_request_id += 1
+        return request_id
+
+    def reqAccountSummary(self, request_id, group, tags):
+        self.owner.calls.append("reqAccountSummary")
+        self.owner.account_summary_requests.append((request_id, group, tags))
+        if self.owner.account_summary_hangs:
+            return
+        batch_index = min(
+            len(self.owner.account_summary_requests) - 1,
+            len(self.owner.account_summary_batches) - 1,
+        )
+        for value in self.owner.account_summary_batches[batch_index]:
+            key = (value.account, value.tag, value.currency)
+            self.owner.wrapper.acctSummary[key] = value
+        self.owner.wrapper.pending.pop(request_id).set_result(None)
+
+    def cancelAccountSummary(self, request_id):
+        self.owner.calls.append("cancelAccountSummary")
+        self.cancelled_request_ids.append(request_id)
+        self.owner.wrapper.pending.pop(request_id, None)
+
+
 class _FakeIB:
     def __init__(self):
         self.calls = []
@@ -45,6 +110,11 @@ class _FakeIB:
         self.account_reads = 0
         self.contract = _contract()
         self.execution_filters = []
+        self.account_summary_batches = [_account_summary_values()]
+        self.account_summary_requests = []
+        self.account_summary_hangs = False
+        self.wrapper = _FakeAccountSummaryWrapper()
+        self.client = _FakeAccountSummaryClient(self)
 
     def isConnected(self):
         self.calls.append("isConnected")
@@ -129,30 +199,6 @@ class _FakeIB:
             )
         ]
 
-    async def accountSummaryAsync(self, account):
-        self.calls.append("accountSummaryAsync")
-        assert account == ACCOUNT
-        return [
-            SimpleNamespace(
-                account=ACCOUNT,
-                tag="NetLiquidation",
-                currency="USD",
-                value="100000.00",
-            ),
-            SimpleNamespace(
-                account=ACCOUNT,
-                tag="TotalCashValue",
-                currency="USD",
-                value="25000.500",
-            ),
-            SimpleNamespace(
-                account=ACCOUNT,
-                tag="BuyingPower",
-                currency="USD",
-                value="999999",
-            ),
-        ]
-
     def accountValues(self, account):
         self.calls.append("accountValues")
         assert account == ACCOUNT
@@ -233,14 +279,16 @@ async def test_worker_snapshot_is_fresh_atomic_read_only_and_precise(fake_ib):
         "reqPositionsAsync",
         "reqAllOpenOrdersAsync",
         "reqExecutionsAsync",
-        "accountSummaryAsync",
+        "reqAccountSummary",
+        "cancelAccountSummary",
         "qualifyContractsAsync",
     }
     assert set(fake_ib.calls) <= allowed
     assert "reqPositionsAsync" in fake_ib.calls
     assert "reqAllOpenOrdersAsync" in fake_ib.calls
     assert "reqExecutionsAsync" in fake_ib.calls
-    assert "accountSummaryAsync" in fake_ib.calls
+    assert "reqAccountSummary" in fake_ib.calls
+    assert "cancelAccountSummary" in fake_ib.calls
     assert "accountValues" not in fake_ib.calls
     execution_request_index = fake_ib.calls.index("reqExecutionsAsync")
     assert fake_ib.calls[execution_request_index - 1] == "reqCurrentTimeAsync"
@@ -273,6 +321,32 @@ async def test_worker_snapshot_rechecks_account_and_suppresses_sensitive_errors(
 
 
 @pytest.mark.asyncio
+async def test_worker_repeated_snapshot_forces_fresh_account_summary(fake_ib):
+    fake_ib.account_summary_batches = [
+        _account_summary_values("100000.00", "25000.00"),
+        _account_summary_values("101000.00", "26000.00"),
+    ]
+
+    first = await worker.handle_get_broker_snapshot({"expected_account": ACCOUNT})
+    second = await worker.handle_get_broker_snapshot({"expected_account": ACCOUNT})
+
+    assert first["status"] == "success"
+    assert second["status"] == "success"
+    first_balances = {
+        (row["tag"], row["currency"]): row["value"] for row in first["data"]["balances"]
+    }
+    second_balances = {
+        (row["tag"], row["currency"]): row["value"] for row in second["data"]["balances"]
+    }
+    assert first_balances[("NetLiquidation", "USD")] == "100000"
+    assert second_balances[("NetLiquidation", "USD")] == "101000"
+    assert first_balances[("TotalCashValue", "USD")] == "25000"
+    assert second_balances[("TotalCashValue", "USD")] == "26000"
+    assert len(fake_ib.account_summary_requests) == 2
+    assert fake_ib.client.cancelled_request_ids == [1, 2]
+
+
+@pytest.mark.asyncio
 async def test_worker_wrong_expected_account_performs_zero_data_reads(fake_ib):
     result = await worker.handle_get_broker_snapshot({"expected_account": "DU_WRONG_ACCOUNT"})
 
@@ -280,7 +354,12 @@ async def test_worker_wrong_expected_account_performs_zero_data_reads(fake_ib):
     assert result["error_type"] == "BrokerSnapshotAccountMismatchError"
     assert not any(
         call.startswith("req")
-        or call in {"accountSummaryAsync", "accountValues", "qualifyContractsAsync"}
+        or call
+        in {
+            "accountValues",
+            "cancelAccountSummary",
+            "qualifyContractsAsync",
+        }
         for call in fake_ib.calls
     )
 
@@ -639,6 +718,25 @@ async def test_worker_snapshot_timeout_preserves_parent_timeout_poison(fake_ib, 
     assert generation.poisoned_reason is not None
     assert "worker-reported broker timeout" in generation.poisoned_reason
     assert "get_broker_snapshot" in generation.poisoned_reason
+
+
+@pytest.mark.asyncio
+async def test_worker_account_summary_timeout_cancels_subscription_and_is_sanitized(
+    fake_ib, monkeypatch
+):
+    fake_ib.account_summary_hangs = True
+    monkeypatch.setattr(worker, "BROKER_SNAPSHOT_STAGE_TIMEOUT_SECONDS", 0.001)
+
+    worker_response = await worker.handle_get_broker_snapshot({"expected_account": ACCOUNT})
+
+    assert worker_response == {
+        "status": "error",
+        "error": "Broker snapshot collection timed out",
+        "error_type": "TimeoutError",
+        "detail": "Broker snapshot stage timed out: account_summary",
+    }
+    assert fake_ib.client.cancelled_request_ids == [1]
+    assert fake_ib.wrapper.pending == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- Put a 5-second, allowlisted stage deadline around every asynchronous broker request used by the read-only reconciliation snapshot.
- Return only a sanitized stage identifier when a broker future never completes.
- Preserve the parent transport's fail-closed generation poison/reap behavior.
- Force each account-summary stage through an owned fresh IBKR request ID and capture only callbacks carrying that exact request ID; never trust the library's global account-summary cache.
- Forward library callbacks unchanged, restore the prior callback, close request bookkeeping, and cancel the owned subscription on success, timeout, cancellation, or cleanup failure.
- Add never-completing-future coverage for every snapshot stage, repeated-snapshot balance freshness, foreign-request interleaving, missing provenance, cancellation cleanup, successful routing, and cache-source regressions.

## Root cause

The worker had no per-stage deadline, so one broker future could consume the parent's entire 30-second command budget with no indication of which stage hung. The account-summary implementation also mixed caches; later review showed that even a fresh request cannot prove provenance if results are read from `ib_async`'s process-global cache, because a reconnect subscription can interleave callbacks. The final implementation captures exact request-scoped callbacks.

## Safety and impact

This is read-only broker evidence collection. It does not grant order authority, clear a kill switch, alter the ledger, start services, or authorize startup. Timeouts and uncertain callback provenance remain fail-closed and poison the exact worker generation where applicable.

## Validation

- Three implementation/review rounds closed the original hang, stale convenience-cache reuse, and foreign-request interleaving.
- Final focused broker snapshot/generation suite: 143 passed.
- Final full suite: 2,297 passed, 5 expected skips.
- Changed-file Black and Flake8: pass.
- `git diff --check`: pass.
