### PR TITLE
PR5: define dormant reconciliation domain policy

### DIFF
--- a/robo_trader/reconciliation/domain.py
+++ b/robo_trader/reconciliation/domain.py
@@ -1,0 +1,808 @@
+"""Immutable, versioned records for dormant broker reconciliation.
+
+These records normalize read-only evidence only.  They carry no broker client,
+database handle, order capability, or runtime activation authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import (
+    MAX_EMAX,
+    MIN_EMIN,
+    ROUND_HALF_EVEN,
+    Context,
+    Decimal,
+    DivisionByZero,
+    InvalidOperation,
+    Overflow,
+    localcontext,
+)
+from enum import Enum
+from typing import Iterable
+
+from .errors import ReconciliationError
+
+DOMAIN_SCHEMA_VERSION = 1
+PAPER_SIMULATOR_SCOPE = "paper-simulator-v1"
+IBKR_READ_ONLY_SCOPE = "ibkr-read-only-v1"
+MAX_COLLECTION_WINDOW_SECONDS = 60
+MAX_RETRIEVAL_DELAY_SECONDS = 5
+
+_ACCOUNT_SCOPE = re.compile(r"^acct_v1_[0-9a-f]{64}$")
+_ACCOUNT_FRAGMENT = re.compile(r"(?:DU|U)\d{4,}", re.IGNORECASE)
+_MASKED_ACCOUNT_ALIAS = re.compile(r"^\*{3}[A-Za-z0-9]{1,4}$")
+_SYMBOL = re.compile(r"^[A-Z0-9][A-Z0-9._-]{0,31}$")
+_IDENTIFIER = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+_CURRENCY = re.compile(r"^[A-Z]{3}$")
+_COLLECTION_EVIDENCE_ID = re.compile(r"^broker-collection-v1-[0-9a-f]{64}$")
+
+
+class ReconciliationDomainError(ReconciliationError):
+    """A normalized reconciliation record cannot be trusted."""
+
+
+class ExecutionDomainScope(str, Enum):
+    """Execution authorities that must never be silently conflated."""
+
+    PAPER_SIMULATOR = PAPER_SIMULATOR_SCOPE
+    IBKR_READ_ONLY = IBKR_READ_ONLY_SCOPE
+
+
+class BrokerOrderCollection(str, Enum):
+    """The broker collection in which an order was observed."""
+
+    OPEN = "open"
+    COMPLETED = "completed"
+
+
+class BrokerOrderSide(str, Enum):
+    BUY = "BUY"
+    SELL = "SELL"
+
+
+class BrokerCollectionKind(str, Enum):
+    """Broker collections whose empty results require explicit evidence."""
+
+    POSITIONS = "positions"
+    OPEN_ORDERS = "open_orders"
+    COMPLETED_ORDERS = "completed_orders"
+    EXECUTIONS = "executions"
+    COMMISSIONS = "commissions"
+
+
+def _strict_text(value: object, field_name: str, *, pattern: re.Pattern[str]) -> str:
+    if not isinstance(value, str) or value != value.strip() or not pattern.fullmatch(value):
+        raise ReconciliationDomainError(f"{field_name} is malformed")
+    if _ACCOUNT_FRAGMENT.search(value):
+        raise ReconciliationDomainError(f"{field_name} contains raw account identity")
+    return value
+
+
+def _account_scope(value: object) -> str:
+    normalized = _strict_text(value, "account_scope", pattern=_ACCOUNT_SCOPE)
+    if len(set(normalized.removeprefix("acct_v1_"))) == 1:
+        raise ReconciliationDomainError("account_scope uses a placeholder digest")
+    return normalized
+
+
+def _timestamp(value: object, field_name: str) -> datetime:
+    if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+        raise ReconciliationDomainError(f"{field_name} must be timezone-aware")
+    try:
+        normalized = value.astimezone(timezone.utc)
+    except (OverflowError, ValueError) as exc:
+        raise ReconciliationDomainError(f"{field_name} is invalid") from exc
+    return normalized
+
+
+def _decimal(
+    value: object,
+    field_name: str,
+    *,
+    positive: bool = False,
+    nonnegative: bool = False,
+) -> Decimal:
+    if isinstance(value, bool) or isinstance(value, float):
+        raise ReconciliationDomainError(
+            f"{field_name} must be an exact decimal, not a binary float"
+        )
+    try:
+        parsed = value if isinstance(value, Decimal) else Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise ReconciliationDomainError(f"{field_name} must be a finite decimal") from exc
+    if not parsed.is_finite():
+        raise ReconciliationDomainError(f"{field_name} must be a finite decimal")
+    if positive and parsed <= 0:
+        raise ReconciliationDomainError(f"{field_name} must be positive")
+    if nonnegative and parsed < 0:
+        raise ReconciliationDomainError(f"{field_name} must be nonnegative")
+    return parsed
+
+
+def _schema_version(value: object, label: str) -> int:
+    if type(value) is not int or value != DOMAIN_SCHEMA_VERSION:
+        raise ReconciliationDomainError(f"{label} schema version is unsupported")
+    return value
+
+
+def _arithmetic_precision(*values: Decimal) -> int:
+    """Return enough precision to align and add all finite decimal operands exactly."""
+
+    highest_place = max(value.adjusted() for value in values)
+    exponents = tuple(value.as_tuple().exponent for value in values)
+    if any(type(exponent) is not int for exponent in exponents):
+        raise ReconciliationDomainError("decimal arithmetic requires finite operands")
+    lowest_place = min(exponent for exponent in exponents if isinstance(exponent, int))
+    return max(1, highest_place - lowest_place + 2)
+
+
+def _exact_context(precision: int) -> Context:
+    """Build a context that cannot inherit ambient decimal process state."""
+
+    return Context(
+        prec=precision,
+        rounding=ROUND_HALF_EVEN,
+        Emin=MIN_EMIN,
+        Emax=MAX_EMAX,
+        capitals=1,
+        clamp=0,
+        flags=[],
+        traps=[InvalidOperation, DivisionByZero, Overflow],
+    )
+
+
+def canonical_decimal(value: Decimal) -> str:
+    """Serialize an exact decimal without exponent or negative-zero drift."""
+
+    if type(value) is not Decimal or not value.is_finite():
+        raise ReconciliationDomainError("canonical decimal must be finite and exact")
+    if value.is_zero():
+        return "0"
+    sign, digits, exponent = value.as_tuple()
+    if type(exponent) is not int:
+        raise ReconciliationDomainError("canonical decimal must have a finite exponent")
+    coefficient = "".join(str(digit) for digit in digits)
+    if exponent >= 0:
+        rendered = coefficient + ("0" * exponent)
+    else:
+        split_at = len(coefficient) + exponent
+        if split_at <= 0:
+            rendered = "0." + ("0" * -split_at) + coefficient
+        else:
+            rendered = coefficient[:split_at] + "." + coefficient[split_at:]
+        rendered = rendered.rstrip("0").rstrip(".")
+    return ("-" if sign else "") + rendered
+
+
+def canonical_timestamp(value: datetime) -> str:
+    """Serialize one normalized UTC instant deterministically."""
+
+    normalized = _timestamp(value, "timestamp")
+    return normalized.isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def canonical_json(payload: object) -> str:
+    """Return the sole JSON encoding admitted to evidence fingerprints."""
+
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def fingerprint(prefix: str, payload: object) -> str:
+    """Build a namespaced SHA-256 identity from canonical public evidence."""
+
+    normalized_prefix = _strict_text(prefix, "fingerprint prefix", pattern=_IDENTIFIER)
+    digest = hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+    return f"{normalized_prefix}-{digest}"
+
+
+def _positive_identifier(value: object, field_name: str, *, allow_zero: bool = False) -> int:
+    if type(value) is not int or value < (0 if allow_zero else 1):
+        qualifier = "nonnegative" if allow_zero else "positive"
+        raise ReconciliationDomainError(f"{field_name} must be a {qualifier} integer")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizedBrokerAccount:
+    """Masked, exact account evidence from an IBKR read-only session."""
+
+    account_scope: str
+    account_alias: str
+    account_type: str
+    base_currency: str
+    total_cash: Decimal
+    buying_power: Decimal
+    observed_at: datetime
+    schema_version: int = DOMAIN_SCHEMA_VERSION
+    source_scope: ExecutionDomainScope = ExecutionDomainScope.IBKR_READ_ONLY
+
+    def __post_init__(self) -> None:
+        _schema_version(self.schema_version, "broker account")
+        if self.source_scope is not ExecutionDomainScope.IBKR_READ_ONLY:
+            raise ReconciliationDomainError("broker account source is not read-only IBKR")
+        object.__setattr__(self, "account_scope", _account_scope(self.account_scope))
+        object.__setattr__(
+            self,
+            "account_alias",
+            _strict_text(
+                self.account_alias,
+                "account_alias",
+                pattern=_MASKED_ACCOUNT_ALIAS,
+            ),
+        )
+        if self.account_type != "paper":
+            raise ReconciliationDomainError("broker account type is not paper")
+        object.__setattr__(
+            self,
+            "base_currency",
+            _strict_text(self.base_currency, "base_currency", pattern=_CURRENCY),
+        )
+        object.__setattr__(self, "total_cash", _decimal(self.total_cash, "total_cash"))
+        object.__setattr__(
+            self,
+            "buying_power",
+            _decimal(self.buying_power, "buying_power", nonnegative=True),
+        )
+        object.__setattr__(
+            self,
+            "observed_at",
+            _timestamp(self.observed_at, "account observed_at"),
+        )
+
+    def canonical_dict(self) -> dict[str, object]:
+        return {
+            "account_alias": self.account_alias,
+            "account_scope": self.account_scope,
+            "account_type": self.account_type,
+            "base_currency": self.base_currency,
+            "buying_power": canonical_decimal(self.buying_power),
+            "observed_at": canonical_timestamp(self.observed_at),
+            "schema_version": self.schema_version,
+            "source_scope": self.source_scope.value,
+            "total_cash": canonical_decimal(self.total_cash),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizedBrokerPosition:
+    """One signed, qualified broker position."""
+
+    account_scope: str
+    con_id: int
+    symbol: str
+    currency: str
+    signed_quantity: Decimal
+    average_cost: Decimal
+    observed_at: datetime
+    schema_version: int = DOMAIN_SCHEMA_VERSION
+    source_scope: ExecutionDomainScope = ExecutionDomainScope.IBKR_READ_ONLY
+
+    def __post_init__(self) -> None:
+        _schema_version(self.schema_version, "broker position")
+        if self.source_scope is not ExecutionDomainScope.IBKR_READ_ONLY:
+            raise ReconciliationDomainError("broker position source is not read-only IBKR")
+        object.__setattr__(self, "account_scope", _account_scope(self.account_scope))
+        object.__setattr__(self, "con_id", _positive_identifier(self.con_id, "con_id"))
+        object.__setattr__(
+            self,
+            "symbol",
+            _strict_text(self.symbol, "symbol", pattern=_SYMBOL),
+        )
+        object.__setattr__(
+            self,
+            "currency",
+            _strict_text(self.currency, "currency", pattern=_CURRENCY),
+        )
+        quantity = _decimal(self.signed_quantity, "signed_quantity")
+        if quantity == 0:
+            raise ReconciliationDomainError("broker position quantity cannot be zero")
+        object.__setattr__(self, "signed_quantity", quantity)
+        object.__setattr__(
+            self,
+            "average_cost",
+            _decimal(self.average_cost, "average_cost", nonnegative=True),
+        )
+        object.__setattr__(
+            self,
+            "observed_at",
+            _timestamp(self.observed_at, "position observed_at"),
+        )
+
+    def canonical_dict(self) -> dict[str, object]:
+        return {
+            "account_scope": self.account_scope,
+            "average_cost": canonical_decimal(self.average_cost),
+            "con_id": self.con_id,
+            "currency": self.currency,
+            "observed_at": canonical_timestamp(self.observed_at),
+            "schema_version": self.schema_version,
+            "signed_quantity": canonical_decimal(self.signed_quantity),
+            "source_scope": self.source_scope.value,
+            "symbol": self.symbol,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizedBrokerOrder:
+    """One open or completed broker order with exact lifecycle identity."""
+
+    account_scope: str
+    collection: BrokerOrderCollection
+    broker_order_id: int
+    client_id: int
+    con_id: int
+    symbol: str
+    side: BrokerOrderSide
+    total_quantity: Decimal
+    filled_quantity: Decimal
+    remaining_quantity: Decimal
+    status: str
+    observed_at: datetime
+    permanent_id: int | None = None
+    schema_version: int = DOMAIN_SCHEMA_VERSION
+    source_scope: ExecutionDomainScope = ExecutionDomainScope.IBKR_READ_ONLY
+
+    def __post_init__(self) -> None:
+        _schema_version(self.schema_version, "broker order")
+        if self.source_scope is not ExecutionDomainScope.IBKR_READ_ONLY:
+            raise ReconciliationDomainError("broker order source is not read-only IBKR")
+        if type(self.collection) is not BrokerOrderCollection:
+            raise ReconciliationDomainError("broker order collection is invalid")
+        if type(self.side) is not BrokerOrderSide:
+            raise ReconciliationDomainError("broker order side is invalid")
+        object.__setattr__(self, "account_scope", _account_scope(self.account_scope))
+        object.__setattr__(
+            self,
+            "broker_order_id",
+            _positive_identifier(self.broker_order_id, "broker_order_id"),
+        )
+        object.__setattr__(
+            self,
+            "client_id",
+            _positive_identifier(self.client_id, "client_id", allow_zero=True),
+        )
+        object.__setattr__(self, "con_id", _positive_identifier(self.con_id, "con_id"))
+        object.__setattr__(
+            self,
+            "symbol",
+            _strict_text(self.symbol, "symbol", pattern=_SYMBOL),
+        )
+        total = _decimal(self.total_quantity, "total_quantity", positive=True)
+        filled = _decimal(self.filled_quantity, "filled_quantity", nonnegative=True)
+        remaining = _decimal(self.remaining_quantity, "remaining_quantity", nonnegative=True)
+        with localcontext(_exact_context(_arithmetic_precision(total, filled, remaining))):
+            quantities_match = filled + remaining == total
+        if not quantities_match:
+            raise ReconciliationDomainError("broker order quantities are inconsistent")
+        object.__setattr__(self, "total_quantity", total)
+        object.__setattr__(self, "filled_quantity", filled)
+        object.__setattr__(self, "remaining_quantity", remaining)
+        object.__setattr__(
+            self,
+            "status",
+            _strict_text(self.status, "order status", pattern=_IDENTIFIER),
+        )
+        object.__setattr__(
+            self,
+            "observed_at",
+            _timestamp(self.observed_at, "order observed_at"),
+        )
+        if self.permanent_id is not None:
+            object.__setattr__(
+                self,
+                "permanent_id",
+                _positive_identifier(self.permanent_id, "permanent_id"),
+            )
+
+    @property
+    def identity(self) -> tuple[int, int]:
+        return (self.client_id, self.broker_order_id)
+
+    def canonical_dict(self) -> dict[str, object]:
+        return {
+            "account_scope": self.account_scope,
+            "broker_order_id": self.broker_order_id,
+            "client_id": self.client_id,
+            "collection": self.collection.value,
+            "con_id": self.con_id,
+            "filled_quantity": canonical_decimal(self.filled_quantity),
+            "observed_at": canonical_timestamp(self.observed_at),
+            "permanent_id": self.permanent_id,
+            "remaining_quantity": canonical_decimal(self.remaining_quantity),
+            "schema_version": self.schema_version,
+            "side": self.side.value,
+            "source_scope": self.source_scope.value,
+            "status": self.status,
+            "symbol": self.symbol,
+            "total_quantity": canonical_decimal(self.total_quantity),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizedBrokerExecution:
+    """One broker execution with explicit commission availability."""
+
+    account_scope: str
+    execution_id: str
+    con_id: int
+    symbol: str
+    side: BrokerOrderSide
+    quantity: Decimal
+    price: Decimal
+    executed_at: datetime
+    broker_order_id: int | None = None
+    permanent_id: int | None = None
+    commission: Decimal | None = None
+    commission_currency: str | None = None
+    commission_unavailable_reason: str | None = None
+    schema_version: int = DOMAIN_SCHEMA_VERSION
+    source_scope: ExecutionDomainScope = ExecutionDomainScope.IBKR_READ_ONLY
+
+    def __post_init__(self) -> None:
+        _schema_version(self.schema_version, "broker execution")
+        if self.source_scope is not ExecutionDomainScope.IBKR_READ_ONLY:
+            raise ReconciliationDomainError("broker execution source is not read-only IBKR")
+        if type(self.side) is not BrokerOrderSide:
+            raise ReconciliationDomainError("broker execution side is invalid")
+        object.__setattr__(self, "account_scope", _account_scope(self.account_scope))
+        object.__setattr__(
+            self,
+            "execution_id",
+            _strict_text(self.execution_id, "execution_id", pattern=_IDENTIFIER),
+        )
+        object.__setattr__(self, "con_id", _positive_identifier(self.con_id, "con_id"))
+        object.__setattr__(
+            self,
+            "symbol",
+            _strict_text(self.symbol, "symbol", pattern=_SYMBOL),
+        )
+        object.__setattr__(self, "quantity", _decimal(self.quantity, "quantity", positive=True))
+        object.__setattr__(self, "price", _decimal(self.price, "price", positive=True))
+        object.__setattr__(
+            self,
+            "executed_at",
+            _timestamp(self.executed_at, "execution executed_at"),
+        )
+        for field_name in ("broker_order_id", "permanent_id"):
+            value = getattr(self, field_name)
+            if value is not None:
+                object.__setattr__(
+                    self,
+                    field_name,
+                    _positive_identifier(value, field_name),
+                )
+        if self.commission is None:
+            if self.commission_currency is not None or self.commission_unavailable_reason is None:
+                raise ReconciliationDomainError(
+                    "missing commission requires exactly one unavailable reason"
+                )
+            object.__setattr__(
+                self,
+                "commission_unavailable_reason",
+                _strict_text(
+                    self.commission_unavailable_reason,
+                    "commission unavailable reason",
+                    pattern=_IDENTIFIER,
+                ),
+            )
+        else:
+            if self.commission_currency is None or self.commission_unavailable_reason is not None:
+                raise ReconciliationDomainError(
+                    "available commission requires currency and no unavailable reason"
+                )
+            object.__setattr__(
+                self,
+                "commission",
+                _decimal(self.commission, "commission"),
+            )
+            object.__setattr__(
+                self,
+                "commission_currency",
+                _strict_text(
+                    self.commission_currency,
+                    "commission_currency",
+                    pattern=_CURRENCY,
+                ),
+            )
+
+    def canonical_dict(self) -> dict[str, object]:
+        return {
+            "account_scope": self.account_scope,
+            "broker_order_id": self.broker_order_id,
+            "commission": (None if self.commission is None else canonical_decimal(self.commission)),
+            "commission_currency": self.commission_currency,
+            "commission_unavailable_reason": self.commission_unavailable_reason,
+            "con_id": self.con_id,
+            "executed_at": canonical_timestamp(self.executed_at),
+            "execution_id": self.execution_id,
+            "permanent_id": self.permanent_id,
+            "price": canonical_decimal(self.price),
+            "quantity": canonical_decimal(self.quantity),
+            "schema_version": self.schema_version,
+            "side": self.side.value,
+            "source_scope": self.source_scope.value,
+            "symbol": self.symbol,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BrokerCollectionEvidence:
+    """Bounded proof that one read-only broker collection was actually queried."""
+
+    account_scope: str
+    collection: BrokerCollectionKind
+    evidence_id: str
+    result_count: int
+    observed_at: datetime
+    schema_version: int = DOMAIN_SCHEMA_VERSION
+    source_scope: ExecutionDomainScope = ExecutionDomainScope.IBKR_READ_ONLY
+
+    def __post_init__(self) -> None:
+        _schema_version(self.schema_version, "broker collection evidence")
+        if self.source_scope is not ExecutionDomainScope.IBKR_READ_ONLY:
+            raise ReconciliationDomainError("broker collection evidence is not read-only IBKR")
+        if type(self.collection) is not BrokerCollectionKind:
+            raise ReconciliationDomainError("broker collection evidence kind is invalid")
+        object.__setattr__(self, "account_scope", _account_scope(self.account_scope))
+        object.__setattr__(
+            self,
+            "evidence_id",
+            _strict_text(
+                self.evidence_id,
+                "broker collection evidence_id",
+                pattern=_COLLECTION_EVIDENCE_ID,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "result_count",
+            _positive_identifier(self.result_count, "result_count", allow_zero=True),
+        )
+        object.__setattr__(
+            self,
+            "observed_at",
+            _timestamp(self.observed_at, "collection evidence observed_at"),
+        )
+
+    def canonical_dict(self) -> dict[str, object]:
+        return {
+            "account_scope": self.account_scope,
+            "collection": self.collection.value,
+            "evidence_id": self.evidence_id,
+            "observed_at": canonical_timestamp(self.observed_at),
+            "result_count": self.result_count,
+            "schema_version": self.schema_version,
+            "source_scope": self.source_scope.value,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BrokerEvidenceCompleteness:
+    """Explicit producer claims for each required broker collection."""
+
+    account: bool
+    positions: bool
+    open_orders: bool
+    completed_orders: bool
+    executions: bool
+    commissions: bool
+
+    def __post_init__(self) -> None:
+        if any(type(getattr(self, field_name)) is not bool for field_name in self.__slots__):
+            raise ReconciliationDomainError("broker completeness flags must be exact booleans")
+
+    @property
+    def complete(self) -> bool:
+        return all(getattr(self, field_name) for field_name in self.__slots__)
+
+    def canonical_dict(self) -> dict[str, bool]:
+        return {field_name: getattr(self, field_name) for field_name in self.__slots__}
+
+
+def _require_unique(values: Iterable[object], label: str) -> None:
+    frozen = tuple(values)
+    if len(frozen) != len(set(frozen)):
+        raise ReconciliationDomainError(f"broker snapshot contains duplicate {label}")
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizedBrokerSnapshot:
+    """One immutable, bounded IBKR read-only evidence generation."""
+
+    account: NormalizedBrokerAccount
+    observed_from: datetime
+    observed_through: datetime
+    retrieved_at: datetime
+    completeness: BrokerEvidenceCompleteness
+    collection_evidence: tuple[BrokerCollectionEvidence, ...]
+    positions: tuple[NormalizedBrokerPosition, ...] = ()
+    orders: tuple[NormalizedBrokerOrder, ...] = ()
+    executions: tuple[NormalizedBrokerExecution, ...] = ()
+    schema_version: int = DOMAIN_SCHEMA_VERSION
+    source_scope: ExecutionDomainScope = ExecutionDomainScope.IBKR_READ_ONLY
+
+    def __post_init__(self) -> None:
+        _schema_version(self.schema_version, "broker snapshot")
+        if self.source_scope is not ExecutionDomainScope.IBKR_READ_ONLY:
+            raise ReconciliationDomainError("broker snapshot source is not read-only IBKR")
+        if type(self.account) is not NormalizedBrokerAccount:
+            raise ReconciliationDomainError("broker snapshot account is not normalized")
+        if type(self.completeness) is not BrokerEvidenceCompleteness:
+            raise ReconciliationDomainError("broker snapshot completeness is malformed")
+        for field_name in ("observed_from", "observed_through", "retrieved_at"):
+            object.__setattr__(self, field_name, _timestamp(getattr(self, field_name), field_name))
+        if self.observed_through < self.observed_from:
+            raise ReconciliationDomainError("broker snapshot observation window is reversed")
+        if (
+            self.observed_through - self.observed_from
+        ).total_seconds() > MAX_COLLECTION_WINDOW_SECONDS:
+            raise ReconciliationDomainError("broker snapshot observation window is unbounded")
+        if self.retrieved_at < self.observed_through:
+            raise ReconciliationDomainError(
+                "broker snapshot retrieval predates completed observation"
+            )
+        if (
+            self.retrieved_at - self.observed_through
+        ).total_seconds() > MAX_RETRIEVAL_DELAY_SECONDS:
+            raise ReconciliationDomainError("broker snapshot retrieval delay is unbounded")
+        for field_name, expected_type in (
+            ("collection_evidence", BrokerCollectionEvidence),
+            ("positions", NormalizedBrokerPosition),
+            ("orders", NormalizedBrokerOrder),
+            ("executions", NormalizedBrokerExecution),
+        ):
+            values = tuple(getattr(self, field_name))
+            if any(type(value) is not expected_type for value in values):
+                raise ReconciliationDomainError(f"broker snapshot {field_name} are not normalized")
+            object.__setattr__(self, field_name, values)
+        all_records = (
+            (self.account,)
+            + self.collection_evidence
+            + self.positions
+            + self.orders
+            + self.executions
+        )
+        if any(record.account_scope != self.account.account_scope for record in all_records):
+            raise ReconciliationDomainError("broker snapshot spans multiple account scopes")
+        if any(
+            record.observed_at < self.observed_from or record.observed_at > self.observed_through
+            for record in (
+                (self.account,) + self.collection_evidence + self.positions + self.orders
+            )
+        ):
+            raise ReconciliationDomainError("broker evidence falls outside its observation window")
+        if any(execution.executed_at > self.observed_through for execution in self.executions):
+            raise ReconciliationDomainError("broker execution is later than its snapshot")
+        _require_unique((position.con_id for position in self.positions), "position conId")
+        _require_unique((position.symbol for position in self.positions), "position symbol")
+        _require_unique(
+            ((order.collection.value, order.identity) for order in self.orders),
+            "order identity within one collection",
+        )
+        permanent_ids = tuple(
+            (order.collection.value, order.permanent_id)
+            for order in self.orders
+            if order.permanent_id is not None
+        )
+        _require_unique(permanent_ids, "permanent order identity within one collection")
+        _require_unique(
+            (execution.execution_id for execution in self.executions),
+            "execution identity",
+        )
+        _require_unique(
+            (evidence.collection for evidence in self.collection_evidence),
+            "collection evidence kind",
+        )
+        _require_unique(
+            (evidence.evidence_id for evidence in self.collection_evidence),
+            "collection evidence identity",
+        )
+        evidence_by_kind = {evidence.collection: evidence for evidence in self.collection_evidence}
+        expected_counts = {
+            BrokerCollectionKind.POSITIONS: len(self.positions),
+            BrokerCollectionKind.OPEN_ORDERS: len(self.open_orders),
+            BrokerCollectionKind.COMPLETED_ORDERS: len(self.completed_orders),
+            BrokerCollectionKind.EXECUTIONS: len(self.executions),
+            BrokerCollectionKind.COMMISSIONS: len(self.executions),
+        }
+        completeness_by_kind = {
+            BrokerCollectionKind.POSITIONS: self.completeness.positions,
+            BrokerCollectionKind.OPEN_ORDERS: self.completeness.open_orders,
+            BrokerCollectionKind.COMPLETED_ORDERS: self.completeness.completed_orders,
+            BrokerCollectionKind.EXECUTIONS: self.completeness.executions,
+            BrokerCollectionKind.COMMISSIONS: self.completeness.commissions,
+        }
+        for kind, is_complete in completeness_by_kind.items():
+            evidence = evidence_by_kind.get(kind)
+            if is_complete and evidence is None:
+                raise ReconciliationDomainError(
+                    f"complete {kind.value} collection lacks explicit evidence"
+                )
+            if not is_complete and evidence is not None:
+                raise ReconciliationDomainError(
+                    f"incomplete {kind.value} collection contradicts explicit evidence"
+                )
+            if evidence is not None and evidence.result_count != expected_counts[kind]:
+                raise ReconciliationDomainError(
+                    f"{kind.value} collection evidence count is inconsistent"
+                )
+        if self.completeness.commissions and any(
+            execution.commission is None for execution in self.executions
+        ):
+            raise ReconciliationDomainError(
+                "complete commissions collection contains unavailable commission"
+            )
+
+    @property
+    def open_orders(self) -> tuple[NormalizedBrokerOrder, ...]:
+        return tuple(
+            order for order in self.orders if order.collection is BrokerOrderCollection.OPEN
+        )
+
+    @property
+    def completed_orders(self) -> tuple[NormalizedBrokerOrder, ...]:
+        return tuple(
+            order for order in self.orders if order.collection is BrokerOrderCollection.COMPLETED
+        )
+
+    def is_fresh(self, *, now: datetime, max_age_seconds: float) -> bool:
+        checked_at = _timestamp(now, "freshness clock")
+        if (
+            isinstance(max_age_seconds, bool)
+            or not isinstance(max_age_seconds, (int, float))
+            or not math.isfinite(float(max_age_seconds))
+            or max_age_seconds <= 0
+        ):
+            raise ReconciliationDomainError("freshness bound must be finite and positive")
+        age = (checked_at - self.retrieved_at).total_seconds()
+        return 0 <= age <= float(max_age_seconds)
+
+    def canonical_dict(self) -> dict[str, object]:
+        return {
+            "account": self.account.canonical_dict(),
+            "completeness": self.completeness.canonical_dict(),
+            "collection_evidence": [
+                evidence.canonical_dict()
+                for evidence in sorted(
+                    self.collection_evidence,
+                    key=lambda value: value.collection.value,
+                )
+            ],
+            "executions": [
+                execution.canonical_dict()
+                for execution in sorted(self.executions, key=lambda value: value.execution_id)
+            ],
+            "observed_from": canonical_timestamp(self.observed_from),
+            "observed_through": canonical_timestamp(self.observed_through),
+            "orders": [
+                order.canonical_dict()
+                for order in sorted(
+                    self.orders,
+                    key=lambda value: (
+                        value.collection.value,
+                        value.client_id,
+                        value.broker_order_id,
+                    ),
+                )
+            ],
+            "positions": [
+                position.canonical_dict()
+                for position in sorted(self.positions, key=lambda value: value.con_id)
+            ],
+            "retrieved_at": canonical_timestamp(self.retrieved_at),
+            "schema_version": self.schema_version,
+            "source_scope": self.source_scope.value,
+        }
+
+    def canonical_payload(self) -> str:
+        return canonical_json(self.canonical_dict())
+
+    @property
+    def snapshot_id(self) -> str:
+        return fingerprint("broker-reconciliation-v1", self.canonical_dict())

--- a/robo_trader/reconciliation/policy.py
+++ b/robo_trader/reconciliation/policy.py
@@ -1,0 +1,592 @@
+"""Pure fail-closed policy for dormant broker-reconciliation evidence."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Iterable
+
+from .domain import (
+    DOMAIN_SCHEMA_VERSION,
+    ExecutionDomainScope,
+    NormalizedBrokerSnapshot,
+    ReconciliationDomainError,
+    _account_scope,
+    _schema_version,
+    _timestamp,
+    canonical_json,
+    canonical_timestamp,
+    fingerprint,
+)
+
+_REASON_CODE = re.compile(r"^[A-Z][A-Z0-9_]{2,127}$")
+_SUBJECT = re.compile(r"^(?:[A-Z][A-Z0-9._-]{0,31}|broker_snapshot|ibkr_account|local_ledger)$")
+_EVIDENCE_ID = re.compile(
+    r"^(?:(?:broker-reconciliation|broker-event|ledger-event|timing-proof)-v1-" r"[0-9a-f]{64})$"
+)
+_SNAPSHOT_ID = re.compile(r"^broker-reconciliation-v1-[0-9a-f]{64}$")
+_BROKER_EVENT_ID = re.compile(r"^broker-event-v1-[0-9a-f]{64}$")
+_TIMING_PROOF_ID = re.compile(r"^timing-proof-v1-[0-9a-f]{64}$")
+_ACCOUNT_FRAGMENT = re.compile(r"(?:DU|U)\d{4,}", re.IGNORECASE)
+MAX_EXPECTED_TIMING_LAG_SECONDS = 120
+_ELIGIBLE_TIMING_LAG_REASONS = frozenset(
+    {
+        "BROKER_ORDER_EVENT_PENDING",
+        "BROKER_EXECUTION_EVENT_PENDING",
+        "BROKER_COMMISSION_REPORT_PENDING",
+    }
+)
+
+
+class DifferenceKind(str, Enum):
+    """Exact PR 5 mismatch taxonomy from the remediation plan."""
+
+    EXPECTED_TIMING_LAG = "expected_timing_lag"
+    RECOVERABLE_MISSING_EVENT = "recoverable_missing_event"
+    DUPLICATE_EVENT = "duplicate_event"
+    ACCOUNT_MISMATCH = "account_mismatch"
+    QUANTITY_MISMATCH = "quantity_mismatch"
+    CASH_MISMATCH = "cash_mismatch"
+    UNKNOWN = "unknown"
+
+
+class DifferenceMateriality(str, Enum):
+    INFORMATIONAL = "informational"
+    MATERIAL = "material"
+    UNKNOWN = "unknown"
+
+
+class ReconciliationStatus(str, Enum):
+    PASSED = "passed"
+    DEGRADED = "degraded"
+    QUARANTINED = "quarantined"
+
+
+_REQUIRED_MATERIALITY = {
+    DifferenceKind.EXPECTED_TIMING_LAG: DifferenceMateriality.INFORMATIONAL,
+    DifferenceKind.RECOVERABLE_MISSING_EVENT: DifferenceMateriality.MATERIAL,
+    DifferenceKind.DUPLICATE_EVENT: DifferenceMateriality.MATERIAL,
+    DifferenceKind.ACCOUNT_MISMATCH: DifferenceMateriality.MATERIAL,
+    DifferenceKind.QUANTITY_MISMATCH: DifferenceMateriality.MATERIAL,
+    DifferenceKind.CASH_MISMATCH: DifferenceMateriality.MATERIAL,
+    DifferenceKind.UNKNOWN: DifferenceMateriality.UNKNOWN,
+}
+
+
+def _safe_identifier(value: object, field_name: str, pattern: re.Pattern[str]) -> str:
+    if not isinstance(value, str) or value != value.strip() or not pattern.fullmatch(value):
+        raise ReconciliationDomainError(f"{field_name} is malformed")
+    if _ACCOUNT_FRAGMENT.search(value):
+        raise ReconciliationDomainError(f"{field_name} contains raw account identity")
+    return value
+
+
+def _timing_proof_payload(
+    *,
+    broker_snapshot_id: str,
+    difference_kind: DifferenceKind,
+    reason_code: str,
+    subject: str,
+    broker_event_id: str,
+    started_at: datetime,
+    expires_at: datetime,
+    schema_version: int,
+) -> dict[str, object]:
+    return {
+        "broker_event_id": broker_event_id,
+        "broker_snapshot_id": broker_snapshot_id,
+        "difference_kind": difference_kind.value,
+        "expires_at": canonical_timestamp(expires_at),
+        "reason_code": reason_code,
+        "schema_version": schema_version,
+        "started_at": canonical_timestamp(started_at),
+        "subject": subject,
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class ExpectedTimingLagProof:
+    """Trusted producer evidence bound to one exact snapshot difference."""
+
+    broker_snapshot_id: str
+    difference_kind: DifferenceKind
+    reason_code: str
+    subject: str
+    broker_event_id: str
+    started_at: datetime
+    expires_at: datetime
+    proof_id: str
+    schema_version: int = DOMAIN_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        _schema_version(self.schema_version, "timing lag proof")
+        object.__setattr__(
+            self,
+            "broker_snapshot_id",
+            _safe_identifier(self.broker_snapshot_id, "broker_snapshot_id", _SNAPSHOT_ID),
+        )
+        if self.difference_kind is not DifferenceKind.EXPECTED_TIMING_LAG:
+            raise ReconciliationDomainError("timing proof difference kind is ineligible")
+        object.__setattr__(
+            self,
+            "reason_code",
+            _safe_identifier(self.reason_code, "timing proof reason_code", _REASON_CODE),
+        )
+        if self.reason_code not in _ELIGIBLE_TIMING_LAG_REASONS:
+            raise ReconciliationDomainError("timing proof reason is not eligible")
+        object.__setattr__(
+            self,
+            "subject",
+            _safe_identifier(self.subject, "timing proof subject", _SUBJECT),
+        )
+        object.__setattr__(
+            self,
+            "broker_event_id",
+            _safe_identifier(
+                self.broker_event_id,
+                "timing proof broker_event_id",
+                _BROKER_EVENT_ID,
+            ),
+        )
+        started_at = _timestamp(self.started_at, "timing proof started_at")
+        expires_at = _timestamp(self.expires_at, "timing proof expires_at")
+        if expires_at <= started_at:
+            raise ReconciliationDomainError("timing proof bound is reversed")
+        if (expires_at - started_at).total_seconds() > MAX_EXPECTED_TIMING_LAG_SECONDS:
+            raise ReconciliationDomainError("timing proof bound exceeds policy maximum")
+        object.__setattr__(self, "started_at", started_at)
+        object.__setattr__(self, "expires_at", expires_at)
+        object.__setattr__(
+            self,
+            "proof_id",
+            _safe_identifier(self.proof_id, "timing proof_id", _TIMING_PROOF_ID),
+        )
+        if self.proof_id != fingerprint("timing-proof-v1", self.binding_dict()):
+            raise ReconciliationDomainError("timing proof fingerprint is not bound")
+
+    @classmethod
+    def from_trusted_producer(
+        cls,
+        *,
+        broker_snapshot_id: str,
+        reason_code: str,
+        subject: str,
+        broker_event_id: str,
+        started_at: datetime,
+        expires_at: datetime,
+    ) -> ExpectedTimingLagProof:
+        normalized_snapshot_id = _safe_identifier(
+            broker_snapshot_id,
+            "broker_snapshot_id",
+            _SNAPSHOT_ID,
+        )
+        normalized_reason = _safe_identifier(
+            reason_code,
+            "timing proof reason_code",
+            _REASON_CODE,
+        )
+        normalized_subject = _safe_identifier(subject, "timing proof subject", _SUBJECT)
+        normalized_event = _safe_identifier(
+            broker_event_id,
+            "timing proof broker_event_id",
+            _BROKER_EVENT_ID,
+        )
+        normalized_started = _timestamp(started_at, "timing proof started_at")
+        normalized_expires = _timestamp(expires_at, "timing proof expires_at")
+        payload = _timing_proof_payload(
+            broker_snapshot_id=normalized_snapshot_id,
+            difference_kind=DifferenceKind.EXPECTED_TIMING_LAG,
+            reason_code=normalized_reason,
+            subject=normalized_subject,
+            broker_event_id=normalized_event,
+            started_at=normalized_started,
+            expires_at=normalized_expires,
+            schema_version=DOMAIN_SCHEMA_VERSION,
+        )
+        return cls(
+            broker_snapshot_id=normalized_snapshot_id,
+            difference_kind=DifferenceKind.EXPECTED_TIMING_LAG,
+            reason_code=normalized_reason,
+            subject=normalized_subject,
+            broker_event_id=normalized_event,
+            started_at=normalized_started,
+            expires_at=normalized_expires,
+            proof_id=fingerprint("timing-proof-v1", payload),
+        )
+
+    def binding_dict(self) -> dict[str, object]:
+        return _timing_proof_payload(
+            broker_snapshot_id=self.broker_snapshot_id,
+            difference_kind=self.difference_kind,
+            reason_code=self.reason_code,
+            subject=self.subject,
+            broker_event_id=self.broker_event_id,
+            started_at=self.started_at,
+            expires_at=self.expires_at,
+            schema_version=self.schema_version,
+        )
+
+    @property
+    def binding_key(self) -> tuple[str, str, str, str, str]:
+        return (
+            self.broker_snapshot_id,
+            self.difference_kind.value,
+            self.reason_code,
+            self.subject,
+            self.broker_event_id,
+        )
+
+    def canonical_dict(self) -> dict[str, object]:
+        return {**self.binding_dict(), "proof_id": self.proof_id}
+
+
+@dataclass(frozen=True, slots=True)
+class ReconciliationDifference:
+    """One deterministic, public-safe reconciliation difference."""
+
+    kind: DifferenceKind
+    materiality: DifferenceMateriality
+    reason_code: str
+    subject: str
+    evidence_ids: tuple[str, ...] = ()
+    schema_version: int = DOMAIN_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        _schema_version(self.schema_version, "difference")
+        if type(self.kind) is not DifferenceKind:
+            raise ReconciliationDomainError("difference kind is invalid")
+        if type(self.materiality) is not DifferenceMateriality:
+            raise ReconciliationDomainError("difference materiality is invalid")
+        if self.materiality is not _REQUIRED_MATERIALITY[self.kind]:
+            raise ReconciliationDomainError("difference materiality contradicts its kind")
+        object.__setattr__(
+            self,
+            "reason_code",
+            _safe_identifier(self.reason_code, "difference reason_code", _REASON_CODE),
+        )
+        object.__setattr__(
+            self,
+            "subject",
+            _safe_identifier(self.subject, "difference subject", _SUBJECT),
+        )
+        evidence_ids = tuple(self.evidence_ids)
+        if any(
+            _safe_identifier(value, "difference evidence_id", _EVIDENCE_ID) != value
+            for value in evidence_ids
+        ):
+            raise ReconciliationDomainError("difference evidence IDs are not canonical")
+        if len(evidence_ids) != len(set(evidence_ids)):
+            raise ReconciliationDomainError("difference evidence IDs contain duplicates")
+        object.__setattr__(self, "evidence_ids", tuple(sorted(evidence_ids)))
+        if self.kind is DifferenceKind.EXPECTED_TIMING_LAG:
+            if self.reason_code not in _ELIGIBLE_TIMING_LAG_REASONS:
+                raise ReconciliationDomainError("timing lag reason is not eligible")
+            if len(evidence_ids) != 1 or not _BROKER_EVENT_ID.fullmatch(evidence_ids[0]):
+                raise ReconciliationDomainError("timing lag requires one bound broker event")
+
+    @property
+    def identity(self) -> tuple[str, str, str, tuple[str, ...]]:
+        return (self.kind.value, self.reason_code, self.subject, self.evidence_ids)
+
+    def canonical_dict(self) -> dict[str, object]:
+        return {
+            "evidence_ids": list(self.evidence_ids),
+            "kind": self.kind.value,
+            "materiality": self.materiality.value,
+            "reason_code": self.reason_code,
+            "schema_version": self.schema_version,
+            "subject": self.subject,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ReconciliationCoverage:
+    """Explicit comparison coverage; absence can never be interpreted as clean."""
+
+    broker_account: bool
+    broker_positions: bool
+    broker_open_orders: bool
+    broker_completed_orders: bool
+    broker_executions: bool
+    broker_commissions: bool
+    ledger_positions: bool
+    ledger_orders: bool
+    ledger_executions: bool
+    ledger_cash: bool
+
+    def __post_init__(self) -> None:
+        if any(type(getattr(self, field_name)) is not bool for field_name in self.__slots__):
+            raise ReconciliationDomainError("reconciliation coverage flags must be exact booleans")
+
+    @property
+    def complete(self) -> bool:
+        return all(getattr(self, field_name) for field_name in self.__slots__)
+
+    def canonical_dict(self) -> dict[str, bool]:
+        return {field_name: getattr(self, field_name) for field_name in self.__slots__}
+
+
+@dataclass(frozen=True, slots=True)
+class ReconciliationVerdict:
+    """A non-authorizing result produced only by the pure policy evaluator."""
+
+    execution_domain_scope: ExecutionDomainScope
+    broker_snapshot_id: str
+    expected_account_scope: str
+    checked_at: datetime
+    fresh_until: datetime
+    evidence_fresh: bool
+    comparison_complete: bool
+    coverage: ReconciliationCoverage
+    status: ReconciliationStatus
+    differences: tuple[ReconciliationDifference, ...]
+    schema_version: int = DOMAIN_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        _schema_version(self.schema_version, "verdict")
+        if self.execution_domain_scope is not ExecutionDomainScope.PAPER_SIMULATOR:
+            raise ReconciliationDomainError(
+                "this dormant policy supports only the local paper-simulator domain"
+            )
+        object.__setattr__(
+            self,
+            "broker_snapshot_id",
+            _safe_identifier(self.broker_snapshot_id, "broker_snapshot_id", _SNAPSHOT_ID),
+        )
+        object.__setattr__(
+            self,
+            "expected_account_scope",
+            _account_scope(self.expected_account_scope),
+        )
+        object.__setattr__(self, "checked_at", _timestamp(self.checked_at, "checked_at"))
+        object.__setattr__(
+            self,
+            "fresh_until",
+            _timestamp(self.fresh_until, "fresh_until"),
+        )
+        if self.fresh_until < self.checked_at and self.evidence_fresh:
+            raise ReconciliationDomainError("fresh verdict expires before it was checked")
+        if type(self.evidence_fresh) is not bool or type(self.comparison_complete) is not bool:
+            raise ReconciliationDomainError("verdict evidence flags must be exact booleans")
+        if type(self.coverage) is not ReconciliationCoverage:
+            raise ReconciliationDomainError("verdict coverage is malformed")
+        if type(self.status) is not ReconciliationStatus:
+            raise ReconciliationDomainError("verdict status is malformed")
+        differences = tuple(self.differences)
+        if any(type(value) is not ReconciliationDifference for value in differences):
+            raise ReconciliationDomainError("verdict differences are not normalized")
+        identities = tuple(value.identity for value in differences)
+        if len(identities) != len(set(identities)):
+            raise ReconciliationDomainError("verdict contains duplicate differences")
+        ordered = tuple(sorted(differences, key=lambda value: value.identity))
+        object.__setattr__(self, "differences", ordered)
+        expected_status = _status_for(ordered)
+        if self.status is not expected_status:
+            raise ReconciliationDomainError("verdict status contradicts its differences")
+        if self.comparison_complete is not self.coverage.complete:
+            raise ReconciliationDomainError("verdict completeness contradicts its coverage")
+        reason_codes = {difference.reason_code for difference in ordered}
+        if not self.evidence_fresh and "BROKER_EVIDENCE_STALE" not in reason_codes:
+            raise ReconciliationDomainError("stale verdict lacks fail-closed difference")
+        if not self.comparison_complete and "LOCAL_COMPARISON_INCOMPLETE" not in reason_codes:
+            raise ReconciliationDomainError("partial verdict lacks fail-closed difference")
+
+    @property
+    def quarantine_required(self) -> bool:
+        return self.status is ReconciliationStatus.QUARANTINED
+
+    @property
+    def mutated_state(self) -> bool:
+        return False
+
+    @property
+    def authorizes_startup(self) -> bool:
+        return False
+
+    def canonical_dict(self) -> dict[str, object]:
+        return {
+            "authorizes_startup": False,
+            "broker_snapshot_id": self.broker_snapshot_id,
+            "checked_at": canonical_timestamp(self.checked_at),
+            "comparison_complete": self.comparison_complete,
+            "coverage": self.coverage.canonical_dict(),
+            "differences": [difference.canonical_dict() for difference in self.differences],
+            "evidence_fresh": self.evidence_fresh,
+            "execution_domain_scope": self.execution_domain_scope.value,
+            "expected_account_scope": self.expected_account_scope,
+            "fresh_until": canonical_timestamp(self.fresh_until),
+            "mutated_state": False,
+            "quarantine_required": self.quarantine_required,
+            "schema_version": self.schema_version,
+            "status": self.status.value,
+        }
+
+    def canonical_payload(self) -> str:
+        return canonical_json(self.canonical_dict())
+
+    @property
+    def verdict_id(self) -> str:
+        return fingerprint("reconciliation-verdict-v1", self.canonical_dict())
+
+
+def _difference(
+    kind: DifferenceKind,
+    reason_code: str,
+    subject: str,
+    *evidence_ids: str,
+) -> ReconciliationDifference:
+    return ReconciliationDifference(
+        kind=kind,
+        materiality=_REQUIRED_MATERIALITY[kind],
+        reason_code=reason_code,
+        subject=subject,
+        evidence_ids=tuple(evidence_ids),
+    )
+
+
+def _status_for(differences: Iterable[ReconciliationDifference]) -> ReconciliationStatus:
+    materialities = {difference.materiality for difference in differences}
+    if materialities & {DifferenceMateriality.MATERIAL, DifferenceMateriality.UNKNOWN}:
+        return ReconciliationStatus.QUARANTINED
+    if DifferenceMateriality.INFORMATIONAL in materialities:
+        return ReconciliationStatus.DEGRADED
+    return ReconciliationStatus.PASSED
+
+
+def evaluate_paper_simulator_reconciliation(
+    snapshot: NormalizedBrokerSnapshot,
+    coverage: ReconciliationCoverage,
+    differences: Iterable[ReconciliationDifference] = (),
+    timing_lag_proofs: Iterable[ExpectedTimingLagProof] = (),
+    *,
+    expected_account_scope: str,
+    now: datetime,
+    max_age_seconds: float,
+) -> ReconciliationVerdict:
+    """Evaluate containment without equating IBKR and simulator positions.
+
+    The current execution authority is the local paper simulator.  Therefore a
+    nonzero IBKR position or open IBKR order is unexpected external exposure,
+    not a simulator-ledger row to copy, replace, or automatically reconcile.
+    """
+
+    if type(snapshot) is not NormalizedBrokerSnapshot:
+        raise ReconciliationDomainError("policy requires one normalized broker snapshot")
+    if type(coverage) is not ReconciliationCoverage:
+        raise ReconciliationDomainError("policy requires explicit reconciliation coverage")
+    expected_scope = _account_scope(expected_account_scope)
+    checked_at = _timestamp(now, "policy clock")
+    evidence_fresh = snapshot.is_fresh(now=checked_at, max_age_seconds=max_age_seconds)
+    fresh_until = snapshot.retrieved_at + timedelta(seconds=float(max_age_seconds))
+
+    normalized = tuple(differences)
+    if any(type(value) is not ReconciliationDifference for value in normalized):
+        raise ReconciliationDomainError("policy differences are not normalized")
+    collected = {difference.identity: difference for difference in normalized}
+    normalized_proofs = tuple(timing_lag_proofs)
+    if any(type(value) is not ExpectedTimingLagProof for value in normalized_proofs):
+        raise ReconciliationDomainError("policy timing-lag proofs are not normalized")
+    proof_keys = tuple(proof.binding_key for proof in normalized_proofs)
+    if len(proof_keys) != len(set(proof_keys)):
+        raise ReconciliationDomainError("policy contains duplicate timing-lag proofs")
+    proofs_by_key = {proof.binding_key: proof for proof in normalized_proofs}
+
+    def add(value: ReconciliationDifference) -> None:
+        collected[value.identity] = value
+
+    for difference in normalized:
+        if difference.kind is not DifferenceKind.EXPECTED_TIMING_LAG:
+            continue
+        broker_event_id = difference.evidence_ids[0]
+        proof = proofs_by_key.get(
+            (
+                snapshot.snapshot_id,
+                difference.kind.value,
+                difference.reason_code,
+                difference.subject,
+                broker_event_id,
+            )
+        )
+        if proof is None or not proof.started_at <= checked_at <= proof.expires_at:
+            evidence_ids = difference.evidence_ids
+            if proof is not None:
+                evidence_ids += (proof.proof_id,)
+            add(
+                _difference(
+                    DifferenceKind.UNKNOWN,
+                    "EXPECTED_TIMING_LAG_UNPROVEN_OR_EXPIRED",
+                    difference.subject,
+                    *evidence_ids,
+                )
+            )
+
+    if snapshot.account.account_scope != expected_scope:
+        add(
+            _difference(
+                DifferenceKind.ACCOUNT_MISMATCH,
+                "ACCOUNT_SCOPE_MISMATCH",
+                "ibkr_account",
+                snapshot.snapshot_id,
+            )
+        )
+    if not evidence_fresh:
+        add(
+            _difference(
+                DifferenceKind.UNKNOWN,
+                "BROKER_EVIDENCE_STALE",
+                "broker_snapshot",
+                snapshot.snapshot_id,
+            )
+        )
+    if not snapshot.completeness.complete:
+        add(
+            _difference(
+                DifferenceKind.UNKNOWN,
+                "BROKER_EVIDENCE_INCOMPLETE",
+                "broker_snapshot",
+                snapshot.snapshot_id,
+            )
+        )
+    if not coverage.complete:
+        add(
+            _difference(
+                DifferenceKind.UNKNOWN,
+                "LOCAL_COMPARISON_INCOMPLETE",
+                "local_ledger",
+                snapshot.snapshot_id,
+            )
+        )
+    for position in snapshot.positions:
+        add(
+            _difference(
+                DifferenceKind.QUANTITY_MISMATCH,
+                "UNEXPECTED_IBKR_POSITION_IN_PAPER_SIMULATOR",
+                position.symbol,
+                snapshot.snapshot_id,
+            )
+        )
+    for order in snapshot.open_orders:
+        add(
+            _difference(
+                DifferenceKind.UNKNOWN,
+                "UNEXPECTED_IBKR_OPEN_ORDER_IN_PAPER_SIMULATOR",
+                order.symbol,
+                snapshot.snapshot_id,
+            )
+        )
+
+    ordered = tuple(sorted(collected.values(), key=lambda value: value.identity))
+    return ReconciliationVerdict(
+        execution_domain_scope=ExecutionDomainScope.PAPER_SIMULATOR,
+        broker_snapshot_id=snapshot.snapshot_id,
+        expected_account_scope=expected_scope,
+        checked_at=checked_at,
+        fresh_until=fresh_until,
+        evidence_fresh=evidence_fresh,
+        comparison_complete=coverage.complete,
+        coverage=coverage,
+        status=_status_for(ordered),
+        differences=ordered,
+    )

--- a/tests/test_pr5_reconciliation_domain.py
+++ b/tests/test_pr5_reconciliation_domain.py
@@ -1,0 +1,729 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import FrozenInstanceError, replace
+from datetime import datetime, timedelta, timezone
+from decimal import ROUND_DOWN, Decimal, Overflow, localcontext
+
+import pytest
+
+from robo_trader.reconciliation.domain import (
+    BrokerCollectionEvidence,
+    BrokerCollectionKind,
+    BrokerEvidenceCompleteness,
+    BrokerOrderCollection,
+    BrokerOrderSide,
+    ExecutionDomainScope,
+    NormalizedBrokerAccount,
+    NormalizedBrokerExecution,
+    NormalizedBrokerOrder,
+    NormalizedBrokerPosition,
+    NormalizedBrokerSnapshot,
+    ReconciliationDomainError,
+)
+from robo_trader.reconciliation.policy import (
+    DifferenceKind,
+    DifferenceMateriality,
+    ExpectedTimingLagProof,
+    ReconciliationCoverage,
+    ReconciliationDifference,
+    ReconciliationStatus,
+    evaluate_paper_simulator_reconciliation,
+)
+
+NOW = datetime(2026, 7, 28, 12, 0, tzinfo=timezone.utc)
+ACCOUNT_SCOPE = "acct_v1_" + "0123456789abcdef" * 4
+OTHER_ACCOUNT_SCOPE = "acct_v1_" + "fedcba9876543210" * 4
+
+
+def _account(*, scope: str = ACCOUNT_SCOPE) -> NormalizedBrokerAccount:
+    return NormalizedBrokerAccount(
+        account_scope=scope,
+        account_alias="***1234",
+        account_type="paper",
+        base_currency="USD",
+        total_cash=Decimal("25000.00"),
+        buying_power=Decimal("100000.00"),
+        observed_at=NOW - timedelta(seconds=1),
+    )
+
+
+def _position(*, scope: str = ACCOUNT_SCOPE) -> NormalizedBrokerPosition:
+    return NormalizedBrokerPosition(
+        account_scope=scope,
+        con_id=265598,
+        symbol="AAPL",
+        currency="USD",
+        signed_quantity=Decimal("-2"),
+        average_cost=Decimal("210.125"),
+        observed_at=NOW - timedelta(seconds=1),
+    )
+
+
+def _order(
+    *,
+    collection: BrokerOrderCollection = BrokerOrderCollection.OPEN,
+    broker_order_id: int = 7,
+    permanent_id: int = 70,
+    symbol: str = "AAPL",
+) -> NormalizedBrokerOrder:
+    completed = collection is BrokerOrderCollection.COMPLETED
+    return NormalizedBrokerOrder(
+        account_scope=ACCOUNT_SCOPE,
+        collection=collection,
+        broker_order_id=broker_order_id,
+        client_id=4,
+        con_id=265598 if symbol == "AAPL" else 272093,
+        symbol=symbol,
+        side=BrokerOrderSide.SELL,
+        total_quantity=Decimal("2"),
+        filled_quantity=Decimal("2") if completed else Decimal("1"),
+        remaining_quantity=Decimal("0") if completed else Decimal("1"),
+        status="Filled" if completed else "Submitted",
+        observed_at=NOW - timedelta(seconds=1),
+        permanent_id=permanent_id,
+    )
+
+
+def _execution(*, execution_id: str = "0001.abc") -> NormalizedBrokerExecution:
+    return NormalizedBrokerExecution(
+        account_scope=ACCOUNT_SCOPE,
+        execution_id=execution_id,
+        con_id=265598,
+        symbol="AAPL",
+        side=BrokerOrderSide.SELL,
+        quantity=Decimal("2"),
+        price=Decimal("215.50"),
+        executed_at=NOW - timedelta(seconds=1),
+        broker_order_id=7,
+        permanent_id=70,
+        commission=Decimal("1.23"),
+        commission_currency="USD",
+    )
+
+
+def _completeness(**overrides: bool) -> BrokerEvidenceCompleteness:
+    values = {
+        "account": True,
+        "positions": True,
+        "open_orders": True,
+        "completed_orders": True,
+        "executions": True,
+        "commissions": True,
+    }
+    values.update(overrides)
+    return BrokerEvidenceCompleteness(**values)
+
+
+def _collection_evidence(
+    collection: BrokerCollectionKind,
+    result_count: int,
+    observed_at: datetime,
+) -> BrokerCollectionEvidence:
+    digest = hashlib.sha256(
+        f"{collection.value}:{result_count}:{observed_at.isoformat()}".encode()
+    ).hexdigest()
+    return BrokerCollectionEvidence(
+        account_scope=ACCOUNT_SCOPE,
+        collection=collection,
+        evidence_id=f"broker-collection-v1-{digest}",
+        result_count=result_count,
+        observed_at=observed_at,
+    )
+
+
+def _coverage(**overrides: bool) -> ReconciliationCoverage:
+    values = {
+        "broker_account": True,
+        "broker_positions": True,
+        "broker_open_orders": True,
+        "broker_completed_orders": True,
+        "broker_executions": True,
+        "broker_commissions": True,
+        "ledger_positions": True,
+        "ledger_orders": True,
+        "ledger_executions": True,
+        "ledger_cash": True,
+    }
+    values.update(overrides)
+    return ReconciliationCoverage(**values)
+
+
+def _snapshot(
+    *,
+    account: NormalizedBrokerAccount | None = None,
+    positions: tuple[NormalizedBrokerPosition, ...] = (),
+    orders: tuple[NormalizedBrokerOrder, ...] = (),
+    executions: tuple[NormalizedBrokerExecution, ...] = (),
+    completeness: BrokerEvidenceCompleteness | None = None,
+    collection_evidence: tuple[BrokerCollectionEvidence, ...] | None = None,
+    retrieved_at: datetime | None = None,
+) -> NormalizedBrokerSnapshot:
+    retrieval = retrieved_at or NOW - timedelta(seconds=1)
+    claims = completeness or _completeness()
+    open_order_count = sum(order.collection is BrokerOrderCollection.OPEN for order in orders)
+    completed_order_count = sum(
+        order.collection is BrokerOrderCollection.COMPLETED for order in orders
+    )
+    counts = {
+        BrokerCollectionKind.POSITIONS: len(positions),
+        BrokerCollectionKind.OPEN_ORDERS: open_order_count,
+        BrokerCollectionKind.COMPLETED_ORDERS: completed_order_count,
+        BrokerCollectionKind.EXECUTIONS: len(executions),
+        BrokerCollectionKind.COMMISSIONS: len(executions),
+    }
+    completeness_by_kind = {
+        BrokerCollectionKind.POSITIONS: claims.positions,
+        BrokerCollectionKind.OPEN_ORDERS: claims.open_orders,
+        BrokerCollectionKind.COMPLETED_ORDERS: claims.completed_orders,
+        BrokerCollectionKind.EXECUTIONS: claims.executions,
+        BrokerCollectionKind.COMMISSIONS: claims.commissions,
+    }
+    evidence = collection_evidence
+    if evidence is None:
+        evidence = tuple(
+            _collection_evidence(kind, counts[kind], retrieval)
+            for kind in BrokerCollectionKind
+            if completeness_by_kind[kind]
+        )
+    return NormalizedBrokerSnapshot(
+        account=account or replace(_account(), observed_at=retrieval),
+        observed_from=retrieval - timedelta(seconds=1),
+        observed_through=retrieval,
+        retrieved_at=retrieval,
+        completeness=claims,
+        collection_evidence=evidence,
+        positions=positions,
+        orders=orders,
+        executions=executions,
+    )
+
+
+def _difference(kind: DifferenceKind) -> ReconciliationDifference:
+    materiality = {
+        DifferenceKind.EXPECTED_TIMING_LAG: DifferenceMateriality.INFORMATIONAL,
+        DifferenceKind.UNKNOWN: DifferenceMateriality.UNKNOWN,
+    }.get(kind, DifferenceMateriality.MATERIAL)
+    reason_code = f"TEST_{kind.value.upper()}"
+    evidence_ids: tuple[str, ...] = ()
+    if kind is DifferenceKind.EXPECTED_TIMING_LAG:
+        reason_code = "BROKER_ORDER_EVENT_PENDING"
+        evidence_ids = ("broker-event-v1-" + "b2" * 32,)
+    return ReconciliationDifference(
+        kind=kind,
+        materiality=materiality,
+        reason_code=reason_code,
+        subject="AAPL",
+        evidence_ids=evidence_ids,
+    )
+
+
+def _timing_proof(
+    snapshot: NormalizedBrokerSnapshot,
+    difference: ReconciliationDifference,
+    *,
+    started_at: datetime = NOW - timedelta(seconds=5),
+    expires_at: datetime = NOW + timedelta(seconds=5),
+) -> ExpectedTimingLagProof:
+    return ExpectedTimingLagProof.from_trusted_producer(
+        broker_snapshot_id=snapshot.snapshot_id,
+        reason_code=difference.reason_code,
+        subject=difference.subject,
+        broker_event_id=difference.evidence_ids[0],
+        started_at=started_at,
+        expires_at=expires_at,
+    )
+
+
+def _evaluate(
+    snapshot: NormalizedBrokerSnapshot,
+    *,
+    coverage: ReconciliationCoverage | None = None,
+    differences: tuple[ReconciliationDifference, ...] = (),
+    timing_lag_proofs: tuple[ExpectedTimingLagProof, ...] = (),
+    expected_account_scope: str = ACCOUNT_SCOPE,
+    now: datetime = NOW,
+):
+    return evaluate_paper_simulator_reconciliation(
+        snapshot,
+        coverage or _coverage(),
+        differences,
+        timing_lag_proofs,
+        expected_account_scope=expected_account_scope,
+        now=now,
+        max_age_seconds=30,
+    )
+
+
+def test_exact_difference_kind_taxonomy_is_stable() -> None:
+    assert {kind.value for kind in DifferenceKind} == {
+        "expected_timing_lag",
+        "recoverable_missing_event",
+        "duplicate_event",
+        "account_mismatch",
+        "quantity_mismatch",
+        "cash_mismatch",
+        "unknown",
+    }
+
+
+def test_normalized_records_are_immutable_exact_and_versioned() -> None:
+    account = _account()
+    position = _position()
+    order = _order(collection=BrokerOrderCollection.COMPLETED)
+    execution = _execution()
+
+    assert account.schema_version == 1
+    assert position.signed_quantity == Decimal("-2")
+    assert order.collection is BrokerOrderCollection.COMPLETED
+    assert execution.commission == Decimal("1.23")
+    assert account.source_scope is ExecutionDomainScope.IBKR_READ_ONLY
+    with pytest.raises(FrozenInstanceError):
+        account.total_cash = Decimal("0")  # type: ignore[misc]
+
+
+def test_decimal_canonicalization_is_independent_of_ambient_context() -> None:
+    snapshot = _snapshot(
+        account=replace(
+            _account(),
+            total_cash=Decimal("123456789.123450000"),
+            observed_at=NOW - timedelta(seconds=1),
+        )
+    )
+    with localcontext() as context:
+        context.prec = 6
+        context.rounding = ROUND_DOWN
+        context.Emax = 3
+        context.Emin = -3
+        context.capitals = 0
+        context.clamp = 1
+        context.traps[Overflow] = False
+        adversarial_payload = snapshot.canonical_payload()
+        adversarial_id = snapshot.snapshot_id
+    with localcontext() as context:
+        context.prec = 50
+        context.rounding = ROUND_DOWN
+        context.Emax = 999999
+        context.Emin = -999999
+        context.capitals = 1
+        context.clamp = 0
+        context.traps[Overflow] = True
+        high_precision_payload = snapshot.canonical_payload()
+        high_precision_id = snapshot.snapshot_id
+
+    assert adversarial_payload == high_precision_payload
+    assert adversarial_id == high_precision_id
+    assert '"total_cash":"123456789.12345"' in adversarial_payload
+    assert "Infinity" not in adversarial_payload
+
+
+def test_order_quantity_arithmetic_is_exact_under_low_ambient_precision() -> None:
+    with localcontext() as context:
+        context.prec = 3
+        with pytest.raises(ReconciliationDomainError, match="quantities are inconsistent"):
+            replace(
+                _order(),
+                total_quantity=Decimal("1.23"),
+                filled_quantity=Decimal("1.23"),
+                remaining_quantity=Decimal("0.0001"),
+            )
+    with localcontext() as context:
+        context.prec = 3
+        context.rounding = ROUND_DOWN
+        context.Emax = 3
+        context.Emin = -3
+        context.capitals = 0
+        context.clamp = 1
+        context.traps[Overflow] = False
+        valid = replace(
+            _order(),
+            total_quantity=Decimal("10000"),
+            filled_quantity=Decimal("10000"),
+            remaining_quantity=Decimal("0"),
+        )
+    assert valid.total_quantity == Decimal("10000")
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        lambda: replace(_account(), schema_version=True),
+        lambda: replace(_position(), schema_version=True),
+        lambda: replace(_order(), schema_version=True),
+        lambda: replace(_execution(), schema_version=True),
+        lambda: replace(
+            _collection_evidence(
+                BrokerCollectionKind.POSITIONS,
+                0,
+                NOW - timedelta(seconds=1),
+            ),
+            schema_version=True,
+        ),
+        lambda: replace(_snapshot(), schema_version=True),
+        lambda: replace(_difference(DifferenceKind.UNKNOWN), schema_version=True),
+        lambda: replace(
+            _timing_proof(
+                _snapshot(),
+                _difference(DifferenceKind.EXPECTED_TIMING_LAG),
+            ),
+            schema_version=True,
+        ),
+        lambda: replace(_evaluate(_snapshot()), schema_version=True),
+    ],
+)
+def test_schema_version_rejects_boolean_true_everywhere(record) -> None:
+    with pytest.raises(ReconciliationDomainError, match="schema version is unsupported"):
+        record()
+
+
+@pytest.mark.parametrize(
+    ("record", "message"),
+    [
+        (
+            lambda: replace(_account(), account_alias="DU123456"),
+            "account_alias",
+        ),
+        (
+            lambda: replace(_account(), account_scope="acct_v1_" + "a" * 64),
+            "placeholder",
+        ),
+        (
+            lambda: replace(_account(), account_type="live"),
+            "not paper",
+        ),
+        (
+            lambda: replace(_account(), total_cash=12.5),
+            "binary float",
+        ),
+        (
+            lambda: replace(_position(), signed_quantity=Decimal("NaN")),
+            "finite decimal",
+        ),
+        (
+            lambda: replace(_order(), remaining_quantity=Decimal("0")),
+            "quantities are inconsistent",
+        ),
+        (
+            lambda: replace(_execution(), commission=None),
+            "unavailable reason",
+        ),
+    ],
+)
+def test_normalized_records_fail_closed(record, message: str) -> None:
+    with pytest.raises(ReconciliationDomainError, match=message):
+        record()
+
+
+def test_unavailable_commission_requires_explicit_reason_code() -> None:
+    execution = replace(
+        _execution(),
+        commission=None,
+        commission_currency=None,
+        commission_unavailable_reason="COMMISSION_REPORT_UNAVAILABLE",
+    )
+    assert execution.commission is None
+    assert execution.commission_unavailable_reason == "COMMISSION_REPORT_UNAVAILABLE"
+
+
+def test_snapshot_rejects_cross_account_and_duplicate_identity() -> None:
+    with pytest.raises(ReconciliationDomainError, match="multiple account scopes"):
+        _snapshot(positions=(replace(_position(), account_scope=OTHER_ACCOUNT_SCOPE),))
+
+    with pytest.raises(ReconciliationDomainError, match="duplicate order identity"):
+        _snapshot(orders=(_order(), replace(_order(), permanent_id=71)))
+
+    with pytest.raises(ReconciliationDomainError, match="duplicate execution identity"):
+        _snapshot(executions=(_execution(), _execution()))
+
+
+def test_snapshot_enforces_retrieval_and_record_chronology() -> None:
+    snapshot = _snapshot()
+    with pytest.raises(ReconciliationDomainError, match="retrieval predates"):
+        replace(
+            snapshot,
+            retrieved_at=snapshot.observed_through - timedelta(microseconds=1),
+        )
+    with pytest.raises(ReconciliationDomainError, match="later than its snapshot"):
+        _snapshot(executions=(replace(_execution(), executed_at=NOW + timedelta(microseconds=1)),))
+
+
+def test_empty_complete_snapshot_requires_bound_collection_evidence() -> None:
+    with pytest.raises(ReconciliationDomainError, match="lacks explicit evidence"):
+        _snapshot(collection_evidence=())
+
+    snapshot = _snapshot()
+    assert snapshot.completeness.complete is True
+    assert {evidence.collection for evidence in snapshot.collection_evidence} == set(
+        BrokerCollectionKind
+    )
+
+
+def test_complete_commissions_rejects_execution_without_commission() -> None:
+    unavailable = replace(
+        _execution(),
+        commission=None,
+        commission_currency=None,
+        commission_unavailable_reason="COMMISSION_REPORT_UNAVAILABLE",
+    )
+    with pytest.raises(ReconciliationDomainError, match="unavailable commission"):
+        _snapshot(executions=(unavailable,))
+
+    incomplete = _snapshot(
+        executions=(unavailable,),
+        completeness=_completeness(commissions=False),
+    )
+    assert incomplete.completeness.commissions is False
+
+
+def test_order_collection_is_observation_source_not_terminal_fill_claim() -> None:
+    cancelled = replace(
+        _order(
+            collection=BrokerOrderCollection.COMPLETED,
+            broker_order_id=8,
+            permanent_id=80,
+            symbol="MSFT",
+        ),
+        filled_quantity=Decimal("0"),
+        remaining_quantity=Decimal("2"),
+        status="Cancelled",
+    )
+    overlapping = replace(_order(), collection=BrokerOrderCollection.COMPLETED)
+    snapshot = _snapshot(orders=(_order(), overlapping, cancelled))
+
+    assert len(snapshot.open_orders) == 1
+    assert len(snapshot.completed_orders) == 2
+
+
+def test_snapshot_payload_and_fingerprint_are_order_independent() -> None:
+    first_order = _order(
+        collection=BrokerOrderCollection.COMPLETED,
+        broker_order_id=8,
+        permanent_id=80,
+        symbol="MSFT",
+    )
+    second_order = _order()
+    first = _snapshot(orders=(first_order, second_order))
+    second = _snapshot(orders=(second_order, first_order))
+
+    assert first.canonical_payload() == second.canonical_payload()
+    assert first.snapshot_id == second.snapshot_id
+    assert first.snapshot_id.startswith("broker-reconciliation-v1-")
+
+
+def test_snapshot_freshness_rejects_bad_clock_and_bound() -> None:
+    snapshot = _snapshot()
+    assert snapshot.is_fresh(now=NOW, max_age_seconds=30) is True
+    assert snapshot.is_fresh(now=NOW + timedelta(minutes=1), max_age_seconds=30) is False
+    assert snapshot.is_fresh(now=NOW - timedelta(minutes=1), max_age_seconds=30) is False
+    with pytest.raises(ReconciliationDomainError, match="finite and positive"):
+        snapshot.is_fresh(now=NOW, max_age_seconds=float("inf"))
+
+
+def test_complete_fresh_zero_broker_exposure_is_non_authorizing_pass() -> None:
+    verdict = _evaluate(_snapshot())
+
+    assert verdict.status is ReconciliationStatus.PASSED
+    assert verdict.quarantine_required is False
+    assert verdict.evidence_fresh is True
+    assert verdict.comparison_complete is True
+    assert verdict.mutated_state is False
+    assert verdict.authorizes_startup is False
+    assert verdict.execution_domain_scope is ExecutionDomainScope.PAPER_SIMULATOR
+    assert verdict.verdict_id.startswith("reconciliation-verdict-v1-")
+    assert '"authorizes_startup":false' in verdict.canonical_payload()
+
+
+def test_expected_timing_lag_is_degraded_but_not_quarantined() -> None:
+    snapshot = _snapshot()
+    difference = _difference(DifferenceKind.EXPECTED_TIMING_LAG)
+    verdict = _evaluate(
+        snapshot,
+        differences=(difference,),
+        timing_lag_proofs=(_timing_proof(snapshot, difference),),
+    )
+
+    assert verdict.status is ReconciliationStatus.DEGRADED
+    assert verdict.quarantine_required is False
+
+
+def test_expected_timing_lag_requires_eligible_bounded_proof() -> None:
+    with pytest.raises(ReconciliationDomainError, match="reason is not eligible"):
+        replace(
+            _difference(DifferenceKind.EXPECTED_TIMING_LAG),
+            reason_code="TEST_EXPECTED_TIMING_LAG",
+        )
+    with pytest.raises(ReconciliationDomainError, match="bound broker event"):
+        replace(
+            _difference(DifferenceKind.EXPECTED_TIMING_LAG),
+            evidence_ids=(),
+        )
+    snapshot = _snapshot()
+    difference = _difference(DifferenceKind.EXPECTED_TIMING_LAG)
+    with pytest.raises(ReconciliationDomainError, match="exceeds policy maximum"):
+        _timing_proof(
+            snapshot,
+            difference,
+            expires_at=NOW + timedelta(seconds=121),
+        )
+
+
+def test_timing_proof_rejects_forged_hashes_and_wrong_kind() -> None:
+    snapshot = _snapshot()
+    difference = _difference(DifferenceKind.EXPECTED_TIMING_LAG)
+    proof = _timing_proof(snapshot, difference)
+
+    for forged_hash in ("a" * 64, "b" * 64):
+        with pytest.raises(ReconciliationDomainError, match="fingerprint is not bound"):
+            replace(proof, proof_id=f"timing-proof-v1-{forged_hash}")
+    with pytest.raises(ReconciliationDomainError, match="difference kind is ineligible"):
+        replace(proof, difference_kind=DifferenceKind.QUANTITY_MISMATCH)
+
+
+def test_unproven_expired_future_or_wrong_snapshot_lag_quarantines() -> None:
+    snapshot = _snapshot()
+    lag = _difference(DifferenceKind.EXPECTED_TIMING_LAG)
+    proof = _timing_proof(snapshot, lag)
+    unproven = _evaluate(snapshot, differences=(lag,))
+    expired = _evaluate(
+        snapshot,
+        differences=(lag,),
+        timing_lag_proofs=(proof,),
+        now=NOW + timedelta(seconds=6),
+    )
+    future = _evaluate(
+        snapshot,
+        differences=(lag,),
+        timing_lag_proofs=(proof,),
+        now=NOW - timedelta(seconds=6),
+    )
+    other_snapshot = replace(
+        snapshot,
+        retrieved_at=snapshot.retrieved_at + timedelta(microseconds=1),
+    )
+    wrong_snapshot = _evaluate(
+        other_snapshot,
+        differences=(lag,),
+        timing_lag_proofs=(proof,),
+    )
+
+    for verdict in (unproven, expired, future, wrong_snapshot):
+        assert verdict.quarantine_required is True
+        assert "EXPECTED_TIMING_LAG_UNPROVEN_OR_EXPIRED" in {
+            difference.reason_code for difference in verdict.differences
+        }
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        DifferenceKind.RECOVERABLE_MISSING_EVENT,
+        DifferenceKind.DUPLICATE_EVENT,
+        DifferenceKind.ACCOUNT_MISMATCH,
+        DifferenceKind.QUANTITY_MISMATCH,
+        DifferenceKind.CASH_MISMATCH,
+        DifferenceKind.UNKNOWN,
+    ],
+)
+def test_material_or_unknown_difference_requires_quarantine(kind: DifferenceKind) -> None:
+    verdict = _evaluate(_snapshot(), differences=(_difference(kind),))
+    assert verdict.status is ReconciliationStatus.QUARANTINED
+    assert verdict.quarantine_required is True
+
+
+def test_difference_rejects_downgraded_materiality() -> None:
+    with pytest.raises(ReconciliationDomainError, match="materiality contradicts"):
+        ReconciliationDifference(
+            kind=DifferenceKind.ACCOUNT_MISMATCH,
+            materiality=DifferenceMateriality.INFORMATIONAL,
+            reason_code="ACCOUNT_SCOPE_MISMATCH",
+            subject="ibkr_account",
+        )
+
+
+def test_difference_rejects_raw_account_identity() -> None:
+    with pytest.raises(ReconciliationDomainError, match="raw account identity"):
+        ReconciliationDifference(
+            kind=DifferenceKind.UNKNOWN,
+            materiality=DifferenceMateriality.UNKNOWN,
+            reason_code="UNEXPECTED_ACCOUNT",
+            subject="DU123456",
+        )
+
+
+def test_difference_rejects_freeform_subjects_and_evidence_identifiers() -> None:
+    with pytest.raises(ReconciliationDomainError, match="subject is malformed"):
+        replace(_difference(DifferenceKind.UNKNOWN), subject="customer-account-1234")
+    with pytest.raises(ReconciliationDomainError, match="evidence_id is malformed"):
+        replace(_difference(DifferenceKind.UNKNOWN), evidence_ids=("freeform-id",))
+
+
+def test_stale_or_incomplete_evidence_requires_quarantine() -> None:
+    stale = _snapshot(retrieved_at=NOW - timedelta(minutes=5))
+    stale_verdict = _evaluate(stale)
+    assert stale_verdict.quarantine_required is True
+    assert {difference.reason_code for difference in stale_verdict.differences} == {
+        "BROKER_EVIDENCE_STALE"
+    }
+
+    incomplete = _snapshot(completeness=_completeness(completed_orders=False))
+    incomplete_verdict = _evaluate(incomplete)
+    assert incomplete_verdict.quarantine_required is True
+    assert "BROKER_EVIDENCE_INCOMPLETE" in {
+        difference.reason_code for difference in incomplete_verdict.differences
+    }
+
+    partial_comparison = _evaluate(
+        _snapshot(),
+        coverage=_coverage(ledger_executions=False),
+    )
+    assert partial_comparison.quarantine_required is True
+    assert "LOCAL_COMPARISON_INCOMPLETE" in {
+        difference.reason_code for difference in partial_comparison.differences
+    }
+
+
+def test_account_scope_mismatch_requires_quarantine_without_raw_identity() -> None:
+    verdict = _evaluate(_snapshot(), expected_account_scope=OTHER_ACCOUNT_SCOPE)
+    assert verdict.quarantine_required is True
+    assert verdict.differences[0].kind is DifferenceKind.ACCOUNT_MISMATCH
+    assert "DU" not in verdict.canonical_payload()
+
+
+def test_simulator_policy_does_not_equate_local_and_broker_positions() -> None:
+    verdict = _evaluate(_snapshot(positions=(_position(),)))
+
+    assert verdict.quarantine_required is True
+    assert any(
+        difference.kind is DifferenceKind.QUANTITY_MISMATCH
+        and difference.reason_code == "UNEXPECTED_IBKR_POSITION_IN_PAPER_SIMULATOR"
+        for difference in verdict.differences
+    )
+    assert all("local" not in difference.subject for difference in verdict.differences)
+
+
+def test_simulator_policy_quarantines_open_broker_orders_but_not_completed_history() -> None:
+    open_verdict = _evaluate(_snapshot(orders=(_order(),)))
+    assert open_verdict.quarantine_required is True
+    assert "UNEXPECTED_IBKR_OPEN_ORDER_IN_PAPER_SIMULATOR" in {
+        difference.reason_code for difference in open_verdict.differences
+    }
+
+    completed = _order(collection=BrokerOrderCollection.COMPLETED)
+    completed_verdict = _evaluate(_snapshot(orders=(completed,), executions=(_execution(),)))
+    assert completed_verdict.status is ReconciliationStatus.PASSED
+
+
+def test_direct_verdict_construction_cannot_claim_a_stale_pass() -> None:
+    passed = _evaluate(_snapshot())
+    with pytest.raises(ReconciliationDomainError, match="stale verdict lacks"):
+        replace(passed, evidence_fresh=False)
+
+
+def test_verdict_fingerprint_is_deterministic_across_difference_order() -> None:
+    missing = _difference(DifferenceKind.RECOVERABLE_MISSING_EVENT)
+    duplicate = _difference(DifferenceKind.DUPLICATE_EVENT)
+    first = _evaluate(_snapshot(), differences=(missing, duplicate))
+    second = _evaluate(_snapshot(), differences=(duplicate, missing))
+
+    assert first.canonical_payload() == second.canonical_payload()
+    assert first.verdict_id == second.verdict_id


### PR DESCRIPTION
## Summary

- add immutable, schema-versioned normalized broker records, typed collection evidence, and deterministic snapshot identities
- define the exact reconciliation taxonomy and a fail-closed paper-simulator policy for freshness, chronology, completeness, materiality, bounded timing lag, and quarantine
- add focused adversarial tests for exact Decimal behavior, proof binding, identity protection, and dormant containment

## Base and safety boundary

Rebased after PR #111 onto exact `origin/main` `85969202080c53cb2390b3524acca2d40f9e6cb3`.

This slice is additive and dormant. It does not modify or wire into BrokerSnapshot v1, the IBKR worker/client, runner, database, Gateway, dashboard, startup scripts, runtime data, or safety state. It cannot start or restart the trader, authorize startup, place orders, mutate reconciliation inputs, or reconcile simulator positions against IBKR by copying state. The only supported execution-domain verdict is `paper-simulator-v1`; IBKR remains read-only evidence and unexpected IBKR exposure fails closed.

## Exact-head review remediation

Findings from prior heads `9452b8d` and `f27a67c` are closed on current head `76068d2`:

- canonical Decimal rendering uses direct `Decimal.as_tuple()` reconstruction, so finite evidence cannot become `Infinity` under ambient context
- exact quantity arithmetic uses a fully specified local `Context` with explicit precision, rounding, exponent bounds, capitals, clamp, flags, and traps
- retrieval/observation/record chronology is enforced
- empty complete collections require typed, count-bound read-only collection evidence
- schema versions reject `True` and every non-exact integer form
- complete commission evidence cannot contain unavailable execution commissions
- informational timing lag requires separately supplied typed trusted evidence whose fingerprint binds the exact snapshot, difference kind, reason, subject, broker event, and bounded time window
- forged, absent, expired, future, wrong-kind, and wrong-snapshot timing proof fails closed or quarantines as unknown
- the importable marker and misleading anti-forgery test were removed; verdicts remain structurally fail-closed and permanently non-authorizing
- public difference subjects and evidence IDs accept only narrow token shapes

## Validation on current head

- `48 passed` — focused PR5 domain/policy tests
- `146 passed` — focused plus existing reconciliation suites
- `2408 passed, 5 skipped` — full test suite
- targeted Black, isort, Flake8, Bandit, compileall, and `git diff --check` passed
- targeted mypy with `--follow-imports=skip` passed for both owned source files
- dormant import-isolation check passed

Ordinary targeted mypy on the rebased package traverses the repository package initializer and reports 181 pre-existing errors across 25 unrelated files; none are in this PR’s two source modules. Repository-wide Black/isort/Flake8 baselines also remain red only in unrelated pre-existing files (28 Black files, unrelated isort findings, and 9 unrelated Flake8 findings). This PR does not touch or expand into those files.

## Review note

This is intentionally a domain/policy contract only. Future integration must be separately reviewed and must not treat these verdicts as startup or order authority.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New modules are isolated from broker, runner, and startup paths; verdicts cannot authorize orders or startup. Future wiring of this policy into live flows would need separate review.
> 
> **Overview**
> Introduces an **additive, unwired** reconciliation contract for read-only IBKR evidence against the local paper-simulator execution domain.
> 
> **`domain.py`** adds schema-versioned immutable types (accounts, positions, orders, executions, collection evidence, bounded snapshots) with strict validation: masked account scopes, no floats for money, deterministic canonical JSON/fingerprints, observation windows, and completeness tied to per-collection evidence counts.
> 
> **`policy.py`** defines the PR5 difference taxonomy, materiality → `passed` / `degraded` / `quarantined`, fingerprint-bound timing-lag proofs, and `evaluate_paper_simulator_reconciliation`, which **fails closed** on stale/incomplete evidence or partial ledger coverage and treats any IBKR position or open order as unexpected exposure (not ledger reconciliation). Verdicts are explicitly **non-authorizing** (`authorizes_startup` is always false).
> 
> **`tests/test_pr5_reconciliation_domain.py`** adds adversarial coverage for decimal canonicalization, proof binding, identity redaction, and policy containment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76068d251380eb7fb27eed05543b7389a6a19247. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->