### PR TITLE
PR3: establish canonical market-data contract

### DIFF
--- a/app.py
+++ b/app.py
@@ -4299,7 +4299,14 @@ HTML_TEMPLATE = """
         function handleRealtimeUpdate(data) {
             switch(data.type) {
                 case 'market_data':
-                    updateMarketPrice(data.symbol, data.price, data.bid, data.ask, data.volume);
+                    updateMarketPrice(
+                        data.symbol,
+                        data.price,
+                        data.bid,
+                        data.ask,
+                        data.volume,
+                        data
+                    );
                     break;
                 case 'trade':
                     handleTradeUpdate(data);
@@ -4367,7 +4374,7 @@ HTML_TEMPLATE = """
             }
         }
 
-        function updateMarketPrice(symbol, price, bid, ask, volume) {
+        function updateMarketPrice(symbol, price, bid, ask, volume, lineage = {}) {
             console.log('updateMarketPrice called:', symbol, price);
             // Update watchlist prices in real-time
             const rows = document.querySelectorAll('#watchlist-table tr');
@@ -4380,6 +4387,15 @@ HTML_TEMPLATE = """
                     if (priceCell) {
                         const oldPrice = parseFloat(priceCell.textContent.replace('$', ''));
                         priceCell.textContent = `$${price.toFixed(2)}`;
+                        priceCell.dataset.marketDataSource = lineage.source || 'unknown';
+                        priceCell.dataset.marketDataFreshness = lineage.freshness_status || 'unknown';
+                        priceCell.dataset.marketDataEventTime = lineage.event_timestamp || '';
+                        priceCell.title = [
+                            `Source: ${lineage.source || 'unknown'}`,
+                            `Freshness: ${lineage.freshness_status || 'unknown'}`,
+                            `Event: ${lineage.event_timestamp || 'unknown'}`,
+                            `Retrieved: ${lineage.retrieval_timestamp || 'unknown'}`
+                        ].join('\n');
                         
                         // Flash color based on price change
                         if (oldPrice && oldPrice !== price) {
@@ -5406,6 +5422,39 @@ def market_status():
     return jsonify(result)
 
 
+@app.route("/api/market-data/<symbol>")
+@requires_auth
+def latest_market_data(symbol):
+    """Expose one observation with explicit event, source, and freshness lineage."""
+
+    from robo_trader.database_validator import DatabaseValidator, ValidationError
+    from robo_trader.market_data_contract import MarketDataContractError, bar_interval_seconds
+    from sync_db_reader import MarketDataReadError, SyncDatabaseReader
+
+    try:
+        normalized = DatabaseValidator.validate_symbol(symbol)
+    except ValidationError:
+        return jsonify({"error": "invalid symbol"}), 400
+    timeframe = request.args.get("timeframe")
+    if timeframe is not None:
+        try:
+            bar_interval_seconds(timeframe)
+        except MarketDataContractError:
+            return jsonify({"error": "invalid timeframe"}), 400
+    try:
+        rows = SyncDatabaseReader().get_latest_market_data(
+            normalized,
+            limit=1,
+            timeframe=timeframe,
+        )
+    except MarketDataReadError:
+        logger.exception("market-data API read failed for symbol=%s", normalized)
+        return jsonify({"error": "market_data_unavailable"}), 503
+    if not rows:
+        return jsonify({"symbol": normalized, "observation": None}), 404
+    return jsonify({"symbol": normalized, "observation": rows[0]})
+
+
 def _resolve_lsof_binary():
     """Resolve lsof without relying on the reduced launchd/container PATH."""
     discovered = shutil.which("lsof")
@@ -6355,6 +6404,7 @@ def get_watchlist():
             # Get latest market data
             market_data = db.get_latest_market_data(symbol, limit=1)
             current_price = market_data[0]["close"] if market_data else 0
+            market_observation = market_data[0] if market_data else {}
 
             # Check if we have a position
             position = position_map.get(symbol)
@@ -6373,6 +6423,13 @@ def get_watchlist():
                     "pnl": pnl,
                     "notes": "Active" if position else "Watching",
                     "has_position": position is not None,
+                    "market_data_source": market_observation.get("source", "unavailable"),
+                    "market_data_event_time": market_observation.get("timestamp"),
+                    "market_data_retrieval_time": market_observation.get("retrieval_timestamp"),
+                    "market_data_freshness": market_observation.get(
+                        "freshness_status", "unavailable"
+                    ),
+                    "market_data_age_seconds": market_observation.get("age_seconds"),
                 }
             )
 

--- a/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
+++ b/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
@@ -471,9 +471,8 @@ runtime-integration changes:
   boundary remains hard-disabled.
 - **PR 2B.3 / issue #102:** add exact settlement, ambiguity handling, and
   crash/restart quarantine release, and bind every reduction price to
-  producer-owned fresh protective-quote price, timestamp, and lineage. This
-  implementation and exact-head local review are complete at `14f6b55` on
-  `codex/pr2b3-terminal-settlement`; hosted review and merge remain pending.
+  producer-owned fresh protective-quote price, timestamp, and lineage. PR
+  #107 merged this stage as `017f43e5c31283e6cf5cc630c6fd15acd2af683b`.
   The shared readiness gate remains false.
 
 PR 2A grants no broker connection or submission authority by itself. PR 2B.1
@@ -1514,7 +1513,9 @@ Update after each merge.
   inference with zero input or output tokens; it produced no code verdict and
   was not counted as a pass. The merge grants no order authority or startup
   approval. Gate A remains closed and the trader remains stopped.
-- PR 3: Not started
+- PR 3: In progress on `codex/pr3-market-data-contract`; implementation and
+  adversarial local review are not yet complete. This status does not authorize
+  startup.
 - PR 4: Not started
 - PR 5: Not started
 - PR 6: Not started

--- a/docs/reviews/PR3_LOCAL_REVIEW_EVIDENCE_2026-07-27.md
+++ b/docs/reviews/PR3_LOCAL_REVIEW_EVIDENCE_2026-07-27.md
@@ -1,0 +1,139 @@
+# PR 3 Local Review Evidence
+
+Date: 2026-07-27
+Branch: `codex/pr3-market-data-contract`
+
+This file records local implementation and review evidence for PR 3. It is not
+a GitHub approval object and does not authorize starting the trader. The shared
+paper-readiness gate remains false.
+
+## Scope and non-goals
+
+PR 3 establishes one versioned market-data contract for historical strategy
+bars and a separate broker event contract for protective monitoring. It does
+not enable broker order writes, enable live trading, reconcile broker and local
+financial state, migrate the legacy financial ledger, clear any kill switch,
+or bypass startup preflight.
+
+IBKR remains paper-port and read-only. Exposure-reducing paper executions keep
+the PR 2B reduce-only authorization and exact-settlement boundary. Exposure-
+increasing paper simulation is admitted only when current producer-owned broker
+quote evidence and validated canonical strategy bars are both present.
+
+## Canonical historical-bar contract
+
+The subprocess broker boundary normalizes IBKR historical `TRADES` bars into a
+versioned immutable batch with:
+
+- exact symbol, contract ID, exchange, timezone, timeframe, and broker request
+  semantics;
+- timezone-aware broker and retrieval timestamps;
+- explicit regular or extended session classification;
+- exact decimal OHLC values, nonnegative volume, adjustment state, source, and
+  quality flags; and
+- validation of ordering, duplicates, gaps, staleness, session membership,
+  finite values, and OHLC relationships.
+
+The DataFrame is a compatibility projection for strategy calculations. It
+retains the canonical batch as lineage metadata, but it is not the authority
+for execution prices. A legacy or untagged DataFrame cannot reach entry
+execution.
+
+## Protective broker-event channel
+
+Protective monitoring uses an independent read-only IBKR tick-by-tick `Last`
+subscription channel. Subscriptions persist across polling intervals, are
+retired when symbols leave the protected set, and expose every unseen event in
+broker order. Stable event identities, contract IDs, broker timestamps,
+transport generations, and exact decimal prices are validated before the stop
+monitor accepts them.
+
+Feed failure retires the transport generation and synchronously invalidates its
+unlatched quote evidence. A stop crossing already latched by the monitor keeps
+its immutable event evidence through the existing PR 2B terminal-settlement
+flow. Dashboard status is observational; it cannot mint or revoke order
+authority.
+
+## Entry admission and paper-fill price
+
+Historical bars determine strategy signals. A current authoritative broker
+quote determines entry sizing, the paper order price, and the initial
+protective stop. Immediately before exposure increase, the account-wide paper
+gateway serializes admission, verifies broker connectivity, refreshes the
+protective quote inside that serialization boundary, and requires a second
+freshness and generation check. This closes the previous time-of-check/time-
+of-use gap.
+
+Extended-hours entries additionally require a canonical batch explicitly
+requested for extended sessions and a latest bar classified in the matching
+pre-market or after-hours session. The runtime never silently substitutes a
+regular-session close.
+
+## Durable history and operator visibility
+
+Canonical rows accumulate by explicit identity instead of replacing numbered
+legacy rows. Stored lineage includes request/session semantics as well as bar
+values and timestamps. Database admission revalidates the complete row rather
+than trusting dictionary key presence. Reads choose an explicit timeframe and
+use deterministic ordering.
+
+The dashboard and WebSocket payloads expose event time, retrieval time, source,
+session, timeframe, and freshness. An empty valid result is distinct from a
+database-read failure; the market-data API returns a sanitized service error
+for the latter. Periodic cleanup does not delete canonical audit history, and a
+portfolio-scoped signal cleanup cannot trigger global market-data deletion.
+
+## Rollback and data implications
+
+Rollback removes the new canonical read/write and protective-feed wiring while
+leaving the pre-existing legacy market-data table untouched. This PR does not
+delete, rewrite, or migrate user trades, positions, accounts, equity history,
+the safety journal, or broker credentials. Canonical history is additive.
+
+## Two-phase review findings
+
+The first review phase found unsafe bar-close paper fills, an entry freshness
+race, recovery-generation/status coupling, leaked tick subscriptions, missing
+multi-event replay coverage, incomplete persisted lineage, weak database
+admission, ambiguous timeframe reads, incorrect API error classification,
+unbounded staleness configuration, global cleanup side effects, incomplete
+extended-hours admission, and a legacy-data execution path. Each confirmed
+finding must be closed by code and adversarial tests before hosted review.
+
+The phase-two challenger result will be recorded here after reviewing the exact
+post-fix tree.
+
+## Final local verification
+
+The implementation tree based on PR 2B.3 merge `017f43e` passed the following
+local checks on 2026-07-28 before rebasing onto the PR 108 merge:
+
+- the focused PR 3 and affected PR 1/PR 2 regression suite passed 490 tests;
+- the full local suite passed 2,301 tests with 5 expected skips and 20 known
+  warnings;
+- Black check, isort check, Flake8, and `git diff --check` passed for every
+  modified or added Python file.
+
+After rebasing onto PR 108 merge `8fbf0f6`, the focused suite plus the PR 108
+WebSocket ownership and authentication regressions passed 567 tests with one
+known warning. The full post-rebase local suite passed 2,333 tests with 5
+expected skips and 20 known warnings. The phase-two challenger result remains
+to be recorded. No in-progress or concurrently edited test run counts as final
+evidence.
+
+## Remaining launch blockers
+
+PR 3 does not make paper startup safe by itself:
+
+- the shared paper-readiness flag remains false;
+- PR 4 financial-state/database durability is outstanding;
+- PR 5 read-only broker reconciliation is outstanding;
+- the Gate A subset of PR 7, exact-state bootstrap/FIFO work, and verified
+  backup restoration are outstanding;
+- the current machine's loss-triggered TSLA kill switch and lock require
+  explicit operator resolution; and
+- startup requires a clean ordinary preflight, immediate operator
+  notification, and explicit user confirmation.
+
+No trader, dashboard, WebSocket server, Gateway, watchdog, safety state, user
+trading data, or broker credential is started or modified by this review.

--- a/robo_trader/clients/ibkr_subprocess_worker.py
+++ b/robo_trader/clients/ibkr_subprocess_worker.py
@@ -11,8 +11,10 @@ where API handshakes timeout despite successful TCP connections.
 
 import asyncio
 import atexit
+import hashlib
 import inspect
 import ipaddress
+import itertools
 import json
 import os
 import queue
@@ -34,6 +36,10 @@ from ib_async import IB, ExecutionFilter  # noqa: E402
 
 from robo_trader.broker_account_identity import (  # noqa: E402
     is_supported_paper_account_identifier,
+)
+from robo_trader.market_hours import get_market_session  # noqa: E402
+from robo_trader.protective_quote_evidence import (  # noqa: E402
+    MAX_PROTECTIVE_SOURCE_EVENT_ID_LENGTH,
 )
 from robo_trader.utils.ibkr_safe import safe_disconnect  # noqa: E402
 
@@ -77,6 +83,8 @@ INTRADAY_BAR_SIZES = {
 }
 PROTOCOL_ERROR_STATUS = "protocol_error"
 PROTOCOL_ERROR_TYPE = "TransportProtocolError"
+PROTECTIVE_TICK_TIMEOUT_SECONDS = 6.0
+PROTECTIVE_TICK_REQUEST_PACING_SECONDS = 15.0
 _SYNTHETIC_ACCOUNT_ENVIRONMENT_KEY = "ROBOTRADER_WORKER_SYNTHETIC_ACCOUNT_ENVIRONMENT"
 _FORBIDDEN_AMBIENT_POLICY_KEYS = frozenset(
     {
@@ -90,6 +98,31 @@ _FORBIDDEN_AMBIENT_POLICY_KEYS = frozenset(
         "VIRTUAL_ENV",
     }
 )
+_PROTECTIVE_TICK_SUBSCRIPTIONS: dict[int, tuple[Any, Any]] = {}
+_PROTECTIVE_TICK_CURSORS: dict[int, int] = {}
+_PROTECTIVE_SYMBOL_CON_IDS: dict[str, int] = {}
+_PROTECTIVE_TICK_REQUEST_TIMES: dict[int, float] = {}
+_PROTECTIVE_TICK_EVENT_IDS: dict[int, dict[int, str]] = {}
+_PROTECTIVE_TICK_EVENT_SEQUENCE = itertools.count(1)
+
+
+def _protective_request_monotonic() -> float:
+    """Return the injectable monotonic clock used for IBKR request pacing."""
+
+    return time.monotonic()
+
+
+def _clear_protective_tick_subscriptions() -> None:
+    """Forget subscription state before an IB session is retired."""
+
+    global _PROTECTIVE_TICK_EVENT_SEQUENCE
+
+    _PROTECTIVE_TICK_SUBSCRIPTIONS.clear()
+    _PROTECTIVE_TICK_CURSORS.clear()
+    _PROTECTIVE_SYMBOL_CON_IDS.clear()
+    _PROTECTIVE_TICK_REQUEST_TIMES.clear()
+    _PROTECTIVE_TICK_EVENT_IDS.clear()
+    _PROTECTIVE_TICK_EVENT_SEQUENCE = itertools.count(1)
 
 
 def _worker_environment() -> str:
@@ -510,6 +543,7 @@ def _stdin_reader():
 def _cleanup_on_exit():
     """Atexit handler to ensure we disconnect from IBKR to prevent zombies"""
     global ib
+    _clear_protective_tick_subscriptions()
     if ib is not None:
         print("atexit: Disconnecting from IBKR...", file=sys.stderr, flush=True)
         try:
@@ -601,6 +635,7 @@ async def handle_connect(params: dict) -> dict:
             }
 
         if ib is not None:
+            _clear_protective_tick_subscriptions()
             safe_disconnect(
                 ib,
                 context="diagnostic_worker:replace_connection",
@@ -1623,6 +1658,7 @@ async def handle_disconnect() -> dict:
     global ib, worker_connection_identity
 
     try:
+        _clear_protective_tick_subscriptions()
         if ib:
             # Properly disconnect to avoid zombie connections
             print("Disconnecting from IBKR...", file=sys.stderr, flush=True)
@@ -1804,6 +1840,245 @@ async def handle_get_historical_bars(params: dict) -> dict:
         }
 
 
+async def handle_get_protective_quotes(params: dict) -> dict:
+    """Fetch an independent, live last-trade snapshot for protective use."""
+
+    try:
+        if not ib or not ib.isConnected():
+            raise ConnectionError("Not connected to IBKR")
+        symbols = params.get("symbols")
+        if (
+            not isinstance(symbols, list)
+            or len(symbols) > 64
+            or any(
+                not isinstance(symbol, str) or not BROKER_SAFETY_SYMBOL_RE.fullmatch(symbol)
+                for symbol in symbols
+            )
+            or len(set(symbols)) != len(symbols)
+        ):
+            raise ValueError("protective quote symbols are malformed")
+
+        # One account-wide active set accompanies every bounded fetch chunk.
+        # Subscription retirement must use this full set, not the current
+        # chunk, otherwise adjacent chunks cancel and recreate one another.
+        active_symbols = params.get("active_symbols", symbols)
+        if (
+            not isinstance(active_symbols, list)
+            or len(active_symbols) > 4096
+            or any(
+                not isinstance(symbol, str) or not BROKER_SAFETY_SYMBOL_RE.fullmatch(symbol)
+                for symbol in active_symbols
+            )
+            or len(set(active_symbols)) != len(active_symbols)
+            or not set(symbols).issubset(active_symbols)
+        ):
+            raise ValueError("protective quote active symbols are malformed")
+
+        account_active_symbols = set(active_symbols)
+        cancel = getattr(ib, "cancelTickByTickData", None)
+        if cancel is None:
+            raise RuntimeError("IBKR client has no tick-by-tick cancellation API")
+        for stale_symbol in sorted(set(_PROTECTIVE_SYMBOL_CON_IDS) - account_active_symbols):
+            stale_con_id = _PROTECTIVE_SYMBOL_CON_IDS[stale_symbol]
+            stale = _PROTECTIVE_TICK_SUBSCRIPTIONS.get(stale_con_id)
+            if stale is None:
+                raise RuntimeError("Protective subscription registry is inconsistent")
+            requested_at = _PROTECTIVE_TICK_REQUEST_TIMES.get(stale_con_id)
+            if requested_at is None:
+                raise RuntimeError("Protective subscription pacing registry is inconsistent")
+            request_age = _protective_request_monotonic() - requested_at
+            if request_age < 0:
+                raise RuntimeError("Protective subscription pacing clock moved backwards")
+            # IBKR prohibits a second tick-by-tick request for the same
+            # instrument inside 15 seconds. Retain and reuse a recently
+            # inactive subscription until that window is safely closed.
+            if request_age < PROTECTIVE_TICK_REQUEST_PACING_SECONDS:
+                continue
+            cancelled = cancel(stale[0], "Last")
+            if inspect.isawaitable(cancelled):
+                cancelled = await cancelled
+            # ib_async's cancellation API normally returns None. Only an
+            # exception or explicit False is a failure; retain the registry in
+            # that case so the parent can retire the ambiguous worker session.
+            if cancelled is False:
+                raise RuntimeError("IBKR protective subscription cancellation failed")
+            _PROTECTIVE_TICK_SUBSCRIPTIONS.pop(stale_con_id, None)
+            _PROTECTIVE_TICK_CURSORS.pop(stale_con_id, None)
+            _PROTECTIVE_TICK_REQUEST_TIMES.pop(stale_con_id, None)
+            _PROTECTIVE_TICK_EVENT_IDS.pop(stale_con_id, None)
+            _PROTECTIVE_SYMBOL_CON_IDS.pop(stale_symbol, None)
+
+        from ib_async import Stock
+
+        contracts = []
+        for symbol in symbols:
+            cached_con_id = _PROTECTIVE_SYMBOL_CON_IDS.get(symbol)
+            cached = (
+                _PROTECTIVE_TICK_SUBSCRIPTIONS.get(cached_con_id)
+                if cached_con_id is not None
+                else None
+            )
+            if cached is not None:
+                qualified = cached[0]
+                _validate_stock_identity(qualified, symbol)
+            else:
+                qualified = await _qualify_one_contract(Stock(symbol, "SMART", "USD"))
+                _validate_stock_identity(qualified, symbol)
+                _PROTECTIVE_SYMBOL_CON_IDS[symbol] = int(qualified.conId)
+            contracts.append(qualified)
+
+        broker_time_before = await _request_broker_time()
+        request = getattr(ib, "reqTickByTickData", None)
+        if request is None:
+            raise RuntimeError("IBKR client has no tick-by-tick last-trade API")
+        subscriptions = []
+        for contract in contracts:
+            con_id = int(contract.conId)
+            existing = _PROTECTIVE_TICK_SUBSCRIPTIONS.get(con_id)
+            if existing is None:
+                _PROTECTIVE_TICK_REQUEST_TIMES[con_id] = _protective_request_monotonic()
+                ticker = request(
+                    contract,
+                    "Last",
+                    # Zero requests the unlimited live stream directly. A
+                    # nonzero value asks IBKR to preload that many historical
+                    # ticks before streaming, which is not admissible here.
+                    numberOfTicks=0,
+                    ignoreSize=False,
+                )
+                if inspect.isawaitable(ticker):
+                    ticker = await ticker
+                _PROTECTIVE_TICK_SUBSCRIPTIONS[con_id] = (contract, ticker)
+                _PROTECTIVE_TICK_CURSORS[con_id] = 0
+            else:
+                subscribed_contract, ticker = existing
+                if con_id not in _PROTECTIVE_TICK_REQUEST_TIMES:
+                    raise RuntimeError("Protective subscription pacing registry is inconsistent")
+                _validate_stock_identity(subscribed_contract, contract.symbol)
+                if int(subscribed_contract.conId) != con_id:
+                    raise ContractIdentityProtocolError(
+                        "Protective subscription contract identity changed"
+                    )
+            subscriptions.append((contract, ticker))
+
+        deadline = time.monotonic() + PROTECTIVE_TICK_TIMEOUT_SECONDS
+        while any(
+            not isinstance(getattr(ticker, "tickByTicks", None), list) or not ticker.tickByTicks
+            for _, ticker in subscriptions
+        ):
+            if time.monotonic() >= deadline:
+                raise TimeoutError("Timed out waiting for bound last-trade events")
+            await asyncio.sleep(0.05)
+
+        broker_time_after = await _request_broker_time()
+
+        retrieval_time = datetime.now(timezone.utc)
+        quotes = []
+        for contract, ticker in subscriptions:
+            ticker_contract = cast(Any, getattr(ticker, "contract", None))
+            _validate_stock_identity(ticker_contract, contract.symbol)
+            if int(ticker_contract.conId) != int(contract.conId):
+                raise ContractIdentityProtocolError(
+                    "Protective quote does not match its qualified contract"
+                )
+            ticks = getattr(ticker, "tickByTicks", None)
+            if not isinstance(ticks, list) or not ticks:
+                raise RuntimeError("IBKR protective last-trade event is missing")
+            con_id = int(contract.conId)
+            cursor = _PROTECTIVE_TICK_CURSORS.get(con_id, 0)
+            emitted_ticks = list(ticks[cursor:])
+            if not emitted_ticks:
+                emitted_ticks = [ticks[-1]]
+            ordered_ticks = sorted(
+                emitted_ticks,
+                key=lambda item: getattr(item, "time", datetime.min.replace(tzinfo=timezone.utc)),
+            )
+            event_ids = _PROTECTIVE_TICK_EVENT_IDS.setdefault(con_id, {})
+            retained_tick = ordered_ticks[-1]
+            retained_event_id = None
+            for tick in ordered_ticks:
+                source_timestamp = getattr(tick, "time", None)
+                source_timestamp_text = _aware_iso(source_timestamp)
+                session = get_market_session(source_timestamp)
+                if session == "closed":
+                    raise ValueError("Protective quote is outside an admitted market session")
+                price_text = _canonical_decimal(getattr(tick, "price", None))
+                tick_identity = id(tick)
+                source_event_id = event_ids.get(tick_identity)
+                if source_event_id is None:
+                    event_sequence = next(_PROTECTIVE_TICK_EVENT_SEQUENCE)
+                    event_fingerprint = hashlib.sha256(
+                        (
+                            f"v1|{WORKER_GENERATION_ID}|{con_id}|{event_sequence}|"
+                            f"{source_timestamp_text}|{price_text}|"
+                            f"{getattr(tick, 'size', '')}|"
+                            f"{getattr(tick, 'exchange', '')}"
+                        ).encode("utf-8")
+                    ).hexdigest()
+                    # Hash every variable-width component, including the
+                    # sequence, into one fixed-width opaque identity. This
+                    # remains unique per arrival and stable for the retained
+                    # fallback without leaking an unbounded generation ID.
+                    source_event_id = f"protective:v1:{event_fingerprint}"
+                    if len(source_event_id) > MAX_PROTECTIVE_SOURCE_EVENT_ID_LENGTH:
+                        raise RuntimeError("Protective event identity exceeds its bound")
+                    event_ids[tick_identity] = source_event_id
+                if tick is retained_tick:
+                    retained_event_id = source_event_id
+                quotes.append(
+                    {
+                        "schema_version": 1,
+                        "symbol": contract.symbol,
+                        "con_id": con_id,
+                        "exchange": contract.exchange,
+                        "primary_exchange": contract.primaryExchange,
+                        "currency": contract.currency,
+                        "security_type": contract.secType,
+                        "price": price_text,
+                        "source_timestamp": source_timestamp_text,
+                        "retrieval_timestamp": retrieval_time.isoformat(),
+                        "session": session,
+                        "source": "ibkr-live-last-trade",
+                        "source_event_id": source_event_id,
+                        # IBKR does not offer delayed tick-by-tick Last. A
+                        # successfully delivered event is therefore live type 1.
+                        "market_data_type": 1,
+                    }
+                )
+            if retained_event_id is None:
+                raise RuntimeError("IBKR protective event identity was not retained")
+            # Retain one stable fallback event while bounding the long-lived
+            # ib_async ticker list and identity registry. All new events were
+            # copied above before this synchronous mutation, so no crossing
+            # can be discarded.
+            ticker.tickByTicks[:] = [retained_tick]
+            _PROTECTIVE_TICK_CURSORS[con_id] = 1
+            _PROTECTIVE_TICK_EVENT_IDS[con_id] = {id(retained_tick): retained_event_id}
+        return {
+            "status": "success",
+            "data": {
+                "quotes": quotes,
+                "broker_time_before": _aware_iso(broker_time_before),
+                "broker_time_after": _aware_iso(broker_time_after),
+                "retrieval_timestamp": retrieval_time.isoformat(),
+            },
+        }
+    except ContractIdentityProtocolError as error:
+        return {
+            "status": PROTOCOL_ERROR_STATUS,
+            "error": str(error),
+            "error_type": PROTOCOL_ERROR_TYPE,
+            "traceback": traceback.format_exc(),
+        }
+    except Exception as error:
+        return {
+            "status": "error",
+            "error": str(error),
+            "error_type": type(error).__name__,
+            "traceback": traceback.format_exc(),
+        }
+
+
 async def handle_command(command: dict) -> dict:
     """Route command to appropriate handler"""
     cmd = command.get("command")
@@ -1828,6 +2103,8 @@ async def handle_command(command: dict) -> dict:
         return await handle_get_broker_contract_safety_snapshot(command.get("params", {}))
     elif cmd == "get_historical_bars":
         return await handle_get_historical_bars(command.get("params", {}))
+    elif cmd == "get_protective_quotes":
+        return await handle_get_protective_quotes(command.get("params", {}))
     elif cmd == "disconnect":
         return await handle_disconnect()
     elif cmd == "ping":

--- a/robo_trader/clients/subprocess_ibkr_client.py
+++ b/robo_trader/clients/subprocess_ibkr_client.py
@@ -59,6 +59,7 @@ from robo_trader.market_data_contract import (
     MarketSession,
     canonicalize_historical_bars,
 )
+from robo_trader.market_hours import get_market_session
 from robo_trader.protective_quote_evidence import (
     MAX_PROTECTIVE_SOURCE_EVENT_ID_LENGTH,
 )
@@ -3279,6 +3280,15 @@ class SubprocessIBKRClient:
                 if (now - source_timestamp).total_seconds() < 0:
                     raise ValueError("protective quote source timestamp is in the future")
                 try:
+                    reported_session = MarketSession(raw["session"])
+                    derived_session = MarketSession(get_market_session(source_timestamp))
+                except (TypeError, ValueError) as exc:
+                    raise ValueError(
+                        "protective quote source timestamp is outside an admitted market session"
+                    ) from exc
+                if reported_session is not derived_session:
+                    raise ValueError("protective quote session contradicts its source timestamp")
+                try:
                     quote = BrokerProtectiveQuote(
                         schema_version=raw["schema_version"],
                         symbol=raw["symbol"],
@@ -3290,7 +3300,7 @@ class SubprocessIBKRClient:
                         price=Decimal(str(raw["price"])),
                         source_timestamp=source_timestamp,
                         retrieval_timestamp=quote_retrieval,
-                        session=MarketSession(raw["session"]),
+                        session=derived_session,
                         source=MarketDataSource(raw["source"]),
                         source_event_id=raw["source_event_id"],
                         transport_generation=generation.generation_id,

--- a/robo_trader/clients/subprocess_ibkr_client.py
+++ b/robo_trader/clients/subprocess_ibkr_client.py
@@ -52,6 +52,16 @@ from robo_trader.broker_safety_evidence import (
     assert_producer_owned_broker_contract_safety_snapshot,
     assert_producer_owned_broker_safety_snapshot,
 )
+from robo_trader.market_data_contract import (
+    BrokerProtectiveQuote,
+    CanonicalBarBatch,
+    MarketDataSource,
+    MarketSession,
+    canonicalize_historical_bars,
+)
+from robo_trader.protective_quote_evidence import (
+    MAX_PROTECTIVE_SOURCE_EVENT_ID_LENGTH,
+)
 from robo_trader.reconciliation.identity import (
     RuntimeSafetyContext,
     assert_validated_runtime_safety_context,
@@ -3133,6 +3143,223 @@ class SubprocessIBKRClient:
                 timeout=60.0,  # Historical data can take longer
             )
             return self._validate_historical_response(normalized_symbol, data, generation)
+
+    async def get_canonical_historical_bars(
+        self,
+        symbol: str,
+        duration: str = "2 D",
+        bar_size: str = "5 mins",
+        what_to_show: str = "TRADES",
+        use_rth: bool = True,
+    ) -> CanonicalBarBatch:
+        """Return bars atomically bound to their exact broker lineage."""
+
+        normalized_symbol = self._normalize_historical_symbol(symbol)
+        if what_to_show != "TRADES":
+            raise ValueError("Canonical historical bars require exact what_to_show='TRADES'")
+        if bar_size not in _INTRADAY_BAR_SIZES:
+            raise ValueError(
+                "Subprocess transport supports only intraday datetime bars; "
+                f"unsupported bar_size={bar_size!r}"
+            )
+        async with self._lifecycle_lock:
+            generation = self._generation
+            data = await self._execute_command_unlocked(
+                {
+                    "command": "get_historical_bars",
+                    "params": {
+                        "symbol": normalized_symbol,
+                        "duration": duration,
+                        "bar_size": bar_size,
+                        "what_to_show": what_to_show,
+                        "use_rth": use_rth,
+                    },
+                },
+                timeout=60.0,
+            )
+            bars = self._validate_historical_response(normalized_symbol, data, generation)
+            # The lifecycle lock prevents generation replacement between the
+            # response validation above and this exact lineage read.
+            lineage = self.get_cached_historical_lineage(normalized_symbol)
+            return canonicalize_historical_bars(
+                symbol=normalized_symbol,
+                records=bars,
+                lineage=lineage,
+                bar_size=bar_size,
+                use_rth=use_rth,
+                what_to_show=what_to_show,
+            )
+
+    def _validate_protective_quote_response(
+        self,
+        symbols: tuple[str, ...],
+        data: dict,
+        generation: Optional[_WorkerGeneration],
+    ) -> tuple[BrokerProtectiveQuote, ...]:
+        """Validate live quote snapshots and bind them to one generation."""
+
+        try:
+            if generation is None:
+                raise ValueError("protective quote response has no worker generation")
+            with generation.state_lock:
+                generation_current = (
+                    self._generation is generation and generation.poisoned_reason is None
+                )
+            if not generation_current:
+                raise ValueError("protective quote response belongs to a stale generation")
+            if set(data) != {
+                "quotes",
+                "broker_time_before",
+                "broker_time_after",
+                "retrieval_timestamp",
+            }:
+                raise ValueError("protective quote response schema is invalid")
+            broker_before = self._strict_timestamp(
+                data["broker_time_before"], "protective broker_time_before"
+            )
+            broker_after = self._strict_timestamp(
+                data["broker_time_after"], "protective broker_time_after"
+            )
+            retrieval_time = self._strict_timestamp(
+                data["retrieval_timestamp"], "protective retrieval_timestamp"
+            )
+            if broker_after < broker_before:
+                raise ValueError("protective quote broker times are reversed")
+            now = datetime.now(timezone.utc)
+            if abs((now - retrieval_time).total_seconds()) > 10:
+                raise ValueError("protective quote retrieval time is stale")
+            if any(
+                abs((broker_time - retrieval_time).total_seconds())
+                > _BROKER_SNAPSHOT_MAX_CLOCK_SKEW_SECONDS
+                for broker_time in (broker_before, broker_after)
+            ):
+                raise ValueError("protective quote broker clock skew exceeds safety bound")
+            raw_quotes = data["quotes"]
+            if not isinstance(raw_quotes, list) or len(raw_quotes) < len(symbols):
+                raise ValueError("protective quote response coverage is incomplete")
+            expected_keys = {
+                "schema_version",
+                "symbol",
+                "con_id",
+                "exchange",
+                "primary_exchange",
+                "currency",
+                "security_type",
+                "price",
+                "source_timestamp",
+                "retrieval_timestamp",
+                "session",
+                "source",
+                "source_event_id",
+                "market_data_type",
+            }
+            expected_symbols = set(symbols)
+            quotes = []
+            seen_symbols = set()
+            con_id_by_symbol: dict[str, int] = {}
+            symbol_by_con_id: dict[int, str] = {}
+            last_timestamp_by_symbol: dict[str, datetime] = {}
+            seen_event_ids = set()
+            for raw in raw_quotes:
+                if not isinstance(raw, dict) or set(raw) != expected_keys:
+                    raise ValueError("protective quote record schema is invalid")
+                if (
+                    type(raw["source_event_id"]) is not str
+                    or len(raw["source_event_id"]) > MAX_PROTECTIVE_SOURCE_EVENT_ID_LENGTH
+                ):
+                    raise ValueError("protective quote event identity exceeds its bound")
+                source_timestamp = self._strict_timestamp(
+                    raw["source_timestamp"], "protective source_timestamp"
+                )
+                quote_retrieval = self._strict_timestamp(
+                    raw["retrieval_timestamp"], "protective quote retrieval_timestamp"
+                )
+                if quote_retrieval != retrieval_time:
+                    raise ValueError("protective quote retrieval timestamps disagree")
+                if (now - source_timestamp).total_seconds() < 0:
+                    raise ValueError("protective quote source timestamp is in the future")
+                try:
+                    quote = BrokerProtectiveQuote(
+                        schema_version=raw["schema_version"],
+                        symbol=raw["symbol"],
+                        con_id=raw["con_id"],
+                        exchange=raw["exchange"],
+                        primary_exchange=raw["primary_exchange"],
+                        currency=raw["currency"],
+                        security_type=raw["security_type"],
+                        price=Decimal(str(raw["price"])),
+                        source_timestamp=source_timestamp,
+                        retrieval_timestamp=quote_retrieval,
+                        session=MarketSession(raw["session"]),
+                        source=MarketDataSource(raw["source"]),
+                        source_event_id=raw["source_event_id"],
+                        transport_generation=generation.generation_id,
+                        market_data_type=raw["market_data_type"],
+                    )
+                except (InvalidOperation, TypeError, ValueError) as exc:
+                    raise ValueError(f"protective quote record is invalid: {exc}") from exc
+                if quote.symbol not in expected_symbols:
+                    raise ValueError("protective quote symbol was not requested")
+                prior_con_id = con_id_by_symbol.setdefault(quote.symbol, quote.con_id)
+                prior_symbol = symbol_by_con_id.setdefault(quote.con_id, quote.symbol)
+                if prior_con_id != quote.con_id or prior_symbol != quote.symbol:
+                    raise ValueError("protective quote contract identity changed")
+                previous_timestamp = last_timestamp_by_symbol.get(quote.symbol)
+                if previous_timestamp is not None and quote.source_timestamp < previous_timestamp:
+                    raise ValueError("protective quote events are out of order")
+                if quote.source_event_id in seen_event_ids:
+                    raise ValueError("protective quote event identity is duplicated")
+                seen_symbols.add(quote.symbol)
+                seen_event_ids.add(quote.source_event_id)
+                last_timestamp_by_symbol[quote.symbol] = quote.source_timestamp
+                quotes.append(quote)
+            if seen_symbols != expected_symbols:
+                raise ValueError("protective quote response coverage is incomplete")
+            return tuple(quotes)
+        except (KeyError, TypeError, ValueError) as exc:
+            reason = str(exc)
+            if generation is not None:
+                self._poison_generation(generation, reason)
+            raise IBKRTransportPoisonedError(reason) from exc
+
+    async def get_protective_quotes(
+        self,
+        symbols: list[str] | tuple[str, ...],
+        *,
+        active_symbols: list[str] | tuple[str, ...] | None = None,
+    ) -> tuple[BrokerProtectiveQuote, ...]:
+        """Fetch live protective quotes on this exact read-only generation."""
+
+        if not isinstance(symbols, (list, tuple)) or len(symbols) > 64:
+            raise ValueError("protective quote symbols are malformed")
+        normalized = tuple(self._normalize_historical_symbol(symbol) for symbol in symbols)
+        if len(set(normalized)) != len(normalized):
+            raise ValueError("protective quote symbols are duplicated")
+        if active_symbols is None:
+            normalized_active = normalized
+        else:
+            if not isinstance(active_symbols, (list, tuple)) or len(active_symbols) > 4096:
+                raise ValueError("protective quote active symbols are malformed")
+            normalized_active = tuple(
+                self._normalize_historical_symbol(symbol) for symbol in active_symbols
+            )
+            if len(set(normalized_active)) != len(normalized_active):
+                raise ValueError("protective quote active symbols are duplicated")
+            if not set(normalized).issubset(normalized_active):
+                raise ValueError("protective quote symbols are not account-active")
+        async with self._lifecycle_lock:
+            generation = self._generation
+            data = await self._execute_command_unlocked(
+                {
+                    "command": "get_protective_quotes",
+                    "params": {
+                        "symbols": list(normalized),
+                        "active_symbols": list(normalized_active),
+                    },
+                },
+                timeout=10.0,
+            )
+            return self._validate_protective_quote_response(normalized, data, generation)
 
     async def disconnect(self) -> None:
         """Disconnect from IBKR"""

--- a/robo_trader/database_async.py
+++ b/robo_trader/database_async.py
@@ -2746,13 +2746,17 @@ class AsyncTradingDatabase:
                     await conn.execute("BEGIN IMMEDIATE")
                     for group_key, group_rows in grouped_rows.items():
                         timestamps = [row["timestamp"] for row in group_rows]
+                        # Both interpolated identifier lists come exclusively
+                        # from the fixed source-code tuples above; row values
+                        # remain bound through SQLite parameters.
+                        existing_query = (
+                            f"SELECT {', '.join(storage_columns)} "  # nosec B608
+                            "FROM canonical_market_data WHERE "
+                            f"{' AND '.join(f'{column} = ?' for column in identity_columns)} "
+                            "AND timestamp BETWEEN ? AND ?"
+                        )
                         existing_cursor = await conn.execute(
-                            f"""
-                            SELECT {", ".join(storage_columns)}
-                            FROM canonical_market_data
-                            WHERE {" AND ".join(f"{column} = ?" for column in identity_columns)}
-                              AND timestamp BETWEEN ? AND ?
-                            """,
+                            existing_query,
                             (*group_key, min(timestamps), max(timestamps)),
                         )
                         existing_rows = {

--- a/robo_trader/database_async.py
+++ b/robo_trader/database_async.py
@@ -28,6 +28,13 @@ import aiosqlite
 
 from robo_trader.database_validator import DatabaseValidator, ValidationError
 from robo_trader.logger import get_logger
+from robo_trader.market_data_contract import (
+    CANONICAL_STORAGE_KEYS,
+    MarketDataContractError,
+    bar_interval_seconds,
+    market_data_max_age_seconds,
+    validate_canonical_storage_row,
+)
 from robo_trader.paper_terminal_settlement import (
     PaperAccountSettlementState,
     PaperTerminalSettlementConflict,
@@ -1141,7 +1148,7 @@ class AsyncTradingDatabase:
                 CREATE TABLE IF NOT EXISTS positions (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     portfolio_id TEXT NOT NULL DEFAULT 'default',
-                    symbol TEXT NOT NULL,
+                    symbol TEXT NOT NULL CHECK (length(symbol) BETWEEN 1 AND 32),
                     quantity INTEGER NOT NULL,
                     avg_cost REAL NOT NULL,
                     market_price REAL,
@@ -1159,7 +1166,7 @@ class AsyncTradingDatabase:
             await conn.execute("""
                 CREATE TABLE IF NOT EXISTS ticks (
                     timestamp DATETIME NOT NULL,
-                    symbol TEXT NOT NULL,
+                    symbol TEXT NOT NULL CHECK (length(symbol) BETWEEN 1 AND 32),
                     bid REAL,
                     ask REAL,
                     last REAL,
@@ -1391,6 +1398,71 @@ class AsyncTradingDatabase:
                     volume INTEGER,
                     timestamp DATETIME NOT NULL,
                     UNIQUE(symbol, timestamp)
+                )
+            """)
+
+            # PR 3 canonical market-data store. Keep the legacy table intact so
+            # existing history is never rewritten or deleted during rollout.
+            # Canonical rows use broker identity + source + timeframe + event
+            # time as their stable identity, so repeated overlapping refreshes
+            # accumulate without collisions between different bar contracts.
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS canonical_market_data (
+                    schema_version INTEGER NOT NULL CHECK (schema_version = 1),
+                    symbol TEXT NOT NULL,
+                    con_id INTEGER NOT NULL CHECK (con_id > 0),
+                    exchange TEXT NOT NULL CHECK (exchange = 'SMART'),
+                    primary_exchange TEXT NOT NULL CHECK (length(primary_exchange) > 0),
+                    timeframe TEXT NOT NULL CHECK (length(timeframe) > 0),
+                    interval_seconds INTEGER NOT NULL CHECK (interval_seconds > 0),
+                    timezone_name TEXT NOT NULL CHECK (timezone_name = 'UTC'),
+                    session_policy TEXT NOT NULL CHECK (
+                        session_policy IN ('regular-only', 'extended')
+                    ),
+                    timestamp TEXT NOT NULL,
+                    open REAL NOT NULL CHECK (open > 0),
+                    high REAL NOT NULL CHECK (high > 0),
+                    low REAL NOT NULL CHECK (low > 0),
+                    close REAL NOT NULL CHECK (close > 0),
+                    volume INTEGER NOT NULL CHECK (volume >= 0),
+                    session TEXT NOT NULL CHECK (
+                        session IN ('pre-market', 'regular', 'after-hours')
+                    ),
+                    source TEXT NOT NULL CHECK (source = 'ibkr-historical-trades'),
+                    retrieval_timestamp TEXT NOT NULL CHECK (length(retrieval_timestamp) > 0),
+                    broker_timestamp TEXT NOT NULL CHECK (length(broker_timestamp) > 0),
+                    adjustment_state TEXT NOT NULL CHECK (
+                        adjustment_state IN ('unknown', 'raw', 'adjusted')
+                    ),
+                    quality_flags TEXT NOT NULL DEFAULT '' CHECK (
+                        quality_flags IN ('', 'zero-volume')
+                    ),
+                    transport_generation TEXT NOT NULL CHECK (
+                        length(transport_generation) BETWEEN 1 AND 128
+                    ),
+                    timestamp_semantics TEXT NOT NULL CHECK (
+                        timestamp_semantics = 'bar-start'
+                    ),
+                    use_rth INTEGER NOT NULL CHECK (use_rth IN (0, 1)),
+                    what_to_show TEXT NOT NULL CHECK (what_to_show = 'TRADES'),
+                    CHECK (high >= open AND high >= low AND high >= close),
+                    CHECK (low <= open AND low <= high AND low <= close),
+                    CHECK (
+                        (volume = 0 AND quality_flags = 'zero-volume') OR
+                        (volume > 0 AND quality_flags = '')
+                    ),
+                    PRIMARY KEY (
+                        schema_version, source, con_id, timeframe,
+                        session_policy, adjustment_state, timestamp_semantics,
+                        use_rth, what_to_show, timestamp
+                    )
+                ) WITHOUT ROWID
+            """)
+            await conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_canonical_market_data_symbol_time
+                ON canonical_market_data (
+                    symbol, timestamp DESC, interval_seconds ASC,
+                    retrieval_timestamp DESC
                 )
             """)
 
@@ -2569,6 +2641,12 @@ class AsyncTradingDatabase:
             "close",
             "volume",
         }
+        canonical_only_keys = CANONICAL_STORAGE_KEYS - required_keys
+        first_row = data[0]
+        canonical_mode = isinstance(first_row, dict) and bool(
+            canonical_only_keys.intersection(first_row)
+        )
+        normalized_canonical_rows: list[dict] = []
         for idx, row in enumerate(data):
             if not isinstance(row, dict):
                 raise ValueError(
@@ -2580,18 +2658,82 @@ class AsyncTradingDatabase:
                 raise ValueError(
                     f"batch_store_market_data row[{idx}] missing keys: {sorted(missing)}"
                 )
+            row_is_canonical = bool(canonical_only_keys.intersection(row))
+            if row_is_canonical is not canonical_mode:
+                raise ValueError("batch_store_market_data cannot mix canonical and legacy rows")
+            if row_is_canonical:
+                try:
+                    normalized_canonical_rows.append(validate_canonical_storage_row(row))
+                except MarketDataContractError as exc:
+                    raise ValueError(
+                        f"batch_store_market_data row[{idx}] is not canonical: {exc}"
+                    ) from exc
 
         async with self.get_connection() as conn:
-            await conn.executemany(
-                """
-                INSERT OR REPLACE INTO market_data
-                (symbol, timestamp, open, high, low, close, volume)
-                VALUES (:symbol, :timestamp, :open, :high, :low, :close, :volume)
-            """,
-                data,
-            )
+            if canonical_mode:
+                await conn.executemany(
+                    """
+                    INSERT INTO canonical_market_data (
+                        schema_version, symbol, con_id, exchange,
+                        primary_exchange, timeframe, interval_seconds,
+                        timezone_name, session_policy, timestamp,
+                        open, high, low, close, volume, session, source,
+                        retrieval_timestamp, broker_timestamp,
+                        adjustment_state, quality_flags, transport_generation,
+                        timestamp_semantics, use_rth, what_to_show
+                    ) VALUES (
+                        :schema_version, :symbol, :con_id, :exchange,
+                        :primary_exchange, :timeframe, :interval_seconds,
+                        :timezone_name, :session_policy, :timestamp,
+                        :open, :high, :low, :close, :volume, :session, :source,
+                        :retrieval_timestamp, :broker_timestamp,
+                        :adjustment_state, :quality_flags, :transport_generation,
+                        :timestamp_semantics, :use_rth, :what_to_show
+                    )
+                    ON CONFLICT (
+                        schema_version, source, con_id, timeframe,
+                        session_policy, adjustment_state, timestamp_semantics,
+                        use_rth, what_to_show, timestamp
+                    ) DO UPDATE SET
+                        symbol = excluded.symbol,
+                        exchange = excluded.exchange,
+                        primary_exchange = excluded.primary_exchange,
+                        interval_seconds = excluded.interval_seconds,
+                        timezone_name = excluded.timezone_name,
+                        open = excluded.open,
+                        high = excluded.high,
+                        low = excluded.low,
+                        close = excluded.close,
+                        volume = excluded.volume,
+                        session = excluded.session,
+                        retrieval_timestamp = excluded.retrieval_timestamp,
+                        broker_timestamp = excluded.broker_timestamp,
+                        quality_flags = excluded.quality_flags,
+                        transport_generation = excluded.transport_generation
+                    """,
+                    normalized_canonical_rows,
+                )
+            else:
+                await conn.executemany(
+                    """
+                    INSERT INTO market_data
+                    (symbol, timestamp, open, high, low, close, volume)
+                    VALUES (:symbol, :timestamp, :open, :high, :low, :close, :volume)
+                    ON CONFLICT(symbol, timestamp) DO UPDATE SET
+                        open = excluded.open,
+                        high = excluded.high,
+                        low = excluded.low,
+                        close = excluded.close,
+                        volume = excluded.volume
+                    """,
+                    data,
+                )
             await conn.commit()
-            logger.debug(f"Stored {len(data)} market data bars")
+            logger.debug(
+                "Stored %d %s market data bars",
+                len(data),
+                "canonical" if canonical_mode else "legacy",
+            )
 
     async def get_position(
         self, symbol: str, portfolio_id: str = DEFAULT_PORTFOLIO_ID
@@ -3327,9 +3469,136 @@ class AsyncTradingDatabase:
                 }
             return {}
 
-    async def get_latest_market_data(self, symbol: str, limit: int = 100) -> List[Dict]:
-        """Get latest market data for a symbol."""
+    async def get_latest_market_data(
+        self,
+        symbol: str,
+        limit: int = 100,
+        timeframe: Optional[str] = None,
+    ) -> List[Dict]:
+        """Get one deterministic canonical series for a symbol."""
+
+        symbol = DatabaseValidator.validate_symbol(symbol)
+        if type(limit) is not int or not 1 <= limit <= 10_000:
+            raise ValueError("market data limit must be an integer between 1 and 10000")
+        if timeframe is not None:
+            bar_interval_seconds(timeframe)
         async with self.get_connection() as conn:
+            if timeframe is None:
+                selector_sql = """
+                    SELECT timestamp, open, high, low, close, volume,
+                           schema_version, con_id, exchange, primary_exchange,
+                           timeframe, interval_seconds, timezone_name, session_policy,
+                           session, source, retrieval_timestamp, broker_timestamp,
+                           adjustment_state, quality_flags, transport_generation,
+                           timestamp_semantics, use_rth, what_to_show
+                    FROM canonical_market_data
+                    WHERE symbol = ?
+                    ORDER BY timestamp DESC, interval_seconds ASC,
+                             retrieval_timestamp DESC, con_id DESC
+                    LIMIT 1
+                """
+                selector_params = (symbol,)
+            else:
+                selector_sql = """
+                    SELECT timestamp, open, high, low, close, volume,
+                           schema_version, con_id, exchange, primary_exchange,
+                           timeframe, interval_seconds, timezone_name, session_policy,
+                           session, source, retrieval_timestamp, broker_timestamp,
+                           adjustment_state, quality_flags, transport_generation,
+                           timestamp_semantics, use_rth, what_to_show
+                    FROM canonical_market_data
+                    WHERE symbol = ? AND timeframe = ?
+                    ORDER BY timestamp DESC, interval_seconds ASC,
+                             retrieval_timestamp DESC, con_id DESC
+                    LIMIT 1
+                """
+                selector_params = (symbol, timeframe)
+            selected = await (await conn.execute(selector_sql, selector_params)).fetchone()
+            rows = []
+            if selected is not None:
+                identity = (
+                    symbol,
+                    selected[7],
+                    selected[10],
+                    selected[13],
+                    selected[15],
+                    selected[18],
+                    selected[21],
+                    selected[22],
+                    selected[23],
+                )
+                cursor = await conn.execute(
+                    """
+                    SELECT timestamp, open, high, low, close, volume,
+                           schema_version, con_id, exchange, primary_exchange,
+                           timeframe, interval_seconds, timezone_name, session_policy,
+                           session, source, retrieval_timestamp, broker_timestamp,
+                           adjustment_state, quality_flags, transport_generation,
+                           timestamp_semantics, use_rth, what_to_show
+                    FROM canonical_market_data
+                    WHERE symbol = ? AND con_id = ? AND timeframe = ?
+                      AND session_policy = ? AND source = ?
+                      AND adjustment_state = ? AND timestamp_semantics = ?
+                      AND use_rth = ? AND what_to_show = ?
+                    ORDER BY timestamp DESC, retrieval_timestamp DESC
+                    LIMIT ?
+                    """,
+                    (*identity, limit),
+                )
+                rows = await cursor.fetchall()
+            if rows:
+                now = datetime.now(timezone.utc)
+                output = []
+                for row in rows:
+                    stored_item = {
+                        "symbol": symbol,
+                        "timestamp": row[0],
+                        "open": row[1],
+                        "high": row[2],
+                        "low": row[3],
+                        "close": row[4],
+                        "volume": row[5],
+                        "schema_version": row[6],
+                        "con_id": row[7],
+                        "exchange": row[8],
+                        "primary_exchange": row[9],
+                        "timeframe": row[10],
+                        "interval_seconds": row[11],
+                        "timezone_name": row[12],
+                        "session_policy": row[13],
+                        "session": row[14],
+                        "source": row[15],
+                        "retrieval_timestamp": row[16],
+                        "broker_timestamp": row[17],
+                        "adjustment_state": row[18],
+                        "quality_flags": row[19],
+                        "transport_generation": row[20],
+                        "timestamp_semantics": row[21],
+                        "use_rth": bool(row[22]),
+                        "what_to_show": row[23],
+                    }
+                    item = validate_canonical_storage_row(stored_item)
+                    item["use_rth"] = bool(item["use_rth"])
+                    item["quality_flags"] = tuple(
+                        flag for flag in str(item["quality_flags"] or "").split(",") if flag
+                    )
+                    event_time = datetime.fromisoformat(
+                        str(item["timestamp"]).replace("Z", "+00:00")
+                    ).astimezone(timezone.utc)
+                    age_seconds = (now - event_time).total_seconds()
+                    freshness_limit = market_data_max_age_seconds(item["interval_seconds"])
+                    freshness_status = (
+                        "future"
+                        if age_seconds < 0
+                        else ("fresh" if age_seconds <= freshness_limit else "stale")
+                    )
+                    item["age_seconds"] = age_seconds
+                    item["freshness_limit_seconds"] = freshness_limit
+                    item["freshness_status"] = freshness_status
+                    output.append(item)
+                return output
+            if timeframe is not None:
+                return []
             cursor = await conn.execute(
                 """
                 SELECT timestamp, open, high, low, close, volume
@@ -3349,6 +3618,10 @@ class AsyncTradingDatabase:
                     "low": row[3],
                     "close": row[4],
                     "volume": row[5],
+                    "source": "legacy-unknown",
+                    "freshness_status": "unknown",
+                    "age_seconds": None,
+                    "freshness_limit_seconds": None,
                 }
                 for row in rows
             ]
@@ -3546,28 +3819,24 @@ class AsyncTradingDatabase:
     ) -> None:
         """Clean up old data from the database.
 
-        Always cleans truly-global tables (market_data, ticks). The signals table
-        is portfolio-scoped, so it is only cleaned when an explicit portfolio_id
-        is provided — never blanketly across all tenants.
+        A scoped call cleans only that portfolio's signals. An unscoped call
+        cleans legacy global observations and ticks. Canonical market-data rows
+        are immutable audit evidence and are never deleted by routine cleanup.
         """
         async with self.get_connection() as conn:
             cutoff_date = datetime.now().timestamp() - (days_to_keep * 86400)
             cutoff_dt = datetime.fromtimestamp(cutoff_date)
 
-            # Clean up old market data (global)
-            await conn.execute(
-                "DELETE FROM market_data WHERE timestamp < ?",
-                (cutoff_dt,),
-            )
-
-            # Clean up old ticks (global)
-            await conn.execute(
-                "DELETE FROM ticks WHERE timestamp < ?",
-                (cutoff_dt,),
-            )
-
-            # Signals are portfolio-scoped; only clean if a specific portfolio is named.
-            if portfolio_id is not None:
+            if portfolio_id is None:
+                await conn.execute(
+                    "DELETE FROM market_data WHERE timestamp < ?",
+                    (cutoff_dt,),
+                )
+                await conn.execute(
+                    "DELETE FROM ticks WHERE timestamp < ?",
+                    (cutoff_dt,),
+                )
+            else:
                 portfolio_id = DatabaseValidator.validate_portfolio_id(portfolio_id)
                 await conn.execute(
                     "DELETE FROM signals WHERE portfolio_id = ? AND timestamp < ?",
@@ -3577,7 +3846,8 @@ class AsyncTradingDatabase:
             await conn.commit()
             logger.info(
                 f"Cleaned up data older than {days_to_keep} days "
-                f"(portfolio={portfolio_id or 'global-only'})"
+                f"(scope={'global-legacy' if portfolio_id is None else portfolio_id}; "
+                "canonical_audit_rows=preserved)"
             )
 
 

--- a/robo_trader/database_async.py
+++ b/robo_trader/database_async.py
@@ -2669,50 +2669,144 @@ class AsyncTradingDatabase:
                         f"batch_store_market_data row[{idx}] is not canonical: {exc}"
                     ) from exc
 
+        canonical_conflict: Optional[Tuple[dict, Tuple[str, ...]]] = None
         async with self.get_connection() as conn:
             if canonical_mode:
-                await conn.executemany(
-                    """
-                    INSERT INTO canonical_market_data (
-                        schema_version, symbol, con_id, exchange,
-                        primary_exchange, timeframe, interval_seconds,
-                        timezone_name, session_policy, timestamp,
-                        open, high, low, close, volume, session, source,
-                        retrieval_timestamp, broker_timestamp,
-                        adjustment_state, quality_flags, transport_generation,
-                        timestamp_semantics, use_rth, what_to_show
-                    ) VALUES (
-                        :schema_version, :symbol, :con_id, :exchange,
-                        :primary_exchange, :timeframe, :interval_seconds,
-                        :timezone_name, :session_policy, :timestamp,
-                        :open, :high, :low, :close, :volume, :session, :source,
-                        :retrieval_timestamp, :broker_timestamp,
-                        :adjustment_state, :quality_flags, :transport_generation,
-                        :timestamp_semantics, :use_rth, :what_to_show
-                    )
-                    ON CONFLICT (
-                        schema_version, source, con_id, timeframe,
-                        session_policy, adjustment_state, timestamp_semantics,
-                        use_rth, what_to_show, timestamp
-                    ) DO UPDATE SET
-                        symbol = excluded.symbol,
-                        exchange = excluded.exchange,
-                        primary_exchange = excluded.primary_exchange,
-                        interval_seconds = excluded.interval_seconds,
-                        timezone_name = excluded.timezone_name,
-                        open = excluded.open,
-                        high = excluded.high,
-                        low = excluded.low,
-                        close = excluded.close,
-                        volume = excluded.volume,
-                        session = excluded.session,
-                        retrieval_timestamp = excluded.retrieval_timestamp,
-                        broker_timestamp = excluded.broker_timestamp,
-                        quality_flags = excluded.quality_flags,
-                        transport_generation = excluded.transport_generation
-                    """,
-                    normalized_canonical_rows,
+                storage_columns = (
+                    "schema_version",
+                    "symbol",
+                    "con_id",
+                    "exchange",
+                    "primary_exchange",
+                    "timeframe",
+                    "interval_seconds",
+                    "timezone_name",
+                    "session_policy",
+                    "timestamp",
+                    "open",
+                    "high",
+                    "low",
+                    "close",
+                    "volume",
+                    "session",
+                    "source",
+                    "retrieval_timestamp",
+                    "broker_timestamp",
+                    "adjustment_state",
+                    "quality_flags",
+                    "transport_generation",
+                    "timestamp_semantics",
+                    "use_rth",
+                    "what_to_show",
                 )
+                identity_columns = (
+                    "schema_version",
+                    "source",
+                    "con_id",
+                    "timeframe",
+                    "session_policy",
+                    "adjustment_state",
+                    "timestamp_semantics",
+                    "use_rth",
+                    "what_to_show",
+                )
+                event_columns = tuple(
+                    column
+                    for column in storage_columns
+                    if column
+                    not in {
+                        "retrieval_timestamp",
+                        "broker_timestamp",
+                        "transport_generation",
+                    }
+                )
+                grouped_rows: Dict[Tuple, List[dict]] = {}
+                incoming_events: Dict[Tuple, dict] = {}
+                for row in normalized_canonical_rows:
+                    group_key = tuple(row[column] for column in identity_columns)
+                    event_key = (*group_key, row["timestamp"])
+                    prior = incoming_events.get(event_key)
+                    if prior is not None:
+                        changed = tuple(
+                            column for column in event_columns if prior[column] != row[column]
+                        )
+                        if changed:
+                            canonical_conflict = (row, changed)
+                            break
+                        continue
+                    incoming_events[event_key] = row
+                    grouped_rows.setdefault(group_key, []).append(row)
+
+                # Lock the writer before comparing immutable event identities.
+                # The retrieval clocks and transport generation describe later
+                # observations of the same broker event; they never rewrite the
+                # first admitted observation. A changed event payload is a
+                # conflict and fails the whole batch before any row is inserted.
+                if canonical_conflict is None:
+                    await conn.execute("BEGIN IMMEDIATE")
+                    for group_key, group_rows in grouped_rows.items():
+                        timestamps = [row["timestamp"] for row in group_rows]
+                        existing_cursor = await conn.execute(
+                            f"""
+                            SELECT {", ".join(storage_columns)}
+                            FROM canonical_market_data
+                            WHERE {" AND ".join(f"{column} = ?" for column in identity_columns)}
+                              AND timestamp BETWEEN ? AND ?
+                            """,
+                            (*group_key, min(timestamps), max(timestamps)),
+                        )
+                        existing_rows = {
+                            existing[storage_columns.index("timestamp")]: dict(
+                                zip(storage_columns, existing)
+                            )
+                            for existing in await existing_cursor.fetchall()
+                        }
+                        for row in group_rows:
+                            existing = existing_rows.get(row["timestamp"])
+                            if existing is None:
+                                continue
+                            changed = tuple(
+                                column
+                                for column in event_columns
+                                if existing[column] != row[column]
+                            )
+                            if changed:
+                                canonical_conflict = (row, changed)
+                                break
+                        if canonical_conflict is not None:
+                            break
+
+                if canonical_conflict is not None:
+                    await conn.rollback()
+                else:
+                    await conn.executemany(
+                        """
+                        INSERT INTO canonical_market_data (
+                            schema_version, symbol, con_id, exchange,
+                            primary_exchange, timeframe, interval_seconds,
+                            timezone_name, session_policy, timestamp,
+                            open, high, low, close, volume, session, source,
+                            retrieval_timestamp, broker_timestamp,
+                            adjustment_state, quality_flags, transport_generation,
+                            timestamp_semantics, use_rth, what_to_show
+                        ) VALUES (
+                            :schema_version, :symbol, :con_id, :exchange,
+                            :primary_exchange, :timeframe, :interval_seconds,
+                            :timezone_name, :session_policy, :timestamp,
+                            :open, :high, :low, :close, :volume, :session, :source,
+                            :retrieval_timestamp, :broker_timestamp,
+                            :adjustment_state, :quality_flags, :transport_generation,
+                            :timestamp_semantics, :use_rth, :what_to_show
+                        )
+                        ON CONFLICT (
+                            schema_version, source, con_id, timeframe,
+                            session_policy, adjustment_state, timestamp_semantics,
+                            use_rth, what_to_show, timestamp
+                        ) DO NOTHING
+                        """,
+                        normalized_canonical_rows,
+                    )
+                    await conn.commit()
             else:
                 await conn.executemany(
                     """
@@ -2728,11 +2822,28 @@ class AsyncTradingDatabase:
                     """,
                     data,
                 )
-            await conn.commit()
-            logger.debug(
-                "Stored %d %s market data bars",
-                len(data),
-                "canonical" if canonical_mode else "legacy",
+            if not canonical_mode:
+                await conn.commit()
+            if canonical_conflict is None:
+                logger.debug(
+                    "Stored %d %s market data bars",
+                    len(data),
+                    "canonical" if canonical_mode else "legacy",
+                )
+        if canonical_conflict is not None:
+            conflict_row, changed_fields = canonical_conflict
+            logger.critical(
+                "event=canonical_market_data_conflict symbol=%s con_id=%s "
+                "timeframe=%s timestamp=%s changed_fields=%s",
+                conflict_row["symbol"],
+                conflict_row["con_id"],
+                conflict_row["timeframe"],
+                conflict_row["timestamp"],
+                ",".join(changed_fields),
+            )
+            raise ValueError(
+                "canonical market-data event conflicts with immutable stored evidence: "
+                + ", ".join(changed_fields)
             )
 
     async def get_position(

--- a/robo_trader/market_data_contract.py
+++ b/robo_trader/market_data_contract.py
@@ -1,0 +1,607 @@
+"""Versioned, fail-closed market-data contracts for the active runtime."""
+
+from __future__ import annotations
+
+import math
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from enum import Enum
+from typing import Any, Iterable, Mapping, Optional
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+
+from .market_hours import get_market_session
+from .protective_quote_evidence import MAX_PROTECTIVE_SOURCE_EVENT_ID_LENGTH
+
+CANONICAL_BAR_SCHEMA_VERSION = 1
+MAX_MARKET_DATA_AGE_SECONDS = 24 * 60 * 60
+_EXCHANGE_TIMEZONE = ZoneInfo("America/New_York")
+
+
+class MarketDataContractError(ValueError):
+    """Market data cannot be admitted to a trading consumer."""
+
+
+class MarketDataIdentityError(MarketDataContractError):
+    """Market data cannot be bound to one exact broker contract."""
+
+
+class MarketSession(str, Enum):
+    PRE_MARKET = "pre-market"
+    REGULAR = "regular"
+    AFTER_HOURS = "after-hours"
+
+
+class MarketSessionPolicy(str, Enum):
+    REGULAR_ONLY = "regular-only"
+    EXTENDED = "extended"
+
+
+class AdjustmentState(str, Enum):
+    UNKNOWN = "unknown"
+    RAW = "raw"
+    ADJUSTED = "adjusted"
+
+
+class MarketDataSource(str, Enum):
+    IBKR_HISTORICAL_TRADES = "ibkr-historical-trades"
+    IBKR_LIVE_LAST_TRADE = "ibkr-live-last-trade"
+
+
+class BarTimestampSemantics(str, Enum):
+    BAR_START = "bar-start"
+
+
+class BarQualityFlag(str, Enum):
+    ZERO_VOLUME = "zero-volume"
+
+
+def market_data_max_age_seconds(interval_seconds: int) -> float:
+    """Return one finite, bounded freshness limit for runtime and UI readers."""
+
+    if type(interval_seconds) is not int or interval_seconds <= 0:
+        raise MarketDataContractError("market-data interval must be a positive integer")
+    default_max_age = max(180, (interval_seconds * 2) + 30)
+    relative_ceiling = max(default_max_age, (interval_seconds * 3) + 60)
+    hard_ceiling = min(MAX_MARKET_DATA_AGE_SECONDS, relative_ceiling)
+    try:
+        configured = float(os.getenv("MARKET_DATA_MAX_AGE_SECONDS", str(default_max_age)))
+    except (TypeError, ValueError) as exc:
+        raise MarketDataContractError("MARKET_DATA_MAX_AGE_SECONDS must be numeric") from exc
+    if not math.isfinite(configured) or configured <= 0 or configured > hard_ceiling:
+        raise MarketDataContractError(
+            "MARKET_DATA_MAX_AGE_SECONDS must be finite, positive, and no greater "
+            f"than {hard_ceiling:g} for this timeframe"
+        )
+    return configured
+
+
+@dataclass(frozen=True, slots=True)
+class BrokerProtectiveQuote:
+    """One exact live last-trade quote from a current IBKR generation."""
+
+    schema_version: int
+    symbol: str
+    con_id: int
+    exchange: str
+    primary_exchange: str
+    currency: str
+    security_type: str
+    price: Decimal
+    source_timestamp: datetime
+    retrieval_timestamp: datetime
+    session: MarketSession
+    source: MarketDataSource
+    source_event_id: str
+    transport_generation: str
+    market_data_type: int
+
+    def __post_init__(self) -> None:
+        if type(self.schema_version) is not int or self.schema_version != 1:
+            raise MarketDataContractError("protective quote schema version is unsupported")
+        if not isinstance(self.symbol, str) or not re.fullmatch(
+            r"[A-Z0-9][A-Z0-9._-]{0,31}", self.symbol
+        ):
+            raise MarketDataIdentityError("protective quote symbol is malformed")
+        if type(self.con_id) is not int or self.con_id <= 0:
+            raise MarketDataIdentityError("protective quote con_id is invalid")
+        if (
+            self.exchange != "SMART"
+            or not self.primary_exchange
+            or self.currency != "USD"
+            or self.security_type != "STK"
+        ):
+            raise MarketDataIdentityError("protective quote contract identity is invalid")
+        if type(self.price) is not Decimal or not self.price.is_finite() or self.price <= 0:
+            raise MarketDataContractError("protective quote price is invalid")
+        for field_name in ("source_timestamp", "retrieval_timestamp"):
+            value = getattr(self, field_name)
+            if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+                raise MarketDataContractError(f"protective quote {field_name} is invalid")
+            object.__setattr__(self, field_name, value.astimezone(timezone.utc))
+        if type(self.session) is not MarketSession:
+            raise MarketDataContractError("protective quote session is invalid")
+        if self.source_timestamp > self.retrieval_timestamp:
+            raise MarketDataContractError("protective quote event follows retrieval time")
+        if self.source is not MarketDataSource.IBKR_LIVE_LAST_TRADE:
+            raise MarketDataContractError("protective quote source is not live IBKR last trade")
+        if type(self.market_data_type) is not int or self.market_data_type != 1:
+            raise MarketDataContractError("protective quote market data is not live")
+        if (
+            not isinstance(self.source_event_id, str)
+            or not self.source_event_id
+            or self.source_event_id != self.source_event_id.strip()
+            or len(self.source_event_id) > MAX_PROTECTIVE_SOURCE_EVENT_ID_LENGTH
+        ):
+            raise MarketDataIdentityError("protective quote source_event_id is malformed")
+        if (
+            not isinstance(self.transport_generation, str)
+            or not self.transport_generation
+            or self.transport_generation != self.transport_generation.strip()
+            or len(self.transport_generation) > 256
+        ):
+            raise MarketDataIdentityError("protective quote transport_generation is malformed")
+
+
+def bar_interval_seconds(bar_size: str) -> int:
+    """Return the requested interval in seconds or reject ambiguity."""
+
+    normalized = str(bar_size).strip().lower()
+    values = normalized.split()
+    if not values:
+        raise MarketDataContractError("bar size is missing")
+    try:
+        amount = int(values[0])
+    except (TypeError, ValueError) as exc:
+        raise MarketDataContractError("bar size amount is invalid") from exc
+    if amount <= 0:
+        raise MarketDataContractError("bar size amount must be positive")
+    unit = values[1] if len(values) > 1 else "min"
+    if unit.startswith("sec"):
+        seconds = amount
+    elif unit.startswith("min"):
+        seconds = amount * 60
+    elif unit.startswith("hour"):
+        seconds = amount * 3600
+    elif unit.startswith("day"):
+        seconds = amount * 86400
+    else:
+        raise MarketDataContractError("bar size unit is unsupported")
+    if (
+        seconds >= 86400
+        or "day" in normalized
+        or "week" in normalized
+        or "month" in normalized
+        or re.fullmatch(r"\d+\s*(d|w|wk|wks|mo|mos)", normalized) is not None
+    ):
+        raise MarketDataContractError(
+            "active trading requires timezone-aware intraday datetime bars; "
+            "daily-or-coarser bars are unsupported"
+        )
+    return seconds
+
+
+def _decimal(value: Any, field_name: str, *, positive: bool = False) -> Decimal:
+    if isinstance(value, bool):
+        raise MarketDataContractError(f"broker bar {field_name} is invalid")
+    try:
+        result = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise MarketDataContractError(f"broker bar {field_name} is invalid") from exc
+    if not result.is_finite() or (positive and result <= 0):
+        raise MarketDataContractError(f"broker bar {field_name} is invalid")
+    return result
+
+
+def _aware_utc(value: Any, field_name: str) -> datetime:
+    if isinstance(value, (int, float, bool)):
+        raise MarketDataContractError(f"numeric {field_name} is ambiguous")
+    try:
+        parsed = pd.Timestamp(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise MarketDataContractError(f"invalid {field_name}: {value!r}") from exc
+    if pd.isna(parsed):
+        raise MarketDataContractError(f"{field_name} is missing")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise MarketDataContractError(f"timezone-naive {field_name} rejected")
+    return parsed.tz_convert("UTC").to_pydatetime()
+
+
+@dataclass(frozen=True, slots=True)
+class HistoricalBarContract:
+    """Identity, source, session, and retrieval metadata for one bar batch."""
+
+    schema_version: int
+    symbol: str
+    con_id: int
+    exchange: str
+    primary_exchange: str
+    timezone_name: str
+    timeframe: str
+    session_policy: MarketSessionPolicy
+    source: MarketDataSource
+    retrieval_time: datetime
+    broker_time: datetime
+    adjustment_state: AdjustmentState
+    transport_generation: str
+    timestamp_semantics: BarTimestampSemantics
+    use_rth: bool
+    what_to_show: str
+
+    def __post_init__(self) -> None:
+        if (
+            type(self.schema_version) is not int
+            or self.schema_version != CANONICAL_BAR_SCHEMA_VERSION
+        ):
+            raise MarketDataContractError("canonical bar schema version is unsupported")
+        if not isinstance(self.symbol, str) or not re.fullmatch(
+            r"[A-Z0-9][A-Z0-9._-]{0,31}", self.symbol
+        ):
+            raise MarketDataIdentityError("canonical bar symbol is malformed")
+        if type(self.con_id) is not int or self.con_id <= 0:
+            raise MarketDataIdentityError("canonical bar con_id is invalid")
+        if self.exchange != "SMART" or not re.fullmatch(
+            r"[A-Z0-9][A-Z0-9._:/-]{0,63}", self.primary_exchange
+        ):
+            raise MarketDataIdentityError("canonical bar exchange identity is incomplete")
+        if self.timezone_name != "UTC":
+            raise MarketDataContractError("canonical bar timezone must be UTC")
+        bar_interval_seconds(self.timeframe)
+        if self.use_rth is not (self.session_policy is MarketSessionPolicy.REGULAR_ONLY):
+            raise MarketDataContractError("bar session policy and use_rth disagree")
+        for field_name in ("retrieval_time", "broker_time"):
+            value = getattr(self, field_name)
+            if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+                raise MarketDataContractError(f"{field_name} must be timezone-aware")
+            object.__setattr__(self, field_name, value.astimezone(timezone.utc))
+        if abs((self.broker_time - self.retrieval_time).total_seconds()) > 120:
+            raise MarketDataContractError(
+                "bar broker and retrieval timestamps exceed clock-skew tolerance"
+            )
+        if type(self.session_policy) is not MarketSessionPolicy:
+            raise MarketDataContractError("bar session policy is invalid")
+        if self.source is not MarketDataSource.IBKR_HISTORICAL_TRADES:
+            raise MarketDataContractError("historical bar source is invalid")
+        if type(self.adjustment_state) is not AdjustmentState:
+            raise MarketDataContractError("bar adjustment state is invalid")
+        if self.timestamp_semantics is not BarTimestampSemantics.BAR_START:
+            raise MarketDataContractError("bar timestamp semantics are invalid")
+        if self.what_to_show != "TRADES":
+            raise MarketDataContractError("canonical historical bars must be TRADES")
+        if (
+            not isinstance(self.transport_generation, str)
+            or not self.transport_generation
+            or self.transport_generation != self.transport_generation.strip()
+            or len(self.transport_generation) > 128
+        ):
+            raise MarketDataIdentityError("bar transport generation is malformed")
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalBar:
+    """One immutable validated OHLCV event."""
+
+    contract: HistoricalBarContract
+    timestamp: datetime
+    open: Decimal
+    high: Decimal
+    low: Decimal
+    close: Decimal
+    volume: int
+    session: MarketSession
+    quality_flags: tuple[BarQualityFlag, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.timestamp.tzinfo is None or self.timestamp.utcoffset() is None:
+            raise MarketDataContractError("canonical bar timestamp must be timezone-aware")
+        object.__setattr__(self, "timestamp", self.timestamp.astimezone(timezone.utc))
+        for field_name in ("open", "high", "low", "close"):
+            value = getattr(self, field_name)
+            if type(value) is not Decimal or not value.is_finite() or value <= 0:
+                raise MarketDataContractError(f"canonical bar {field_name} is invalid")
+        if self.high < max(self.open, self.low, self.close) or self.low > min(
+            self.open, self.high, self.close
+        ):
+            raise MarketDataContractError("broker OHLC ordering is invalid")
+        if type(self.volume) is not int or self.volume < 0:
+            raise MarketDataContractError("broker volume cannot be negative")
+        if type(self.session) is not MarketSession:
+            raise MarketDataContractError("canonical bar session is invalid")
+        if (
+            self.contract.session_policy is MarketSessionPolicy.REGULAR_ONLY
+            and self.session is not MarketSession.REGULAR
+        ):
+            raise MarketDataContractError("canonical bar violates regular-only policy")
+        expected_flags = (BarQualityFlag.ZERO_VOLUME,) if self.volume == 0 else ()
+        if self.quality_flags != expected_flags:
+            raise MarketDataContractError("canonical bar quality flags are inconsistent")
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalBarBatch:
+    """An atomic contract-lineage batch admitted to runtime consumers."""
+
+    contract: HistoricalBarContract
+    bars: tuple[CanonicalBar, ...]
+
+    def __post_init__(self) -> None:
+        if not self.bars:
+            raise MarketDataContractError("canonical bar batch is empty")
+        if any(bar.contract is not self.contract for bar in self.bars):
+            raise MarketDataIdentityError("canonical bars do not share exact batch identity")
+
+    def to_frame(self) -> pd.DataFrame:
+        frame = pd.DataFrame(
+            {
+                "open": [float(bar.open) for bar in self.bars],
+                "high": [float(bar.high) for bar in self.bars],
+                "low": [float(bar.low) for bar in self.bars],
+                "close": [float(bar.close) for bar in self.bars],
+                "volume": [bar.volume for bar in self.bars],
+            },
+            index=pd.DatetimeIndex([bar.timestamp for bar in self.bars], name="timestamp"),
+        )
+        frame.attrs["market_data_contract"] = self.contract
+        frame.attrs["canonical_bar_batch"] = self
+        frame.attrs["market_data_quality_flags"] = tuple(
+            tuple(flag.value for flag in bar.quality_flags) for bar in self.bars
+        )
+        return frame
+
+    def storage_rows(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "schema_version": self.contract.schema_version,
+                "symbol": self.contract.symbol,
+                "con_id": self.contract.con_id,
+                "exchange": self.contract.exchange,
+                "primary_exchange": self.contract.primary_exchange,
+                "timeframe": self.contract.timeframe,
+                "interval_seconds": bar_interval_seconds(self.contract.timeframe),
+                "timezone_name": self.contract.timezone_name,
+                "session_policy": self.contract.session_policy.value,
+                "timestamp": bar.timestamp.isoformat(),
+                "open": float(bar.open),
+                "high": float(bar.high),
+                "low": float(bar.low),
+                "close": float(bar.close),
+                "volume": bar.volume,
+                "session": bar.session.value,
+                "source": self.contract.source.value,
+                "retrieval_timestamp": self.contract.retrieval_time.isoformat(),
+                "broker_timestamp": self.contract.broker_time.isoformat(),
+                "adjustment_state": self.contract.adjustment_state.value,
+                "quality_flags": ",".join(flag.value for flag in bar.quality_flags),
+                "transport_generation": self.contract.transport_generation,
+                "timestamp_semantics": self.contract.timestamp_semantics.value,
+                "use_rth": self.contract.use_rth,
+                "what_to_show": self.contract.what_to_show,
+            }
+            for bar in self.bars
+        ]
+
+
+CANONICAL_STORAGE_KEYS = frozenset(
+    {
+        "schema_version",
+        "symbol",
+        "con_id",
+        "exchange",
+        "primary_exchange",
+        "timeframe",
+        "interval_seconds",
+        "timezone_name",
+        "session_policy",
+        "timestamp",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+        "session",
+        "source",
+        "retrieval_timestamp",
+        "broker_timestamp",
+        "adjustment_state",
+        "quality_flags",
+        "transport_generation",
+        "timestamp_semantics",
+        "use_rth",
+        "what_to_show",
+    }
+)
+
+
+def validate_canonical_storage_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    """Reconstruct and validate one complete canonical persistence record."""
+
+    if not isinstance(row, Mapping) or set(row) != CANONICAL_STORAGE_KEYS:
+        raise MarketDataContractError("canonical storage row schema is invalid")
+    try:
+        session_policy = MarketSessionPolicy(row["session_policy"])
+        source = MarketDataSource(row["source"])
+        adjustment_state = AdjustmentState(row["adjustment_state"])
+        timestamp_semantics = BarTimestampSemantics(row["timestamp_semantics"])
+        session = MarketSession(row["session"])
+    except (TypeError, ValueError) as exc:
+        raise MarketDataContractError("canonical storage enum value is invalid") from exc
+    use_rth = row["use_rth"]
+    if type(use_rth) is not bool:
+        raise MarketDataContractError("canonical storage use_rth must be boolean")
+    interval_seconds = bar_interval_seconds(row["timeframe"])
+    if type(row["interval_seconds"]) is not int or row["interval_seconds"] != interval_seconds:
+        raise MarketDataContractError("canonical storage interval is inconsistent")
+    contract = HistoricalBarContract(
+        schema_version=row["schema_version"],
+        symbol=row["symbol"],
+        con_id=row["con_id"],
+        exchange=row["exchange"],
+        primary_exchange=row["primary_exchange"],
+        timezone_name=row["timezone_name"],
+        timeframe=row["timeframe"],
+        session_policy=session_policy,
+        source=source,
+        retrieval_time=_aware_utc(row["retrieval_timestamp"], "retrieval timestamp"),
+        broker_time=_aware_utc(row["broker_timestamp"], "broker timestamp"),
+        adjustment_state=adjustment_state,
+        transport_generation=row["transport_generation"],
+        timestamp_semantics=timestamp_semantics,
+        use_rth=use_rth,
+        what_to_show=row["what_to_show"],
+    )
+    timestamp = _aware_utc(row["timestamp"], "canonical event timestamp")
+    if timestamp > contract.retrieval_time:
+        raise MarketDataContractError("canonical event follows retrieval timestamp")
+    if get_market_session(timestamp) != session.value:
+        raise MarketDataContractError("canonical storage session contradicts event time")
+    volume = row["volume"]
+    if type(volume) is not int:
+        raise MarketDataContractError("canonical storage volume must be an integer")
+    flags_text = row["quality_flags"]
+    if not isinstance(flags_text, str):
+        raise MarketDataContractError("canonical storage quality flags are malformed")
+    try:
+        quality_flags = tuple(BarQualityFlag(flag) for flag in flags_text.split(",") if flag)
+    except ValueError as exc:
+        raise MarketDataContractError("canonical storage quality flag is invalid") from exc
+    bar = CanonicalBar(
+        contract=contract,
+        timestamp=timestamp,
+        open=_decimal(row["open"], "open", positive=True),
+        high=_decimal(row["high"], "high", positive=True),
+        low=_decimal(row["low"], "low", positive=True),
+        close=_decimal(row["close"], "close", positive=True),
+        volume=volume,
+        session=session,
+        quality_flags=quality_flags,
+    )
+    return {
+        **row,
+        "timestamp": bar.timestamp.isoformat(),
+        "open": float(bar.open),
+        "high": float(bar.high),
+        "low": float(bar.low),
+        "close": float(bar.close),
+        "session": bar.session.value,
+        "retrieval_timestamp": contract.retrieval_time.isoformat(),
+        "broker_timestamp": contract.broker_time.isoformat(),
+        "quality_flags": ",".join(flag.value for flag in bar.quality_flags),
+        "use_rth": contract.use_rth,
+    }
+
+
+def canonicalize_historical_bars(
+    *,
+    symbol: str,
+    records: Iterable[Mapping[str, Any]],
+    lineage: Any,
+    bar_size: str,
+    use_rth: bool,
+    what_to_show: str,
+    now: Optional[datetime] = None,
+) -> CanonicalBarBatch:
+    """Validate wire records and bind them atomically to broker lineage."""
+
+    interval_seconds = bar_interval_seconds(bar_size)
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None or current.utcoffset() is None:
+        raise ValueError("validation clock must be timezone-aware")
+    current = current.astimezone(timezone.utc)
+    requested = str(symbol).strip().upper()
+    if getattr(lineage, "symbol", None) != requested:
+        raise MarketDataIdentityError("historical lineage symbol mismatch")
+    con_id = getattr(lineage, "con_id", None)
+    exchange = getattr(lineage, "exchange", None)
+    primary_exchange = getattr(lineage, "primary_exchange", None)
+    retrieval_time = getattr(lineage, "retrieval_timestamp", None)
+    broker_time = getattr(lineage, "broker_timestamp", None)
+    transport_generation = getattr(lineage, "transport_generation", None)
+    if type(con_id) is not int:
+        raise MarketDataIdentityError("historical lineage con_id is invalid")
+    if type(exchange) is not str or type(primary_exchange) is not str:
+        raise MarketDataIdentityError("historical lineage exchange is invalid")
+    if not isinstance(retrieval_time, datetime) or not isinstance(broker_time, datetime):
+        raise MarketDataIdentityError("historical lineage clocks are invalid")
+    if type(transport_generation) is not str:
+        raise MarketDataIdentityError("historical lineage generation is invalid")
+    contract = HistoricalBarContract(
+        schema_version=CANONICAL_BAR_SCHEMA_VERSION,
+        symbol=requested,
+        con_id=con_id,
+        exchange=exchange,
+        primary_exchange=primary_exchange,
+        timezone_name="UTC",
+        timeframe=bar_size,
+        session_policy=(
+            MarketSessionPolicy.REGULAR_ONLY if use_rth else MarketSessionPolicy.EXTENDED
+        ),
+        source=MarketDataSource.IBKR_HISTORICAL_TRADES,
+        retrieval_time=retrieval_time,
+        broker_time=broker_time,
+        adjustment_state=AdjustmentState.UNKNOWN,
+        transport_generation=transport_generation,
+        timestamp_semantics=BarTimestampSemantics.BAR_START,
+        use_rth=use_rth,
+        what_to_show=what_to_show,
+    )
+    bars: list[CanonicalBar] = []
+    previous: Optional[CanonicalBar] = None
+    seen: set[datetime] = set()
+    for raw in records:
+        if not isinstance(raw, Mapping):
+            raise MarketDataContractError("broker bar record is malformed")
+        timestamp = _aware_utc(raw.get("date"), "broker timestamp")
+        if timestamp in seen:
+            raise MarketDataContractError("duplicate broker timestamps rejected")
+        if previous is not None and timestamp <= previous.timestamp:
+            raise MarketDataContractError("reversed or out-of-order broker timestamps rejected")
+        if timestamp > current:
+            raise MarketDataContractError("broker bars contain a future timestamp")
+        session_text = get_market_session(timestamp)
+        if session_text == "closed":
+            raise MarketDataContractError("broker bar is outside an admitted market session")
+        session = MarketSession(session_text)
+        if use_rth and session is not MarketSession.REGULAR:
+            raise MarketDataContractError("regular-hours response contains an extended-session bar")
+        volume_decimal = _decimal(raw.get("volume"), "volume")
+        if volume_decimal != volume_decimal.to_integral_value():
+            raise MarketDataContractError("broker bar volume is invalid")
+        try:
+            volume = int(volume_decimal)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise MarketDataContractError("broker bar volume is invalid") from exc
+        bar = CanonicalBar(
+            contract=contract,
+            timestamp=timestamp,
+            open=_decimal(raw.get("open"), "open", positive=True),
+            high=_decimal(raw.get("high"), "high", positive=True),
+            low=_decimal(raw.get("low"), "low", positive=True),
+            close=_decimal(raw.get("close"), "close", positive=True),
+            volume=volume,
+            session=session,
+            quality_flags=((BarQualityFlag.ZERO_VOLUME,) if volume == 0 else ()),
+        )
+        if previous is not None:
+            same_session = (
+                previous.session is bar.session
+                and previous.timestamp.astimezone(_EXCHANGE_TIMEZONE).date()
+                == bar.timestamp.astimezone(_EXCHANGE_TIMEZONE).date()
+            )
+            if same_session and (bar.timestamp - previous.timestamp).total_seconds() > (
+                interval_seconds * 1.5
+            ):
+                raise MarketDataContractError("unexpected in-session broker bar gap rejected")
+        seen.add(timestamp)
+        bars.append(bar)
+        previous = bar
+    if not bars:
+        raise MarketDataContractError("canonical bar batch is empty")
+    max_age_seconds = market_data_max_age_seconds(interval_seconds)
+    age = (current - bars[-1].timestamp).total_seconds()
+    if age > max_age_seconds:
+        raise MarketDataContractError(f"stale broker bars rejected (age={age:.1f}s)")
+    return CanonicalBarBatch(contract=contract, bars=tuple(bars))

--- a/robo_trader/monitoring/performance.py
+++ b/robo_trader/monitoring/performance.py
@@ -8,6 +8,7 @@ This implements Phase 1 F5: Add Basic Performance Monitoring
 """
 
 import asyncio
+import itertools
 import time
 from collections import deque
 from dataclasses import dataclass, field
@@ -17,6 +18,8 @@ from typing import Dict, List, Optional
 from robo_trader.logger import get_logger
 
 logger = get_logger(__name__)
+
+_TIMER_INSTANCE_IDS = itertools.count()
 
 
 @dataclass
@@ -106,11 +109,11 @@ class PerformanceMonitor:
         """
         return Timer(operation, self)
 
-    def start_timer(self, operation: str) -> None:
+    def start_timer(self, operation: str, *, timer_id: Optional[str] = None) -> None:
         """Start timing an operation."""
-        self._timers[operation] = time.perf_counter()
+        self._timers[timer_id or operation] = time.perf_counter()
 
-    def end_timer(self, operation: str) -> float:
+    def end_timer(self, operation: str, *, timer_id: Optional[str] = None) -> float:
         """
         End timing an operation and return duration in milliseconds.
 
@@ -120,12 +123,13 @@ class PerformanceMonitor:
         Returns:
             Duration in milliseconds
         """
-        if operation not in self._timers:
-            logger.warning(f"Timer for {operation} was not started")
+        key = timer_id or operation
+        if key not in self._timers:
+            logger.warning(f"Timer for {key} was not started")
             return 0.0
 
-        duration_ms = (time.perf_counter() - self._timers[operation]) * 1000
-        del self._timers[operation]
+        duration_ms = (time.perf_counter() - self._timers[key]) * 1000
+        del self._timers[key]
 
         # Record the sample based on operation type
         if operation == "data_fetch":
@@ -350,15 +354,23 @@ def get_monitor() -> PerformanceMonitor:
 class Timer:
     """Context manager for timing operations."""
 
-    def __init__(self, operation: str, monitor: Optional[PerformanceMonitor] = None):
+    def __init__(
+        self,
+        operation: str,
+        monitor: Optional[PerformanceMonitor] = None,
+        *,
+        instance: Optional[str] = None,
+    ):
         self.operation = operation
         self.monitor = monitor or get_monitor()
+        suffix = "" if instance is None else f":{instance}"
+        self.timer_id = f"{operation}{suffix}:{next(_TIMER_INSTANCE_IDS)}"
 
     def __enter__(self):
-        self.monitor.start_timer(self.operation)
+        self.monitor.start_timer(self.operation, timer_id=self.timer_id)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        duration = self.monitor.end_timer(self.operation)
+        duration = self.monitor.end_timer(self.operation, timer_id=self.timer_id)
         if duration > 1000:  # Log slow operations (> 1 second)
             logger.warning(f"Slow operation: {self.operation} took {duration:.1f}ms")

--- a/robo_trader/paper_reduction_gateway.py
+++ b/robo_trader/paper_reduction_gateway.py
@@ -12,16 +12,18 @@ import asyncio
 import logging
 import os
 import stat
+import time
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from decimal import ROUND_HALF_EVEN, Decimal, InvalidOperation
 from pathlib import Path
-from typing import AsyncIterator, Optional
+from typing import AsyncIterator, Awaitable, Callable, Optional
 
 from .broker_safety_evidence import BrokerContractSafetySnapshot
 from .clients.subprocess_ibkr_client import SubprocessIBKRClient
 from .database_async import AsyncTradingDatabase
 from .execution import Order, PaperExecutor
+from .market_data_contract import BrokerProtectiveQuote
 from .paper_reduction_submitter import (
     LocalPaperOrderStatus,
     LocalPaperTerminalOutcome,
@@ -32,6 +34,7 @@ from .paper_runtime_settlement import PaperRuntimeSettlementParticipant
 from .paper_terminal_settlement import PaperTerminalSettlementRequest
 from .protective_quote_evidence import (
     ProtectiveQuoteEvidence,
+    ProtectiveQuoteSource,
     assert_current_authoritative_protective_quote,
 )
 from .reconciliation.identity import (
@@ -75,6 +78,9 @@ class PaperReductionGateway:
         runtime_context: RuntimeSafetyContext,
         coordinator: SafetyRuntimeCoordinator,
         database: AsyncTradingDatabase,
+        *,
+        monotonic: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
     ) -> None:
         self._runtime_context = assert_validated_runtime_safety_context(runtime_context)
         if type(coordinator) is not SafetyRuntimeCoordinator or not coordinator.started:
@@ -127,6 +133,31 @@ class PaperReductionGateway:
         self._started = False
         self._diagnostic_recovery_required = False
         self._terminal_quarantine_reason: str | None = None
+        self._protective_quote_producers: dict[str, object] = {}
+        self._protective_feed_task: asyncio.Task | None = None
+        self._protective_feed_enabled = False
+        self._protective_feed_interval_seconds = 2.0
+        self._protective_feed_max_recovery_attempts = 3
+        self._monotonic = monotonic
+        self._sleep = sleep
+        self._generation_symbol_first_request: dict[str, float] = {}
+        self._generation_subscribed_symbols: set[str] = set()
+        self._resubscribe_not_before = 0.0
+        self._tick_resubscribe_cooldown_seconds = 15.0
+
+    def _ensure_protective_feed_task(self) -> None:
+        """Run exactly one feed loop whenever the broker generation is active."""
+
+        if (
+            self._started
+            and self._protective_feed_enabled
+            and self._protective_quote_producers
+            and (self._protective_feed_task is None or self._protective_feed_task.done())
+        ):
+            self._protective_feed_task = asyncio.create_task(
+                self._protective_feed_loop(),
+                name="paper-gateway-protective-feed",
+            )
 
     @property
     def started(self) -> bool:
@@ -184,6 +215,23 @@ class PaperReductionGateway:
     ) -> None:
         """Drain one client stop through cancellation and preserve the first error."""
 
+        # IBKR forbids requesting tick-by-tick data for the same instrument
+        # more than once in 15 seconds. Retiring a worker loses its local
+        # subscription memory, so preserve a conservative account-wide lower
+        # bound before the generation can disappear.
+        first_requests = getattr(self, "_generation_symbol_first_request", {})
+        if first_requests:
+            cooldown = getattr(self, "_tick_resubscribe_cooldown_seconds", 15.0)
+            previous = getattr(self, "_resubscribe_not_before", 0.0)
+            self._resubscribe_not_before = max(
+                previous,
+                max(requested_at + cooldown for requested_at in first_requests.values()),
+            )
+            first_requests.clear()
+        subscribed = getattr(self, "_generation_subscribed_symbols", None)
+        if subscribed is not None:
+            subscribed.clear()
+
         task = asyncio.create_task(self._client.stop())
         cancellation: asyncio.CancelledError | None = None
         stop_failure: BaseException | None = None
@@ -222,12 +270,220 @@ class PaperReductionGateway:
         if stop_failure is not None:
             raise stop_failure.with_traceback(stop_failure.__traceback__)
 
+    async def _invalidate_protective_quote_producers(self) -> None:
+        for producer in tuple(self._protective_quote_producers.values()):
+            invalidate = getattr(producer, "invalidate_protective_quotes", None)
+            if callable(invalidate):
+                await invalidate()
+
+    def attach_protective_quote_producer(
+        self,
+        portfolio_id: str,
+        producer: object,
+    ) -> None:
+        """Attach a monitor before startup position coverage is asserted."""
+
+        from .stop_loss_monitor import StopLossMonitor
+
+        if (
+            not isinstance(portfolio_id, str)
+            or not portfolio_id
+            or portfolio_id != portfolio_id.strip()
+            or type(producer) is not StopLossMonitor
+            or producer.portfolio_id != portfolio_id
+        ):
+            raise PaperReductionGatewayError("protective quote producer binding is malformed")
+        existing = self._protective_quote_producers.get(portfolio_id)
+        if existing is not None and existing is not producer:
+            raise PaperReductionGatewayError("portfolio quote producer is already attached")
+        self._protective_quote_producers[portfolio_id] = producer
+
+    def start_protective_feed(self) -> None:
+        """Enable continuous quote refresh after runner activation is complete."""
+
+        if not self._started or not self._protective_quote_producers:
+            raise PaperReductionGatewayError("protective quote feed cannot be activated")
+        self._protective_feed_enabled = True
+        self._ensure_protective_feed_task()
+
+    def _protected_symbols(self) -> tuple[str, ...]:
+        symbols = set()
+        for producer in self._protective_quote_producers.values():
+            active_stops = getattr(producer, "active_stops", None)
+            if isinstance(active_stops, dict):
+                for stop in active_stops.values():
+                    symbol = getattr(stop, "symbol", None)
+                    if isinstance(symbol, str) and symbol:
+                        symbols.add(symbol)
+        return tuple(sorted(symbols))
+
+    async def refresh_protective_quotes(
+        self,
+        symbols: list[str] | tuple[str, ...],
+    ) -> tuple[BrokerProtectiveQuote, ...]:
+        """Publish quotes under the account gate using bounded worker requests."""
+
+        requested = tuple(symbols)
+        effective_symbols = tuple(sorted(set(requested).union(self._protected_symbols())))
+        if not set(requested).issubset(effective_symbols):
+            raise PaperReductionGatewayError("protective quote request is malformed")
+        async with self._account_order_gate:
+            await self._ensure_diagnostic_ready_locked()
+            try:
+                quotes = await self._fetch_protective_quotes_locked(
+                    requested,
+                    active_symbols=effective_symbols,
+                )
+                await self._publish_protective_quotes_locked(quotes)
+                requested_set = set(requested)
+                return tuple(quote for quote in quotes if quote.symbol in requested_set)
+            except asyncio.CancelledError:
+                raise
+            except Exception as error:
+                self._started = False
+                self._diagnostic_recovery_required = True
+                await self._invalidate_protective_quote_producers()
+                try:
+                    await self._stop_client_owned()
+                except Exception as stop_error:
+                    logger.error(
+                        "event=protective_quote_client_stop_failed error_type=%s",
+                        type(stop_error).__name__,
+                    )
+                raise error.with_traceback(error.__traceback__)
+
+    async def _fetch_protective_quotes_locked(
+        self,
+        requested: tuple[str, ...],
+        *,
+        active_symbols: tuple[str, ...],
+    ) -> tuple[BrokerProtectiveQuote, ...]:
+        """Respect the client's 64-symbol request cap without subscription churn."""
+
+        monotonic = getattr(self, "_monotonic", time.monotonic)
+        sleep = getattr(self, "_sleep", asyncio.sleep)
+        not_before = getattr(self, "_resubscribe_not_before", 0.0)
+        remaining = not_before - monotonic()
+        if remaining > 0:
+            await sleep(remaining)
+
+        chunks = [requested[index : index + 64] for index in range(0, len(requested), 64)]
+        if not chunks:
+            # The explicit empty call is the worker protocol for cancelling all
+            # subscriptions when the full effective set is empty.
+            chunks = [tuple()]
+        quotes: list[BrokerProtectiveQuote] = []
+        for chunk in chunks:
+            first_requests = getattr(self, "_generation_symbol_first_request", None)
+            if first_requests is None:
+                first_requests = {}
+                self._generation_symbol_first_request = first_requests
+            subscribed = getattr(self, "_generation_subscribed_symbols", None)
+            if subscribed is None:
+                subscribed = set()
+                self._generation_subscribed_symbols = subscribed
+            # The worker may retire symbols outside the full active set. Treat
+            # any later reactivation as a possible new broker request even if
+            # its worker-side 15-second retention happened to reuse it.
+            subscribed.intersection_update(active_symbols)
+            newly_requested = set(chunk) - subscribed
+            try:
+                response = await self._client.get_protective_quotes(
+                    chunk,
+                    active_symbols=active_symbols,
+                )
+            finally:
+                # Contract qualification and broker-time collection happen
+                # inside the worker command before reqTickByTickData. The
+                # parent completion time is therefore the conservative bound:
+                # it is never earlier than a broker request that may have
+                # succeeded even when the command ultimately failed.
+                completed_at = monotonic()
+                for requested_symbol in newly_requested:
+                    first_requests[requested_symbol] = completed_at
+            if not isinstance(response, tuple):
+                raise PaperReductionGatewayError("broker quote response is malformed")
+            subscribed.update(chunk)
+            quotes.extend(response)
+        observed_symbols = {quote.symbol for quote in quotes}
+        if observed_symbols != set(requested):
+            raise PaperReductionGatewayError("broker quote coverage is incomplete")
+        return tuple(quotes)
+
+    async def _publish_protective_quotes_locked(
+        self,
+        quotes: tuple[BrokerProtectiveQuote, ...],
+    ) -> None:
+        """Publish exact Decimal quotes while the account evidence gate is held."""
+
+        for quote in quotes:
+            if type(quote) is not BrokerProtectiveQuote:
+                raise PaperReductionGatewayError("broker returned a non-canonical quote")
+            for producer in tuple(self._protective_quote_producers.values()):
+                update_price = getattr(producer, "update_price", None)
+                if not callable(update_price):
+                    raise PaperReductionGatewayError("protective quote producer is malformed")
+                accepted = await update_price(
+                    quote.symbol,
+                    quote.price,
+                    source_timestamp=quote.source_timestamp,
+                    source=ProtectiveQuoteSource.LIVE_BROKER,
+                    con_id=quote.con_id,
+                    transport_generation=quote.transport_generation,
+                    source_event_id=quote.source_event_id,
+                )
+                if accepted is not True:
+                    raise PaperReductionGatewayError(
+                        f"protective quote was rejected for {quote.symbol}"
+                    )
+
+    async def _protective_feed_loop(self) -> None:
+        """Continuously refresh every symbol with an active protective stop."""
+
+        consecutive_failures = 0
+        while self._protective_feed_enabled and (
+            self._started or self._diagnostic_recovery_required
+        ):
+            try:
+                symbols = self._protected_symbols()
+                await self.refresh_protective_quotes(symbols)
+                consecutive_failures = 0
+            except asyncio.CancelledError:
+                raise
+            except Exception as error:
+                consecutive_failures += 1
+                logger.error(
+                    "event=protective_quote_refresh_failed error_type=%s "
+                    "consecutive_failures=%d",
+                    type(error).__name__,
+                    consecutive_failures,
+                )
+                if consecutive_failures >= self._protective_feed_max_recovery_attempts:
+                    self._protective_feed_enabled = False
+                    logger.critical(
+                        "event=protective_quote_feed_disabled "
+                        "operator_action_required=true consecutive_failures=%d",
+                        consecutive_failures,
+                    )
+                    break
+            await asyncio.sleep(self._protective_feed_interval_seconds)
+
     async def close(self) -> None:
         """Stop only the gateway-owned diagnostic client."""
 
         async with self._account_order_gate:
             self._started = False
             self._diagnostic_recovery_required = False
+            self._protective_feed_enabled = False
+            feed_task = self._protective_feed_task
+            self._protective_feed_task = None
+            if feed_task is not None and not feed_task.done():
+                feed_task.cancel()
+                try:
+                    await feed_task
+                except asyncio.CancelledError:
+                    pass
+            await self._invalidate_protective_quote_producers()
             try:
                 await self._stop_client_owned()
             finally:
@@ -239,6 +495,7 @@ class PaperReductionGateway:
 
         self._started = False
         self._diagnostic_recovery_required = True
+        await self._invalidate_protective_quote_producers()
         try:
             context = assert_validated_runtime_safety_context(self._runtime_context)
             connection = context.diagnostic_connection
@@ -258,6 +515,7 @@ class PaperReductionGateway:
             raise
         self._started = True
         self._diagnostic_recovery_required = False
+        self._ensure_protective_feed_task()
 
     async def refresh_diagnostic_connection(self) -> None:
         """Replace stale broker state before order admission can resume.
@@ -321,6 +579,7 @@ class PaperReductionGateway:
 
         self._started = False
         self._diagnostic_recovery_required = True
+        await self._invalidate_protective_quote_producers()
         await self._stop_client_owned(error)
 
     def register_paper_executor(
@@ -365,6 +624,11 @@ class PaperReductionGateway:
             ):
                 return
             raise PaperReductionGatewayError("portfolio paper runtime is already registered")
+        attached = self._protective_quote_producers.get(portfolio_id)
+        if attached is not protective_quote_producer:
+            raise PaperReductionGatewayError(
+                "paper runtime quote producer was not provisionally attached"
+            )
         self._bindings[portfolio_id] = _PaperRuntimeBinding(
             submitter=_bind_paper_reduction_submitter(
                 executor,
@@ -375,8 +639,11 @@ class PaperReductionGateway:
         )
 
     @asynccontextmanager
-    async def serialize_entry(self) -> AsyncIterator[None]:
-        """Prevent an entry dispatch from interleaving with reduction evidence."""
+    async def serialize_entry(
+        self,
+        symbol: str | None = None,
+    ) -> AsyncIterator[BrokerProtectiveQuote | None]:
+        """Refresh entry evidence and hold it stable through paper dispatch."""
 
         require_paper_terminal_settlement_ready()
         async with self._account_order_gate:
@@ -397,7 +664,42 @@ class PaperReductionGateway:
                 raise PaperReductionGatewayError(
                     "diagnostic broker is unavailable for entry admission"
                 )
-            yield
+            current_quote: BrokerProtectiveQuote | None = None
+            if symbol is not None:
+                effective_symbols = tuple(sorted(set((symbol,)).union(self._protected_symbols())))
+                try:
+                    quotes = await self._fetch_protective_quotes_locked(
+                        effective_symbols,
+                        active_symbols=effective_symbols,
+                    )
+                    await self._publish_protective_quotes_locked(quotes)
+                    matching = tuple(quote for quote in quotes if quote.symbol == symbol)
+                    if not matching:
+                        raise PaperReductionGatewayError(
+                            "entry quote refresh returned no matching evidence"
+                        )
+                    current_quote = matching[-1]
+                except asyncio.CancelledError:
+                    raise
+                except Exception as error:
+                    self._started = False
+                    self._diagnostic_recovery_required = True
+                    await self._invalidate_protective_quote_producers()
+                    try:
+                        await self._stop_client_owned()
+                    except Exception as stop_error:
+                        logger.error(
+                            "event=entry_quote_client_stop_failed error_type=%s",
+                            type(stop_error).__name__,
+                        )
+                    raise error.with_traceback(error.__traceback__)
+                for producer in tuple(self._protective_quote_producers.values()):
+                    pending = getattr(producer, "has_pending_reduction", None)
+                    if not callable(pending) or await pending() is not False:
+                        raise PaperReductionGatewayError(
+                            "entry blocked while a protective reduction is pending"
+                        )
+            yield current_quote
 
     async def submit_reduction(
         self,

--- a/robo_trader/paper_reduction_gateway.py
+++ b/robo_trader/paper_reduction_gateway.py
@@ -9,6 +9,7 @@ shared by every portfolio runner in the process.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import os
 import stat
@@ -460,13 +461,69 @@ class PaperReductionGateway:
                 )
                 if consecutive_failures >= self._protective_feed_max_recovery_attempts:
                     self._protective_feed_enabled = False
+                    reason = (
+                        "protective quote feed disabled after "
+                        f"{consecutive_failures} consecutive refresh failures"
+                    )
+                    self._latch_protective_feed_quarantine(reason)
                     logger.critical(
                         "event=protective_quote_feed_disabled "
                         "operator_action_required=true consecutive_failures=%d",
                         consecutive_failures,
                     )
+                    await self._emit_protective_feed_operator_alert(reason)
                     break
-            await asyncio.sleep(self._protective_feed_interval_seconds)
+            await self._sleep(self._protective_feed_interval_seconds)
+
+    def _latch_protective_feed_quarantine(self, reason: str) -> None:
+        """Synchronously close account admission when continuous protection dies."""
+
+        reason_text = str(reason or "protective quote feed failure").strip()
+        if not reason_text:
+            reason_text = "protective quote feed failure"
+        if self._terminal_quarantine_reason is not None:
+            return
+        self._terminal_quarantine_reason = reason_text
+        for portfolio_id, binding in tuple(getattr(self, "_bindings", {}).items()):
+            if type(binding) is not _PaperRuntimeBinding:
+                continue
+            try:
+                binding.settlement_participant.latch_quarantine(reason_text)
+            except Exception:
+                logger.critical(
+                    "event=paper_runtime_quarantine_callback_failed portfolio_id=%s",
+                    portfolio_id,
+                    exc_info=True,
+                )
+        logger.critical(
+            "event=paper_reduction_gateway_terminal_quarantine " "scope=account reason=%s",
+            reason_text,
+        )
+
+    async def _emit_protective_feed_operator_alert(self, reason: str) -> None:
+        """Use each runner's existing emergency callback to alert and freeze entries."""
+
+        for portfolio_id, producer in tuple(self._protective_quote_producers.items()):
+            callback = getattr(producer, "emergency_shutdown", None)
+            if not callable(callback):
+                logger.critical(
+                    "event=protective_quote_operator_alert_unavailable portfolio_id=%s",
+                    portfolio_id,
+                )
+                continue
+            try:
+                result = callback(reason)
+                if not inspect.isawaitable(result):
+                    raise PaperReductionGatewayError(
+                        "protective quote operator alert callback must be awaitable"
+                    )
+                await result
+            except Exception:
+                logger.critical(
+                    "event=protective_quote_operator_alert_failed portfolio_id=%s",
+                    portfolio_id,
+                    exc_info=True,
+                )
 
     async def close(self) -> None:
         """Stop only the gateway-owned diagnostic client."""

--- a/robo_trader/protective_quote_evidence.py
+++ b/robo_trader/protective_quote_evidence.py
@@ -27,7 +27,8 @@ from enum import Enum
 from typing import Optional
 
 _SYMBOL_RE = re.compile(r"^[A-Z0-9][A-Z0-9._-]{0,31}$")
-_TEXT_RE = re.compile(r"^[^\x00-\x1f\x7f]{1,128}$")
+MAX_PROTECTIVE_SOURCE_EVENT_ID_LENGTH = 128
+_TEXT_RE = re.compile(rf"^[^\x00-\x1f\x7f]{{1,{MAX_PROTECTIVE_SOURCE_EVENT_ID_LENGTH}}}$")
 _PRODUCER_MARKER = object()
 _REGISTRY_KEY = secrets.token_bytes(32)
 _REGISTRY_LOCK = threading.Lock()

--- a/robo_trader/runner/data_fetcher.py
+++ b/robo_trader/runner/data_fetcher.py
@@ -184,7 +184,7 @@ class DataFetcher:
 
         try:
             start_time = asyncio.get_event_loop().time()
-            with Timer("data_fetch", self.monitor):
+            with Timer("data_fetch", self.monitor, instance=symbol):
                 # Fetch historical bars using IB connection directly
                 df = await self.fetch_historical_bars(
                     symbol=symbol, duration=self.duration, bar_size=self.bar_size
@@ -223,7 +223,7 @@ class DataFetcher:
                 )
 
             if batch_data:
-                with Timer("database_write", self.monitor):
+                with Timer("database_write", self.monitor, instance=symbol):
                     await self.db.batch_store_market_data(batch_data)
                 self.monitor.record_data_points(len(batch_data))
 

--- a/robo_trader/runner_async.py
+++ b/robo_trader/runner_async.py
@@ -26,7 +26,7 @@ from dotenv import load_dotenv  # isort:skip
 load_dotenv()  # noqa: E402 - must run before imports that use os.getenv()
 from dataclasses import dataclass  # isort:skip  # noqa: E402
 from datetime import date, datetime, timezone
-from decimal import Decimal, localcontext
+from decimal import Decimal, InvalidOperation, localcontext
 from pathlib import Path
 from types import SimpleNamespace, TracebackType
 from typing import Any, Callable, Coroutine, Dict, List, NoReturn, Optional, Tuple
@@ -40,6 +40,15 @@ from .correlation import CorrelationTracker
 from .database_async import AsyncTradingDatabase
 from .execution import ExecutionResult, Order, PaperExecutor
 from .logger import get_logger
+from .market_data_contract import (
+    BrokerProtectiveQuote,
+    CanonicalBarBatch,
+    MarketDataContractError,
+    MarketDataIdentityError,
+    MarketSession,
+    bar_interval_seconds,
+    market_data_max_age_seconds,
+)
 from .market_hours import (
     get_market_session,
     is_extended_hours,
@@ -124,14 +133,6 @@ from .utils.connection_recovery import OrderRateLimiter
 
 # Initialize logger early for use in import error handling
 logger = get_logger(__name__)
-
-
-class MarketDataContractError(ValueError):
-    """Broker bars failed the runner's fail-closed event-time contract."""
-
-
-class MarketDataIdentityError(MarketDataContractError):
-    """Broker response identity is ambiguous or contradicts the request."""
 
 
 class SymbolCycleAbortError(RuntimeError):
@@ -563,6 +564,8 @@ class AsyncRunner:
         self.latest_price_sources: Dict[str, str] = {}
         self._trusted_bar_closes: Dict[str, float] = {}
         self._protective_feed_status: Dict[str, dict] = {}
+        self._canonical_bar_batches: Dict[str, tuple[CanonicalBarBatch, pd.DataFrame]] = {}
+        self._broker_protective_quotes: Dict[str, BrokerProtectiveQuote] = {}
         self.daily_pnl = 0.0
         self._daily_pnl_exact = Decimal(0)
         self._account_settlement_source_id: Optional[str] = None
@@ -918,32 +921,243 @@ class AsyncRunner:
             fill_price=None,
         )
 
+    @staticmethod
+    def _exact_entry_fill_price(result: object) -> Decimal:
+        """Return the executor's actual opening fill without quote fallback."""
+
+        exact_fill = getattr(result, "exact_fill_price", None)
+        if exact_fill is not None:
+            if type(exact_fill) is Decimal and exact_fill.is_finite() and exact_fill > 0:
+                return exact_fill
+            raise RuntimeError("successful entry has an invalid exact fill price")
+        fill_price = getattr(result, "fill_price", None)
+        try:
+            normalized = Decimal(str(fill_price))
+        except (InvalidOperation, TypeError, ValueError) as exc:
+            raise RuntimeError("successful entry has no valid fill price") from exc
+        if not normalized.is_finite() or normalized <= 0:
+            raise RuntimeError("successful entry has no valid fill price")
+        return normalized
+
+    async def _record_entry_fill_accounting(
+        self,
+        *,
+        symbol: str,
+        side: str,
+        quantity: int,
+        fill_price: Decimal,
+        strategy_reference_price: float,
+    ) -> None:
+        """Persist opening-fill risk and marks from the actual executor fill."""
+
+        fill_price_float = float(fill_price)
+        self.daily_executed_notional += float(fill_price * Decimal(quantity))
+        await self.db.record_trade(
+            symbol,
+            side,
+            quantity,
+            fill_price_float,
+            slippage=(fill_price_float - strategy_reference_price) * quantity,
+        )
+        position = self.positions[symbol]
+        await self.db.update_position(
+            symbol,
+            position.quantity,
+            position.avg_price,
+            fill_price,
+        )
+
     def _order_increases_exposure(self, order: Order) -> bool:
         """Conservatively classify entry intents for temporary session gates."""
         side = str(getattr(order, "side", "") or "").upper()
         return side in {"BUY", "SELL_SHORT"}
 
+    def _record_authoritative_broker_quote(
+        self,
+        quote: BrokerProtectiveQuote,
+    ) -> ProtectiveQuoteEvidence:
+        """Bind gateway-published evidence to runner pricing state."""
+
+        if type(quote) is not BrokerProtectiveQuote:
+            raise MarketDataContractError("broker quote is not canonical")
+        monitor = getattr(self, "stop_loss_monitor", None)
+        if type(monitor) is not StopLossMonitor:
+            raise MarketDataContractError("protective quote producer is unavailable")
+        evidence = monitor.get_protective_quote_evidence(quote.symbol)
+        if type(evidence) is not ProtectiveQuoteEvidence:
+            raise MarketDataContractError("protective monitor did not retain exact quote evidence")
+        try:
+            evidence = assert_current_authoritative_protective_quote(
+                evidence,
+                producer=monitor,
+                expected_portfolio_id=self.portfolio_id,
+                expected_symbol=quote.symbol,
+                expected_con_id=quote.con_id,
+                expected_transport_generation=quote.transport_generation,
+            )
+        except ProtectiveQuoteValidationError as exc:
+            raise MarketDataContractError("protective quote authority is not current") from exc
+        if (
+            evidence.price != quote.price
+            or evidence.source_timestamp != quote.source_timestamp
+            or evidence.source_event_id != quote.source_event_id
+        ):
+            raise MarketDataContractError("monitor evidence differs from the broker quote")
+
+        if not hasattr(self, "_broker_protective_quotes"):
+            self._broker_protective_quotes = {}
+        self._broker_protective_quotes[quote.symbol] = quote
+        self.latest_prices[quote.symbol] = float(quote.price)
+        self.latest_price_times[quote.symbol] = quote.source_timestamp
+        self.latest_price_sources[quote.symbol] = "live_protective"
+        self._protective_feed_status[quote.symbol] = {
+            "available": True,
+            "live_grade": True,
+            "source": "live_protective",
+            "source_timestamp": quote.source_timestamp.isoformat(),
+            "retrieval_timestamp": quote.retrieval_timestamp.isoformat(),
+            "con_id": quote.con_id,
+            "transport_generation": quote.transport_generation,
+            "source_event_id": quote.source_event_id,
+            "session": quote.session.value,
+        }
+        return evidence
+
+    def _canonical_batch_for_execution(self, symbol: str) -> CanonicalBarBatch | None:
+        cached = getattr(self, "_canonical_bar_batches", {}).get(symbol)
+        if (
+            not isinstance(cached, tuple)
+            or len(cached) != 2
+            or type(cached[0]) is not CanonicalBarBatch
+            or cached[0].contract.symbol != symbol
+            or cached[1].attrs.get("canonical_bar_batch") is not cached[0]
+        ):
+            return None
+        return cached[0]
+
+    def _entry_session_is_canonical(
+        self,
+        symbol: str,
+        quote: BrokerProtectiveQuote,
+    ) -> bool:
+        """Require matching exact quote/bar evidence for the current session."""
+
+        batch = self._canonical_batch_for_execution(symbol)
+        if type(batch) is not CanonicalBarBatch or not batch.bars:
+            return False
+        if batch.contract.con_id != quote.con_id:
+            return False
+        try:
+            max_age = market_data_max_age_seconds(bar_interval_seconds(batch.contract.timeframe))
+            now = datetime.now(timezone.utc)
+            bar_age = (now - batch.bars[-1].timestamp).total_seconds()
+            retrieval_age = (now - batch.contract.retrieval_time).total_seconds()
+        except (MarketDataContractError, TypeError, ValueError):
+            return False
+        if not (0 <= bar_age <= max_age and 0 <= retrieval_age <= max_age):
+            return False
+        latest_session = batch.bars[-1].session
+        if is_extended_hours():
+            current = get_market_session()
+            expected = {
+                "pre-market": MarketSession.PRE_MARKET,
+                "after-hours": MarketSession.AFTER_HOURS,
+            }.get(current)
+            return expected is not None and quote.session is expected and latest_session is expected
+        return quote.session is MarketSession.REGULAR and latest_session is MarketSession.REGULAR
+
+    async def _refresh_live_protective_quotes(self, symbols: object) -> bool:
+        """Publish and record complete current-generation broker quote coverage."""
+
+        if not isinstance(symbols, (list, tuple, set)):
+            return False
+        requested = tuple(
+            sorted(
+                {
+                    symbol
+                    for symbol in symbols
+                    if isinstance(symbol, str) and symbol and symbol == symbol.strip()
+                }
+            )
+        )
+        if not requested:
+            return True
+        gateway = getattr(self, "paper_reduction_gateway", None)
+        monitor = getattr(self, "stop_loss_monitor", None)
+        if type(gateway) is not PaperReductionGateway or type(monitor) is not StopLossMonitor:
+            return False
+
+        try:
+            quotes = await gateway.refresh_protective_quotes(requested)
+            by_symbol = {
+                quote.symbol: quote for quote in quotes if type(quote) is BrokerProtectiveQuote
+            }
+            if set(by_symbol) != set(requested):
+                raise RuntimeError("protective broker quote coverage is incomplete")
+
+            if not hasattr(self, "_protective_feed_status"):
+                self._protective_feed_status = {}
+            if not hasattr(self, "latest_price_times"):
+                self.latest_price_times = {}
+            if not hasattr(self, "latest_price_sources"):
+                self.latest_price_sources = {}
+
+            for symbol in requested:
+                self._record_authoritative_broker_quote(by_symbol[symbol])
+            return all(self._has_live_protective_feed(symbol) for symbol in requested)
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            statuses = getattr(self, "_protective_feed_status", None)
+            if not isinstance(statuses, dict):
+                self._protective_feed_status = {}
+                statuses = self._protective_feed_status
+            for symbol in requested:
+                statuses[symbol] = {
+                    "available": False,
+                    "live_grade": False,
+                    "source": "live_protective",
+                    "reason": "broker_protective_quote_refresh_failed",
+                }
+            logger.error(
+                "event=protective_quote_refresh_failed symbols=%s error_type=%s",
+                ",".join(requested),
+                type(error).__name__,
+            )
+            return False
+
     def _has_live_protective_feed(self, symbol: str) -> bool:
         """Return whether monitor-accepted live protection is still fresh.
 
-        Provenance flags are necessary but never sufficient: order admission
-        trusts the stop monitor's accepted event and monotonic receipt state,
-        evaluated against its own validated clocks and maximum age. Missing,
-        malformed, stale, or future state fails closed.
+        Mutable dashboard status is deliberately not an authority. Order
+        admission trusts the stop monitor's producer-owned broker event and
+        monotonic receipt state, evaluated against its own validated clocks.
+        Missing, malformed, stale, future, or invalidated state fails closed.
         """
-        statuses = getattr(self, "_protective_feed_status", None)
-        if not isinstance(statuses, dict):
-            return False
-        status = statuses.get(symbol)
-        if not (
-            isinstance(status, dict)
-            and status.get("available") is True
-            and status.get("live_grade") is True
-            and status.get("source") == "live_protective"
+        monitor = getattr(self, "stop_loss_monitor", None)
+        quote = (
+            monitor.get_protective_quote_evidence(symbol)
+            if type(monitor) is StopLossMonitor
+            else None
+        )
+        if (
+            type(quote) is not ProtectiveQuoteEvidence
+            or quote.source is not ProtectiveQuoteSource.LIVE_BROKER
+            or type(quote.con_id) is not int
+            or type(quote.transport_generation) is not str
         ):
             return False
-
-        monitor = getattr(self, "stop_loss_monitor", None)
+        try:
+            assert_current_authoritative_protective_quote(
+                quote,
+                producer=monitor,
+                expected_portfolio_id=self.portfolio_id,
+                expected_symbol=symbol,
+                expected_con_id=quote.con_id,
+                expected_transport_generation=quote.transport_generation,
+            )
+        except ProtectiveQuoteValidationError:
+            return False
         prices = getattr(monitor, "last_prices", None)
         event_times = getattr(monitor, "price_event_times", None)
         receipt_times = getattr(monitor, "price_receipt_monotonic", None)
@@ -988,6 +1202,8 @@ class AsyncRunner:
             or not isinstance(receipt_time, (int, float))
             or isinstance(receipt_time, bool)
             or not math.isfinite(float(receipt_time))
+            or Decimal(str(price)) != quote.price
+            or event_time.astimezone(timezone.utc) != quote.source_timestamp
         ):
             return False
 
@@ -1026,18 +1242,10 @@ class AsyncRunner:
             return False
 
         monitor = self.stop_loss_monitor
-        statuses = getattr(self, "_protective_feed_status", None)
-        status = statuses.get(symbol) if isinstance(statuses, dict) else None
-        if not isinstance(status, dict):
-            return False
-        expected_con_id = status.get("con_id")
-        expected_generation = status.get("transport_generation")
         quote = monitor.get_protective_quote_evidence(symbol)
         if (
             type(quote) is not ProtectiveQuoteEvidence
             or quote.source is not ProtectiveQuoteSource.LIVE_BROKER
-            or type(expected_con_id) is not int
-            or type(expected_generation) is not str
         ):
             return False
         try:
@@ -1046,8 +1254,8 @@ class AsyncRunner:
                 producer=monitor,
                 expected_portfolio_id=self.portfolio_id,
                 expected_symbol=symbol,
-                expected_con_id=expected_con_id,
-                expected_transport_generation=expected_generation,
+                expected_con_id=quote.con_id,
+                expected_transport_generation=quote.transport_generation,
             )
         except ProtectiveQuoteValidationError:
             return False
@@ -1062,9 +1270,9 @@ class AsyncRunner:
             or monitor_event_time.utcoffset() is None
         ):
             return False
-        return float(monitor_price) == float(price) and monitor_event_time.astimezone(
-            timezone.utc
-        ) == event_time.astimezone(timezone.utc)
+        return Decimal(str(monitor_price)) == quote.price == Decimal(
+            str(price)
+        ) and monitor_event_time.astimezone(timezone.utc) == event_time.astimezone(timezone.utc)
 
     def _pairs_execution_admitted(self, pair: object) -> bool:
         """Fail closed until pairs have an atomic two-leg execution lifecycle."""
@@ -1401,30 +1609,19 @@ class AsyncRunner:
                     return self._rejected_order_result(
                         "Order admission blocked: broker transport unavailable"
                     )
-                if not self._has_live_protective_feed(order.symbol):
-                    logger.error(
-                        "Order admission blocked for %s: no admitted " "live-protective feed",
-                        order.symbol,
-                    )
+                if self._canonical_batch_for_execution(order.symbol) is None:
                     return self._rejected_order_result(
-                        "Order admission blocked: live protective feed unavailable"
-                    )
-                if is_extended_hours() and self._order_increases_exposure(order):
-                    logger.warning(
-                        "Extended-hours entry blocked for %s until session-aware "
-                        "market data lands in PR 3",
-                        order.symbol,
-                    )
-                    return self._rejected_order_result(
-                        "Entry blocked: extended-hours session data unavailable"
+                        "Entry blocked: canonical market-data evidence unavailable"
                     )
 
                 # Synchronous paper placement is the point of no return. Hold
                 # admission through the call so an abort is ordered either
                 # before it (no fill) or after it (caller drains accounting).
                 current_task = asyncio.current_task()
-                cycle_workers: set[asyncio.Task] = getattr(self, "_cycle_worker_tasks", set())
-                if current_task is not None and current_task in cycle_workers:
+                admission_cycle_workers: set[asyncio.Task] = getattr(
+                    self, "_cycle_worker_tasks", set()
+                )
+                if current_task is not None and current_task in admission_cycle_workers:
                     if not hasattr(self, "_order_admitted_tasks"):
                         self._order_admitted_tasks = set()
                     self._order_admitted_tasks.add(current_task)
@@ -1437,9 +1634,74 @@ class AsyncRunner:
                 # Hold the same account-wide lock used by reductions. This
                 # prevents an entry from changing the simulator allocation
                 # between a reduction's initial and final evidence snapshots.
-                async with gateway.serialize_entry():
+                async with gateway.serialize_entry(order.symbol) as broker_quote:
+                    if type(broker_quote) is not BrokerProtectiveQuote:
+                        return self._rejected_order_result(
+                            "Entry blocked: refreshed broker quote unavailable"
+                        )
+                    try:
+                        self._record_authoritative_broker_quote(broker_quote)
+                    except MarketDataContractError:
+                        return self._rejected_order_result(
+                            "Entry blocked: refreshed broker quote was not authoritative"
+                        )
+                    if not self._entry_session_is_canonical(order.symbol, broker_quote):
+                        return self._rejected_order_result(
+                            "Entry blocked: canonical session evidence unavailable"
+                        )
+
+                    exact_order = Order(
+                        symbol=order.symbol,
+                        quantity=order.quantity,
+                        side=side,
+                        price=broker_quote.price,
+                        order_ref=order.order_ref,
+                    )
+                    portfolio = getattr(self, "portfolio", None)
+                    risk = getattr(self, "risk", None)
+                    if portfolio is None or risk is None:
+                        return self._rejected_order_result(
+                            "Entry blocked: risk revalidation unavailable"
+                        )
+                    equity_prices = {
+                        sym: self.latest_prices.get(sym, position.avg_price)
+                        for sym, position in self.positions.items()
+                    }
+                    equity_prices[order.symbol] = float(broker_quote.price)
+                    equity = await portfolio.equity(equity_prices)
+                    valid, validation_message = risk.validate_order(
+                        order.symbol,
+                        order.quantity,
+                        broker_quote.price,
+                        equity,
+                        self.daily_pnl,
+                        self.positions,
+                        self.daily_executed_notional,
+                    )
+                    if valid is not True:
+                        return self._rejected_order_result(
+                            f"Entry blocked after quote refresh: {validation_message}"
+                        )
+                    # ``portfolio.equity`` is awaited above and can consume the
+                    # entire protective quote lifetime. Re-prove the exact
+                    # monitor/broker identity and canonical session at the last
+                    # synchronous boundary before the executor can be touched.
+                    try:
+                        self._record_authoritative_broker_quote(broker_quote)
+                    except MarketDataContractError:
+                        return self._rejected_order_result(
+                            "Entry blocked: protective quote expired during final admission"
+                        )
+                    if not self._has_live_protective_feed(order.symbol):
+                        return self._rejected_order_result(
+                            "Entry blocked: protective quote expired during final admission"
+                        )
+                    if not self._entry_session_is_canonical(order.symbol, broker_quote):
+                        return self._rejected_order_result(
+                            "Entry blocked: canonical session evidence expired during final admission"
+                        )
                     with Timer("order_execution", self.monitor):
-                        result = self.executor.place_order(order)
+                        result = self.executor.place_order(exact_order)
 
             # Record success/failure with circuit breaker
             if result.ok:
@@ -2274,6 +2536,10 @@ class AsyncRunner:
                 position_closed_callback=None,
                 order_timeout_seconds=self.cfg.execution.order_timeout_seconds,
             )
+            self.paper_reduction_gateway.attach_protective_quote_producer(
+                self.portfolio_id,
+                self.stop_loss_monitor,
+            )
             await self.stop_loss_monitor.start_monitoring()
             if self.use_trailing_stop:
                 logger.info(
@@ -2496,6 +2762,12 @@ class AsyncRunner:
 
         # Load existing positions from database to prevent duplicate buying
         await self.load_existing_positions()
+        if self.positions and not await self._refresh_live_protective_quotes(tuple(self.positions)):
+            raise UnprotectedExistingPositionsError(
+                self.portfolio_id,
+                len(self.positions),
+                "initial_live_protective_quote_refresh_failed",
+            )
         self._assert_existing_position_protection()
 
         # Registration and the healthy-runtime audit transition are deferred
@@ -2530,6 +2802,7 @@ class AsyncRunner:
             protective_quote_producer=self.stop_loss_monitor,
             settlement_participant=participant,
         )
+        gateway.start_protective_feed()
         self._setup_complete = True
         logger.info("AsyncRunner setup complete")
 
@@ -3559,6 +3832,19 @@ class AsyncRunner:
             raise ConnectionError("Not connected to IBKR")
 
         # Check if subprocess client or legacy IB client
+        if hasattr(self.ib, "get_canonical_historical_bars"):
+            batch = await self.ib.get_canonical_historical_bars(
+                symbol=symbol,
+                duration=duration,
+                bar_size=bar_size,
+                what_to_show=what_to_show,
+                use_rth=use_rth,
+            )
+            if type(batch) is not CanonicalBarBatch:
+                raise MarketDataContractError(
+                    "IBKR client returned a non-canonical historical batch"
+                )
+            return batch.to_frame()
         if hasattr(self.ib, "get_historical_bars"):
             # Subprocess client - use async method
             bars = await self.ib.get_historical_bars(
@@ -3939,10 +4225,13 @@ class AsyncRunner:
         try:
             start_time = asyncio.get_event_loop().time()
             try:
-                with Timer("data_fetch", self.monitor):
+                with Timer("data_fetch", self.monitor, instance=symbol):
                     # Fetch historical bars using IB connection directly
                     df = await self._fetch_historical_bars(
-                        symbol=symbol, duration=self.duration, bar_size=self.bar_size
+                        symbol=symbol,
+                        duration=self.duration,
+                        bar_size=self.bar_size,
+                        use_rth=not is_extended_hours(),
                     )
             finally:
                 self._release_cycle_broker_request(request_owner)
@@ -3963,25 +4252,30 @@ class AsyncRunner:
             logger.info(f"Fetched {len(df)} bars for {symbol}")
 
             # Prepare batch data for efficient storage
-            batch_data = []
-            for timestamp, row in df.iterrows():
-                # Convert pandas Timestamp to datetime for SQLite compatibility
-                if hasattr(timestamp, "to_pydatetime"):
-                    timestamp = timestamp.to_pydatetime()
-                batch_data.append(
-                    {
-                        "symbol": symbol,
-                        "timestamp": timestamp,
-                        "open": float(row.get("open", 0)),
-                        "high": float(row.get("high", 0)),
-                        "low": float(row.get("low", 0)),
-                        "close": float(row.get("close", 0)),
-                        "volume": int(row.get("volume", 0)),
-                    }
-                )
+            canonical_batch = df.attrs.get("canonical_bar_batch")
+            if type(canonical_batch) is CanonicalBarBatch:
+                batch_data = canonical_batch.storage_rows()
+            else:
+                batch_data = []
+                for timestamp, row in df.iterrows():
+                    # Compatibility-only legacy clients cannot provide full
+                    # canonical lineage and remain blocked from trading.
+                    if hasattr(timestamp, "to_pydatetime"):
+                        timestamp = timestamp.to_pydatetime()
+                    batch_data.append(
+                        {
+                            "symbol": symbol,
+                            "timestamp": timestamp,
+                            "open": float(row.get("open", 0)),
+                            "high": float(row.get("high", 0)),
+                            "low": float(row.get("low", 0)),
+                            "close": float(row.get("close", 0)),
+                            "volume": int(row.get("volume", 0)),
+                        }
+                    )
 
             if batch_data:
-                with Timer("database_write", self.monitor):
+                with Timer("database_write", self.monitor, instance=symbol):
                     await self.db.batch_store_market_data(batch_data)
                 self.monitor.record_data_points(len(batch_data))
             if not hasattr(self, "_trusted_bar_closes"):
@@ -4082,6 +4376,12 @@ class AsyncRunner:
                 message="symbol validation error",
             )
 
+        # A failed or legacy fetch must not inherit a still-fresh execution
+        # token from an earlier cycle.
+        if not hasattr(self, "_canonical_bar_batches"):
+            self._canonical_bar_batches = {}
+        self._canonical_bar_batches.pop(symbol, None)
+
         # Fetch and store market data
         df = await self.fetch_and_store_data(symbol)
         if df is None or df.empty:
@@ -4106,6 +4406,26 @@ class AsyncRunner:
             )
         latest_timestamp = latest_timestamp.astimezone(timezone.utc)
 
+        canonical_batch = df.attrs.get("canonical_bar_batch")
+        if (
+            type(canonical_batch) is not CanonicalBarBatch
+            or canonical_batch.contract.symbol != symbol
+        ):
+            logger.error(
+                "Execution sealed for %s: market data lacks CanonicalBarBatch authority",
+                symbol,
+            )
+            return self._blocked_result(
+                symbol,
+                0,
+                latest_price,
+                "Execution blocked: canonical market-data evidence unavailable",
+                df,
+            )
+        if not hasattr(self, "_canonical_bar_batches"):
+            self._canonical_bar_batches = {}
+        self._canonical_bar_batches[symbol] = (canonical_batch, df)
+
         # Historical bars are validated observations, but they are not a
         # live-grade protective feed. A one-minute bar carries its bar event
         # time and cannot honestly satisfy StopLossMonitor's ten-second quote
@@ -4127,7 +4447,20 @@ class AsyncRunner:
 
         if WEBSOCKET_ENABLED and ws_client:
             try:
-                ws_client.send_market_update(symbol, latest_price)
+                canonical_batch = df.attrs.get("canonical_bar_batch")
+                lineage = {}
+                if type(canonical_batch) is CanonicalBarBatch:
+                    lineage = {
+                        "event_timestamp": latest_timestamp.isoformat(),
+                        "retrieval_timestamp": (
+                            canonical_batch.contract.retrieval_time.isoformat()
+                        ),
+                        "source": canonical_batch.contract.source.value,
+                        "session": canonical_batch.bars[-1].session.value,
+                        "timeframe": canonical_batch.contract.timeframe,
+                        "freshness_status": "fresh",
+                    }
+                ws_client.send_market_update(symbol, latest_price, **lineage)
                 logger.info(f"Sent WebSocket update for {symbol}: ${latest_price:.2f}")
             except Exception as e:
                 logger.error(f"Could not send WebSocket update: {e}")
@@ -4136,30 +4469,31 @@ class AsyncRunner:
         if self.use_advanced_risk and self.advanced_risk and latest_price:
             self.advanced_risk.update_market_prices({symbol: latest_price})
 
-        if not hasattr(self, "_protective_feed_status"):
-            self._protective_feed_status = {}
-        self._protective_feed_status[symbol] = {
-            "available": False,
-            "live_grade": False,
-            "source": "historical_bar",
-            "source_timestamp": latest_timestamp.isoformat(),
-            "reason": "independent_live_protective_feed_pending_pr3",
-        }
-        logger.error(
-            "Protective feed unavailable for %s: historical bars are "
-            "observational only; strategy and order paths blocked",
-            symbol,
-        )
-        return self._blocked_result(
-            symbol,
-            0,
-            latest_price,
-            "Protective feed unavailable: historical bars are observational only",
-            df,
-        )
+        if not await self._refresh_live_protective_quotes((symbol,)):
+            if not hasattr(self, "_protective_feed_status"):
+                self._protective_feed_status = {}
+            self._protective_feed_status[symbol] = {
+                "available": False,
+                "live_grade": False,
+                "source": "historical_bar",
+                "source_timestamp": latest_timestamp.isoformat(),
+                "reason": "independent_live_protective_feed_unavailable",
+            }
+            logger.error(
+                "Protective feed unavailable for %s: historical bars are "
+                "observational only; strategy and order paths blocked",
+                symbol,
+            )
+            return self._blocked_result(
+                symbol,
+                0,
+                latest_price,
+                "Protective feed unavailable: historical bars are observational only",
+                df,
+            )
 
         # Generate trading signal
-        with Timer("signal_generation", self.monitor):
+        with Timer("signal_generation", self.monitor, instance=symbol):
             if self.use_ml_enhanced and self.ml_enhanced_strategy:
                 # Use ML Enhanced strategy for signal generation
                 signal_obj = await self.ml_enhanced_strategy.analyze(symbol, df)
@@ -4526,7 +4860,28 @@ class AsyncRunner:
             )
 
         last = signals.iloc[-1]
-        price = PrecisePricing.to_decimal(last.get("close", df["close"].iloc[-1]))
+        broker_quote = getattr(self, "_broker_protective_quotes", {}).get(symbol)
+        if type(broker_quote) is not BrokerProtectiveQuote:
+            return self._blocked_result(
+                symbol,
+                int(last.get("signal", 0)),
+                latest_price,
+                "Execution blocked: authoritative broker quote unavailable",
+                df,
+            )
+        try:
+            self._record_authoritative_broker_quote(broker_quote)
+        except MarketDataContractError:
+            return self._blocked_result(
+                symbol,
+                int(last.get("signal", 0)),
+                latest_price,
+                "Execution blocked: authoritative broker quote is stale",
+                df,
+            )
+        # Historical closes remain feature inputs only. Exact live broker
+        # evidence prices sizing, validation, orders, fills, and derived stops.
+        price = broker_quote.price
         price_float = float(price)
         self.latest_prices[symbol] = price_float
 
@@ -4829,32 +5184,19 @@ class AsyncRunner:
                             Order(symbol=symbol, quantity=qty, side="BUY", price=price)
                         )
                         if res.ok:
-                            fill_price = (
-                                res.fill_price if res.fill_price is not None else price_float
-                            )
+                            exact_fill_price = self._exact_entry_fill_price(res)
+                            fill_price = float(exact_fill_price)
                             # Use atomic position update to prevent race conditions
                             success = await self._update_position_atomic(
                                 symbol, qty, fill_price, "BUY"
                             )
                             if success:
-                                self.daily_executed_notional += price_float * qty
-
-                                # Record trade in database
-                                await self.db.record_trade(
-                                    symbol,
-                                    "BUY",
-                                    qty,
-                                    fill_price,
-                                    slippage=(
-                                        (fill_price - price_float) * qty
-                                        if res.fill_price is not None
-                                        else 0
-                                    ),
-                                )
-                                # Use accumulated position qty/avg from self.positions, not just this order's qty
-                                pos = self.positions[symbol]
-                                await self.db.update_position(
-                                    symbol, pos.quantity, pos.avg_price, price
+                                await self._record_entry_fill_accounting(
+                                    symbol=symbol,
+                                    side="BUY",
+                                    quantity=qty,
+                                    fill_price=exact_fill_price,
+                                    strategy_reference_price=price_float,
                                 )
 
                                 self.monitor.record_order_placed(symbol, qty)
@@ -5051,7 +5393,8 @@ class AsyncRunner:
                         Order(symbol=symbol, quantity=qty, side="SELL_SHORT", price=price)
                     )
                     if res.ok:
-                        fill_price = res.fill_price if res.fill_price is not None else price_float
+                        exact_fill_price = self._exact_entry_fill_price(res)
+                        fill_price = float(exact_fill_price)
 
                         # R2-M4: do the atomic position update FIRST. If it
                         # fails we must not leave an orphaned stop-loss
@@ -5093,23 +5436,12 @@ class AsyncRunner:
                                 except Exception as e:
                                     logger.error(f"Failed to add stop-loss for short {symbol}: {e}")
 
-                            self.daily_executed_notional += price_float * qty
-
-                            await self.db.record_trade(
-                                symbol,
-                                "SELL_SHORT",
-                                qty,
-                                fill_price,
-                                slippage=(
-                                    (fill_price - price_float) * qty
-                                    if res.fill_price is not None
-                                    else 0
-                                ),
-                            )
-                            # Use accumulated position qty/avg from self.positions
-                            pos = self.positions[symbol]
-                            await self.db.update_position(
-                                symbol, pos.quantity, pos.avg_price, price
+                            await self._record_entry_fill_accounting(
+                                symbol=symbol,
+                                side="SELL_SHORT",
+                                quantity=qty,
+                                fill_price=exact_fill_price,
+                                strategy_reference_price=price_float,
                             )
 
                             self.monitor.record_order_placed(symbol, qty)
@@ -6794,85 +7126,31 @@ class AsyncRunner:
             self._recovery_exhausted = True
 
     async def _rewarm_stop_loss_prices_after_recovery(self) -> bool:
-        """Offer cached live protective events after a successful reconnect.
-
-        Reconnect must not manufacture freshness for historical closes.
-        Provenance is therefore mandatory and only ``live_protective`` events
-        may be offered to the stop monitor. The monitor independently rejects
-        any source event older than its ten-second threshold.
-
-        Flat/no-stop runtimes deliberately succeed without a rewarm. If active
-        stops exist, every stop must accept its live-protective event; partial,
-        stale, missing, or failed updates return False so recovery remains
-        fail-closed. Calls remain independent so one failure does not hide
-        evidence about the other active stops.
-        """
+        """Fetch replacement-generation live quotes for every active stop."""
         stop_monitor = getattr(self, "stop_loss_monitor", None)
         active_stops = getattr(stop_monitor, "active_stops", None) if stop_monitor else None
         if not active_stops:
             logger.debug("event=stop_loss_prices_rewarm_skipped reason=no_active_stops")
             return True
-
-        prices = getattr(self, "latest_prices", None)
-        price_times = getattr(self, "latest_price_times", None)
-        price_sources = getattr(self, "latest_price_sources", None)
-        if not all(isinstance(value, dict) for value in (prices, price_times, price_sources)):
-            logger.error(
-                "event=stop_loss_prices_rewarm_incomplete "
-                "reason=missing_or_invalid_cache active_stop_count=%d",
-                len(active_stops),
+        symbols = tuple(
+            sorted(
+                {
+                    stop.symbol
+                    for stop in active_stops.values()
+                    if isinstance(getattr(stop, "symbol", None), str)
+                }
             )
+        )
+        if len(symbols) != len(active_stops):
+            logger.error("event=stop_loss_prices_rewarm_incomplete reason=invalid_stop_symbols")
             return False
-
-        rewarmed = 0
-        skipped = 0
-        # active_stops is keyed by portfolio_id:symbol but the StopLossOrder
-        # objects carry the bare symbol on .symbol.
-        for stop in list(active_stops.values()):
-            symbol = getattr(stop, "symbol", None)
-            if symbol is None or symbol not in prices or symbol not in price_times:
-                skipped += 1
-                continue
-            if price_sources.get(symbol) != "live_protective":
-                logger.warning(
-                    "event=stop_loss_price_rewarm_skipped symbol=%s "
-                    "reason=non_protective_source source=%r",
-                    symbol,
-                    price_sources.get(symbol),
-                )
-                skipped += 1
-                continue
-            try:
-                if self._monitor_owns_exact_fresh_protective_event(
-                    symbol,
-                    prices[symbol],
-                    price_times[symbol],
-                ):
-                    logger.info(
-                        "event=stop_loss_price_rewarm_exact_live_evidence symbol=%s",
-                        symbol,
-                    )
-                    rewarmed += 1
-                else:
-                    logger.warning(
-                        "event=stop_loss_price_rewarm_skipped symbol=%s "
-                        "reason=no_exact_current_transport_lineage",
-                        symbol,
-                    )
-                    skipped += 1
-            except Exception as e:
-                logger.warning(
-                    "event=stop_loss_price_rewarm_failed symbol=%s error=%r",
-                    symbol,
-                    e,
-                )
-                skipped += 1
+        refreshed = await self._refresh_live_protective_quotes(symbols)
         logger.info(
             "event=stop_loss_prices_rewarmed count=%d skipped=%d",
-            rewarmed,
-            skipped,
+            len(symbols) if refreshed else 0,
+            0 if refreshed else len(symbols),
         )
-        return skipped == 0 and rewarmed == len(active_stops)
+        return refreshed
 
     def _maybe_auto_reset_kill_switch_after_recovery(self) -> None:
         """Auto-reset the AdvancedRiskManager kill switch iff it was

--- a/robo_trader/stop_loss_monitor.py
+++ b/robo_trader/stop_loss_monitor.py
@@ -588,7 +588,7 @@ class StopLossMonitor:
     async def update_price(
         self,
         symbol: str,
-        price: float,
+        price: float | Decimal,
         *,
         source_timestamp: Optional[datetime] = None,
         source: ProtectiveQuoteSource = ProtectiveQuoteSource.LEGACY_CALLBACK,
@@ -612,7 +612,15 @@ class StopLossMonitor:
         """
         try:
             symbol = DatabaseValidator.validate_symbol(symbol)
-            price = DatabaseValidator.validate_price(price)
+            if type(price) is Decimal:
+                if not price.is_finite() or price <= 0:
+                    raise ValidationError("price must be finite and positive")
+                exact_price = price
+                price_float = float(price)
+                DatabaseValidator.validate_price(price_float)
+            else:
+                price_float = DatabaseValidator.validate_price(price)
+                exact_price = Decimal(str(price_float))
         except ValidationError as e:
             logger.error(f"Invalid price update: {e}")
             return False
@@ -663,7 +671,7 @@ class StopLossMonitor:
                     self,
                     portfolio_id=self.portfolio_id,
                     symbol=symbol,
-                    price=Decimal(str(price)),
+                    price=exact_price,
                     source_timestamp=event_time,
                     receipt_monotonic=receipt_monotonic,
                     receipt_order=receipt_order,
@@ -675,7 +683,7 @@ class StopLossMonitor:
             except ProtectiveQuoteValidationError as exc:
                 logger.error("Rejected price update for %s: %s", symbol, exc)
                 return False
-            self.last_prices[symbol] = price
+            self.last_prices[symbol] = price_float
             self.price_event_times[symbol] = event_time
             self.price_receipt_monotonic[symbol] = receipt_monotonic
             self.price_receipt_orders[symbol] = receipt_order
@@ -689,15 +697,15 @@ class StopLossMonitor:
                 and stop_key not in self._pending_stop_triggers
             ):
                 if stop.stop_type in [StopType.TRAILING, StopType.TRAILING_PERCENT]:
-                    self._update_trailing_stop(stop, price)
+                    self._update_trailing_stop(stop, price_float)
 
-                if self._price_crosses_stop(stop, price):
+                if self._price_crosses_stop(stop, price_float):
                     stop.status = StopStatus.TRIGGERED
                     stop.triggered_at = event_time
-                    stop.trigger_price = price
+                    stop.trigger_price = price_float
                     evidence = _PendingStopTrigger(
                         stop=stop,
-                        trigger_price=price,
+                        trigger_price=price_float,
                         event_time=event_time,
                         receipt_monotonic=receipt_monotonic,
                         receipt_order=receipt_order,
@@ -714,7 +722,7 @@ class StopLossMonitor:
                         "Latched stop-loss crossing for %s at %.2f "
                         "(stop=%.2f event=%s receipt_order=%d)",
                         symbol,
-                        price,
+                        price_float,
                         stop.stop_price,
                         event_time.isoformat(),
                         receipt_order,
@@ -742,6 +750,17 @@ class StopLossMonitor:
                 normalized_symbol,
             )
             return None
+
+    async def has_pending_reduction(self) -> bool:
+        """Return whether any monitor-owned stop reduction must run first."""
+
+        async with self._price_update_lock:
+            return bool(
+                self._pending_stop_triggers
+                or self._queued_stop_orders
+                or self._inflight_stop_orders
+                or any(stop.status is StopStatus.TRIGGERED for stop in self.active_stops.values())
+            )
 
     @staticmethod
     def _price_crosses_stop(stop: StopLossOrder, price: float) -> bool:
@@ -1153,6 +1172,16 @@ class StopLossMonitor:
             await self.emergency_shutdown("Stop-loss execution failed")
 
         return False
+
+    async def invalidate_protective_quotes(self) -> None:
+        """Synchronously revoke every quote from a retired broker generation."""
+
+        async with self._price_update_lock:
+            self.last_prices.clear()
+            self.price_event_times.clear()
+            self.price_receipt_monotonic.clear()
+            self.price_receipt_orders.clear()
+            self._protective_quote_evidence.clear()
 
     async def _execute_tracked_stop(self, stop: StopLossOrder) -> bool:
         """Execute one stop while publishing exact in-flight ownership."""

--- a/robo_trader/websocket_client.py
+++ b/robo_trader/websocket_client.py
@@ -138,6 +138,13 @@ class WebSocketClient:
         bid: Optional[float] = None,
         ask: Optional[float] = None,
         volume: Optional[int] = None,
+        *,
+        event_timestamp: Optional[str] = None,
+        retrieval_timestamp: Optional[str] = None,
+        source: Optional[str] = None,
+        session: Optional[str] = None,
+        timeframe: Optional[str] = None,
+        freshness_status: Optional[str] = None,
     ):
         """Queue a market data update with overflow protection."""
         message = {
@@ -153,6 +160,16 @@ class WebSocketClient:
             message["ask"] = ask
         if volume is not None:
             message["volume"] = volume
+        for key, value in (
+            ("event_timestamp", event_timestamp),
+            ("retrieval_timestamp", retrieval_timestamp),
+            ("source", source),
+            ("session", session),
+            ("timeframe", timeframe),
+            ("freshness_status", freshness_status),
+        ):
+            if value is not None:
+                message[key] = value
 
         self._queue_message_safe(message)
 

--- a/robo_trader/websocket_server.py
+++ b/robo_trader/websocket_server.py
@@ -458,6 +458,13 @@ class WebSocketManager:
         bid: Optional[float] = None,
         ask: Optional[float] = None,
         volume: Optional[int] = None,
+        *,
+        event_timestamp: Optional[str] = None,
+        retrieval_timestamp: Optional[str] = None,
+        source: Optional[str] = None,
+        session: Optional[str] = None,
+        timeframe: Optional[str] = None,
+        freshness_status: Optional[str] = None,
     ):
         """Queue a market data update for broadcast."""
         if not self.thread or not self.thread.is_alive():
@@ -477,6 +484,16 @@ class WebSocketManager:
             message["ask"] = ask
         if volume is not None:
             message["volume"] = volume
+        for key, value in (
+            ("event_timestamp", event_timestamp),
+            ("retrieval_timestamp", retrieval_timestamp),
+            ("source", source),
+            ("session", session),
+            ("timeframe", timeframe),
+            ("freshness_status", freshness_status),
+        ):
+            if value is not None:
+                message[key] = value
 
         self.message_queue.put(message)
         logger.debug(

--- a/sync_db_reader.py
+++ b/sync_db_reader.py
@@ -10,12 +10,22 @@ Hardened for concurrent access with the async trader:
 import os
 import sqlite3
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List, Optional, Tuple
 
 from robo_trader.database_validator import ValidationError, validate_portfolio_id
+from robo_trader.market_data_contract import (
+    MarketDataContractError,
+    bar_interval_seconds,
+    market_data_max_age_seconds,
+    validate_canonical_storage_row,
+)
 
 DEFAULT_PORTFOLIO_ID = "default"
+
+
+class MarketDataReadError(RuntimeError):
+    """The dashboard could not prove a trustworthy market-data read."""
 
 
 class SyncDatabaseReader:
@@ -214,9 +224,105 @@ class SyncDatabaseReader:
                 "unrealized_pnl": 0,
             }
 
-    def get_latest_market_data(self, symbol: str, limit: int = 100) -> List[Dict]:
-        """Get latest market data for a symbol"""
+    def get_latest_market_data(
+        self,
+        symbol: str,
+        limit: int = 100,
+        timeframe: Optional[str] = None,
+    ) -> List[Dict]:
+        """Get one deterministic canonical series or raise a typed read error."""
+
+        if type(limit) is not int or not 1 <= limit <= 10_000:
+            raise ValueError("market data limit must be an integer between 1 and 10000")
+        if timeframe is not None:
+            bar_interval_seconds(timeframe)
+        columns = """
+            timestamp, open, high, low, close, volume,
+            schema_version, con_id, exchange, primary_exchange,
+            timeframe, interval_seconds, timezone_name, session_policy,
+            session, source, retrieval_timestamp, broker_timestamp,
+            adjustment_state, quality_flags, transport_generation,
+            timestamp_semantics, use_rth, what_to_show
+        """
         try:
+            try:
+                selector_sql = f"""
+                    SELECT {columns}
+                    FROM canonical_market_data
+                    WHERE symbol = ? {"AND timeframe = ?" if timeframe is not None else ""}
+                    ORDER BY timestamp DESC, interval_seconds ASC,
+                             retrieval_timestamp DESC, con_id DESC
+                    LIMIT 1
+                """
+                selector_params = (symbol, timeframe) if timeframe is not None else (symbol,)
+                selected_rows = self._fetch_all(selector_sql, selector_params)
+                selected = selected_rows[0] if selected_rows else None
+                rows = []
+                if selected is not None:
+                    rows = self._fetch_all(
+                        f"""
+                        SELECT {columns}
+                        FROM canonical_market_data
+                        WHERE symbol = ? AND con_id = ? AND timeframe = ?
+                          AND session_policy = ? AND source = ?
+                          AND adjustment_state = ? AND timestamp_semantics = ?
+                          AND use_rth = ? AND what_to_show = ?
+                        ORDER BY timestamp DESC, retrieval_timestamp DESC
+                        LIMIT ?
+                        """,
+                        (
+                            symbol,
+                            selected["con_id"],
+                            selected["timeframe"],
+                            selected["session_policy"],
+                            selected["source"],
+                            selected["adjustment_state"],
+                            selected["timestamp_semantics"],
+                            selected["use_rth"],
+                            selected["what_to_show"],
+                            limit,
+                        ),
+                    )
+            except sqlite3.OperationalError as error:
+                if "no such table" not in str(error).lower():
+                    raise
+                rows = []
+            if rows:
+                now = datetime.now(timezone.utc)
+                output = []
+                for row in rows:
+                    stored_item = dict(row)
+                    stored_item["symbol"] = symbol
+                    stored_item["use_rth"] = bool(stored_item["use_rth"])
+                    item = validate_canonical_storage_row(stored_item)
+                    event_time = datetime.fromisoformat(
+                        str(item["timestamp"]).replace("Z", "+00:00")
+                    )
+                    if event_time.tzinfo is None or event_time.utcoffset() is None:
+                        raise MarketDataContractError(
+                            "stored canonical timestamp is timezone-naive"
+                        )
+                    event_time = event_time.astimezone(timezone.utc)
+                    age_seconds = (now - event_time).total_seconds()
+                    freshness_limit = market_data_max_age_seconds(item["interval_seconds"])
+                    freshness_status = (
+                        "future"
+                        if age_seconds < 0
+                        else ("fresh" if age_seconds <= freshness_limit else "stale")
+                    )
+                    item["quality_flags"] = tuple(
+                        flag for flag in str(item.get("quality_flags") or "").split(",") if flag
+                    )
+                    item["use_rth"] = bool(item["use_rth"])
+                    item["age_seconds"] = age_seconds
+                    item["freshness_limit_seconds"] = freshness_limit
+                    item["freshness_status"] = freshness_status
+                    output.append(item)
+                return output
+
+            if timeframe is not None:
+                return []
+
             rows = self._fetch_all(
                 """
                 SELECT timestamp, open, high, low, close, volume
@@ -227,10 +333,18 @@ class SyncDatabaseReader:
                 """,
                 (symbol, limit),
             )
-            return [dict(row) for row in rows]
-        except Exception as e:
-            print(f"Error getting market data: {e}")
-            return []
+            return [
+                {
+                    **dict(row),
+                    "source": "legacy-unknown",
+                    "freshness_status": "unknown",
+                    "age_seconds": None,
+                    "freshness_limit_seconds": None,
+                }
+                for row in rows
+            ]
+        except (MarketDataContractError, sqlite3.Error, TypeError, ValueError) as exc:
+            raise MarketDataReadError("market data read is unavailable") from exc
 
     def get_signals(self, hours: int = 1, portfolio_id: str = DEFAULT_PORTFOLIO_ID) -> List[Dict]:
         """Get recent signals for a portfolio."""

--- a/tests/test_pr1a_existing_position_protection.py
+++ b/tests/test_pr1a_existing_position_protection.py
@@ -24,6 +24,10 @@ from robo_trader.paper_reduction_submitter import (
     LocalPaperTerminalOutcome,
 )
 from robo_trader.portfolio import Portfolio
+from robo_trader.protective_quote_evidence import (
+    ProtectiveQuoteSource,
+    _produce_protective_quote,
+)
 from robo_trader.risk_manager import Position
 from robo_trader.runner_async import (
     AsyncRunner,
@@ -113,34 +117,41 @@ def _protected_runner(
     if status is StopStatus.TRIGGERED:
         stop.trigger_price = 97.0
         stop.triggered_at = now + timedelta(seconds=event_offset_seconds)
-    monitor = SimpleNamespace(
+    monitor = StopLossMonitor(
+        execute_reduction=_unused_reduction,
+        risk_manager=None,
         portfolio_id="default",
-        monitoring_active=True,
-        monitor_task=_AliveTask(),
-        active_stops={"default:AAPL": stop},
-        last_prices={"AAPL": 101.0},
-        price_event_times={"AAPL": now + timedelta(seconds=event_offset_seconds)},
-        price_receipt_monotonic={"AAPL": monotonic_now + receipt_offset_seconds},
-        price_receipt_orders={"AAPL": 1},
-        _price_receipt_order=1,
-        _pending_stop_triggers={},
-        _latched_stop_crossings={},
-        _queued_stop_orders={},
-        _inflight_stop_orders={},
-        pending_drain_timeout_seconds=30.0,
-        queue_timeout_seconds=30.0,
-        broker_attempt_timeout_seconds=30.0,
-        settlement_timeout_seconds=30.0,
-        max_price_age_seconds=10,
-        _utcnow=lambda: now,
-        _monotonic=lambda: monotonic_now,
-        _stop_key=lambda symbol: f"default:{symbol}",
-        _price_crosses_stop=lambda tracked_stop, price: (
-            price <= tracked_stop.stop_price
-            if tracked_stop.position_qty > 0
-            else price >= tracked_stop.stop_price
-        ),
     )
+    monitor.monitoring_active = True
+    monitor.monitor_task = _AliveTask()
+    monitor.pending_drain_timeout_seconds = 30.0
+    monitor.queue_timeout_seconds = 30.0
+    monitor.broker_attempt_timeout_seconds = 30.0
+    monitor.settlement_timeout_seconds = 30.0
+    monitor.active_stops = {"default:AAPL": stop}
+    monitor.last_prices = {"AAPL": 101.0}
+    event_time = now + timedelta(seconds=event_offset_seconds)
+    receipt_time = monotonic_now + receipt_offset_seconds
+    monitor.price_event_times = {"AAPL": event_time}
+    monitor.price_receipt_monotonic = {"AAPL": receipt_time}
+    monitor.price_receipt_orders = {"AAPL": 1}
+    monitor._price_receipt_order = 1
+    monitor._utcnow = lambda: now
+    monitor._monotonic = lambda: monotonic_now
+    if available and live_grade and source == "live_protective":
+        monitor._protective_quote_evidence["AAPL"] = _produce_protective_quote(
+            monitor,
+            portfolio_id="default",
+            symbol="AAPL",
+            price=Decimal("101.0"),
+            source_timestamp=event_time,
+            receipt_monotonic=float(receipt_time),
+            receipt_order=1,
+            source=ProtectiveQuoteSource.LIVE_BROKER,
+            con_id=265598,
+            transport_generation="test-generation-1",
+            source_event_id="protected-runner-event",
+        )
     runner = object.__new__(AsyncRunner)
     runner.portfolio_id = "default"
     runner.positions = {"AAPL": Position("AAPL", quantity, 100.0)}
@@ -150,6 +161,8 @@ def _protected_runner(
             "available": available,
             "live_grade": live_grade,
             "source": source,
+            "con_id": 265598,
+            "transport_generation": "test-generation-1",
         }
     }
     return runner
@@ -607,6 +620,20 @@ def test_profit_protecting_fixed_stop_is_valid_relative_to_current_quote(
     stop.entry_price = entry_price
     stop.stop_price = stop_price
     runner.stop_loss_monitor.last_prices["AAPL"] = current_price
+    previous_quote = runner.stop_loss_monitor.get_protective_quote_evidence("AAPL")
+    runner.stop_loss_monitor._protective_quote_evidence["AAPL"] = _produce_protective_quote(
+        runner.stop_loss_monitor,
+        portfolio_id="default",
+        symbol="AAPL",
+        price=Decimal(str(current_price)),
+        source_timestamp=previous_quote.source_timestamp,
+        receipt_monotonic=previous_quote.receipt_monotonic,
+        receipt_order=previous_quote.receipt_order,
+        source=ProtectiveQuoteSource.LIVE_BROKER,
+        con_id=previous_quote.con_id,
+        transport_generation=previous_quote.transport_generation,
+        source_event_id="profit-protecting-event",
+    )
 
     _assert_protection(runner)
 
@@ -840,6 +867,10 @@ async def test_persistent_fast_path_preserves_exact_broker_inflight_execution() 
         "AAPL",
         97.0,
         source_timestamp=now,
+        source=ProtectiveQuoteSource.LIVE_BROKER,
+        con_id=265598,
+        transport_generation="test-generation-1",
+        source_event_id="inflight-stop-event",
     )
 
     runner = object.__new__(AsyncRunner)
@@ -851,6 +882,8 @@ async def test_persistent_fast_path_preserves_exact_broker_inflight_execution() 
             "available": True,
             "live_grade": True,
             "source": "live_protective",
+            "con_id": 265598,
+            "transport_generation": "test-generation-1",
         }
     }
     runner._setup_complete = True
@@ -899,7 +932,15 @@ async def test_pending_replacement_can_coexist_with_unresolved_old_broker_stop()
     monitor._monotonic = lambda: 1000.0
     position = Position("AAPL", 10, 100.0)
     old_stop = await monitor.add_stop_loss("AAPL", position, stop_percent=0.02)
-    assert await monitor.update_price("AAPL", 97.0, source_timestamp=now)
+    assert await monitor.update_price(
+        "AAPL",
+        97.0,
+        source_timestamp=now,
+        source=ProtectiveQuoteSource.LIVE_BROKER,
+        con_id=265598,
+        transport_generation="test-generation-1",
+        source_event_id="old-stop-event",
+    )
 
     runner = object.__new__(AsyncRunner)
     runner.portfolio_id = "default"
@@ -910,6 +951,8 @@ async def test_pending_replacement_can_coexist_with_unresolved_old_broker_stop()
             "available": True,
             "live_grade": True,
             "source": "live_protective",
+            "con_id": 265598,
+            "transport_generation": "test-generation-1",
         }
     }
     runner._setup_complete = True
@@ -922,7 +965,15 @@ async def test_pending_replacement_can_coexist_with_unresolved_old_broker_stop()
     assert replacement.status is StopStatus.PENDING
     assert monitor.active_stops["default:AAPL"] is replacement
     assert monitor._inflight_stop_orders["default:AAPL"].stop is old_stop
-    assert await monitor.update_price("AAPL", 101.0, source_timestamp=now)
+    assert await monitor.update_price(
+        "AAPL",
+        101.0,
+        source_timestamp=now,
+        source=ProtectiveQuoteSource.LIVE_BROKER,
+        con_id=265598,
+        transport_generation="test-generation-1",
+        source_event_id="replacement-stop-event",
+    )
 
     await runner.setup()
 
@@ -997,6 +1048,8 @@ async def test_persistent_fast_path_accepts_exact_terminal_cleanup_in_progress()
             "available": True,
             "live_grade": True,
             "source": "live_protective",
+            "con_id": 265598,
+            "transport_generation": "test-generation-1",
         }
     }
     stop = await monitor.add_stop_loss(
@@ -1008,6 +1061,10 @@ async def test_persistent_fast_path_accepts_exact_terminal_cleanup_in_progress()
         "AAPL",
         97.0,
         source_timestamp=now,
+        source=ProtectiveQuoteSource.LIVE_BROKER,
+        con_id=265598,
+        transport_generation="test-generation-1",
+        source_event_id="settlement-stop-event",
     )
 
     await monitor.start_monitoring()
@@ -1093,6 +1150,10 @@ async def test_persistent_fast_path_accepts_complete_two_stop_execution_batch() 
             symbol,
             0.97 * float(position.avg_price),
             source_timestamp=now,
+            source=ProtectiveQuoteSource.LIVE_BROKER,
+            con_id=265598 if symbol == "AAPL" else 272093,
+            transport_generation="test-generation-1",
+            source_event_id=f"parallel-stop-{symbol}",
         )
 
     runner = object.__new__(AsyncRunner)
@@ -1104,6 +1165,8 @@ async def test_persistent_fast_path_accepts_complete_two_stop_execution_batch() 
             "available": True,
             "live_grade": True,
             "source": "live_protective",
+            "con_id": 265598 if symbol == "AAPL" else 272093,
+            "transport_generation": "test-generation-1",
         }
         for symbol in positions
     }

--- a/tests/test_pr1a_runner_event_time.py
+++ b/tests/test_pr1a_runner_event_time.py
@@ -6,9 +6,11 @@ import asyncio
 import inspect
 from collections import OrderedDict
 from contextlib import asynccontextmanager
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pandas as pd
 import pytest
@@ -16,7 +18,18 @@ import pytest
 import robo_trader.runner_async as runner_module
 from robo_trader.clients.subprocess_ibkr_client import IBKRTimeoutError
 from robo_trader.connection_health import HealthStatus
-from robo_trader.execution import Order
+from robo_trader.execution import ExecutionResult, Order
+from robo_trader.market_data_contract import (
+    AdjustmentState,
+    BarTimestampSemantics,
+    BrokerProtectiveQuote,
+    CanonicalBar,
+    CanonicalBarBatch,
+    HistoricalBarContract,
+    MarketDataSource,
+    MarketSession,
+    MarketSessionPolicy,
+)
 from robo_trader.monitoring.performance import PerformanceMonitor
 from robo_trader.paper_reduction_gateway import PaperReductionGateway
 from robo_trader.protective_quote_evidence import (
@@ -328,7 +341,7 @@ async def test_bad_event_time_has_no_downstream_side_effects() -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("bar_age_seconds", [5, 11, 30, 59])
 @pytest.mark.parametrize("monitor_enabled", [True, False])
-async def test_historical_bar_is_observational_and_always_blocks_trading(
+async def test_unsealed_historical_frame_never_reaches_trading_state(
     bar_age_seconds: int,
     monitor_enabled: bool,
 ) -> None:
@@ -356,14 +369,11 @@ async def test_historical_bar_is_observational_and_always_blocks_trading(
     result = await runner.process_symbol("AAPL")
 
     assert result.executed is False
-    assert result.message.startswith("Protective feed unavailable")
-    assert runner._protective_feed_status["AAPL"]["available"] is False
-    assert runner._protective_feed_status["AAPL"]["source"] == "historical_bar"
-    assert runner._protective_feed_status["AAPL"]["live_grade"] is False
-    assert runner.market_data_cache["AAPL"] is frame
-    assert runner.latest_prices == {"AAPL": 101.0}
-    assert runner.latest_price_sources == {"AAPL": "historical_bar"}
-    runner.advanced_risk.update_market_prices.assert_called_once_with({"AAPL": 101.0})
+    assert result.message == "Execution blocked: canonical market-data evidence unavailable"
+    assert runner.market_data_cache == {}
+    assert runner.latest_prices == {}
+    assert runner.latest_price_times == {}
+    runner.advanced_risk.update_market_prices.assert_not_called()
     if runner.stop_loss_monitor:
         runner.stop_loss_monitor.update_price.assert_not_awaited()
     runner.ml_enhanced_strategy.analyze.assert_not_awaited()
@@ -483,10 +493,8 @@ async def test_process_symbol_normalizes_aware_latest_timestamp_to_utc() -> None
     result = await runner.process_symbol("AAPL")
 
     assert result.executed is False
-    assert runner.latest_price_times["AAPL"] == datetime(2026, 7, 23, 15, 0, tzinfo=timezone.utc)
-    assert runner._protective_feed_status["AAPL"]["source_timestamp"] == (
-        "2026-07-23T15:00:00+00:00"
-    )
+    assert result.message == "Execution blocked: canonical market-data evidence unavailable"
+    assert runner.latest_price_times == {}
     runner.stop_loss_monitor.update_price.assert_not_awaited()
 
 
@@ -577,8 +585,10 @@ async def _configure_order_runtime(runner: AsyncRunner, executor_result=None) ->
             "available": True,
             "live_grade": True,
             "source": "live_protective",
+            "con_id": 265_000 + index,
+            "transport_generation": "test-generation-1",
         }
-        for symbol in ("AAPL", "MSFT", "TSLA", "NVDA")
+        for index, symbol in enumerate(("AAPL", "MSFT", "TSLA", "NVDA"), start=1)
     }
     runner._test_protective_clock = protective_clock
     runner.stop_loss_monitor = StopLossMonitor(
@@ -599,6 +609,68 @@ async def _configure_order_runtime(runner: AsyncRunner, executor_result=None) ->
             source_event_id=f"event-{index}",
         )
     runner.risk = MagicMock(emergency_shutdown_triggered=False)
+    runner.risk.validate_order.return_value = (True, "ok")
+    runner.portfolio = MagicMock()
+    runner.portfolio.equity = AsyncMock(return_value=Decimal("100000"))
+    runner.positions = {}
+    runner.latest_prices = {"AAPL": 100.0}
+    runner.latest_price_times = {"AAPL": accepted_at}
+    runner.latest_price_sources = {"AAPL": "live_protective"}
+    runner.daily_pnl = 0.0
+    runner.daily_executed_notional = 0.0
+    contract = HistoricalBarContract(
+        schema_version=1,
+        symbol="AAPL",
+        con_id=265001,
+        exchange="SMART",
+        primary_exchange="NASDAQ",
+        timezone_name="UTC",
+        timeframe="1 min",
+        session_policy=MarketSessionPolicy.REGULAR_ONLY,
+        source=MarketDataSource.IBKR_HISTORICAL_TRADES,
+        retrieval_time=accepted_at,
+        broker_time=accepted_at,
+        adjustment_state=AdjustmentState.RAW,
+        transport_generation="test-generation-1",
+        timestamp_semantics=BarTimestampSemantics.BAR_START,
+        use_rth=True,
+        what_to_show="TRADES",
+    )
+    batch = CanonicalBarBatch(
+        contract=contract,
+        bars=(
+            CanonicalBar(
+                contract=contract,
+                timestamp=accepted_at - timedelta(seconds=30),
+                open=Decimal("99"),
+                high=Decimal("101"),
+                low=Decimal("98"),
+                close=Decimal("100"),
+                volume=100,
+                session=MarketSession.REGULAR,
+            ),
+        ),
+    )
+    frame = batch.to_frame()
+    runner._canonical_bar_batches = {"AAPL": (batch, frame)}
+    broker_quote = BrokerProtectiveQuote(
+        schema_version=1,
+        symbol="AAPL",
+        con_id=265001,
+        exchange="SMART",
+        primary_exchange="NASDAQ",
+        currency="USD",
+        security_type="STK",
+        price=Decimal("100.0"),
+        source_timestamp=accepted_at,
+        retrieval_timestamp=accepted_at,
+        session=MarketSession.REGULAR,
+        source=MarketDataSource.IBKR_LIVE_LAST_TRADE,
+        source_event_id="event-1",
+        transport_generation="test-generation-1",
+        market_data_type=1,
+    )
+    runner._broker_protective_quotes = {"AAPL": broker_quote}
     runner.advanced_risk = None
     runner.circuit_breaker = MagicMock()
     runner.circuit_breaker.can_proceed = AsyncMock(return_value=True)
@@ -617,8 +689,8 @@ async def _configure_order_runtime(runner: AsyncRunner, executor_result=None) ->
     gateway._started = True
 
     @asynccontextmanager
-    async def serialize_entry():
-        yield
+    async def serialize_entry(symbol=None):
+        yield broker_quote if symbol == "AAPL" else None
 
     gateway.serialize_entry = serialize_entry
     gateway.submit_reduction = AsyncMock(
@@ -639,7 +711,7 @@ async def _configure_order_runtime(runner: AsyncRunner, executor_result=None) ->
         {"available": True, "live_grade": True, "source": "historical_bar"},
     ],
 )
-async def test_central_order_admission_requires_exact_live_protection(
+async def test_dashboard_status_cannot_revoke_exact_live_protection(
     side: str,
     status: dict | None,
 ) -> None:
@@ -651,9 +723,11 @@ async def test_central_order_admission_requires_exact_live_protection(
         Order(symbol="AAPL", quantity=1, side=side, price=100.0)
     )
 
-    assert result.ok is False
-    assert "live protective feed unavailable" in result.message.lower()
-    runner.executor.place_order.assert_not_called()
+    assert result.ok is True
+    if side in {"BUY", "SELL_SHORT"}:
+        runner.executor.place_order.assert_called_once()
+    else:
+        runner.paper_reduction_gateway.submit_reduction.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -709,8 +783,83 @@ async def test_order_admission_rechecks_monitor_owned_protective_freshness(
 
     assert runner._has_live_protective_feed("AAPL") is False
     assert result.ok is False
-    assert "live protective feed unavailable" in result.message.lower()
+    assert any(
+        phrase in result.message.lower()
+        for phrase in ("live protective feed unavailable", "not authoritative")
+    )
     runner.executor.place_order.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_entry_quote_aging_during_equity_await_never_touches_executor() -> None:
+    runner = AsyncRunner.__new__(AsyncRunner)
+    await _configure_order_runtime(runner)
+
+    async def age_quote_during_equity(_prices):
+        runner._test_protective_clock["monotonic"] += 11
+        return Decimal("100000")
+
+    runner.portfolio.equity = AsyncMock(side_effect=age_quote_during_equity)
+
+    result = await runner._place_order_with_circuit_breaker(
+        Order(symbol="AAPL", quantity=1, side="BUY", price=100.0)
+    )
+
+    assert result.ok is False
+    assert result.message == "Entry blocked: protective quote expired during final admission"
+    runner.executor.place_order.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_entry_fill_accounting_uses_exact_fills_for_cumulative_risk_and_marks() -> None:
+    runner = AsyncRunner.__new__(AsyncRunner)
+    runner.daily_executed_notional = 0.0
+    runner.positions = {
+        "AAPL": SimpleNamespace(quantity=2, avg_price=Decimal("400")),
+        "MSFT": SimpleNamespace(quantity=-3, avg_price=Decimal("350")),
+    }
+    runner.db = SimpleNamespace(
+        record_trade=AsyncMock(),
+        update_position=AsyncMock(),
+    )
+    buy_fill = runner._exact_entry_fill_price(
+        ExecutionResult(
+            True,
+            "filled",
+            100.0,
+            exact_fill_price=Decimal("400"),
+        )
+    )
+    short_fill = runner._exact_entry_fill_price(
+        ExecutionResult(
+            True,
+            "filled",
+            100.0,
+            exact_fill_price=Decimal("350"),
+        )
+    )
+
+    await runner._record_entry_fill_accounting(
+        symbol="AAPL",
+        side="BUY",
+        quantity=2,
+        fill_price=buy_fill,
+        strategy_reference_price=100.0,
+    )
+    await runner._record_entry_fill_accounting(
+        symbol="MSFT",
+        side="SELL_SHORT",
+        quantity=3,
+        fill_price=short_fill,
+        strategy_reference_price=100.0,
+    )
+
+    assert runner.daily_executed_notional == 1850.0
+    assert runner.daily_executed_notional > 500.0
+    assert runner.db.update_position.await_args_list == [
+        call("AAPL", 2, Decimal("400"), Decimal("400")),
+        call("MSFT", -3, Decimal("350"), Decimal("350")),
+    ]
 
 
 def test_pairs_historical_cache_cannot_mutate_strategy_state() -> None:
@@ -1500,6 +1649,76 @@ async def test_extended_hours_blocks_entry_sides_but_not_exit() -> None:
         )
         is quote
     )
+    runner.executor.place_order.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_extended_hours_entry_requires_and_accepts_matching_exact_session() -> None:
+    runner = AsyncRunner.__new__(AsyncRunner)
+    await _configure_order_runtime(runner)
+    regular_batch, _ = runner._canonical_bar_batches["AAPL"]
+    extended_contract = replace(
+        regular_batch.contract,
+        session_policy=MarketSessionPolicy.EXTENDED,
+        use_rth=False,
+    )
+    extended_bar = replace(
+        regular_batch.bars[-1],
+        contract=extended_contract,
+        session=MarketSession.PRE_MARKET,
+    )
+    extended_batch = CanonicalBarBatch(extended_contract, (extended_bar,))
+    extended_frame = extended_batch.to_frame()
+    runner._canonical_bar_batches["AAPL"] = (extended_batch, extended_frame)
+    quote = replace(
+        runner._broker_protective_quotes["AAPL"],
+        session=MarketSession.PRE_MARKET,
+    )
+
+    @asynccontextmanager
+    async def serialize_entry(symbol=None):
+        yield quote if symbol == "AAPL" else None
+
+    runner.paper_reduction_gateway.serialize_entry = serialize_entry
+    with (
+        patch("robo_trader.runner_async.is_extended_hours", return_value=True),
+        patch("robo_trader.runner_async.get_market_session", return_value="pre-market"),
+    ):
+        result = await runner._place_order_with_circuit_breaker(
+            Order(symbol="AAPL", quantity=1, side="BUY", price=Decimal("1"))
+        )
+
+    assert result.ok is True
+    submitted = runner.executor.place_order.call_args.args[0]
+    assert submitted.price == Decimal("100.0")
+
+
+@pytest.mark.asyncio
+async def test_final_entry_admission_rejects_stale_canonical_bar_batch() -> None:
+    runner = AsyncRunner.__new__(AsyncRunner)
+    await _configure_order_runtime(runner)
+    current_batch, _ = runner._canonical_bar_batches["AAPL"]
+    stale_time = datetime.now(timezone.utc) - timedelta(hours=1)
+    stale_contract = replace(
+        current_batch.contract,
+        retrieval_time=stale_time,
+        broker_time=stale_time,
+    )
+    stale_bar = replace(
+        current_batch.bars[-1],
+        contract=stale_contract,
+        timestamp=stale_time - timedelta(minutes=1),
+    )
+    stale_batch = CanonicalBarBatch(stale_contract, (stale_bar,))
+    stale_frame = stale_batch.to_frame()
+    runner._canonical_bar_batches["AAPL"] = (stale_batch, stale_frame)
+
+    result = await runner._place_order_with_circuit_breaker(
+        Order(symbol="AAPL", quantity=1, side="BUY", price=Decimal("100"))
+    )
+
+    assert result.ok is False
+    assert "canonical session evidence unavailable" in result.message.lower()
     runner.executor.place_order.assert_not_called()
 
 

--- a/tests/test_pr1a_stop_event_time.py
+++ b/tests/test_pr1a_stop_event_time.py
@@ -481,7 +481,7 @@ async def test_fresh_historical_close_is_never_rewarmed_as_live_protection(caplo
     await runner._rewarm_stop_loss_prices_after_recovery()
 
     assert monitor.last_prices == {}
-    assert "reason=non_protective_source source='historical_bar'" in caplog.text
+    assert "event=stop_loss_prices_rewarmed count=0 skipped=1" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_pr2b1_runtime_startup.py
+++ b/tests/test_pr2b1_runtime_startup.py
@@ -275,6 +275,7 @@ async def test_one_shot_run_activates_recovery_pending_gateway_before_cycle() ->
     gateway._started = False
     gateway._diagnostic_recovery_required = True
     gateway.register_paper_executor = MagicMock()
+    gateway.start_protective_feed = MagicMock()
     runner.paper_reduction_gateway = gateway
 
     activate = runner._activate_after_setup
@@ -298,6 +299,7 @@ async def test_one_shot_run_activates_recovery_pending_gateway_before_cycle() ->
         protective_quote_producer=runner.stop_loss_monitor,
         settlement_participant=runner._paper_settlement_participant,
     )
+    gateway.start_protective_feed.assert_called_once_with()
     runner.cleanup.assert_awaited_once_with()
     assert runner._setup_complete is False
 

--- a/tests/test_pr2b2_paper_reduction_gateway.py
+++ b/tests/test_pr2b2_paper_reduction_gateway.py
@@ -641,6 +641,7 @@ async def _bind_runtime(
     generation: str = "gateway-generation",
 ) -> None:
     monitor, participant = _runtime_components(harness, portfolio_id)
+    harness.gateway.attach_protective_quote_producer(portfolio_id, monitor)
     harness.gateway.register_paper_executor(
         portfolio_id,
         executor,
@@ -719,6 +720,7 @@ def test_gateway_requires_exact_runtime_coordinator_database_and_executor_bindin
 
     executor = PaperExecutor()
     monitor_a, participant_a = _runtime_components(harness, "portfolio-a")
+    harness.gateway.attach_protective_quote_producer("portfolio-a", monitor_a)
     harness.gateway.register_paper_executor(
         "portfolio-a",
         executor,

--- a/tests/test_pr2b2_runner_routing.py
+++ b/tests/test_pr2b2_runner_routing.py
@@ -15,6 +15,17 @@ import pytest
 
 from robo_trader.database_async import AsyncTradingDatabase
 from robo_trader.execution import ExecutionResult, Order, PaperExecutor
+from robo_trader.market_data_contract import (
+    AdjustmentState,
+    BarTimestampSemantics,
+    BrokerProtectiveQuote,
+    CanonicalBar,
+    CanonicalBarBatch,
+    HistoricalBarContract,
+    MarketDataSource,
+    MarketSession,
+    MarketSessionPolicy,
+)
 from robo_trader.paper_reduction_gateway import (
     PaperReductionGateway,
     PaperReductionGatewayError,
@@ -28,16 +39,17 @@ from robo_trader.stop_loss_monitor import StopLossMonitor
 
 
 class _EntrySerializationProbe(AbstractAsyncContextManager):
-    def __init__(self) -> None:
+    def __init__(self, quote: BrokerProtectiveQuote) -> None:
         self.active = False
         self.enter_count = 0
         self.exit_count = 0
+        self.quote = quote
 
     async def __aenter__(self):
         assert self.active is False
         self.active = True
         self.enter_count += 1
-        return self
+        return self.quote
 
     async def __aexit__(self, exc_type, exc_value, traceback) -> None:
         assert self.active is True
@@ -59,7 +71,26 @@ def _exact_gateway(
     gateway.submit_reduction = AsyncMock(
         return_value=reduction_result or ExecutionResult(True, "gateway reduction filled", 100.0)
     )
-    probe = _EntrySerializationProbe()
+    now = datetime.now(timezone.utc)
+    probe = _EntrySerializationProbe(
+        BrokerProtectiveQuote(
+            schema_version=1,
+            symbol="AAPL",
+            con_id=265598,
+            exchange="SMART",
+            primary_exchange="NASDAQ",
+            currency="USD",
+            security_type="STK",
+            price=Decimal("100.0"),
+            source_timestamp=now,
+            retrieval_timestamp=now,
+            session=MarketSession.REGULAR,
+            source=MarketDataSource.IBKR_LIVE_LAST_TRADE,
+            source_event_id="routing-event-1",
+            transport_generation="routing-generation",
+            market_data_type=1,
+        )
+    )
     gateway.serialize_entry = MagicMock(return_value=probe)
     return gateway, probe
 
@@ -83,7 +114,12 @@ def _runner(
     runner._kill_switch_log_last = {}
     runner._kill_switch_log_throttle_seconds = 60.0
 
-    now = datetime.now(timezone.utc)
+    probe = getattr(getattr(gateway, "serialize_entry", None), "return_value", None)
+    now = (
+        probe.quote.source_timestamp
+        if isinstance(probe, _EntrySerializationProbe)
+        else datetime.now(timezone.utc)
+    )
     monotonic_now = 1000.0
     runner._protective_feed_status = (
         {
@@ -91,6 +127,8 @@ def _runner(
                 "available": True,
                 "live_grade": True,
                 "source": "live_protective",
+                "con_id": 265598,
+                "transport_generation": "routing-generation",
             }
         }
         if live_feed
@@ -133,8 +171,55 @@ def _runner(
         runner._test_protective_quote = None
     runner.stop_loss_monitor = monitor
 
+    contract = HistoricalBarContract(
+        schema_version=1,
+        symbol="AAPL",
+        con_id=265598,
+        exchange="SMART",
+        primary_exchange="NASDAQ",
+        timezone_name="UTC",
+        timeframe="1 min",
+        session_policy=MarketSessionPolicy.REGULAR_ONLY,
+        source=MarketDataSource.IBKR_HISTORICAL_TRADES,
+        retrieval_time=now,
+        broker_time=now,
+        adjustment_state=AdjustmentState.RAW,
+        transport_generation="routing-generation",
+        timestamp_semantics=BarTimestampSemantics.BAR_START,
+        use_rth=True,
+        what_to_show="TRADES",
+    )
+    batch = CanonicalBarBatch(
+        contract,
+        (
+            CanonicalBar(
+                contract=contract,
+                timestamp=now,
+                open=Decimal("99"),
+                high=Decimal("101"),
+                low=Decimal("98"),
+                close=Decimal("100"),
+                volume=100,
+                session=MarketSession.REGULAR,
+            ),
+        ),
+    )
+    frame = batch.to_frame()
+    runner._canonical_bar_batches = {"AAPL": (batch, frame)}
+    runner._broker_protective_quotes = (
+        {"AAPL": probe.quote} if isinstance(probe, _EntrySerializationProbe) and live_feed else {}
+    )
+    runner.latest_prices = {"AAPL": 100.0}
+    runner.latest_price_times = {"AAPL": now}
+    runner.latest_price_sources = {"AAPL": "live_protective"}
+    runner.positions = {}
+    runner.portfolio = SimpleNamespace(equity=AsyncMock(return_value=Decimal("100000")))
+    runner.daily_pnl = 0.0
+    runner.daily_executed_notional = 0.0
+
     runner.risk = SimpleNamespace(
         emergency_shutdown_triggered=emergency_block,
+        validate_order=MagicMock(return_value=(True, "ok")),
     )
     runner.advanced_risk = SimpleNamespace(
         kill_switch=SimpleNamespace(
@@ -403,7 +488,7 @@ async def test_entry_dispatch_occurs_inside_gateway_serialization(
     assert probe.active is False
     assert probe.enter_count == 1
     assert probe.exit_count == 1
-    gateway.serialize_entry.assert_called_once_with()
+    gateway.serialize_entry.assert_called_once_with("AAPL")
     gateway.submit_reduction.assert_not_awaited()
     runner.executor.place_order.assert_called_once_with(_order(side))
 
@@ -451,7 +536,7 @@ async def test_entries_reach_gateway_when_diagnostic_recovery_is_pending(
     result = await runner._place_order_with_circuit_breaker(_order(side))
 
     assert result.ok is True
-    gateway.serialize_entry.assert_called_once_with()
+    gateway.serialize_entry.assert_called_once_with("AAPL")
     assert probe.enter_count == 1
     assert probe.exit_count == 1
     runner.executor.place_order.assert_called_once_with(_order(side))

--- a/tests/test_pr2b3_gateway_failure_injection.py
+++ b/tests/test_pr2b3_gateway_failure_injection.py
@@ -98,6 +98,7 @@ async def _bind_projection(
         apply_callback=apply_callback,
         quarantine_callback=harness.quarantine_reasons.append,
     )
+    harness.gateway.attach_protective_quote_producer("portfolio-a", monitor)
     harness.gateway.register_paper_executor(
         "portfolio-a",
         executor,

--- a/tests/test_pr3_market_data_contract.py
+++ b/tests/test_pr3_market_data_contract.py
@@ -1,0 +1,482 @@
+"""PR 3 canonical market-data contract and persistence tests."""
+
+import os
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from robo_trader.clients.subprocess_ibkr_client import (
+    SubprocessIBKRClient,
+    _WorkerGeneration,
+)
+from robo_trader.database_async import AsyncTradingDatabase
+from robo_trader.market_data_contract import (
+    MAX_MARKET_DATA_AGE_SECONDS,
+    BarQualityFlag,
+    CanonicalBarBatch,
+    MarketDataContractError,
+    MarketSession,
+    MarketSessionPolicy,
+    canonicalize_historical_bars,
+    market_data_max_age_seconds,
+)
+from robo_trader.websocket_client import WebSocketClient
+from sync_db_reader import MarketDataReadError, SyncDatabaseReader
+
+
+def _lineage(*, retrieval: datetime | None = None) -> SimpleNamespace:
+    timestamp = retrieval or datetime(2026, 7, 23, 15, 2, tzinfo=timezone.utc)
+    return SimpleNamespace(
+        con_id=265598,
+        symbol="AAPL",
+        exchange="SMART",
+        primary_exchange="NASDAQ",
+        broker_timestamp=timestamp,
+        retrieval_timestamp=timestamp,
+        transport_generation="generation-1",
+    )
+
+
+def _record(timestamp: str, *, volume: int = 100) -> dict:
+    return {
+        "date": timestamp,
+        "open": 100,
+        "high": 102,
+        "low": 99,
+        "close": 101,
+        "volume": volume,
+    }
+
+
+def test_canonical_batch_binds_bars_to_exact_lineage_and_source_time() -> None:
+    batch = canonicalize_historical_bars(
+        symbol="AAPL",
+        records=[
+            _record("2026-07-23T15:00:00+00:00"),
+            _record("2026-07-23T15:01:00+00:00", volume=0),
+        ],
+        lineage=_lineage(),
+        bar_size="1 min",
+        use_rth=True,
+        what_to_show="TRADES",
+        now=datetime(2026, 7, 23, 15, 2, tzinfo=timezone.utc),
+    )
+
+    assert type(batch) is CanonicalBarBatch
+    assert batch.contract.session_policy is MarketSessionPolicy.REGULAR_ONLY
+    assert batch.contract.con_id == 265598
+    assert batch.bars[-1].session is MarketSession.REGULAR
+    assert batch.bars[-1].quality_flags == (BarQualityFlag.ZERO_VOLUME,)
+    frame = batch.to_frame()
+    assert frame.attrs["canonical_bar_batch"] is batch
+    assert str(frame.index.tz) == "UTC"
+    assert frame.index[-1].to_pydatetime() == datetime(2026, 7, 23, 15, 1, tzinfo=timezone.utc)
+    storage = batch.storage_rows()[-1]
+    assert storage["timestamp"] == "2026-07-23T15:01:00+00:00"
+    assert storage["interval_seconds"] == 60
+    assert storage["timezone_name"] == "UTC"
+    assert storage["session_policy"] == "regular-only"
+    assert storage["broker_timestamp"] == "2026-07-23T15:02:00+00:00"
+    assert storage["timestamp_semantics"] == "bar-start"
+    assert storage["use_rth"] is True
+    assert storage["what_to_show"] == "TRADES"
+
+
+def test_session_policy_rejects_extended_bar_from_regular_response() -> None:
+    kwargs = {
+        "symbol": "AAPL",
+        "records": [_record("2026-07-23T12:00:00+00:00")],
+        "lineage": _lineage(retrieval=datetime(2026, 7, 23, 12, 1, tzinfo=timezone.utc)),
+        "bar_size": "1 min",
+        "what_to_show": "TRADES",
+        "now": datetime(2026, 7, 23, 12, 1, tzinfo=timezone.utc),
+    }
+    with pytest.raises(MarketDataContractError, match="regular-hours"):
+        canonicalize_historical_bars(**kwargs, use_rth=True)
+
+    extended = canonicalize_historical_bars(**kwargs, use_rth=False)
+    assert extended.bars[0].session is MarketSession.PRE_MARKET
+
+
+@pytest.mark.parametrize(
+    "records",
+    [
+        [
+            _record("2026-07-23T15:00:00+00:00"),
+            _record("2026-07-23T15:03:00+00:00"),
+        ],
+        [_record("2026-07-03T15:00:00+00:00")],
+    ],
+)
+def test_gap_and_market_holiday_bars_fail_closed(records: list[dict]) -> None:
+    now = (
+        datetime.fromisoformat(records[-1]["date"])
+        if len(records) == 1
+        else datetime(2026, 7, 23, 15, 4, tzinfo=timezone.utc)
+    )
+    with pytest.raises(MarketDataContractError):
+        canonicalize_historical_bars(
+            symbol="AAPL",
+            records=records,
+            lineage=_lineage(retrieval=now),
+            bar_size="1 min",
+            use_rth=True,
+            what_to_show="TRADES",
+            now=now,
+        )
+
+
+@pytest.mark.asyncio
+async def test_canonical_refreshes_accumulate_by_contract_timeframe_and_time(
+    tmp_path: Path,
+) -> None:
+    database = AsyncTradingDatabase(tmp_path / "market-data.db", pool_size=1)
+    await database.initialize()
+    try:
+        one_minute = canonicalize_historical_bars(
+            symbol="AAPL",
+            records=[_record("2026-07-23T15:00:00+00:00")],
+            lineage=_lineage(),
+            bar_size="1 min",
+            use_rth=True,
+            what_to_show="TRADES",
+            now=datetime(2026, 7, 23, 15, 2, tzinfo=timezone.utc),
+        )
+        five_minute = canonicalize_historical_bars(
+            symbol="AAPL",
+            records=[_record("2026-07-23T15:00:00+00:00")],
+            lineage=_lineage(),
+            bar_size="5 mins",
+            use_rth=True,
+            what_to_show="TRADES",
+            now=datetime(2026, 7, 23, 15, 2, tzinfo=timezone.utc),
+        )
+
+        await database.batch_store_market_data(one_minute.storage_rows())
+        await database.batch_store_market_data(one_minute.storage_rows())
+        await database.batch_store_market_data(five_minute.storage_rows())
+
+        async with database.get_connection() as connection:
+            count = await (
+                await connection.execute("SELECT COUNT(*) FROM canonical_market_data")
+            ).fetchone()
+        assert count == (2,)
+        latest = await database.get_latest_market_data("AAPL", limit=10)
+        assert {row["timeframe"] for row in latest} == {"1 min"}
+        assert all(row["source"] == "ibkr-historical-trades" for row in latest)
+        assert all(row["con_id"] == 265598 for row in latest)
+        assert all(row["transport_generation"] == "generation-1" for row in latest)
+        assert all(row["freshness_status"] == "stale" for row in latest)
+        sync_reader = SyncDatabaseReader(str(tmp_path / "market-data.db"))
+        sync_latest = sync_reader.get_latest_market_data("AAPL", limit=10)
+        assert {row["timeframe"] for row in sync_latest} == {"1 min"}
+        assert all(row["source"] == "ibkr-historical-trades" for row in sync_latest)
+        assert all(row["freshness_status"] == "stale" for row in sync_latest)
+        explicit_five = await database.get_latest_market_data("AAPL", limit=10, timeframe="5 mins")
+        assert {row["timeframe"] for row in explicit_five} == {"5 mins"}
+        assert {
+            row["timeframe"]
+            for row in sync_reader.get_latest_market_data("AAPL", limit=10, timeframe="5 mins")
+        } == {"5 mins"}
+    finally:
+        await database.close()
+
+
+def test_canonical_values_remain_exact_before_dataframe_projection() -> None:
+    record = _record("2026-07-23T15:00:00+00:00")
+    record["close"] = "101.1250"
+    batch = canonicalize_historical_bars(
+        symbol="AAPL",
+        records=[record],
+        lineage=_lineage(),
+        bar_size="1 min",
+        use_rth=True,
+        what_to_show="TRADES",
+        now=datetime(2026, 7, 23, 15, 2, tzinfo=timezone.utc),
+    )
+    assert batch.bars[0].close == Decimal("101.1250")
+
+
+def test_canonical_contract_rejects_non_trade_history() -> None:
+    with pytest.raises(MarketDataContractError, match="must be TRADES"):
+        canonicalize_historical_bars(
+            symbol="AAPL",
+            records=[_record("2026-07-23T15:00:00+00:00")],
+            lineage=_lineage(),
+            bar_size="1 min",
+            use_rth=True,
+            what_to_show="MIDPOINT",
+            now=datetime(2026, 7, 23, 15, 2, tzinfo=timezone.utc),
+        )
+
+
+@pytest.mark.parametrize("configured", ["nan", "inf", "3600", "86401"])
+def test_market_data_freshness_configuration_is_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+    configured: str,
+) -> None:
+    monkeypatch.setenv("MARKET_DATA_MAX_AGE_SECONDS", configured)
+    with pytest.raises(MarketDataContractError, match="finite, positive"):
+        canonicalize_historical_bars(
+            symbol="AAPL",
+            records=[_record("2026-07-23T15:00:00+00:00")],
+            lineage=_lineage(),
+            bar_size="1 min",
+            use_rth=True,
+            what_to_show="TRADES",
+            now=datetime(2026, 7, 23, 15, 2, tzinfo=timezone.utc),
+        )
+    assert MAX_MARKET_DATA_AGE_SECONDS == 86_400
+
+
+def test_market_data_freshness_accepts_reasonable_timeframe_bound(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MARKET_DATA_MAX_AGE_SECONDS", "200")
+    assert market_data_max_age_seconds(60) == 200
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("source", "operator-spoofed"),
+        ("timestamp", "2026-07-23T15:00:00"),
+        ("high", 98),
+        ("quality_flags", "unrecognized"),
+        ("what_to_show", "MIDPOINT"),
+    ],
+)
+async def test_canonical_database_admission_rejects_malformed_rows(
+    tmp_path: Path,
+    field: str,
+    value: object,
+) -> None:
+    database = AsyncTradingDatabase(tmp_path / f"invalid-{field}.db", pool_size=1)
+    await database.initialize()
+    batch = canonicalize_historical_bars(
+        symbol="AAPL",
+        records=[_record("2026-07-23T15:00:00+00:00")],
+        lineage=_lineage(),
+        bar_size="1 min",
+        use_rth=True,
+        what_to_show="TRADES",
+        now=datetime(2026, 7, 23, 15, 2, tzinfo=timezone.utc),
+    )
+    row = batch.storage_rows()[0]
+    row[field] = value
+    try:
+        with pytest.raises(ValueError, match="is not canonical"):
+            await database.batch_store_market_data([row])
+    finally:
+        await database.close()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_preserves_canonical_audit_and_scoped_call_is_not_global(
+    tmp_path: Path,
+) -> None:
+    database = AsyncTradingDatabase(tmp_path / "cleanup.db", pool_size=1)
+    await database.initialize()
+    batch = canonicalize_historical_bars(
+        symbol="AAPL",
+        records=[_record("2026-07-23T15:00:00+00:00")],
+        lineage=_lineage(),
+        bar_size="1 min",
+        use_rth=True,
+        what_to_show="TRADES",
+        now=datetime(2026, 7, 23, 15, 2, tzinfo=timezone.utc),
+    )
+    try:
+        await database.batch_store_market_data(batch.storage_rows())
+        await database.store_market_data(
+            "AAPL",
+            datetime(2020, 1, 2, tzinfo=timezone.utc),
+            100,
+            101,
+            99,
+            100,
+            1,
+        )
+        await database.cleanup_old_data(days_to_keep=0, portfolio_id="default")
+        async with database.get_connection() as connection:
+            canonical_count = (
+                await (
+                    await connection.execute("SELECT COUNT(*) FROM canonical_market_data")
+                ).fetchone()
+            )[0]
+            legacy_count = (
+                await (await connection.execute("SELECT COUNT(*) FROM market_data")).fetchone()
+            )[0]
+        assert canonical_count == 1
+        assert legacy_count == 1
+
+        await database.cleanup_old_data(days_to_keep=0)
+        async with database.get_connection() as connection:
+            canonical_count = (
+                await (
+                    await connection.execute("SELECT COUNT(*) FROM canonical_market_data")
+                ).fetchone()
+            )[0]
+            legacy_count = (
+                await (await connection.execute("SELECT COUNT(*) FROM market_data")).fetchone()
+            )[0]
+        assert canonical_count == 1
+        assert legacy_count == 0
+    finally:
+        await database.close()
+
+
+@pytest.mark.asyncio
+async def test_tampered_canonical_row_fails_async_read_and_api_returns_503(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database_path = tmp_path / "tampered.db"
+    database = AsyncTradingDatabase(database_path, pool_size=1)
+    await database.initialize()
+    batch = canonicalize_historical_bars(
+        symbol="AAPL",
+        records=[_record("2026-07-23T15:00:00+00:00")],
+        lineage=_lineage(),
+        bar_size="1 min",
+        use_rth=True,
+        what_to_show="TRADES",
+        now=datetime(2026, 7, 23, 15, 2, tzinfo=timezone.utc),
+    )
+    try:
+        await database.batch_store_market_data(batch.storage_rows())
+        async with database.get_connection() as connection:
+            await connection.execute(
+                "UPDATE canonical_market_data " "SET broker_timestamp = '2020-01-02T15:00:00+00:00'"
+            )
+            await connection.commit()
+        with pytest.raises(MarketDataContractError, match="clock-skew"):
+            await database.get_latest_market_data("AAPL", limit=1)
+    finally:
+        await database.close()
+
+    monkeypatch.setenv("RT_DB_PATH", str(database_path))
+    with patch.dict(os.environ, {"DASH_AUTH_ENABLED": "false"}, clear=False):
+        import app as app_module
+
+    response = app_module.app.test_client().get("/api/market-data/AAPL")
+    assert response.status_code == 503
+    assert response.get_json() == {"error": "market_data_unavailable"}
+
+
+def test_sync_reader_raises_typed_error_for_unavailable_database(tmp_path: Path) -> None:
+    reader = SyncDatabaseReader(str(tmp_path / "missing" / "market.db"))
+    with pytest.raises(MarketDataReadError, match="unavailable"):
+        reader.get_latest_market_data("AAPL", limit=1)
+
+
+@pytest.mark.parametrize(
+    ("reader_result", "expected_status"),
+    [([], 404), (MarketDataReadError("database unavailable"), 503)],
+)
+def test_market_data_api_distinguishes_empty_from_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    reader_result: object,
+    expected_status: int,
+) -> None:
+    with patch.dict(os.environ, {"DASH_AUTH_ENABLED": "false"}, clear=False):
+        import app as app_module
+
+    if isinstance(reader_result, BaseException):
+        replacement = patch.object(
+            SyncDatabaseReader,
+            "get_latest_market_data",
+            side_effect=reader_result,
+        )
+    else:
+        replacement = patch.object(
+            SyncDatabaseReader,
+            "get_latest_market_data",
+            return_value=reader_result,
+        )
+    with replacement:
+        response = app_module.app.test_client().get("/api/market-data/AAPL")
+    assert response.status_code == expected_status
+    if expected_status == 503:
+        assert response.get_json() == {"error": "market_data_unavailable"}
+
+
+@pytest.mark.asyncio
+async def test_client_returns_bars_and_lineage_as_one_canonical_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime.now(timezone.utc)
+    payload = {
+        "bars": [_record("2026-07-23T15:00:00+00:00")],
+        "requested_symbol": "AAPL",
+        "qualified_contract": {
+            "con_id": 265598,
+            "symbol": "AAPL",
+            "local_symbol": "AAPL",
+            "security_type": "STK",
+            "exchange": "SMART",
+            "primary_exchange": "NASDAQ",
+            "currency": "USD",
+            "trading_class": "NMS",
+        },
+        "broker_timestamp": now.isoformat(),
+        "retrieval_timestamp": now.isoformat(),
+    }
+    client = SubprocessIBKRClient()
+    generation = _WorkerGeneration(
+        generation_id="generation-1",
+        process=SimpleNamespace(poll=lambda: 0),
+    )
+    client._generation = generation
+    client._connected = True
+    client._connection_generation_id = generation.generation_id
+    client._connection_identity = ("127.0.0.1", 4002, 7, True)
+    execute = AsyncMock(return_value=payload)
+    monkeypatch.setattr(client, "_execute_command_unlocked", execute)
+    from robo_trader import market_data_contract
+
+    canonicalize = market_data_contract.canonicalize_historical_bars
+
+    def canonicalize_at_fixture_time(**kwargs):
+        return canonicalize(
+            **kwargs,
+            now=datetime(2026, 7, 23, 15, 2, tzinfo=timezone.utc),
+        )
+
+    monkeypatch.setattr(
+        "robo_trader.clients.subprocess_ibkr_client.canonicalize_historical_bars",
+        canonicalize_at_fixture_time,
+    )
+
+    batch = await client.get_canonical_historical_bars("AAPL", bar_size="1 min")
+
+    assert type(batch) is CanonicalBarBatch
+    assert batch.contract.transport_generation == generation.generation_id
+    assert batch.contract.con_id == 265598
+    assert batch.bars[0].timestamp == datetime(2026, 7, 23, 15, tzinfo=timezone.utc)
+
+
+def test_websocket_market_update_preserves_event_and_freshness_lineage() -> None:
+    client = WebSocketClient(max_queue_size=2)
+
+    client.send_market_update(
+        "AAPL",
+        101.25,
+        event_timestamp="2026-07-23T15:00:00+00:00",
+        retrieval_timestamp="2026-07-23T15:00:02+00:00",
+        source="ibkr-historical-trades",
+        session="regular",
+        timeframe="1 min",
+        freshness_status="fresh",
+    )
+
+    message = client.message_queue.get_nowait()
+    assert message["event_timestamp"] == "2026-07-23T15:00:00+00:00"
+    assert message["retrieval_timestamp"] == "2026-07-23T15:00:02+00:00"
+    assert message["source"] == "ibkr-historical-trades"
+    assert message["freshness_status"] == "fresh"

--- a/tests/test_pr3_market_data_contract.py
+++ b/tests/test_pr3_market_data_contract.py
@@ -186,6 +186,60 @@ async def test_canonical_refreshes_accumulate_by_contract_timeframe_and_time(
         await database.close()
 
 
+@pytest.mark.asyncio
+async def test_canonical_event_conflict_rejects_without_overwriting_first_observation(
+    tmp_path: Path,
+) -> None:
+    database = AsyncTradingDatabase(tmp_path / "immutable-market-data.db", pool_size=1)
+    await database.initialize()
+    batch = canonicalize_historical_bars(
+        symbol="AAPL",
+        records=[_record("2026-07-23T15:00:00+00:00")],
+        lineage=_lineage(),
+        bar_size="1 min",
+        use_rth=True,
+        what_to_show="TRADES",
+        now=datetime(2026, 7, 23, 15, 2, tzinfo=timezone.utc),
+    )
+    original = batch.storage_rows()[0]
+    repeated_observation = {
+        **original,
+        "retrieval_timestamp": "2026-07-23T15:03:00+00:00",
+        "broker_timestamp": "2026-07-23T15:03:00+00:00",
+        "transport_generation": "generation-2",
+    }
+    revised = {
+        **repeated_observation,
+        "close": 100.5,
+    }
+    try:
+        await database.batch_store_market_data([original])
+        await database.batch_store_market_data([original])
+        await database.batch_store_market_data([repeated_observation])
+
+        with pytest.raises(ValueError, match="conflicts with immutable stored evidence"):
+            await database.batch_store_market_data([revised])
+
+        async with database.get_connection() as connection:
+            rows = await (
+                await connection.execute(
+                    "SELECT close, retrieval_timestamp, broker_timestamp, "
+                    "transport_generation, quality_flags FROM canonical_market_data"
+                )
+            ).fetchall()
+        assert rows == [
+            (
+                original["close"],
+                original["retrieval_timestamp"],
+                original["broker_timestamp"],
+                original["transport_generation"],
+                original["quality_flags"],
+            )
+        ]
+    finally:
+        await database.close()
+
+
 def test_canonical_values_remain_exact_before_dataframe_projection() -> None:
     record = _record("2026-07-23T15:00:00+00:00")
     record["close"] = "101.1250"

--- a/tests/test_pr3_performance_timers.py
+++ b/tests/test_pr3_performance_timers.py
@@ -1,0 +1,41 @@
+"""PR 3 concurrency tests for per-operation performance timers."""
+
+import asyncio
+
+import pytest
+
+from robo_trader.monitoring.performance import PerformanceMonitor, Timer
+
+
+@pytest.mark.asyncio
+async def test_parallel_symbol_timers_keep_distinct_operation_instances() -> None:
+    monitor = PerformanceMonitor()
+    both_started = asyncio.Event()
+    release = asyncio.Event()
+    started = 0
+    start_lock = asyncio.Lock()
+
+    async def measure(symbol: str) -> None:
+        nonlocal started
+        with Timer("data_fetch", monitor, instance=symbol):
+            async with start_lock:
+                started += 1
+                if started == 2:
+                    both_started.set()
+            await release.wait()
+
+    tasks = [
+        asyncio.create_task(measure("AAPL")),
+        asyncio.create_task(measure("MSFT")),
+    ]
+    await asyncio.wait_for(both_started.wait(), timeout=1)
+
+    assert len(monitor._timers) == 2
+    assert any(":AAPL:" in timer_id for timer_id in monitor._timers)
+    assert any(":MSFT:" in timer_id for timer_id in monitor._timers)
+
+    release.set()
+    await asyncio.gather(*tasks)
+
+    assert monitor._timers == {}
+    assert len(monitor.data_fetch_samples) == 2

--- a/tests/test_pr3_protective_quote_channel.py
+++ b/tests/test_pr3_protective_quote_channel.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from robo_trader.clients import ibkr_subprocess_worker as worker
+from robo_trader.clients import subprocess_ibkr_client as client_module
 from robo_trader.clients.subprocess_ibkr_client import (
     IBKRTransportPoisonedError,
     SubprocessIBKRClient,
@@ -494,6 +495,7 @@ def _connected_client(
     *,
     generation_id: str = "generation-1",
 ):
+    monkeypatch.setattr(client_module, "get_market_session", lambda _timestamp: "regular")
     client = SubprocessIBKRClient()
     generation = _WorkerGeneration(
         generation_id=generation_id,
@@ -786,6 +788,20 @@ async def test_non_live_quote_poisons_the_exact_worker_generation(
     )
 
     with pytest.raises(IBKRTransportPoisonedError, match="not live"):
+        await client.get_protective_quotes(["AAPL"])
+
+    assert generation.poisoned_reason is not None
+
+
+@pytest.mark.asyncio
+async def test_session_timestamp_mismatch_poisons_the_exact_worker_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _client_response()
+    client, generation = _connected_client(monkeypatch, response)
+    monkeypatch.setattr(client_module, "get_market_session", lambda _timestamp: "after-hours")
+
+    with pytest.raises(IBKRTransportPoisonedError, match="session contradicts"):
         await client.get_protective_quotes(["AAPL"])
 
     assert generation.poisoned_reason is not None
@@ -1343,3 +1359,64 @@ async def test_feed_task_is_singleton_and_cancellable() -> None:
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
+
+
+@pytest.mark.asyncio
+async def test_feed_recovers_before_failure_limit_without_quarantine() -> None:
+    gateway = object.__new__(PaperReductionGateway)
+    gateway._started = True
+    gateway._diagnostic_recovery_required = False
+    gateway._terminal_quarantine_reason = None
+    gateway._bindings = {}
+    gateway._protective_quote_producers = {}
+    gateway._protective_feed_enabled = True
+    gateway._protective_feed_interval_seconds = 0
+    gateway._protective_feed_max_recovery_attempts = 3
+    gateway.refresh_protective_quotes = AsyncMock(
+        side_effect=[RuntimeError("transient feed failure"), ()]
+    )
+
+    async def stop_after_recovery(_seconds: float) -> None:
+        if gateway.refresh_protective_quotes.await_count == 2:
+            gateway._protective_feed_enabled = False
+
+    gateway._sleep = stop_after_recovery
+
+    await gateway._protective_feed_loop()
+
+    assert gateway.refresh_protective_quotes.await_count == 2
+    assert gateway.terminal_quarantine_reason is None
+    assert gateway.can_attempt_order_admission is True
+
+
+@pytest.mark.asyncio
+async def test_feed_terminal_failure_quarantines_and_alerts_every_runner() -> None:
+    alerts = {portfolio_id: AsyncMock() for portfolio_id in ("growth", "income")}
+    producers = {
+        portfolio_id: SimpleNamespace(emergency_shutdown=callback)
+        for portfolio_id, callback in alerts.items()
+    }
+    gateway = object.__new__(PaperReductionGateway)
+    gateway._started = True
+    gateway._diagnostic_recovery_required = False
+    gateway._terminal_quarantine_reason = None
+    gateway._bindings = {}
+    gateway._protective_quote_producers = producers
+    gateway._protective_feed_enabled = True
+    gateway._protective_feed_interval_seconds = 0
+    gateway._protective_feed_max_recovery_attempts = 3
+    gateway.refresh_protective_quotes = AsyncMock(
+        side_effect=RuntimeError("persistent feed failure")
+    )
+    sleep = AsyncMock()
+    gateway._sleep = sleep
+
+    await gateway._protective_feed_loop()
+
+    assert gateway.refresh_protective_quotes.await_count == 3
+    assert sleep.await_count == 2
+    assert gateway._protective_feed_enabled is False
+    assert gateway.can_attempt_order_admission is False
+    assert "3 consecutive refresh failures" in gateway.terminal_quarantine_reason
+    for callback in alerts.values():
+        callback.assert_awaited_once_with(gateway.terminal_quarantine_reason)

--- a/tests/test_pr3_protective_quote_channel.py
+++ b/tests/test_pr3_protective_quote_channel.py
@@ -1,0 +1,1345 @@
+"""PR 3 tests for the independent live protective quote channel."""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from robo_trader.clients import ibkr_subprocess_worker as worker
+from robo_trader.clients.subprocess_ibkr_client import (
+    IBKRTransportPoisonedError,
+    SubprocessIBKRClient,
+    _WorkerGeneration,
+)
+from robo_trader.market_data_contract import (
+    BrokerProtectiveQuote,
+    MarketDataIdentityError,
+    MarketDataSource,
+    MarketSession,
+)
+from robo_trader.paper_reduction_gateway import (
+    PaperReductionGateway,
+    PaperReductionGatewayError,
+)
+from robo_trader.protective_quote_evidence import (
+    MAX_PROTECTIVE_SOURCE_EVENT_ID_LENGTH,
+    ProtectiveQuoteSource,
+)
+from robo_trader.risk_manager import Position
+from robo_trader.runner_async import AsyncRunner
+from robo_trader.stop_loss_monitor import StopLossMonitor, StopStatus
+
+
+@pytest.fixture(autouse=True)
+def _isolate_worker_protective_subscription_state():
+    """Keep the worker's process-global subscription cache test-local."""
+
+    worker._clear_protective_tick_subscriptions()
+    yield
+    worker._clear_protective_tick_subscriptions()
+
+
+def _contract(symbol: str = "AAPL", con_id: int = 265598) -> SimpleNamespace:
+    return SimpleNamespace(
+        conId=con_id,
+        symbol=symbol,
+        localSymbol=symbol,
+        secType="STK",
+        currency="USD",
+        exchange="SMART",
+        primaryExchange="NASDAQ",
+        tradingClass="NMS",
+    )
+
+
+@pytest.mark.asyncio
+async def test_worker_emits_only_qualified_live_last_trade_quotes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime.now(timezone.utc)
+    contract = _contract()
+
+    class FakeIB:
+        def isConnected(self) -> bool:
+            return True
+
+        async def qualifyContractsAsync(self, requested):
+            assert requested.symbol == "AAPL"
+            return [contract]
+
+        async def reqCurrentTimeAsync(self):
+            return now
+
+        def reqTickByTickData(
+            self,
+            qualified,
+            tick_type,
+            *,
+            numberOfTicks,
+            ignoreSize,
+        ):
+            assert qualified is contract
+            assert tick_type == "Last"
+            assert numberOfTicks == 0
+            assert ignoreSize is False
+            return SimpleNamespace(
+                contract=contract,
+                time=now,
+                last=999.0,
+                tickByTicks=[SimpleNamespace(time=now, price=187.25)],
+            )
+
+        def cancelTickByTickData(self, qualified, tick_type):
+            assert qualified is contract
+            assert tick_type == "Last"
+            return True
+
+    monkeypatch.setattr(worker, "ib", FakeIB())
+    monkeypatch.setattr(worker, "WORKER_GENERATION_ID", "generation-1")
+    monkeypatch.setattr(worker, "get_market_session", lambda _timestamp: "regular")
+
+    response = await worker.handle_get_protective_quotes({"symbols": ["AAPL"]})
+
+    assert response["status"] == "success"
+    quote = response["data"]["quotes"][0]
+    assert quote["price"] == "187.25"
+    assert quote["con_id"] == 265598
+    assert quote["source"] == "ibkr-live-last-trade"
+    assert quote["market_data_type"] == 1
+    assert quote["source_timestamp"] == now.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_worker_never_pairs_generic_ticker_time_with_stale_last(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime.now(timezone.utc)
+    contract = _contract()
+
+    class FakeIB:
+        def isConnected(self) -> bool:
+            return True
+
+        async def qualifyContractsAsync(self, _requested):
+            return [contract]
+
+        async def reqCurrentTimeAsync(self):
+            return now
+
+        def reqTickByTickData(self, _contract, _tick_type, **_kwargs):
+            return SimpleNamespace(
+                contract=contract,
+                time=now,
+                last=100.00,
+                tickByTicks=[
+                    SimpleNamespace(
+                        time=now,
+                        price=Decimal("95.1250"),
+                    )
+                ],
+            )
+
+        def cancelTickByTickData(self, _contract, _tick_type):
+            return True
+
+    monkeypatch.setattr(worker, "ib", FakeIB())
+    monkeypatch.setattr(worker, "WORKER_GENERATION_ID", "generation-1")
+    monkeypatch.setattr(worker, "get_market_session", lambda _timestamp: "regular")
+
+    response = await worker.handle_get_protective_quotes({"symbols": ["AAPL"]})
+
+    quote = response["data"]["quotes"][0]
+    assert quote["price"] == "95.125"
+    assert quote["price"] != "100"
+
+
+@pytest.mark.asyncio
+async def test_worker_reuses_subscription_and_replays_every_new_event_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime.now(timezone.utc)
+    event_time = now.replace(microsecond=0)
+    contract = _contract()
+    first_tick = SimpleNamespace(
+        time=event_time,
+        price=Decimal("100"),
+        size=1,
+        exchange="NASDAQ",
+    )
+    ticker = SimpleNamespace(contract=contract, tickByTicks=[first_tick])
+
+    class FakeIB:
+        def __init__(self):
+            self.qualify_count = 0
+            self.request_count = 0
+
+        def isConnected(self) -> bool:
+            return True
+
+        async def qualifyContractsAsync(self, _requested):
+            self.qualify_count += 1
+            return [contract]
+
+        async def reqCurrentTimeAsync(self):
+            return now
+
+        def reqTickByTickData(self, _contract, _tick_type, **_kwargs):
+            self.request_count += 1
+            return ticker
+
+        def cancelTickByTickData(self, _contract, _tick_type):
+            return None
+
+    fake_ib = FakeIB()
+    monkeypatch.setattr(worker, "ib", fake_ib)
+    monkeypatch.setattr(worker, "WORKER_GENERATION_ID", "generation-1")
+    monkeypatch.setattr(worker, "get_market_session", lambda _timestamp: "regular")
+
+    first = await worker.handle_get_protective_quotes(
+        {"symbols": ["AAPL"], "active_symbols": ["AAPL"]}
+    )
+    first_id = first["data"]["quotes"][0]["source_event_id"]
+
+    # Distinct broker events can have identical trade fields. Arrival identity,
+    # not a value-only fingerprint, must keep both observable and unique.
+    ticker.tickByTicks.extend(
+        [
+            SimpleNamespace(
+                time=event_time,
+                price=Decimal("95"),
+                size=2,
+                exchange="NASDAQ",
+            ),
+            SimpleNamespace(
+                time=event_time,
+                price=Decimal("95"),
+                size=2,
+                exchange="NASDAQ",
+            ),
+        ]
+    )
+    replay = await worker.handle_get_protective_quotes(
+        {"symbols": ["AAPL"], "active_symbols": ["AAPL"]}
+    )
+    replay_ids = [quote["source_event_id"] for quote in replay["data"]["quotes"]]
+
+    assert [quote["price"] for quote in replay["data"]["quotes"]] == ["95", "95"]
+    assert len(set(replay_ids)) == 2
+    assert first_id not in replay_ids
+    assert fake_ib.qualify_count == 1
+    assert fake_ib.request_count == 1
+    assert len(ticker.tickByTicks) == 1
+
+    fallback = await worker.handle_get_protective_quotes(
+        {"symbols": ["AAPL"], "active_symbols": ["AAPL"]}
+    )
+    assert fallback["data"]["quotes"][0]["source_event_id"] == replay_ids[-1]
+    assert fake_ib.qualify_count == 1
+    assert fake_ib.request_count == 1
+
+
+@pytest.mark.asyncio
+async def test_worker_uses_account_active_set_across_fetch_chunks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime.now(timezone.utc)
+    contracts = {
+        "AAPL": _contract("AAPL", 1),
+        "MSFT": _contract("MSFT", 2),
+    }
+
+    class FakeIB:
+        def __init__(self):
+            self.requested = []
+            self.cancelled = []
+
+        def isConnected(self) -> bool:
+            return True
+
+        async def qualifyContractsAsync(self, requested):
+            return [contracts[requested.symbol]]
+
+        async def reqCurrentTimeAsync(self):
+            return now
+
+        def reqTickByTickData(self, contract, _tick_type, **_kwargs):
+            self.requested.append(contract.symbol)
+            return SimpleNamespace(
+                contract=contract,
+                tickByTicks=[SimpleNamespace(time=now, price=100)],
+            )
+
+        def cancelTickByTickData(self, contract, _tick_type):
+            self.cancelled.append(contract.symbol)
+            return None
+
+    fake_ib = FakeIB()
+    clock = {"now": 0.0}
+    monkeypatch.setattr(worker, "ib", fake_ib)
+    monkeypatch.setattr(worker, "get_market_session", lambda _timestamp: "regular")
+    monkeypatch.setattr(worker, "_protective_request_monotonic", lambda: clock["now"])
+
+    active = ["AAPL", "MSFT"]
+    assert (
+        await worker.handle_get_protective_quotes({"symbols": ["AAPL"], "active_symbols": active})
+    )["status"] == "success"
+    assert (
+        await worker.handle_get_protective_quotes({"symbols": ["MSFT"], "active_symbols": active})
+    )["status"] == "success"
+
+    assert fake_ib.requested == ["AAPL", "MSFT"]
+    assert fake_ib.cancelled == []
+
+    clock["now"] = 16.0
+    assert (
+        await worker.handle_get_protective_quotes({"symbols": ["AAPL"], "active_symbols": ["AAPL"]})
+    )["status"] == "success"
+    assert fake_ib.requested == ["AAPL", "MSFT"]
+    assert fake_ib.cancelled == ["MSFT"]
+    assert set(worker._PROTECTIVE_SYMBOL_CON_IDS) == {"AAPL"}
+
+
+@pytest.mark.asyncio
+async def test_worker_paces_same_instrument_across_rapid_active_set_churn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime.now(timezone.utc)
+    contract = _contract()
+    ticker = SimpleNamespace(
+        contract=contract,
+        tickByTicks=[SimpleNamespace(time=now, price=100)],
+    )
+    clock = {"now": 0.0}
+
+    class FakeIB:
+        def __init__(self):
+            self.qualify_count = 0
+            self.request_count = 0
+            self.cancel_count = 0
+
+        def isConnected(self) -> bool:
+            return True
+
+        async def qualifyContractsAsync(self, _requested):
+            self.qualify_count += 1
+            return [contract]
+
+        async def reqCurrentTimeAsync(self):
+            return now
+
+        def reqTickByTickData(
+            self,
+            _contract,
+            _tick_type,
+            *,
+            numberOfTicks,
+            ignoreSize,
+        ):
+            assert numberOfTicks == 0
+            assert ignoreSize is False
+            self.request_count += 1
+            return ticker
+
+        def cancelTickByTickData(self, _contract, _tick_type):
+            self.cancel_count += 1
+            return None
+
+    fake_ib = FakeIB()
+    monkeypatch.setattr(worker, "ib", fake_ib)
+    monkeypatch.setattr(worker, "get_market_session", lambda _timestamp: "regular")
+    monkeypatch.setattr(worker, "_protective_request_monotonic", lambda: clock["now"])
+
+    started = await worker.handle_get_protective_quotes(
+        {"symbols": ["AAPL"], "active_symbols": ["AAPL"]}
+    )
+    assert started["status"] == "success"
+    assert worker._PROTECTIVE_TICK_REQUEST_TIMES == {contract.conId: 0.0}
+
+    clock["now"] = 5.0
+    removed = await worker.handle_get_protective_quotes({"symbols": [], "active_symbols": []})
+    assert removed["status"] == "success"
+    assert fake_ib.cancel_count == 0
+
+    clock["now"] = 6.0
+    readded = await worker.handle_get_protective_quotes(
+        {"symbols": ["AAPL"], "active_symbols": ["AAPL"]}
+    )
+    assert readded["status"] == "success"
+    assert fake_ib.qualify_count == 1
+    assert fake_ib.request_count == 1
+
+    clock["now"] = 15.0
+    retired = await worker.handle_get_protective_quotes({"symbols": [], "active_symbols": []})
+    assert retired["status"] == "success"
+    assert fake_ib.cancel_count == 1
+    assert worker._PROTECTIVE_TICK_SUBSCRIPTIONS == {}
+    assert worker._PROTECTIVE_TICK_REQUEST_TIMES == {}
+    assert worker._PROTECTIVE_SYMBOL_CON_IDS == {}
+
+
+@pytest.mark.asyncio
+async def test_worker_fails_closed_and_retains_state_when_cancellation_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime.now(timezone.utc)
+    contract = _contract()
+
+    class FakeIB:
+        def isConnected(self) -> bool:
+            return True
+
+        async def qualifyContractsAsync(self, _requested):
+            return [contract]
+
+        async def reqCurrentTimeAsync(self):
+            return now
+
+        def reqTickByTickData(self, _contract, _tick_type, **_kwargs):
+            return SimpleNamespace(
+                contract=contract,
+                tickByTicks=[SimpleNamespace(time=now, price=100)],
+            )
+
+        def cancelTickByTickData(self, _contract, _tick_type):
+            raise RuntimeError("broker cancellation failed")
+
+    clock = {"now": 0.0}
+    monkeypatch.setattr(worker, "ib", FakeIB())
+    monkeypatch.setattr(worker, "get_market_session", lambda _timestamp: "regular")
+    monkeypatch.setattr(worker, "_protective_request_monotonic", lambda: clock["now"])
+    initial = await worker.handle_get_protective_quotes(
+        {"symbols": ["AAPL"], "active_symbols": ["AAPL"]}
+    )
+    assert initial["status"] == "success"
+
+    clock["now"] = 15.0
+    cancelled = await worker.handle_get_protective_quotes({"symbols": [], "active_symbols": []})
+
+    assert cancelled["status"] == "error"
+    assert "broker cancellation failed" in cancelled["error"]
+    assert set(worker._PROTECTIVE_SYMBOL_CON_IDS) == {"AAPL"}
+    assert worker._PROTECTIVE_TICK_REQUEST_TIMES == {contract.conId: 0.0}
+
+
+def _client_response(*, market_data_type: int = 1) -> dict:
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    timestamp = now.isoformat()
+    return {
+        "quotes": [
+            {
+                "schema_version": 1,
+                "symbol": "AAPL",
+                "con_id": 265598,
+                "exchange": "SMART",
+                "primary_exchange": "NASDAQ",
+                "currency": "USD",
+                "security_type": "STK",
+                "price": "187.25",
+                "source_timestamp": timestamp,
+                "retrieval_timestamp": timestamp,
+                "session": "regular",
+                "source": "ibkr-live-last-trade",
+                "source_event_id": "protective:generation-1:1",
+                "market_data_type": market_data_type,
+            }
+        ],
+        "broker_time_before": timestamp,
+        "broker_time_after": timestamp,
+        "retrieval_timestamp": timestamp,
+    }
+
+
+def _broker_quote(
+    *,
+    symbol: str = "AAPL",
+    con_id: int = 265598,
+    price: Decimal = Decimal("187.2500"),
+    generation: str = "generation-1",
+    source_timestamp: datetime | None = None,
+    source_event_id: str | None = None,
+    session: MarketSession = MarketSession.REGULAR,
+) -> BrokerProtectiveQuote:
+    now = datetime.now(timezone.utc)
+    event_time = source_timestamp or now
+    return BrokerProtectiveQuote(
+        schema_version=1,
+        symbol=symbol,
+        con_id=con_id,
+        exchange="SMART",
+        primary_exchange="NASDAQ",
+        currency="USD",
+        security_type="STK",
+        price=price,
+        source_timestamp=event_time,
+        retrieval_timestamp=now,
+        session=session,
+        source=MarketDataSource.IBKR_LIVE_LAST_TRADE,
+        source_event_id=source_event_id
+        or (
+            f"protective:{generation}:1"
+            if symbol == "AAPL"
+            else f"protective:{generation}:{symbol}:1"
+        ),
+        transport_generation=generation,
+        market_data_type=1,
+    )
+
+
+def _connected_client(
+    monkeypatch: pytest.MonkeyPatch,
+    response: dict,
+    *,
+    generation_id: str = "generation-1",
+):
+    client = SubprocessIBKRClient()
+    generation = _WorkerGeneration(
+        generation_id=generation_id,
+        process=SimpleNamespace(poll=lambda: 0),
+    )
+    client._generation = generation
+    client._connected = True
+    client._connection_generation_id = generation.generation_id
+    client._connection_identity = ("127.0.0.1", 4002, 7, True)
+    execute = AsyncMock(return_value=response)
+    monkeypatch.setattr(client, "_execute_command_unlocked", execute)
+    return client, generation
+
+
+@pytest.mark.asyncio
+async def test_fixed_event_id_accepts_worst_case_generation_and_sequence_end_to_end(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime.now(timezone.utc)
+    contract = _contract()
+    # The monitor's producer-owned evidence contract admits generation IDs up
+    # to 128 characters; exercise that exact downstream boundary.
+    generation_id = "g" * 128
+
+    class FakeIB:
+        def isConnected(self) -> bool:
+            return True
+
+        async def qualifyContractsAsync(self, _requested):
+            return [contract]
+
+        async def reqCurrentTimeAsync(self):
+            return now
+
+        def reqTickByTickData(
+            self,
+            _contract,
+            _tick_type,
+            *,
+            numberOfTicks,
+            ignoreSize,
+        ):
+            assert numberOfTicks == 0
+            assert ignoreSize is False
+            return SimpleNamespace(
+                contract=contract,
+                tickByTicks=[
+                    SimpleNamespace(
+                        time=now,
+                        price=Decimal("95"),
+                        size=10**100,
+                        exchange="X" * 256,
+                    )
+                ],
+            )
+
+        def cancelTickByTickData(self, _contract, _tick_type):
+            return None
+
+    monkeypatch.setattr(worker, "ib", FakeIB())
+    monkeypatch.setattr(worker, "WORKER_GENERATION_ID", generation_id)
+    monkeypatch.setattr(worker, "_PROTECTIVE_TICK_EVENT_SEQUENCE", iter([10**1000]))
+    monkeypatch.setattr(worker, "get_market_session", lambda _timestamp: "regular")
+
+    worker_response = await worker.handle_get_protective_quotes(
+        {"symbols": ["AAPL"], "active_symbols": ["AAPL"]}
+    )
+    assert worker_response["status"] == "success"
+    source_event_id = worker_response["data"]["quotes"][0]["source_event_id"]
+    assert len(source_event_id) == len("protective:v1:") + 64
+    assert len(source_event_id) <= MAX_PROTECTIVE_SOURCE_EVENT_ID_LENGTH
+
+    client, _generation = _connected_client(
+        monkeypatch,
+        worker_response["data"],
+        generation_id=generation_id,
+    )
+    quote = (await client.get_protective_quotes(["AAPL"]))[0]
+    monitor = StopLossMonitor(
+        execute_reduction=AsyncMock(),
+        risk_manager=None,
+        portfolio_id="default",
+    )
+
+    accepted = await monitor.update_price(
+        quote.symbol,
+        quote.price,
+        source_timestamp=quote.source_timestamp,
+        source=ProtectiveQuoteSource.LIVE_BROKER,
+        con_id=quote.con_id,
+        transport_generation=quote.transport_generation,
+        source_event_id=quote.source_event_id,
+    )
+
+    assert accepted is True
+    evidence = monitor.get_protective_quote_evidence("AAPL")
+    assert evidence is not None
+    assert evidence.source_event_id == source_event_id
+    assert evidence.transport_generation == generation_id
+
+
+@pytest.mark.asyncio
+async def test_shared_source_event_id_boundary_is_accepted_at_128_and_rejected_at_129() -> None:
+    event_time = datetime.now(timezone.utc)
+    boundary_id = "x" * MAX_PROTECTIVE_SOURCE_EVENT_ID_LENGTH
+    quote = _broker_quote(
+        price=Decimal("101"),
+        source_timestamp=event_time,
+        source_event_id=boundary_id,
+    )
+    assert quote.source_event_id == boundary_id
+
+    with pytest.raises(MarketDataIdentityError, match="source_event_id is malformed"):
+        _broker_quote(
+            price=Decimal("101"),
+            source_timestamp=event_time,
+            source_event_id="x" * (MAX_PROTECTIVE_SOURCE_EVENT_ID_LENGTH + 1),
+        )
+
+    monitor = StopLossMonitor(
+        execute_reduction=AsyncMock(),
+        risk_manager=None,
+        portfolio_id="default",
+    )
+    accepted = await monitor.update_price(
+        quote.symbol,
+        quote.price,
+        source_timestamp=quote.source_timestamp,
+        source=ProtectiveQuoteSource.LIVE_BROKER,
+        con_id=quote.con_id,
+        transport_generation=quote.transport_generation,
+        source_event_id=boundary_id,
+    )
+    rejected = await monitor.update_price(
+        quote.symbol,
+        quote.price,
+        source_timestamp=quote.source_timestamp,
+        source=ProtectiveQuoteSource.LIVE_BROKER,
+        con_id=quote.con_id,
+        transport_generation=quote.transport_generation,
+        source_event_id="x" * (MAX_PROTECTIVE_SOURCE_EVENT_ID_LENGTH + 1),
+    )
+
+    assert accepted is True
+    assert rejected is False
+
+
+@pytest.mark.asyncio
+async def test_client_binds_quote_to_exact_current_transport_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, generation = _connected_client(monkeypatch, _client_response())
+
+    quotes = await client.get_protective_quotes(["AAPL"])
+
+    assert len(quotes) == 1
+    quote = quotes[0]
+    assert type(quote) is BrokerProtectiveQuote
+    assert quote.transport_generation == generation.generation_id
+    assert quote.source is MarketDataSource.IBKR_LIVE_LAST_TRADE
+    assert str(quote.price) == "187.25"
+
+
+@pytest.mark.asyncio
+async def test_client_sends_full_account_active_set_with_each_fetch_chunk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _generation = _connected_client(monkeypatch, _client_response())
+
+    await client.get_protective_quotes(
+        ["AAPL"],
+        active_symbols=["AAPL", "MSFT"],
+    )
+
+    command = client._execute_command_unlocked.await_args.args[0]
+    assert command == {
+        "command": "get_protective_quotes",
+        "params": {
+            "symbols": ["AAPL"],
+            "active_symbols": ["AAPL", "MSFT"],
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_client_empty_fetch_explicitly_cancels_all_account_subscriptions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _client_response()
+    response["quotes"] = []
+    client, _generation = _connected_client(monkeypatch, response)
+
+    quotes = await client.get_protective_quotes([], active_symbols=[])
+
+    assert quotes == ()
+    command = client._execute_command_unlocked.await_args.args[0]
+    assert command["params"] == {"symbols": [], "active_symbols": []}
+
+
+@pytest.mark.asyncio
+async def test_client_rejects_fetch_symbol_missing_from_account_active_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _generation = _connected_client(monkeypatch, _client_response())
+
+    with pytest.raises(ValueError, match="not account-active"):
+        await client.get_protective_quotes(["AAPL"], active_symbols=["MSFT"])
+
+    client._execute_command_unlocked.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_canonical_client_rejects_non_trade_bars_before_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _generation = _connected_client(monkeypatch, {})
+
+    with pytest.raises(ValueError, match="exact what_to_show='TRADES'"):
+        await client.get_canonical_historical_bars(
+            "AAPL",
+            what_to_show="MIDPOINT",
+        )
+
+    client._execute_command_unlocked.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_client_accepts_ordered_multi_event_replay_with_unique_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _client_response()
+    retrieval = datetime.fromisoformat(response["retrieval_timestamp"])
+    first = dict(
+        response["quotes"][0],
+        price="95",
+        source_timestamp=(retrieval - timedelta(seconds=2)).isoformat(),
+        source_event_id="protective:generation-1:1",
+    )
+    second = dict(
+        response["quotes"][0],
+        price="96",
+        source_timestamp=(retrieval - timedelta(seconds=1)).isoformat(),
+        source_event_id="protective:generation-1:2",
+    )
+    response["quotes"] = [first, second]
+    client, _generation = _connected_client(monkeypatch, response)
+
+    quotes = await client.get_protective_quotes(["AAPL"])
+
+    assert [quote.price for quote in quotes] == [Decimal("95"), Decimal("96")]
+    assert [quote.source_event_id for quote in quotes] == [
+        "protective:generation-1:1",
+        "protective:generation-1:2",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_client_poisons_generation_for_out_of_order_event_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _client_response()
+    retrieval = datetime.fromisoformat(response["retrieval_timestamp"])
+    response["quotes"] = [
+        dict(
+            response["quotes"][0],
+            source_timestamp=(retrieval - timedelta(seconds=1)).isoformat(),
+            source_event_id="protective:generation-1:1",
+        ),
+        dict(
+            response["quotes"][0],
+            source_timestamp=(retrieval - timedelta(seconds=2)).isoformat(),
+            source_event_id="protective:generation-1:2",
+        ),
+    ]
+    client, generation = _connected_client(monkeypatch, response)
+
+    with pytest.raises(IBKRTransportPoisonedError, match="out of order"):
+        await client.get_protective_quotes(["AAPL"])
+
+    assert generation.poisoned_reason is not None
+
+
+@pytest.mark.asyncio
+async def test_non_live_quote_poisons_the_exact_worker_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, generation = _connected_client(
+        monkeypatch,
+        _client_response(market_data_type=3),
+    )
+
+    with pytest.raises(IBKRTransportPoisonedError, match="not live"):
+        await client.get_protective_quotes(["AAPL"])
+
+    assert generation.poisoned_reason is not None
+
+
+@pytest.mark.asyncio
+async def test_oversized_event_identity_poisons_the_exact_worker_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _client_response()
+    response["quotes"][0]["source_event_id"] = "x" * (MAX_PROTECTIVE_SOURCE_EVENT_ID_LENGTH + 1)
+    client, generation = _connected_client(monkeypatch, response)
+
+    with pytest.raises(IBKRTransportPoisonedError, match="exceeds its bound"):
+        await client.get_protective_quotes(["AAPL"])
+
+    assert generation.poisoned_reason is not None
+
+
+@pytest.mark.asyncio
+async def test_gateway_distributes_exact_decimal_quote_to_attached_monitor() -> None:
+    quote = _broker_quote()
+
+    class FakeClient:
+        async def get_protective_quotes(self, symbols, *, active_symbols=None):
+            assert tuple(symbols) == ("AAPL",)
+            assert active_symbols is None or tuple(active_symbols) == ("AAPL",)
+            return (quote,)
+
+        async def stop(self):
+            return None
+
+    monitor = StopLossMonitor(
+        execute_reduction=AsyncMock(),
+        risk_manager=None,
+        portfolio_id="default",
+    )
+    gateway = object.__new__(PaperReductionGateway)
+    gateway._started = True
+    gateway._diagnostic_recovery_required = False
+    gateway._account_order_gate = asyncio.Lock()
+    gateway._client = FakeClient()
+    gateway._protective_quote_producers = {"default": monitor}
+
+    result = await gateway.refresh_protective_quotes(("AAPL",))
+
+    assert result == (quote,)
+    evidence = monitor.get_protective_quote_evidence("AAPL")
+    assert evidence is not None
+    assert evidence.price == Decimal("187.2500")
+    assert evidence.source is ProtectiveQuoteSource.LIVE_BROKER
+    assert evidence.transport_generation == "generation-1"
+
+
+@pytest.mark.asyncio
+async def test_gateway_ordered_intrapoll_replay_latches_crossing_before_recovery() -> None:
+    monitor = StopLossMonitor(
+        execute_reduction=AsyncMock(),
+        risk_manager=None,
+        portfolio_id="default",
+    )
+    stop = await monitor.add_stop_loss(
+        "AAPL",
+        Position(symbol="AAPL", quantity=10, avg_price=Decimal("100")),
+        stop_percent=0.02,
+    )
+    event_time = datetime.now(timezone.utc)
+    crossing = _broker_quote(
+        price=Decimal("95"),
+        source_timestamp=event_time,
+        source_event_id="protective:generation-1:crossing",
+    )
+    recovery = _broker_quote(
+        price=Decimal("105"),
+        source_timestamp=event_time,
+        source_event_id="protective:generation-1:recovery",
+    )
+
+    class FakeClient:
+        async def get_protective_quotes(self, symbols, *, active_symbols=None):
+            assert tuple(symbols) == ("AAPL",)
+            assert active_symbols is None or tuple(active_symbols) == ("AAPL",)
+            return (crossing, recovery)
+
+        async def stop(self):
+            return None
+
+    gateway = object.__new__(PaperReductionGateway)
+    gateway._started = True
+    gateway._diagnostic_recovery_required = False
+    gateway._account_order_gate = asyncio.Lock()
+    gateway._client = FakeClient()
+    gateway._protective_quote_producers = {"default": monitor}
+
+    published = await gateway.refresh_protective_quotes(("AAPL",))
+
+    assert [quote.price for quote in published] == [Decimal("95"), Decimal("105")]
+    assert stop.status is StopStatus.TRIGGERED
+    assert stop.trigger_price == 95.0
+    latched = monitor._latched_stop_crossings[id(stop)]
+    assert latched.trigger_price == 95.0
+    assert latched.quote_evidence is not None
+    assert latched.quote_evidence.price == Decimal("95")
+    current = monitor.get_protective_quote_evidence("AAPL")
+    assert current is not None
+    assert current.price == Decimal("105")
+    assert current.source_event_id == "protective:generation-1:recovery"
+    assert monitor.last_prices["AAPL"] == 105.0
+
+
+@pytest.mark.asyncio
+async def test_gateway_distributes_one_account_quote_to_each_portfolio_monitor() -> None:
+    quote = _broker_quote()
+
+    class FakeClient:
+        async def get_protective_quotes(self, _symbols, *, active_symbols=None):
+            return (quote,)
+
+        async def stop(self):
+            return None
+
+    monitors = {
+        portfolio_id: StopLossMonitor(
+            execute_reduction=AsyncMock(),
+            risk_manager=None,
+            portfolio_id=portfolio_id,
+        )
+        for portfolio_id in ("growth", "income")
+    }
+    gateway = object.__new__(PaperReductionGateway)
+    gateway._started = True
+    gateway._diagnostic_recovery_required = False
+    gateway._account_order_gate = asyncio.Lock()
+    gateway._client = FakeClient()
+    gateway._protective_quote_producers = monitors
+
+    await gateway.refresh_protective_quotes(("AAPL",))
+
+    for portfolio_id, monitor in monitors.items():
+        evidence = monitor.get_protective_quote_evidence("AAPL")
+        assert evidence is not None
+        assert evidence.portfolio_id == portfolio_id
+        assert evidence.price == quote.price
+
+
+@pytest.mark.asyncio
+async def test_runner_opens_feed_gate_only_after_gateway_owned_quote_refresh() -> None:
+    quote = _broker_quote()
+
+    class FakeClient:
+        async def get_protective_quotes(self, _symbols, *, active_symbols=None):
+            return (quote,)
+
+        async def stop(self):
+            return None
+
+    monitor = StopLossMonitor(
+        execute_reduction=AsyncMock(),
+        risk_manager=None,
+        portfolio_id="default",
+    )
+    gateway = object.__new__(PaperReductionGateway)
+    gateway._started = True
+    gateway._diagnostic_recovery_required = False
+    gateway._account_order_gate = asyncio.Lock()
+    gateway._client = FakeClient()
+    gateway._protective_quote_producers = {"default": monitor}
+    runner = object.__new__(AsyncRunner)
+    runner.portfolio_id = "default"
+    runner.paper_reduction_gateway = gateway
+    runner.stop_loss_monitor = monitor
+    runner.latest_prices = {}
+    runner.latest_price_times = {}
+    runner.latest_price_sources = {}
+    runner._protective_feed_status = {}
+
+    assert runner._has_live_protective_feed("AAPL") is False
+    assert await runner._refresh_live_protective_quotes(("AAPL",)) is True
+    assert runner._has_live_protective_feed("AAPL") is True
+    assert runner.latest_price_sources["AAPL"] == "live_protective"
+
+
+@pytest.mark.asyncio
+async def test_gateway_refresh_failure_revokes_evidence_and_retires_generation() -> None:
+    quote = _broker_quote()
+
+    class FakeClient:
+        def __init__(self):
+            self.fail = False
+            self.stop_count = 0
+
+        async def get_protective_quotes(self, _symbols, *, active_symbols=None):
+            if self.fail:
+                raise RuntimeError("poisoned protective transport")
+            return (quote,)
+
+        async def stop(self):
+            self.stop_count += 1
+
+    client = FakeClient()
+    monitor = StopLossMonitor(
+        execute_reduction=AsyncMock(),
+        risk_manager=None,
+        portfolio_id="default",
+    )
+    gateway = object.__new__(PaperReductionGateway)
+    gateway._started = True
+    gateway._diagnostic_recovery_required = False
+    gateway._account_order_gate = asyncio.Lock()
+    gateway._client = client
+    gateway._protective_quote_producers = {"default": monitor}
+    await gateway.refresh_protective_quotes(("AAPL",))
+    assert monitor.get_protective_quote_evidence("AAPL") is not None
+
+    client.fail = True
+    with pytest.raises(RuntimeError, match="poisoned protective transport"):
+        await gateway.refresh_protective_quotes(("AAPL",))
+
+    assert monitor.get_protective_quote_evidence("AAPL") is None
+    assert gateway._started is False
+    assert gateway._diagnostic_recovery_required is True
+    assert client.stop_count == 1
+
+
+@pytest.mark.asyncio
+async def test_gateway_chunks_fetches_without_shrinking_account_active_set() -> None:
+    symbols = tuple("Q" + chr(65 + (index // 26)) + chr(65 + (index % 26)) for index in range(130))
+
+    class FakeClient:
+        def __init__(self):
+            self.calls = []
+
+        async def get_protective_quotes(self, requested, *, active_symbols=None):
+            self.calls.append((tuple(requested), tuple(active_symbols or ())))
+            return tuple(
+                _broker_quote(
+                    symbol=symbol,
+                    con_id=300000 + symbols.index(symbol),
+                    source_event_id=f"protective:generation-1:{symbol}",
+                )
+                for symbol in requested
+            )
+
+        async def stop(self):
+            return None
+
+    client = FakeClient()
+    monitor = StopLossMonitor(
+        execute_reduction=AsyncMock(),
+        risk_manager=None,
+        portfolio_id="default",
+    )
+    gateway = object.__new__(PaperReductionGateway)
+    gateway._started = True
+    gateway._diagnostic_recovery_required = False
+    gateway._account_order_gate = asyncio.Lock()
+    gateway._client = client
+    gateway._protective_quote_producers = {"default": monitor}
+
+    quotes = await gateway.refresh_protective_quotes(symbols)
+
+    assert len(quotes) == 130
+    assert [len(call[0]) for call in client.calls] == [64, 64, 2]
+    assert all(call[1] == symbols for call in client.calls)
+
+
+@pytest.mark.asyncio
+async def test_entry_quote_that_crosses_stop_blocks_entry_before_yield(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from robo_trader.safety import readiness as paper_readiness
+
+    monkeypatch.setattr(paper_readiness, "PAPER_TERMINAL_SETTLEMENT_READY", True)
+    monitor = StopLossMonitor(
+        execute_reduction=AsyncMock(),
+        risk_manager=None,
+        portfolio_id="default",
+    )
+    stop = await monitor.add_stop_loss(
+        "AAPL",
+        Position(symbol="AAPL", quantity=10, avg_price=Decimal("100")),
+        stop_percent=0.02,
+    )
+    crossing = _broker_quote(price=Decimal("95"))
+
+    class FakeClient:
+        async def ping(self):
+            return True
+
+        async def get_protective_quotes(self, requested, *, active_symbols=None):
+            assert tuple(requested) == ("AAPL",)
+            assert tuple(active_symbols or ()) == ("AAPL",)
+            return (crossing,)
+
+        async def stop(self):
+            return None
+
+    gateway = object.__new__(PaperReductionGateway)
+    gateway._started = True
+    gateway._diagnostic_recovery_required = False
+    gateway._account_order_gate = asyncio.Lock()
+    gateway._client = FakeClient()
+    gateway._protective_quote_producers = {"default": monitor}
+    entered = False
+
+    with pytest.raises(PaperReductionGatewayError, match="protective reduction is pending"):
+        async with gateway.serialize_entry("AAPL"):
+            entered = True
+
+    assert entered is False
+    assert stop.status is StopStatus.TRIGGERED
+    assert await monitor.has_pending_reduction() is True
+    assert gateway._started is True
+
+
+@pytest.mark.asyncio
+async def test_entry_refresh_crossing_in_another_portfolio_blocks_before_yield(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from robo_trader.safety import readiness as paper_readiness
+
+    monkeypatch.setattr(paper_readiness, "PAPER_TERMINAL_SETTLEMENT_READY", True)
+    entry_monitor = StopLossMonitor(
+        execute_reduction=AsyncMock(),
+        risk_manager=None,
+        portfolio_id="entry",
+    )
+    protected_monitor = StopLossMonitor(
+        execute_reduction=AsyncMock(),
+        risk_manager=None,
+        portfolio_id="protected",
+    )
+    protected_stop = await protected_monitor.add_stop_loss(
+        "MSFT",
+        Position(symbol="MSFT", quantity=10, avg_price=Decimal("100")),
+        stop_percent=0.02,
+    )
+    quotes = {
+        "AAPL": _broker_quote(
+            symbol="AAPL",
+            con_id=265598,
+            price=Decimal("187.25"),
+            source_event_id="protective:generation-1:aapl",
+        ),
+        "MSFT": _broker_quote(
+            symbol="MSFT",
+            con_id=272093,
+            price=Decimal("95"),
+            source_event_id="protective:generation-1:msft-crossing",
+        ),
+    }
+
+    class FakeClient:
+        async def ping(self):
+            return True
+
+        async def get_protective_quotes(self, requested, *, active_symbols=None):
+            assert tuple(requested) == ("AAPL", "MSFT")
+            assert tuple(active_symbols or ()) == ("AAPL", "MSFT")
+            return tuple(quotes[symbol] for symbol in requested)
+
+        async def stop(self):
+            return None
+
+    gateway = object.__new__(PaperReductionGateway)
+    gateway._started = True
+    gateway._diagnostic_recovery_required = False
+    gateway._account_order_gate = asyncio.Lock()
+    gateway._client = FakeClient()
+    gateway._protective_quote_producers = {
+        "entry": entry_monitor,
+        "protected": protected_monitor,
+    }
+    entered = False
+
+    with pytest.raises(PaperReductionGatewayError, match="protective reduction is pending"):
+        async with gateway.serialize_entry("AAPL"):
+            entered = True
+
+    assert entered is False
+    assert protected_stop.status is StopStatus.TRIGGERED
+    assert protected_stop.trigger_price == 95.0
+    assert await protected_monitor.has_pending_reduction() is True
+
+
+@pytest.mark.asyncio
+async def test_retired_generation_waits_before_same_symbol_resubscribe() -> None:
+    clock = {"now": 100.0}
+    sleeps: list[float] = []
+    request_times: list[float] = []
+    quote = _broker_quote()
+
+    async def controlled_sleep(delay: float) -> None:
+        sleeps.append(delay)
+        clock["now"] += delay
+
+    class FakeClient:
+        async def get_protective_quotes(self, requested, *, active_symbols=None):
+            request_times.append(clock["now"])
+            return (quote,)
+
+        async def stop(self):
+            return None
+
+    gateway = object.__new__(PaperReductionGateway)
+    gateway._client = FakeClient()
+    gateway._monotonic = lambda: clock["now"]
+    gateway._sleep = controlled_sleep
+    gateway._generation_symbol_first_request = {}
+    gateway._generation_subscribed_symbols = set()
+    gateway._resubscribe_not_before = 0.0
+    gateway._tick_resubscribe_cooldown_seconds = 15.0
+
+    await gateway._fetch_protective_quotes_locked(
+        ("AAPL",),
+        active_symbols=("AAPL",),
+    )
+    await gateway._stop_client_owned()
+    await gateway._fetch_protective_quotes_locked(
+        ("AAPL",),
+        active_symbols=("AAPL",),
+    )
+
+    assert sleeps == [15.0]
+    assert request_times == [100.0, 115.0]
+    assert request_times[1] - request_times[0] >= 15.0
+
+
+@pytest.mark.asyncio
+async def test_cooldown_starts_after_delayed_worker_command_completion() -> None:
+    clock = {"now": 100.0}
+    command_starts: list[float] = []
+    sleeps: list[float] = []
+    quote = _broker_quote()
+
+    async def controlled_sleep(delay: float) -> None:
+        sleeps.append(delay)
+        clock["now"] += delay
+
+    class FakeClient:
+        def __init__(self):
+            self.call_count = 0
+
+        async def get_protective_quotes(self, requested, *, active_symbols=None):
+            self.call_count += 1
+            command_starts.append(clock["now"])
+            if self.call_count == 1:
+                # Simulate qualification and broker-time work before the
+                # worker reaches reqTickByTickData and completes its command.
+                clock["now"] += 14.0
+            return (quote,)
+
+        async def stop(self):
+            return None
+
+    gateway = object.__new__(PaperReductionGateway)
+    gateway._client = FakeClient()
+    gateway._monotonic = lambda: clock["now"]
+    gateway._sleep = controlled_sleep
+    gateway._generation_symbol_first_request = {}
+    gateway._generation_subscribed_symbols = set()
+    gateway._resubscribe_not_before = 0.0
+    gateway._tick_resubscribe_cooldown_seconds = 15.0
+
+    await gateway._fetch_protective_quotes_locked(
+        ("AAPL",),
+        active_symbols=("AAPL",),
+    )
+    assert clock["now"] == 114.0
+    await gateway._stop_client_owned()
+    await gateway._fetch_protective_quotes_locked(
+        ("AAPL",),
+        active_symbols=("AAPL",),
+    )
+
+    assert sleeps == [15.0]
+    assert command_starts == [100.0, 129.0]
+
+
+@pytest.mark.asyncio
+async def test_cooldown_uses_delayed_first_request_time_from_later_chunk() -> None:
+    symbols = tuple(f"Q{index:03d}" for index in range(65))
+    delayed_symbol = symbols[-1]
+    clock = {"now": 100.0}
+    request_times: dict[str, list[float]] = {}
+    sleeps: list[float] = []
+
+    async def controlled_sleep(delay: float) -> None:
+        sleeps.append(delay)
+        clock["now"] += delay
+
+    class FakeClient:
+        def __init__(self):
+            self.call_count = 0
+
+        async def get_protective_quotes(self, requested, *, active_symbols=None):
+            self.call_count += 1
+            for symbol in requested:
+                request_times.setdefault(symbol, []).append(clock["now"])
+            response = tuple(SimpleNamespace(symbol=symbol) for symbol in requested)
+            if self.call_count == 1:
+                clock["now"] += 14.0
+            return response
+
+        async def stop(self):
+            return None
+
+    gateway = object.__new__(PaperReductionGateway)
+    gateway._client = FakeClient()
+    gateway._monotonic = lambda: clock["now"]
+    gateway._sleep = controlled_sleep
+    gateway._generation_symbol_first_request = {}
+    gateway._generation_subscribed_symbols = set()
+    gateway._resubscribe_not_before = 0.0
+    gateway._tick_resubscribe_cooldown_seconds = 15.0
+
+    await gateway._fetch_protective_quotes_locked(
+        symbols,
+        active_symbols=symbols,
+    )
+    assert request_times[delayed_symbol] == [114.0]
+    clock["now"] += 1.0
+    await gateway._stop_client_owned()
+    await gateway._fetch_protective_quotes_locked(
+        (delayed_symbol,),
+        active_symbols=(delayed_symbol,),
+    )
+
+    assert sleeps == [14.0]
+    assert request_times[delayed_symbol] == [114.0, 129.0]
+
+
+@pytest.mark.asyncio
+async def test_feed_task_is_singleton_and_cancellable() -> None:
+    monitor = StopLossMonitor(
+        execute_reduction=AsyncMock(),
+        risk_manager=None,
+        portfolio_id="default",
+    )
+    gateway = object.__new__(PaperReductionGateway)
+    gateway._started = True
+    gateway._diagnostic_recovery_required = False
+    gateway._protective_quote_producers = {"default": monitor}
+    gateway._protective_feed_task = None
+    gateway._protective_feed_enabled = False
+    gateway._protective_feed_interval_seconds = 3600.0
+    gateway._protective_feed_max_recovery_attempts = 3
+
+    gateway.start_protective_feed()
+    task = gateway._protective_feed_task
+    gateway.start_protective_feed()
+
+    assert task is gateway._protective_feed_task
+    assert task is not None
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/tests/test_recover_connection.py
+++ b/tests/test_recover_connection.py
@@ -12,6 +12,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from robo_trader.connection_health import HealthStatus
+from robo_trader.market_data_contract import (
+    BrokerProtectiveQuote,
+    MarketDataSource,
+    MarketSession,
+)
 from robo_trader.paper_reduction_gateway import PaperReductionGateway
 from robo_trader.protective_quote_evidence import ProtectiveQuoteSource
 from robo_trader.risk_manager import Position
@@ -356,6 +361,33 @@ async def test_recovery_accepts_exact_fresh_event_already_owned_by_monitor():
         Position("AAPL", 10, Decimal("100")),
     )
     runner.stop_loss_monitor = monitor
+
+    gateway = object.__new__(PaperReductionGateway)
+    gateway._started = True
+    gateway._diagnostic_recovery_required = False
+    gateway.refresh_diagnostic_connection = AsyncMock()
+    gateway.refresh_protective_quotes = AsyncMock(
+        return_value=(
+            BrokerProtectiveQuote(
+                schema_version=1,
+                symbol="AAPL",
+                con_id=265598,
+                exchange="SMART",
+                primary_exchange="NASDAQ",
+                currency="USD",
+                security_type="STK",
+                price=Decimal("150.0"),
+                source_timestamp=event_time,
+                retrieval_timestamp=event_time,
+                session=MarketSession.REGULAR,
+                source=MarketDataSource.IBKR_LIVE_LAST_TRADE,
+                source_event_id="recovery-ticker-1",
+                transport_generation="recovered-generation",
+                market_data_type=1,
+            ),
+        )
+    )
+    runner.paper_reduction_gateway = gateway
 
     async def initialize_with_new_transport_quote() -> None:
         assert await monitor.update_price(


### PR DESCRIPTION
## What changed

- Add a versioned canonical bar/quote schema with timezone-aware event time, source, derived session, retrieval time, lineage, and quality flags.
- Normalize and validate IBKR historical responses at the broker boundary; independently re-derive quote sessions in the parent client and poison mismatches.
- Persist canonical market events as first-observation immutable evidence: exact repeats are no-ops and conflicting revisions reject atomically without overwriting provenance.
- Add tick-by-tick protective quote subscriptions and fail closed when entry/protection evidence is stale, missing, cross-symbol, or terminally degraded.
- Quarantine account-wide order admission and invoke existing operator/emergency callbacks when the continuous protective feed exhausts recovery.
- Make entry quote refresh account-wide and performance timers unique per operation.
- Surface market-data freshness/lineage through dashboard, WebSocket, and synchronous readers.
- Record durable PR3 review evidence and update the remediation plan.

## Root cause

Legacy paths could treat a RangeIndex or unrelated delayed broker response as market event time and price evidence. That created the false TSLA 45.13% loss trigger and allowed historical closes to masquerade as protective realtime evidence. Independent review also found that terminal feed failure did not remain quarantined, worker session labels were trusted, and overlapping refreshes could overwrite original audit evidence; all three are fixed on this branch.

## Safety and impact

This PR tightens data admission and protective evidence. It does not start the trader, clear safety state, enable live orders, or authorize Gate A. Stale, ambiguous, conflicting, or terminally degraded data blocks entries and protection decisions.

## Validation

- Initial focused PR3 plus affected PR1/PR2/PR108 regressions: 567 passed.
- Post-rebase affected suite: 494 passed.
- Final rebased full suite: 2,360 passed, 5 expected skips.
- Black, isort, Flake8 on all changed Python files: pass.
- `git diff --check`: pass.
- Rebased onto exact PR #110 merged main `4b2248f` with no conflicts; fresh exact-head checks are running.
- Independent review found and the branch fixed three release blockers: terminal-feed quarantine, parent-side session validation, and immutable market-event persistence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core trading admission, protective stop pricing, and broker transport validation—areas that directly affect whether stale or ambiguous data can trigger entries or exits.
> 
> **Overview**
> **PR 3** replaces ad hoc market-data handling with a **versioned canonical contract** for historical strategy bars and a **separate live last-trade channel** for protective monitoring and entries.
> 
> Historical IBKR `TRADES` bars are normalized into immutable `CanonicalBarBatch` evidence (broker identity, session policy, timestamps, lineage). Strategy signals still use bars, but **entries are blocked** without a matching canonical batch plus **fresh `BrokerProtectiveQuote`** from tick-by-tick subscriptions in the IBKR worker. The paper gateway runs a **continuous protective feed**, refreshes quotes under the account order lock, **invalidates** stale generation evidence on disconnect, and **quarantines** admission if the feed fails repeatedly.
> 
> Persistence adds **`canonical_market_data`** with first-observation semantics (conflicts reject; routine cleanup no longer deletes canonical audit rows). Reads expose freshness and lineage; a new **`/api/market-data/<symbol>`** endpoint and watchlist/WebSocket payloads surface source, event/retrieval times, and freshness. Entry paths re-validate quotes at dispatch, price orders from live quotes (not bar closes), and tie fills to exact executor prices.
> 
> Docs record PR 3 local review evidence and remediation-plan status (PR 2B.3 merged; PR 3 in progress).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7c30c0ff63be0ed30e41765035c8f41550da0b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->