### PR TITLE
feat(safety): persist broker reconciliation runtime evidence

### DIFF
--- a/robo_trader/bootstrap_evidence_auth.py
+++ b/robo_trader/bootstrap_evidence_auth.py
@@ -79,6 +79,7 @@ class AuthenticatedEvidenceReceipt:
     issued_at: datetime
     expires_at: datetime
     public_key_fingerprint: str
+    signature_ed25519: str
 
 
 def _safe_file_bytes(
@@ -145,7 +146,7 @@ def _parse_utc(value: object, label: str) -> datetime:
 
 
 def receipt_signature_payload(values: Mapping[str, object]) -> bytes:
-    fields = (
+    fields: tuple[str, ...] = (
         "schema_version",
         "receipt_id",
         "artifact_kind",
@@ -379,4 +380,5 @@ def verify_receipt(
         issued_at=issued_at,
         expires_at=expires_at,
         public_key_fingerprint=fingerprint,
+        signature_ed25519=str(raw["signature_ed25519"]),
     )

--- a/robo_trader/financial_state_bootstrap.py
+++ b/robo_trader/financial_state_bootstrap.py
@@ -31,9 +31,16 @@ from .bootstrap_evidence_auth import (
     verify_receipt,
 )
 from .reconciliation.domain import IBKR_READ_ONLY_SCOPE, canonical_json, fingerprint
-from .reconciliation.policy import ReconciliationCoverage, ReconciliationStatus
+from .reconciliation.policy import (
+    DifferenceKind,
+    DifferenceMateriality,
+    ExpectedTimingLagProof,
+    ReconciliationCoverage,
+    ReconciliationDifference,
+    ReconciliationStatus,
+)
 from .runtime_contract_constants import PAPER_SAFETY_EXECUTION_DOMAIN_SCOPE
-from .safety.journal import SafetyJournal
+from .safety.journal import JournalError, SafetyJournal
 from .safety.models import decimal_to_fixed, utc_to_text
 from .safety.sqlite_identity import (
     SQLiteIdentityError,
@@ -171,6 +178,8 @@ class ExactStateBootstrapEvidence:
     reconciliation_report_hash: str
     reconciliation_coverage: ReconciliationCoverage
     reconciliation_status: ReconciliationStatus
+    reconciliation_differences: tuple[ReconciliationDifference, ...]
+    reconciliation_timing_lag_proofs: tuple[ExpectedTimingLagProof, ...]
     broker_snapshot_id: str
     broker_snapshot_hash: str
     legacy_snapshot_hash: str
@@ -257,6 +266,12 @@ def _evidence_object_digest(evidence: ExactStateBootstrapEvidence) -> str:
         "reconciliation_report_hash": evidence.reconciliation_report_hash,
         "reconciliation_snapshot_id": evidence.reconciliation_snapshot_id,
         "reconciliation_status": evidence.reconciliation_status.value,
+        "reconciliation_differences": [
+            value.canonical_dict() for value in evidence.reconciliation_differences
+        ],
+        "reconciliation_timing_lag_proofs": [
+            value.canonical_dict() for value in evidence.reconciliation_timing_lag_proofs
+        ],
         "broker_snapshot_id": evidence.broker_snapshot_id,
         "runtime_fingerprint": evidence.runtime_fingerprint,
         "safety_journal_device": evidence.safety_journal_device,
@@ -608,6 +623,76 @@ def _runtime_contract_values(runtime_contract: object) -> tuple[Path, str, str, 
     )
 
 
+def _reconciliation_difference(value: object) -> ReconciliationDifference:
+    if type(value) is not dict:
+        raise ExactStateBootstrapError("reconciliation difference is malformed")
+    _exact_keys(
+        value,
+        {"evidence_ids", "kind", "materiality", "reason_code", "schema_version", "subject"},
+        "reconciliation difference",
+    )
+    evidence_ids = value["evidence_ids"]
+    if type(evidence_ids) is not list or any(type(item) is not str for item in evidence_ids):
+        raise ExactStateBootstrapError("reconciliation difference evidence IDs are malformed")
+    try:
+        difference = ReconciliationDifference(
+            kind=DifferenceKind(_json_string(value["kind"], "difference kind")),
+            materiality=DifferenceMateriality(
+                _json_string(value["materiality"], "difference materiality")
+            ),
+            reason_code=_json_string(value["reason_code"], "difference reason_code"),
+            subject=_json_string(value["subject"], "difference subject"),
+            evidence_ids=tuple(evidence_ids),
+            schema_version=_json_int(value["schema_version"], "difference schema_version"),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ExactStateBootstrapError("reconciliation difference is malformed") from exc
+    if difference.canonical_dict() != value:
+        raise ExactStateBootstrapError("reconciliation difference is not canonical")
+    return difference
+
+
+def _reconciliation_timing_lag_proof(value: object) -> ExpectedTimingLagProof:
+    if type(value) is not dict:
+        raise ExactStateBootstrapError("reconciliation timing proof is malformed")
+    _exact_keys(
+        value,
+        {
+            "broker_event_id",
+            "broker_snapshot_id",
+            "difference_kind",
+            "expires_at",
+            "proof_id",
+            "reason_code",
+            "schema_version",
+            "started_at",
+            "subject",
+        },
+        "reconciliation timing proof",
+    )
+    try:
+        proof = ExpectedTimingLagProof(
+            broker_snapshot_id=_json_string(
+                value["broker_snapshot_id"], "timing proof broker_snapshot_id"
+            ),
+            difference_kind=DifferenceKind(
+                _json_string(value["difference_kind"], "timing proof difference_kind")
+            ),
+            reason_code=_json_string(value["reason_code"], "timing proof reason_code"),
+            subject=_json_string(value["subject"], "timing proof subject"),
+            broker_event_id=_json_string(value["broker_event_id"], "timing proof broker_event_id"),
+            started_at=_utc(value["started_at"], "timing proof started_at"),
+            expires_at=_utc(value["expires_at"], "timing proof expires_at"),
+            proof_id=_json_string(value["proof_id"], "timing proof proof_id"),
+            schema_version=_json_int(value["schema_version"], "timing proof schema_version"),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ExactStateBootstrapError("reconciliation timing proof is malformed") from exc
+    if proof.canonical_dict() != value:
+        raise ExactStateBootstrapError("reconciliation timing proof is not canonical")
+    return proof
+
+
 def load_exact_state_bootstrap_evidence(
     *,
     reconciliation_path: Path,
@@ -798,6 +883,7 @@ def load_exact_state_bootstrap_evidence(
     if type(collections) is not list or len(collections) != len(expected_collections):
         raise ExactStateBootstrapError("broker collection evidence is incomplete")
     collection_names: set[str] = set()
+    collection_counts: dict[str, int] = {}
     broker_collection_ids: list[str] = []
     collection_observed_times: list[datetime] = []
     for collection in collections:
@@ -818,6 +904,9 @@ def load_exact_state_bootstrap_evidence(
         )
         name = _json_string(collection["collection"], "broker collection")
         collection_names.add(name)
+        collection_counts[name] = _json_int(
+            collection["result_count"], "broker collection result_count"
+        )
         evidence_id = _json_string(collection["evidence_id"], "broker collection evidence_id")
         if not re.fullmatch(r"broker-collection-v1-[0-9a-f]{64}", evidence_id):
             raise ExactStateBootstrapError("broker collection evidence identity is malformed")
@@ -830,7 +919,6 @@ def load_exact_state_bootstrap_evidence(
                 _json_string(collection["account_scope"], "broker collection account_scope"),
                 account_scope,
             )
-            or _json_int(collection["result_count"], "broker collection result_count") != 0
             or _json_int(collection["schema_version"], "broker collection schema_version") != 1
             or _json_string(collection["source_scope"], "broker collection source_scope")
             != IBKR_READ_ONLY_SCOPE
@@ -880,15 +968,27 @@ def load_exact_state_bootstrap_evidence(
     ):
         raise ExactStateBootstrapError("broker account financial evidence is malformed")
     _decimal(account["total_cash"], "broker total_cash")
-    if (
-        type(broker["positions"]) is not list
-        or type(broker["orders"]) is not list
-        or type(broker["executions"]) is not list
-        or broker["positions"] != []
-        or broker["orders"] != []
-        or broker["executions"] != []
-    ):
-        raise ExactStateBootstrapError("broker snapshot does not prove zero paper exposure")
+    positions = broker["positions"]
+    orders = broker["orders"]
+    executions = broker["executions"]
+    if type(positions) is not list or type(orders) is not list or type(executions) is not list:
+        raise ExactStateBootstrapError("broker snapshot collections are malformed")
+    open_order_count = sum(
+        1 for order in orders if type(order) is dict and order.get("collection") == "open_orders"
+    )
+    completed_order_count = sum(
+        1
+        for order in orders
+        if type(order) is dict and order.get("collection") == "completed_orders"
+    )
+    if open_order_count + completed_order_count != len(orders) or collection_counts != {
+        "positions": len(positions),
+        "open_orders": open_order_count,
+        "completed_orders": completed_order_count,
+        "executions": len(executions),
+        "commissions": len(executions),
+    }:
+        raise ExactStateBootstrapError("broker collection evidence counts are inconsistent")
     broker_snapshot_id = fingerprint("broker-reconciliation-v1", broker)
     broker_snapshot_hash = hashlib.sha256(canonical_json(broker).encode("utf-8")).hexdigest()
     broker_authenticated_at = _verify_artifact_authentication(
@@ -936,6 +1036,8 @@ def load_exact_state_bootstrap_evidence(
             "broker_verdict_hash",
             "comparison_coverage",
             "reconciliation_status",
+            "reconciliation_differences",
+            "reconciliation_timing_lag_proofs",
             "local_simulator_positions_count",
             "local_position_identities",
             "status",
@@ -952,6 +1054,8 @@ def load_exact_state_bootstrap_evidence(
     if not re.fullmatch(r"bootstrap-evidence-bundle-v1-[0-9a-f]{64}", bundle_id):
         raise ExactStateBootstrapError("reconciliation bundle identity is malformed")
     coverage = reconciliation["comparison_coverage"]
+    raw_differences = reconciliation["reconciliation_differences"]
+    raw_timing_proofs = reconciliation["reconciliation_timing_lag_proofs"]
     collection_ids = reconciliation["broker_collection_evidence_ids"]
     local_position_identities = reconciliation["local_position_identities"]
     safety_journal_path = _json_string(
@@ -1049,12 +1153,12 @@ def load_exact_state_bootstrap_evidence(
         or _json_int(
             reconciliation["broker_positions_count"], "reconciliation broker_positions_count"
         )
-        != 0
+        != len(positions)
         or _json_int(
             reconciliation["broker_open_orders_count"],
             "reconciliation broker_open_orders_count",
         )
-        != 0
+        != open_order_count
         or _json_int(
             reconciliation["local_simulator_positions_count"],
             "reconciliation local simulator positions count",
@@ -1071,7 +1175,7 @@ def load_exact_state_bootstrap_evidence(
             reconciliation["reconciliation_status"],
             "reconciliation status",
         )
-        not in {"passed", "degraded"}
+        not in {"passed", "degraded", "quarantined"}
         or type(collection_ids) is not list
         or len(collection_ids) != 5
         or any(type(value) is not str for value in collection_ids)
@@ -1169,6 +1273,53 @@ def load_exact_state_bootstrap_evidence(
     reconciliation_status = ReconciliationStatus(
         _json_string(reconciliation["reconciliation_status"], "reconciliation status")
     )
+    if type(raw_differences) is not list or type(raw_timing_proofs) is not list:
+        raise ExactStateBootstrapError("reconciliation mismatch evidence is malformed")
+    reconciliation_differences = tuple(
+        _reconciliation_difference(value) for value in raw_differences
+    )
+    if reconciliation_differences != tuple(
+        sorted(reconciliation_differences, key=lambda value: value.identity)
+    ) or len({value.identity for value in reconciliation_differences}) != len(
+        reconciliation_differences
+    ):
+        raise ExactStateBootstrapError("reconciliation differences are not unique and sorted")
+    reconciliation_timing_lag_proofs = tuple(
+        _reconciliation_timing_lag_proof(value) for value in raw_timing_proofs
+    )
+    if reconciliation_timing_lag_proofs != tuple(
+        sorted(reconciliation_timing_lag_proofs, key=lambda value: value.binding_key)
+    ) or len({value.binding_key for value in reconciliation_timing_lag_proofs}) != len(
+        reconciliation_timing_lag_proofs
+    ):
+        raise ExactStateBootstrapError("reconciliation timing proofs are not unique and sorted")
+    timing_difference_keys = {
+        (
+            broker_snapshot_id,
+            difference.kind.value,
+            difference.reason_code,
+            difference.subject,
+            difference.evidence_ids[0],
+        )
+        for difference in reconciliation_differences
+        if difference.kind is DifferenceKind.EXPECTED_TIMING_LAG
+    }
+    if any(
+        proof.broker_snapshot_id != broker_snapshot_id
+        or proof.binding_key not in timing_difference_keys
+        for proof in reconciliation_timing_lag_proofs
+    ):
+        raise ExactStateBootstrapError("reconciliation timing proof lacks a signed difference")
+    materialities = {value.materiality for value in reconciliation_differences}
+    expected_status = (
+        ReconciliationStatus.QUARANTINED
+        if materialities & {DifferenceMateriality.MATERIAL, DifferenceMateriality.UNKNOWN}
+        else ReconciliationStatus.DEGRADED if materialities else ReconciliationStatus.PASSED
+    )
+    if reconciliation_status is not expected_status:
+        raise ExactStateBootstrapError(
+            "reconciliation status contradicts authenticated differences"
+        )
     reconciliation_authenticated_at = _verify_artifact_authentication(
         artifact_path=Path(reconciliation_path),
         artifact_kind="reconciliation_report",
@@ -1354,6 +1505,8 @@ def load_exact_state_bootstrap_evidence(
         reconciliation_report_hash=reconciliation_hash,
         reconciliation_coverage=reconciliation_coverage,
         reconciliation_status=reconciliation_status,
+        reconciliation_differences=reconciliation_differences,
+        reconciliation_timing_lag_proofs=reconciliation_timing_lag_proofs,
         broker_snapshot_id=broker_snapshot_id,
         broker_snapshot_hash=broker_hash,
         legacy_snapshot_hash=legacy_snapshot_hash,
@@ -1375,8 +1528,8 @@ def load_exact_state_bootstrap_evidence(
         portfolio_ids=tuple(portfolio_ids),
         broker_observed_at=broker_observed_at,
         reconciliation_generated_at=generated_at,
-        broker_position_count=0,
-        broker_open_order_count=0,
+        broker_position_count=len(positions),
+        broker_open_order_count=open_order_count,
         marks=tuple(marks),
         authentication_receipts=tuple(authentication_receipts),
         _producer_marker=_EVIDENCE_PRODUCER_MARKER,
@@ -1443,6 +1596,10 @@ def assert_verified_exact_state_reconciliation_evidence(
         or reconciliation.get("comparison_coverage")
         != evidence.reconciliation_coverage.canonical_dict()
         or reconciliation.get("reconciliation_status") != evidence.reconciliation_status.value
+        or reconciliation.get("reconciliation_differences")
+        != [value.canonical_dict() for value in evidence.reconciliation_differences]
+        or reconciliation.get("reconciliation_timing_lag_proofs")
+        != [value.canonical_dict() for value in evidence.reconciliation_timing_lag_proofs]
     ):
         raise ExactStateBootstrapError("signed reconciliation artifact lineage changed")
     verified_receipt = _verify_artifact_authentication(
@@ -1813,7 +1970,7 @@ def acquire_exact_state_safety_journal_guard(
         binding = None
         connection = None
         return guard
-    except (OSError, sqlite3.Error, SQLiteIdentityError) as exc:
+    except (OSError, sqlite3.Error, SQLiteIdentityError, JournalError) as exc:
         raise ExactStateBootstrapError(
             "runtime safety journal cannot be locked and revalidated"
         ) from exc
@@ -2063,3 +2220,75 @@ def inspect_legacy_state(database_path: Path) -> dict[str, object]:
             connection.close()
         if binding is not None:
             binding.close()
+
+
+def assert_exact_state_runtime_sources_unchanged(
+    evidence: ExactStateBootstrapEvidence,
+    runtime_contract: object,
+) -> None:
+    """Re-read the signed ledger and journal lineage immediately before use."""
+
+    verified = assert_verified_exact_state_reconciliation_evidence(
+        evidence,
+        runtime_contract,
+    )
+    guard = acquire_exact_state_safety_journal_guard(verified, runtime_contract)
+    try:
+        database_path = Path(verified.database_path)
+        family_before = tuple(
+            _runtime_state_file_fingerprint(path)
+            for path in (
+                database_path,
+                Path(f"{database_path}-wal"),
+                Path(f"{database_path}-journal"),
+            )
+        )
+        current = inspect_legacy_state(Path(verified.database_path))
+        family_after = tuple(
+            _runtime_state_file_fingerprint(path)
+            for path in (
+                database_path,
+                Path(f"{database_path}-wal"),
+                Path(f"{database_path}-journal"),
+            )
+        )
+        if (
+            family_before != family_after
+            or current.get("database_device") != verified.database_device
+            or current.get("database_inode") != verified.database_inode
+            or not hmac.compare_digest(
+                _hash(current.get("snapshot_hash"), "runtime legacy snapshot hash"),
+                verified.legacy_snapshot_hash,
+            )
+        ):
+            raise ExactStateBootstrapError(
+                "legacy ledger content changed after signed reconciliation load"
+            )
+        guard.assert_unchanged()
+    finally:
+        guard.close()
+
+
+def _runtime_state_file_fingerprint(path: Path) -> tuple[str, int, int, int, str]:
+    """Hash one SQLite family member and prove stable bytes during the read."""
+
+    try:
+        before = os.lstat(path)
+    except FileNotFoundError:
+        return ("absent", 0, 0, 0, "")
+    except OSError as exc:
+        raise ExactStateBootstrapError("runtime SQLite family cannot be inspected") from exc
+    if stat.S_ISLNK(before.st_mode) or not stat.S_ISREG(before.st_mode):
+        raise ExactStateBootstrapError("runtime SQLite family member is not a regular file")
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        after = os.lstat(path)
+    except OSError as exc:
+        raise ExactStateBootstrapError("runtime SQLite family cannot be read safely") from exc
+    stable = ("st_dev", "st_ino", "st_size", "st_mtime_ns", "st_ctime_ns")
+    if any(getattr(before, name) != getattr(after, name) for name in stable):
+        raise ExactStateBootstrapError("runtime SQLite family changed during revalidation")
+    return ("regular", after.st_dev, after.st_ino, after.st_size, digest.hexdigest())

--- a/robo_trader/financial_state_bootstrap.py
+++ b/robo_trader/financial_state_bootstrap.py
@@ -31,6 +31,7 @@ from .bootstrap_evidence_auth import (
     verify_receipt,
 )
 from .reconciliation.domain import IBKR_READ_ONLY_SCOPE, canonical_json, fingerprint
+from .reconciliation.policy import ReconciliationCoverage, ReconciliationStatus
 from .runtime_contract_constants import PAPER_SAFETY_EXECUTION_DOMAIN_SCOPE
 from .safety.journal import SafetyJournal
 from .safety.models import decimal_to_fixed, utc_to_text
@@ -165,8 +166,12 @@ class ExactStateBootstrapEvidence:
     """Cross-linked offline evidence verified from regular owner-only files."""
 
     reconciliation_snapshot_id: str
+    reconciliation_artifact_path: str
     bundle_id: str
     reconciliation_report_hash: str
+    reconciliation_coverage: ReconciliationCoverage
+    reconciliation_status: ReconciliationStatus
+    broker_snapshot_id: str
     broker_snapshot_hash: str
     legacy_snapshot_hash: str
     runtime_fingerprint: str
@@ -217,6 +222,7 @@ def _evidence_object_digest(evidence: ExactStateBootstrapEvidence) -> str:
                 "public_key_fingerprint": receipt.public_key_fingerprint,
                 "receipt_id": receipt.receipt_id,
                 "runtime_fingerprint": receipt.runtime_fingerprint,
+                "signature_ed25519": receipt.signature_ed25519,
             }
             for receipt in evidence.authentication_receipts
         ],
@@ -246,8 +252,12 @@ def _evidence_object_digest(evidence: ExactStateBootstrapEvidence) -> str:
         ],
         "portfolio_ids": list(evidence.portfolio_ids),
         "reconciliation_generated_at": utc_to_text(evidence.reconciliation_generated_at),
+        "reconciliation_artifact_path": evidence.reconciliation_artifact_path,
+        "reconciliation_coverage": evidence.reconciliation_coverage.canonical_dict(),
         "reconciliation_report_hash": evidence.reconciliation_report_hash,
         "reconciliation_snapshot_id": evidence.reconciliation_snapshot_id,
+        "reconciliation_status": evidence.reconciliation_status.value,
+        "broker_snapshot_id": evidence.broker_snapshot_id,
         "runtime_fingerprint": evidence.runtime_fingerprint,
         "safety_journal_device": evidence.safety_journal_device,
         "safety_journal_identity": evidence.safety_journal_identity,
@@ -1150,6 +1160,15 @@ def load_exact_state_bootstrap_evidence(
         raise ExactStateBootstrapError(
             "reconciliation snapshot identity is not bound to its canonical payload"
         )
+    reconciliation_coverage = ReconciliationCoverage(
+        **{
+            field_name: _json_bool(coverage[field_name], f"coverage {field_name}")
+            for field_name in sorted(expected_coverage)
+        }
+    )
+    reconciliation_status = ReconciliationStatus(
+        _json_string(reconciliation["reconciliation_status"], "reconciliation status")
+    )
     reconciliation_authenticated_at = _verify_artifact_authentication(
         artifact_path=Path(reconciliation_path),
         artifact_kind="reconciliation_report",
@@ -1330,8 +1349,12 @@ def load_exact_state_bootstrap_evidence(
 
     evidence = ExactStateBootstrapEvidence(
         reconciliation_snapshot_id=reconciliation_snapshot_id,
+        reconciliation_artifact_path=str(Path(reconciliation_path)),
         bundle_id=bundle_id,
         reconciliation_report_hash=reconciliation_hash,
+        reconciliation_coverage=reconciliation_coverage,
+        reconciliation_status=reconciliation_status,
+        broker_snapshot_id=broker_snapshot_id,
         broker_snapshot_hash=broker_hash,
         legacy_snapshot_hash=legacy_snapshot_hash,
         runtime_fingerprint=runtime_fingerprint,
@@ -1359,6 +1382,84 @@ def load_exact_state_bootstrap_evidence(
         _producer_marker=_EVIDENCE_PRODUCER_MARKER,
     )
     object.__setattr__(evidence, "_producer_digest", _evidence_object_digest(evidence))
+    return evidence
+
+
+def assert_verified_exact_state_reconciliation_evidence(
+    evidence: object,
+    runtime_contract: object,
+) -> ExactStateBootstrapEvidence:
+    """Revalidate one loader-owned signed reconciliation artifact and runtime inode."""
+
+    if type(evidence) is not ExactStateBootstrapEvidence:
+        raise ExactStateBootstrapError("exact-state reconciliation evidence has the wrong type")
+    if evidence._producer_marker is not _EVIDENCE_PRODUCER_MARKER or not hmac.compare_digest(
+        evidence._producer_digest,
+        _evidence_object_digest(evidence),
+    ):
+        raise ExactStateBootstrapError("exact-state reconciliation evidence is not loader-owned")
+    database_path, database_identity, runtime_fingerprint, account_scope = _runtime_contract_values(
+        runtime_contract
+    )
+    try:
+        database_metadata = os.lstat(database_path)
+    except OSError as exc:
+        raise ExactStateBootstrapError("runtime database cannot be revalidated") from exc
+    if (
+        stat.S_ISLNK(database_metadata.st_mode)
+        or not stat.S_ISREG(database_metadata.st_mode)
+        or database_metadata.st_nlink != 1
+        or evidence.database_path != str(database_path)
+        or evidence.database_identity != database_identity
+        or evidence.runtime_fingerprint != runtime_fingerprint
+        or not hmac.compare_digest(evidence.account_scope, account_scope)
+        or (evidence.database_device, evidence.database_inode)
+        != (database_metadata.st_dev, database_metadata.st_ino)
+    ):
+        raise ExactStateBootstrapError("exact-state reconciliation runtime binding changed")
+
+    artifact_path = Path(evidence.reconciliation_artifact_path)
+    reconciliation, artifact_hash = _verified_canonical_json(
+        artifact_path,
+        "reconciliation report",
+    )
+    if (
+        artifact_hash != evidence.reconciliation_report_hash
+        or _safe_id(reconciliation.get("snapshot_id"), "reconciliation snapshot_id")
+        != evidence.reconciliation_snapshot_id
+        or _safe_id(reconciliation.get("bundle_id"), "reconciliation bundle_id")
+        != evidence.bundle_id
+        or _safe_id(reconciliation.get("broker_snapshot_id"), "broker snapshot_id")
+        != evidence.broker_snapshot_id
+        or _json_string(
+            reconciliation.get("runtime_fingerprint"),
+            "reconciliation runtime_fingerprint",
+        )
+        != runtime_fingerprint
+        or not hmac.compare_digest(
+            _json_string(reconciliation.get("account_scope"), "reconciliation account_scope"),
+            account_scope,
+        )
+        or reconciliation.get("comparison_coverage")
+        != evidence.reconciliation_coverage.canonical_dict()
+        or reconciliation.get("reconciliation_status") != evidence.reconciliation_status.value
+    ):
+        raise ExactStateBootstrapError("signed reconciliation artifact lineage changed")
+    verified_receipt = _verify_artifact_authentication(
+        artifact_path=artifact_path,
+        artifact_kind="reconciliation_report",
+        artifact_hash=artifact_hash,
+        runtime_fingerprint=runtime_fingerprint,
+        account_scope=account_scope,
+    )
+    reconciliation_receipts = tuple(
+        receipt
+        for receipt in evidence.authentication_receipts
+        if receipt.artifact_kind == "reconciliation_report"
+    )
+    if len(reconciliation_receipts) != 1 or reconciliation_receipts[0] != verified_receipt:
+        raise ExactStateBootstrapError("reconciliation signature receipt lineage changed")
+    _assert_authentication_receipts_unconsumed(database_path, evidence.authentication_receipts)
     return evidence
 
 

--- a/robo_trader/reconciliation/bootstrap_producer.py
+++ b/robo_trader/reconciliation/bootstrap_producer.py
@@ -69,7 +69,9 @@ from .domain import (
 from .errors import LedgerSafetyError
 from .ledger import ImmutableLedgerReader, validate_portfolio_ids
 from .policy import (
+    ExpectedTimingLagProof,
     ReconciliationCoverage,
+    ReconciliationDifference,
     ReconciliationStatus,
     evaluate_paper_simulator_reconciliation,
 )
@@ -405,7 +407,8 @@ def _strict_ledger_timestamp(value: object, field_name: str) -> None:
 
 def _parsed_ledger_timestamp(value: object, field_name: str) -> datetime:
     _strict_ledger_timestamp(value, field_name)
-    assert isinstance(value, str)
+    if not isinstance(value, str):  # pragma: no cover - validated immediately above
+        raise BootstrapReconciliationBlocked(f"ledger {field_name} is malformed")
     parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)
@@ -1003,6 +1006,8 @@ class UnsignedBootstrapReconciliation:
     broker_verdict_hash: str
     comparison_coverage: ReconciliationCoverage
     reconciliation_status: ReconciliationStatus
+    reconciliation_differences: tuple[ReconciliationDifference, ...]
+    reconciliation_timing_lag_proofs: tuple[ExpectedTimingLagProof, ...]
     broker_positions_count: int
     broker_open_orders_count: int
     _producer_marker: object = field(repr=False, compare=False)
@@ -1040,14 +1045,9 @@ class UnsignedBootstrapReconciliation:
             "terminal_fill_count",
         ):
             _exact_nonnegative_int(getattr(self, field_name), field_name)
-        if (
-            self.database_inode == 0
-            or self.broker_positions_count != 0
-            or self.broker_open_orders_count != 0
-            or self.managed_account_count != 1
-        ):
+        if self.database_inode == 0 or self.managed_account_count != 1:
             raise BootstrapReconciliationBlocked(
-                "unsigned result does not prove one zero-exposure paper account"
+                "unsigned result does not prove one paper diagnostic account"
             )
         _canonical_portfolios(self.portfolio_ids, "portfolio_ids")
         _canonical_position_identities(self.local_position_identities)
@@ -1081,11 +1081,36 @@ class UnsignedBootstrapReconciliation:
             raise BootstrapReconciliationBlocked("comparison coverage is malformed")
         if not self.comparison_coverage.complete:
             raise BootstrapReconciliationBlocked("comparison coverage is incomplete")
-        if self.reconciliation_status not in {
-            ReconciliationStatus.PASSED,
-            ReconciliationStatus.DEGRADED,
-        }:
-            raise BootstrapReconciliationBlocked("reconciliation result is quarantined")
+        if type(self.reconciliation_status) is not ReconciliationStatus:
+            raise BootstrapReconciliationBlocked("reconciliation status is malformed")
+        differences = tuple(self.reconciliation_differences)
+        if any(type(value) is not ReconciliationDifference for value in differences):
+            raise BootstrapReconciliationBlocked("reconciliation differences are malformed")
+        ordered_differences = tuple(sorted(differences, key=lambda value: value.identity))
+        if differences != ordered_differences or len(
+            {item.identity for item in differences}
+        ) != len(differences):
+            raise BootstrapReconciliationBlocked(
+                "reconciliation differences must be unique and sorted"
+            )
+        proofs = tuple(self.reconciliation_timing_lag_proofs)
+        if any(type(value) is not ExpectedTimingLagProof for value in proofs):
+            raise BootstrapReconciliationBlocked("reconciliation timing proofs are malformed")
+        ordered_proofs = tuple(sorted(proofs, key=lambda value: value.binding_key))
+        if proofs != ordered_proofs or len({item.binding_key for item in proofs}) != len(proofs):
+            raise BootstrapReconciliationBlocked(
+                "reconciliation timing proofs must be unique and sorted"
+            )
+        materialities = {item.materiality.value for item in differences}
+        expected_status = (
+            ReconciliationStatus.QUARANTINED
+            if materialities & {"material", "unknown"}
+            else ReconciliationStatus.DEGRADED if materialities else ReconciliationStatus.PASSED
+        )
+        if self.reconciliation_status is not expected_status:
+            raise BootstrapReconciliationBlocked(
+                "reconciliation status contradicts authenticated differences"
+            )
         if self.status != BOOTSTRAP_RECONCILIATION_STATUS:
             raise BootstrapReconciliationBlocked("bootstrap reconciliation status is invalid")
         if not _HEX_64.fullmatch(self._producer_nonce):
@@ -1150,6 +1175,12 @@ class UnsignedBootstrapReconciliation:
             "mutated_state": False,
             "portfolio_ids": list(self.portfolio_ids),
             "reconciliation_status": self.reconciliation_status.value,
+            "reconciliation_differences": [
+                value.canonical_dict() for value in self.reconciliation_differences
+            ],
+            "reconciliation_timing_lag_proofs": [
+                value.canonical_dict() for value in self.reconciliation_timing_lag_proofs
+            ],
             "runtime_fingerprint": self.runtime_fingerprint,
             "safety_journal_device": self.safety_journal_device,
             "safety_journal_identity": self.safety_journal_identity,
@@ -1394,14 +1425,6 @@ def produce_bootstrap_reconciliation(
                 now=checked_at,
                 max_age_seconds=BOOTSTRAP_RECONCILIATION_MAX_AGE.total_seconds(),
             )
-            if verdict.quarantine_required:
-                raise BootstrapReconciliationBlocked(
-                    "reconciliation contains stale, incomplete, unknown, or material differences"
-                )
-            if snapshot.positions or snapshot.open_orders:
-                raise BootstrapReconciliationBlocked(
-                    "IBKR diagnostic account does not have zero exposure and open orders"
-                )
             evidence_by_kind = {item.collection: item for item in snapshot.collection_evidence}
             if not snapshot.completeness.complete or set(evidence_by_kind) != set(
                 BrokerCollectionKind
@@ -1441,6 +1464,8 @@ def produce_bootstrap_reconciliation(
                 ).hexdigest(),
                 comparison_coverage=collected.coverage,
                 reconciliation_status=verdict.status,
+                reconciliation_differences=verdict.differences,
+                reconciliation_timing_lag_proofs=(),
                 broker_positions_count=len(snapshot.positions),
                 broker_open_orders_count=len(snapshot.open_orders),
                 _producer_marker=_RESULT_PRODUCER_MARKER,

--- a/robo_trader/reconciliation/persistence.py
+++ b/robo_trader/reconciliation/persistence.py
@@ -279,10 +279,7 @@ class ReconciliationPersistence:
             await assert_reconciliation_schema(connection)
             existing = await connection.execute(
                 """
-                SELECT payload_sha256, payload_json, runtime_fingerprint,
-                       database_identity, database_device, database_inode,
-                       broker_artifact_hash, broker_receipt_id,
-                       broker_public_key_fingerprint, bundle_id, snapshot_hash
+                SELECT payload_sha256, payload_json
                 FROM rt_reconciliation_snapshots WHERE snapshot_id = ?
                 """,
                 (snapshot.snapshot_id,),
@@ -292,31 +289,15 @@ class ReconciliationPersistence:
                 await connection.execute(
                     """
                     INSERT INTO rt_reconciliation_snapshots(
-                        snapshot_id, schema_version, account_scope, account_alias,
-                        snapshot_hash, bundle_id, runtime_fingerprint, database_path,
-                        database_identity, database_device, database_inode,
-                        broker_artifact_hash, broker_receipt_id,
-                        broker_public_key_fingerprint, broker_evidence_expires_at,
-                        observed_from, observed_through, retrieved_at, complete,
-                        payload_json, payload_sha256, persisted_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        snapshot_id, schema_version, account_scope, observed_from,
+                        observed_through, retrieved_at, complete, payload_json,
+                        payload_sha256, persisted_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         snapshot.snapshot_id,
                         snapshot.schema_version,
                         runtime_evidence.account_scope,
-                        runtime_evidence.account_alias,
-                        runtime_evidence.snapshot_hash,
-                        runtime_evidence.bundle_id,
-                        runtime_evidence.runtime_fingerprint,
-                        runtime_evidence.database_path,
-                        runtime_evidence.database_identity,
-                        runtime_evidence.database_device,
-                        runtime_evidence.database_inode,
-                        runtime_evidence.broker_artifact_hash,
-                        runtime_evidence.broker_receipt_id,
-                        runtime_evidence.broker_public_key_fingerprint,
-                        canonical_timestamp(runtime_evidence.expires_at),
                         canonical_timestamp(snapshot.observed_from),
                         canonical_timestamp(snapshot.observed_through),
                         canonical_timestamp(snapshot.retrieved_at),
@@ -326,28 +307,81 @@ class ReconciliationPersistence:
                         canonical_timestamp(completed),
                     ),
                 )
-            elif tuple(existing_row) != (
-                _sha256(snapshot_payload),
-                snapshot_payload,
+            elif tuple(existing_row) != (_sha256(snapshot_payload), snapshot_payload):
+                raise ReconciliationPersistenceError(
+                    "stored snapshot identity has conflicting evidence"
+                )
+            lineage_values = (
+                snapshot.snapshot_id,
+                2,
+                runtime_evidence.account_alias,
+                runtime_evidence.snapshot_hash,
+                runtime_evidence.bundle_id,
                 runtime_evidence.runtime_fingerprint,
+                runtime_evidence.database_path,
                 runtime_evidence.database_identity,
                 runtime_evidence.database_device,
                 runtime_evidence.database_inode,
                 runtime_evidence.broker_artifact_hash,
                 runtime_evidence.broker_receipt_id,
                 runtime_evidence.broker_public_key_fingerprint,
-                runtime_evidence.bundle_id,
-                runtime_evidence.snapshot_hash,
-            ):
+                canonical_timestamp(runtime_evidence.broker_evidence_expires_at),
+                runtime_evidence.reconciliation_snapshot_id,
+                runtime_evidence.reconciliation_artifact_path,
+                runtime_evidence.reconciliation_artifact_hash,
+                runtime_evidence.reconciliation_receipt_id,
+                runtime_evidence.reconciliation_public_key_fingerprint,
+                runtime_evidence.reconciliation_signature_ed25519,
+                canonical_timestamp(runtime_evidence.reconciliation_evidence_issued_at),
+                canonical_timestamp(runtime_evidence.reconciliation_evidence_expires_at),
+            )
+            existing_lineage = await connection.execute(
+                """
+                SELECT snapshot_id, schema_version, account_alias, snapshot_hash,
+                       bundle_id, runtime_fingerprint, database_path, database_identity,
+                       database_device, database_inode, broker_artifact_hash,
+                       broker_receipt_id, broker_public_key_fingerprint,
+                       broker_evidence_expires_at, reconciliation_snapshot_id,
+                       reconciliation_artifact_path, reconciliation_artifact_hash,
+                       reconciliation_receipt_id,
+                       reconciliation_public_key_fingerprint,
+                       reconciliation_signature_ed25519,
+                       reconciliation_evidence_issued_at,
+                       reconciliation_evidence_expires_at
+                FROM rt_reconciliation_snapshot_lineage WHERE snapshot_id = ?
+                """,
+                (snapshot.snapshot_id,),
+            )
+            existing_lineage_row = await existing_lineage.fetchone()
+            if existing_lineage_row is None:
+                await connection.execute(
+                    """
+                    INSERT INTO rt_reconciliation_snapshot_lineage(
+                        snapshot_id, schema_version, account_alias, snapshot_hash,
+                        bundle_id, runtime_fingerprint, database_path, database_identity,
+                        database_device, database_inode, broker_artifact_hash,
+                        broker_receipt_id, broker_public_key_fingerprint,
+                        broker_evidence_expires_at, reconciliation_snapshot_id,
+                        reconciliation_artifact_path, reconciliation_artifact_hash,
+                        reconciliation_receipt_id,
+                        reconciliation_public_key_fingerprint,
+                        reconciliation_signature_ed25519,
+                        reconciliation_evidence_issued_at,
+                        reconciliation_evidence_expires_at, persisted_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (*lineage_values, canonical_timestamp(completed)),
+                )
+            elif tuple(existing_lineage_row) != lineage_values:
                 raise ReconciliationPersistenceError(
-                    "stored snapshot identity has conflicting evidence"
+                    "stored snapshot lineage has conflicting evidence"
                 )
 
             entry_eligible = not verdict.quarantine_required
             existing_run = await connection.execute(
                 """
                 SELECT snapshot_id, trigger_type, verdict_id, verdict_payload_json,
-                       verdict_sha256, entry_eligible, eligible_until
+                       verdict_sha256, entry_eligible
                 FROM rt_reconciliation_runs WHERE run_id = ?
                 """,
                 (run_id,),
@@ -361,7 +395,6 @@ class ReconciliationPersistence:
                     verdict_payload,
                     _sha256(verdict_payload),
                     int(entry_eligible),
-                    canonical_timestamp(eligibility_expiry),
                 )
                 if tuple(existing_run_row) != expected_run_row:
                     raise ReconciliationPersistenceError(
@@ -380,6 +413,20 @@ class ReconciliationPersistence:
                     raise ReconciliationPersistenceError(
                         "stored reconciliation differences are incomplete"
                     )
+                existing_eligibility = await connection.execute(
+                    """
+                    SELECT schema_version, eligible_until
+                    FROM rt_reconciliation_run_eligibility WHERE run_id = ?
+                    """,
+                    (run_id,),
+                )
+                if await existing_eligibility.fetchone() != (
+                    2,
+                    canonical_timestamp(eligibility_expiry),
+                ):
+                    raise ReconciliationPersistenceError(
+                        "stored reconciliation eligibility has conflicting evidence"
+                    )
                 await self._assert_binding(connection, binding, runtime_evidence)
                 await connection.execute("COMMIT")
                 return PersistedReconciliation(
@@ -394,10 +441,9 @@ class ReconciliationPersistence:
                 INSERT INTO rt_reconciliation_runs(
                     run_id, schema_version, trigger_type, snapshot_id, verdict_id,
                     expected_account_scope, started_at, completed_at, status,
-                    eligible_until,
                     evidence_fresh, comparison_complete, quarantine_required,
                     entry_eligible, coverage_json, verdict_payload_json, verdict_sha256
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     run_id,
@@ -409,7 +455,6 @@ class ReconciliationPersistence:
                     canonical_timestamp(started),
                     canonical_timestamp(completed),
                     verdict.status.value,
-                    canonical_timestamp(eligibility_expiry),
                     int(verdict.evidence_fresh),
                     int(verdict.comparison_complete),
                     int(verdict.quarantine_required),
@@ -418,6 +463,14 @@ class ReconciliationPersistence:
                     verdict_payload,
                     _sha256(verdict_payload),
                 ),
+            )
+            await connection.execute(
+                """
+                INSERT INTO rt_reconciliation_run_eligibility(
+                    run_id, schema_version, eligible_until
+                ) VALUES (?, ?, ?)
+                """,
+                (run_id, 2, canonical_timestamp(eligibility_expiry)),
             )
             for ordinal, (difference_id, difference, payload) in enumerate(difference_rows):
                 await connection.execute(

--- a/robo_trader/reconciliation/persistence.py
+++ b/robo_trader/reconciliation/persistence.py
@@ -1,0 +1,421 @@
+"""Append-only persistence for broker reconciliation evidence and operator notes."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+
+import aiosqlite
+
+from robo_trader.reconciliation_migrations import (
+    apply_reconciliation_migrations,
+    assert_reconciliation_schema,
+)
+
+from .domain import (
+    DOMAIN_SCHEMA_VERSION,
+    NormalizedBrokerSnapshot,
+    ReconciliationDomainError,
+    _timestamp,
+    canonical_json,
+    canonical_timestamp,
+    fingerprint,
+)
+from .policy import ReconciliationDifference, ReconciliationVerdict
+
+_OPERATOR_ID = re.compile(r"^[A-Za-z0-9._@:-]{1,64}$")
+_EVIDENCE_REFERENCE = re.compile(r"^[A-Za-z0-9._:/-]{1,256}$")
+_ACCOUNT_FRAGMENT = re.compile(r"(?:DU|U)\d{4,}", re.IGNORECASE)
+
+
+class ReconciliationPersistenceError(ReconciliationDomainError):
+    """Durable reconciliation evidence could not be safely recorded."""
+
+
+class OperatorResolutionKind(str, Enum):
+    """Non-authorizing annotations; none changes or removes prior evidence."""
+
+    ACKNOWLEDGED = "acknowledged"
+    EXTERNAL_REMEDIATION_RECORDED = "external_remediation_recorded"
+    INVESTIGATION_NOTE = "investigation_note"
+
+
+@dataclass(frozen=True, slots=True)
+class PersistedReconciliation:
+    run_id: str
+    snapshot_id: str
+    verdict_id: str
+    difference_ids: tuple[str, ...]
+    entry_eligible: bool
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorResolutionEvent:
+    resolution_id: str
+    run_id: str
+    difference_id: str
+    resolution_kind: OperatorResolutionKind
+    operator_id: str
+    reason: str
+    evidence_reference: str | None
+    created_at: datetime
+    schema_version: int = DOMAIN_SCHEMA_VERSION
+
+    def canonical_dict(self) -> dict[str, object]:
+        return {
+            "created_at": canonical_timestamp(self.created_at),
+            "difference_id": self.difference_id,
+            "evidence_reference": self.evidence_reference,
+            "operator_id": self.operator_id,
+            "reason": self.reason,
+            "resolution_kind": self.resolution_kind.value,
+            "run_id": self.run_id,
+            "schema_version": self.schema_version,
+        }
+
+
+def _sha256(payload: str) -> str:
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _strict_text(
+    value: object,
+    field_name: str,
+    *,
+    pattern: re.Pattern[str],
+) -> str:
+    if not isinstance(value, str) or value != value.strip() or not pattern.fullmatch(value):
+        raise ReconciliationPersistenceError(f"{field_name} is malformed")
+    if _ACCOUNT_FRAGMENT.search(value):
+        raise ReconciliationPersistenceError(f"{field_name} contains raw account identity")
+    return value
+
+
+class ReconciliationPersistence:
+    """Own a dedicated SQLite connection per atomic reconciliation append."""
+
+    def __init__(self, database_path: Path) -> None:
+        if not isinstance(database_path, Path) or not database_path.is_absolute():
+            raise ReconciliationPersistenceError("reconciliation database path must be absolute")
+        self._database_path = database_path
+
+    async def _connect(self) -> aiosqlite.Connection:
+        connection = await aiosqlite.connect(self._database_path, isolation_level=None)
+        await connection.execute("PRAGMA foreign_keys = ON")
+        foreign_keys = await connection.execute("PRAGMA foreign_keys")
+        if await foreign_keys.fetchone() != (1,):
+            await connection.close()
+            raise ReconciliationPersistenceError(
+                "reconciliation database cannot enforce foreign keys"
+            )
+        return connection
+
+    async def initialize(self) -> None:
+        """Register and validate this component without touching legacy rows."""
+
+        connection = await self._connect()
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            await apply_reconciliation_migrations(connection)
+            await assert_reconciliation_schema(connection)
+            await connection.execute("COMMIT")
+        except BaseException:
+            await connection.execute("ROLLBACK")
+            raise
+        finally:
+            await connection.close()
+
+    async def append_reconciliation(
+        self,
+        *,
+        trigger_type: str,
+        snapshot: NormalizedBrokerSnapshot,
+        verdict: ReconciliationVerdict,
+        started_at: datetime,
+        completed_at: datetime,
+    ) -> PersistedReconciliation:
+        """Atomically append one snapshot, verdict, and all difference rows."""
+
+        if type(snapshot) is not NormalizedBrokerSnapshot:
+            raise ReconciliationPersistenceError("normalized broker snapshot is required")
+        if type(verdict) is not ReconciliationVerdict:
+            raise ReconciliationPersistenceError("normalized reconciliation verdict is required")
+        if verdict.broker_snapshot_id != snapshot.snapshot_id:
+            raise ReconciliationPersistenceError("verdict does not bind the broker snapshot")
+        started = _timestamp(started_at, "reconciliation started_at")
+        completed = _timestamp(completed_at, "reconciliation completed_at")
+        if completed < started or verdict.checked_at < started or verdict.checked_at > completed:
+            raise ReconciliationPersistenceError("reconciliation run chronology is invalid")
+        allowed_triggers = {
+            "startup",
+            "reconnect",
+            "periodic",
+            "before_live",
+            "ambiguous_order",
+        }
+        if trigger_type not in allowed_triggers:
+            raise ReconciliationPersistenceError("reconciliation trigger is invalid")
+
+        snapshot_payload = snapshot.canonical_payload()
+        verdict_payload = verdict.canonical_payload()
+        run_id = fingerprint(
+            "reconciliation-run-v1",
+            {
+                "completed_at": canonical_timestamp(completed),
+                "started_at": canonical_timestamp(started),
+                "trigger_type": trigger_type,
+                "verdict_id": verdict.verdict_id,
+            },
+        )
+        difference_rows: list[tuple[str, ReconciliationDifference, str]] = []
+        for ordinal, difference in enumerate(verdict.differences):
+            payload = canonical_json(difference.canonical_dict())
+            difference_id = fingerprint(
+                "reconciliation-difference-v1",
+                {"ordinal": ordinal, "payload": difference.canonical_dict(), "run_id": run_id},
+            )
+            difference_rows.append((difference_id, difference, payload))
+
+        connection = await self._connect()
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            await assert_reconciliation_schema(connection)
+            existing = await connection.execute(
+                """
+                SELECT payload_sha256, payload_json
+                FROM rt_reconciliation_snapshots WHERE snapshot_id = ?
+                """,
+                (snapshot.snapshot_id,),
+            )
+            existing_row = await existing.fetchone()
+            if existing_row is None:
+                await connection.execute(
+                    """
+                    INSERT INTO rt_reconciliation_snapshots(
+                        snapshot_id, schema_version, account_scope, observed_from,
+                        observed_through, retrieved_at, complete, payload_json,
+                        payload_sha256, persisted_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        snapshot.snapshot_id,
+                        snapshot.schema_version,
+                        snapshot.account.account_scope,
+                        canonical_timestamp(snapshot.observed_from),
+                        canonical_timestamp(snapshot.observed_through),
+                        canonical_timestamp(snapshot.retrieved_at),
+                        int(snapshot.completeness.complete),
+                        snapshot_payload,
+                        _sha256(snapshot_payload),
+                        canonical_timestamp(completed),
+                    ),
+                )
+            elif tuple(existing_row) != (_sha256(snapshot_payload), snapshot_payload):
+                raise ReconciliationPersistenceError(
+                    "stored snapshot identity has conflicting evidence"
+                )
+
+            entry_eligible = not verdict.quarantine_required
+            existing_run = await connection.execute(
+                """
+                SELECT snapshot_id, trigger_type, verdict_id, verdict_payload_json,
+                       verdict_sha256, entry_eligible
+                FROM rt_reconciliation_runs WHERE run_id = ?
+                """,
+                (run_id,),
+            )
+            existing_run_row = await existing_run.fetchone()
+            if existing_run_row is not None:
+                expected_run_row = (
+                    snapshot.snapshot_id,
+                    trigger_type,
+                    verdict.verdict_id,
+                    verdict_payload,
+                    _sha256(verdict_payload),
+                    int(entry_eligible),
+                )
+                if tuple(existing_run_row) != expected_run_row:
+                    raise ReconciliationPersistenceError(
+                        "stored reconciliation run has conflicting evidence"
+                    )
+                existing_differences = await connection.execute(
+                    """
+                    SELECT difference_id FROM rt_reconciliation_differences
+                    WHERE run_id = ? ORDER BY ordinal
+                    """,
+                    (run_id,),
+                )
+                existing_ids = tuple(str(row[0]) for row in await existing_differences.fetchall())
+                expected_ids = tuple(row[0] for row in difference_rows)
+                if existing_ids != expected_ids:
+                    raise ReconciliationPersistenceError(
+                        "stored reconciliation differences are incomplete"
+                    )
+                await connection.execute("COMMIT")
+                return PersistedReconciliation(
+                    run_id=run_id,
+                    snapshot_id=snapshot.snapshot_id,
+                    verdict_id=verdict.verdict_id,
+                    difference_ids=existing_ids,
+                    entry_eligible=entry_eligible,
+                )
+            await connection.execute(
+                """
+                INSERT INTO rt_reconciliation_runs(
+                    run_id, schema_version, trigger_type, snapshot_id, verdict_id,
+                    expected_account_scope, started_at, completed_at, status,
+                    evidence_fresh, comparison_complete, quarantine_required,
+                    entry_eligible, coverage_json, verdict_payload_json, verdict_sha256
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run_id,
+                    verdict.schema_version,
+                    trigger_type,
+                    snapshot.snapshot_id,
+                    verdict.verdict_id,
+                    verdict.expected_account_scope,
+                    canonical_timestamp(started),
+                    canonical_timestamp(completed),
+                    verdict.status.value,
+                    int(verdict.evidence_fresh),
+                    int(verdict.comparison_complete),
+                    int(verdict.quarantine_required),
+                    int(entry_eligible),
+                    canonical_json(verdict.coverage.canonical_dict()),
+                    verdict_payload,
+                    _sha256(verdict_payload),
+                ),
+            )
+            for ordinal, (difference_id, difference, payload) in enumerate(difference_rows):
+                await connection.execute(
+                    """
+                    INSERT INTO rt_reconciliation_differences(
+                        difference_id, run_id, ordinal, kind, materiality, reason_code,
+                        subject, evidence_ids_json, payload_json, payload_sha256, persisted_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        difference_id,
+                        run_id,
+                        ordinal,
+                        difference.kind.value,
+                        difference.materiality.value,
+                        difference.reason_code,
+                        difference.subject,
+                        canonical_json(list(difference.evidence_ids)),
+                        payload,
+                        _sha256(payload),
+                        canonical_timestamp(completed),
+                    ),
+                )
+            await connection.execute("COMMIT")
+        except BaseException:
+            await connection.execute("ROLLBACK")
+            raise
+        finally:
+            await connection.close()
+        return PersistedReconciliation(
+            run_id=run_id,
+            snapshot_id=snapshot.snapshot_id,
+            verdict_id=verdict.verdict_id,
+            difference_ids=tuple(row[0] for row in difference_rows),
+            entry_eligible=entry_eligible,
+        )
+
+    async def append_operator_resolution(
+        self,
+        *,
+        run_id: str,
+        difference_id: str,
+        resolution_kind: OperatorResolutionKind,
+        operator_id: str,
+        reason: str,
+        created_at: datetime,
+        evidence_reference: str | None = None,
+    ) -> OperatorResolutionEvent:
+        """Append an operator note; it never changes the recorded run or eligibility."""
+
+        if type(resolution_kind) is not OperatorResolutionKind:
+            raise ReconciliationPersistenceError("operator resolution kind is invalid")
+        operator = _strict_text(operator_id, "operator_id", pattern=_OPERATOR_ID)
+        if not isinstance(reason, str) or reason != reason.strip() or len(reason) < 10:
+            raise ReconciliationPersistenceError("operator resolution reason is too short")
+        if _ACCOUNT_FRAGMENT.search(reason):
+            raise ReconciliationPersistenceError(
+                "operator resolution reason contains raw account identity"
+            )
+        evidence = None
+        if evidence_reference is not None:
+            evidence = _strict_text(
+                evidence_reference,
+                "evidence_reference",
+                pattern=_EVIDENCE_REFERENCE,
+            )
+        created = _timestamp(created_at, "operator resolution created_at")
+        payload = {
+            "created_at": canonical_timestamp(created),
+            "difference_id": difference_id,
+            "evidence_reference": evidence,
+            "operator_id": operator,
+            "reason": reason,
+            "resolution_kind": resolution_kind.value,
+            "run_id": run_id,
+            "schema_version": DOMAIN_SCHEMA_VERSION,
+        }
+        resolution_id = fingerprint("reconciliation-resolution-v1", payload)
+        event = OperatorResolutionEvent(
+            resolution_id=resolution_id,
+            run_id=run_id,
+            difference_id=difference_id,
+            resolution_kind=resolution_kind,
+            operator_id=operator,
+            reason=reason,
+            evidence_reference=evidence,
+            created_at=created,
+        )
+        connection = await self._connect()
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            await assert_reconciliation_schema(connection)
+            target = await connection.execute(
+                """
+                SELECT 1 FROM rt_reconciliation_differences
+                WHERE difference_id = ? AND run_id = ?
+                """,
+                (difference_id, run_id),
+            )
+            if await target.fetchone() is None:
+                raise ReconciliationPersistenceError(
+                    "operator resolution target does not exist in the run"
+                )
+            await connection.execute(
+                """
+                INSERT INTO rt_reconciliation_operator_resolutions(
+                    resolution_id, schema_version, run_id, difference_id,
+                    resolution_kind, operator_id, reason, evidence_reference, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event.resolution_id,
+                    event.schema_version,
+                    event.run_id,
+                    event.difference_id,
+                    event.resolution_kind.value,
+                    event.operator_id,
+                    event.reason,
+                    event.evidence_reference,
+                    canonical_timestamp(event.created_at),
+                ),
+            )
+            await connection.execute("COMMIT")
+        except BaseException:
+            await connection.execute("ROLLBACK")
+            raise
+        finally:
+            await connection.close()
+        return event

--- a/robo_trader/reconciliation/persistence.py
+++ b/robo_trader/reconciliation/persistence.py
@@ -15,10 +15,15 @@ from robo_trader.reconciliation_migrations import (
     apply_reconciliation_migrations,
     assert_reconciliation_schema,
 )
+from robo_trader.safety.sqlite_identity import (
+    SQLiteDescriptorIdentity,
+    SQLiteIdentityError,
+    SQLitePathBinding,
+    sqlite_connection_file_identity,
+)
 
 from .domain import (
     DOMAIN_SCHEMA_VERSION,
-    NormalizedBrokerSnapshot,
     ReconciliationDomainError,
     _timestamp,
     canonical_json,
@@ -26,6 +31,7 @@ from .domain import (
     fingerprint,
 )
 from .policy import ReconciliationDifference, ReconciliationVerdict
+from .runtime_evidence import VerifiedRuntimeReconciliationEvidence
 
 _OPERATOR_ID = re.compile(r"^[A-Za-z0-9._@:-]{1,64}$")
 _EVIDENCE_REFERENCE = re.compile(r"^[A-Za-z0-9._:/-]{1,256}$")
@@ -103,53 +109,137 @@ class ReconciliationPersistence:
             raise ReconciliationPersistenceError("reconciliation database path must be absolute")
         self._database_path = database_path
 
-    async def _connect(self) -> aiosqlite.Connection:
-        connection = await aiosqlite.connect(self._database_path, isolation_level=None)
-        await connection.execute("PRAGMA foreign_keys = ON")
-        foreign_keys = await connection.execute("PRAGMA foreign_keys")
-        if await foreign_keys.fetchone() != (1,):
-            await connection.close()
-            raise ReconciliationPersistenceError(
-                "reconciliation database cannot enforce foreign keys"
+    @staticmethod
+    async def _descriptor_identity(
+        connection: aiosqlite.Connection,
+    ) -> SQLiteDescriptorIdentity:
+        try:
+            return await connection._execute(  # type: ignore[attr-defined]
+                sqlite_connection_file_identity,
+                connection._conn,  # type: ignore[attr-defined]
             )
-        return connection
+        except Exception as exc:
+            raise ReconciliationPersistenceError(
+                "reconciliation SQLite descriptor identity is unavailable"
+            ) from exc
+
+    async def _connect(
+        self,
+        *,
+        initialize: bool = False,
+    ) -> tuple[aiosqlite.Connection, SQLitePathBinding]:
+        try:
+            if initialize:
+                try:
+                    binding = SQLitePathBinding.open_for_initialization(
+                        self._database_path,
+                        create=True,
+                    )
+                except SQLiteIdentityError:
+                    binding = SQLitePathBinding.open_for_initialization(
+                        self._database_path,
+                        create=False,
+                    )
+            else:
+                binding = SQLitePathBinding.open_readonly(self._database_path)
+        except Exception as exc:
+            raise ReconciliationPersistenceError(
+                "reconciliation database path identity cannot be guarded"
+            ) from exc
+        try:
+            connection = await aiosqlite.connect(binding.path, isolation_level=None)
+            bound = binding.bind_sqlite_connection(await self._descriptor_identity(connection))
+            await connection.execute("PRAGMA foreign_keys = ON")
+            foreign_keys = await connection.execute("PRAGMA foreign_keys")
+            if await foreign_keys.fetchone() != (1,):
+                raise ReconciliationPersistenceError(
+                    "reconciliation database cannot enforce foreign keys"
+                )
+            return connection, bound
+        except BaseException:
+            if "connection" in locals():
+                await connection.close()
+            binding.close()
+            raise
+
+    async def _assert_binding(
+        self,
+        connection: aiosqlite.Connection,
+        binding: SQLitePathBinding,
+        runtime_evidence: VerifiedRuntimeReconciliationEvidence | None = None,
+    ) -> None:
+        try:
+            binding.assert_connection_identity(await self._descriptor_identity(connection))
+        except Exception as exc:
+            raise ReconciliationPersistenceError(
+                "reconciliation database path or descriptor was replaced"
+            ) from exc
+        if runtime_evidence is not None and (
+            runtime_evidence.database_path != str(binding.path)
+            or runtime_evidence.database_identity == ""
+            or (runtime_evidence.database_device, runtime_evidence.database_inode)
+            != (binding.device, binding.inode)
+        ):
+            raise ReconciliationPersistenceError(
+                "runtime evidence belongs to a different database identity"
+            )
 
     async def initialize(self) -> None:
         """Register and validate this component without touching legacy rows."""
 
-        connection = await self._connect()
+        connection, binding = await self._connect(initialize=True)
         try:
             await connection.execute("BEGIN IMMEDIATE")
             await apply_reconciliation_migrations(connection)
             await assert_reconciliation_schema(connection)
+            await self._assert_binding(connection, binding)
             await connection.execute("COMMIT")
         except BaseException:
-            await connection.execute("ROLLBACK")
+            if connection.in_transaction:
+                await connection.execute("ROLLBACK")
             raise
         finally:
             await connection.close()
+            binding.close()
 
     async def append_reconciliation(
         self,
         *,
         trigger_type: str,
-        snapshot: NormalizedBrokerSnapshot,
+        runtime_evidence: VerifiedRuntimeReconciliationEvidence,
         verdict: ReconciliationVerdict,
         started_at: datetime,
         completed_at: datetime,
+        eligible_until: datetime,
     ) -> PersistedReconciliation:
         """Atomically append one snapshot, verdict, and all difference rows."""
 
-        if type(snapshot) is not NormalizedBrokerSnapshot:
-            raise ReconciliationPersistenceError("normalized broker snapshot is required")
+        if type(runtime_evidence) is not VerifiedRuntimeReconciliationEvidence:
+            raise ReconciliationPersistenceError(
+                "verified runtime reconciliation evidence is required"
+            )
+        snapshot = runtime_evidence.snapshot
         if type(verdict) is not ReconciliationVerdict:
             raise ReconciliationPersistenceError("normalized reconciliation verdict is required")
         if verdict.broker_snapshot_id != snapshot.snapshot_id:
             raise ReconciliationPersistenceError("verdict does not bind the broker snapshot")
         started = _timestamp(started_at, "reconciliation started_at")
         completed = _timestamp(completed_at, "reconciliation completed_at")
+        eligibility_expiry = _timestamp(eligible_until, "reconciliation eligible_until")
         if completed < started or verdict.checked_at < started or verdict.checked_at > completed:
             raise ReconciliationPersistenceError("reconciliation run chronology is invalid")
+        if not verdict.quarantine_required and eligibility_expiry < completed:
+            raise ReconciliationPersistenceError(
+                "reconciliation evidence expired before durable completion"
+            )
+        if (
+            runtime_evidence.snapshot_id != snapshot.snapshot_id
+            or runtime_evidence.account_scope != verdict.expected_account_scope
+            or runtime_evidence.database_path != str(self._database_path)
+        ):
+            raise ReconciliationPersistenceError(
+                "runtime evidence is outside the persistence binding"
+            )
         allowed_triggers = {
             "startup",
             "reconnect",
@@ -166,6 +256,8 @@ class ReconciliationPersistence:
             "reconciliation-run-v1",
             {
                 "completed_at": canonical_timestamp(completed),
+                "eligible_until": canonical_timestamp(eligibility_expiry),
+                "runtime_fingerprint": runtime_evidence.runtime_fingerprint,
                 "started_at": canonical_timestamp(started),
                 "trigger_type": trigger_type,
                 "verdict_id": verdict.verdict_id,
@@ -180,13 +272,17 @@ class ReconciliationPersistence:
             )
             difference_rows.append((difference_id, difference, payload))
 
-        connection = await self._connect()
+        connection, binding = await self._connect()
         try:
             await connection.execute("BEGIN IMMEDIATE")
+            await self._assert_binding(connection, binding, runtime_evidence)
             await assert_reconciliation_schema(connection)
             existing = await connection.execute(
                 """
-                SELECT payload_sha256, payload_json
+                SELECT payload_sha256, payload_json, runtime_fingerprint,
+                       database_identity, database_device, database_inode,
+                       broker_artifact_hash, broker_receipt_id,
+                       broker_public_key_fingerprint, bundle_id, snapshot_hash
                 FROM rt_reconciliation_snapshots WHERE snapshot_id = ?
                 """,
                 (snapshot.snapshot_id,),
@@ -196,15 +292,31 @@ class ReconciliationPersistence:
                 await connection.execute(
                     """
                     INSERT INTO rt_reconciliation_snapshots(
-                        snapshot_id, schema_version, account_scope, observed_from,
-                        observed_through, retrieved_at, complete, payload_json,
-                        payload_sha256, persisted_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        snapshot_id, schema_version, account_scope, account_alias,
+                        snapshot_hash, bundle_id, runtime_fingerprint, database_path,
+                        database_identity, database_device, database_inode,
+                        broker_artifact_hash, broker_receipt_id,
+                        broker_public_key_fingerprint, broker_evidence_expires_at,
+                        observed_from, observed_through, retrieved_at, complete,
+                        payload_json, payload_sha256, persisted_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         snapshot.snapshot_id,
                         snapshot.schema_version,
-                        snapshot.account.account_scope,
+                        runtime_evidence.account_scope,
+                        runtime_evidence.account_alias,
+                        runtime_evidence.snapshot_hash,
+                        runtime_evidence.bundle_id,
+                        runtime_evidence.runtime_fingerprint,
+                        runtime_evidence.database_path,
+                        runtime_evidence.database_identity,
+                        runtime_evidence.database_device,
+                        runtime_evidence.database_inode,
+                        runtime_evidence.broker_artifact_hash,
+                        runtime_evidence.broker_receipt_id,
+                        runtime_evidence.broker_public_key_fingerprint,
+                        canonical_timestamp(runtime_evidence.expires_at),
                         canonical_timestamp(snapshot.observed_from),
                         canonical_timestamp(snapshot.observed_through),
                         canonical_timestamp(snapshot.retrieved_at),
@@ -214,7 +326,19 @@ class ReconciliationPersistence:
                         canonical_timestamp(completed),
                     ),
                 )
-            elif tuple(existing_row) != (_sha256(snapshot_payload), snapshot_payload):
+            elif tuple(existing_row) != (
+                _sha256(snapshot_payload),
+                snapshot_payload,
+                runtime_evidence.runtime_fingerprint,
+                runtime_evidence.database_identity,
+                runtime_evidence.database_device,
+                runtime_evidence.database_inode,
+                runtime_evidence.broker_artifact_hash,
+                runtime_evidence.broker_receipt_id,
+                runtime_evidence.broker_public_key_fingerprint,
+                runtime_evidence.bundle_id,
+                runtime_evidence.snapshot_hash,
+            ):
                 raise ReconciliationPersistenceError(
                     "stored snapshot identity has conflicting evidence"
                 )
@@ -223,7 +347,7 @@ class ReconciliationPersistence:
             existing_run = await connection.execute(
                 """
                 SELECT snapshot_id, trigger_type, verdict_id, verdict_payload_json,
-                       verdict_sha256, entry_eligible
+                       verdict_sha256, entry_eligible, eligible_until
                 FROM rt_reconciliation_runs WHERE run_id = ?
                 """,
                 (run_id,),
@@ -237,6 +361,7 @@ class ReconciliationPersistence:
                     verdict_payload,
                     _sha256(verdict_payload),
                     int(entry_eligible),
+                    canonical_timestamp(eligibility_expiry),
                 )
                 if tuple(existing_run_row) != expected_run_row:
                     raise ReconciliationPersistenceError(
@@ -255,6 +380,7 @@ class ReconciliationPersistence:
                     raise ReconciliationPersistenceError(
                         "stored reconciliation differences are incomplete"
                     )
+                await self._assert_binding(connection, binding, runtime_evidence)
                 await connection.execute("COMMIT")
                 return PersistedReconciliation(
                     run_id=run_id,
@@ -268,9 +394,10 @@ class ReconciliationPersistence:
                 INSERT INTO rt_reconciliation_runs(
                     run_id, schema_version, trigger_type, snapshot_id, verdict_id,
                     expected_account_scope, started_at, completed_at, status,
+                    eligible_until,
                     evidence_fresh, comparison_complete, quarantine_required,
                     entry_eligible, coverage_json, verdict_payload_json, verdict_sha256
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     run_id,
@@ -282,6 +409,7 @@ class ReconciliationPersistence:
                     canonical_timestamp(started),
                     canonical_timestamp(completed),
                     verdict.status.value,
+                    canonical_timestamp(eligibility_expiry),
                     int(verdict.evidence_fresh),
                     int(verdict.comparison_complete),
                     int(verdict.quarantine_required),
@@ -313,12 +441,15 @@ class ReconciliationPersistence:
                         canonical_timestamp(completed),
                     ),
                 )
+            await self._assert_binding(connection, binding, runtime_evidence)
             await connection.execute("COMMIT")
         except BaseException:
-            await connection.execute("ROLLBACK")
+            if connection.in_transaction:
+                await connection.execute("ROLLBACK")
             raise
         finally:
             await connection.close()
+            binding.close()
         return PersistedReconciliation(
             run_id=run_id,
             snapshot_id=snapshot.snapshot_id,
@@ -378,9 +509,10 @@ class ReconciliationPersistence:
             evidence_reference=evidence,
             created_at=created,
         )
-        connection = await self._connect()
+        connection, binding = await self._connect()
         try:
             await connection.execute("BEGIN IMMEDIATE")
+            await self._assert_binding(connection, binding)
             await assert_reconciliation_schema(connection)
             target = await connection.execute(
                 """
@@ -393,6 +525,34 @@ class ReconciliationPersistence:
                 raise ReconciliationPersistenceError(
                     "operator resolution target does not exist in the run"
                 )
+            existing = await connection.execute(
+                """
+                SELECT schema_version, run_id, difference_id, resolution_kind,
+                       operator_id, reason, evidence_reference, created_at
+                FROM rt_reconciliation_operator_resolutions
+                WHERE resolution_id = ?
+                """,
+                (event.resolution_id,),
+            )
+            existing_row = await existing.fetchone()
+            expected_row = (
+                event.schema_version,
+                event.run_id,
+                event.difference_id,
+                event.resolution_kind.value,
+                event.operator_id,
+                event.reason,
+                event.evidence_reference,
+                canonical_timestamp(event.created_at),
+            )
+            if existing_row is not None:
+                if tuple(existing_row) != expected_row:
+                    raise ReconciliationPersistenceError(
+                        "stored operator resolution has conflicting evidence"
+                    )
+                await self._assert_binding(connection, binding)
+                await connection.execute("COMMIT")
+                return event
             await connection.execute(
                 """
                 INSERT INTO rt_reconciliation_operator_resolutions(
@@ -412,10 +572,13 @@ class ReconciliationPersistence:
                     canonical_timestamp(event.created_at),
                 ),
             )
+            await self._assert_binding(connection, binding)
             await connection.execute("COMMIT")
         except BaseException:
-            await connection.execute("ROLLBACK")
+            if connection.in_transaction:
+                await connection.execute("ROLLBACK")
             raise
         finally:
             await connection.close()
+            binding.close()
         return event

--- a/robo_trader/reconciliation/runtime_evidence.py
+++ b/robo_trader/reconciliation/runtime_evidence.py
@@ -7,9 +7,10 @@ import hmac
 import secrets
 import threading
 import weakref
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+from typing import SupportsIndex
 
 from robo_trader.bootstrap_evidence_receivers import (
     ProtectiveMarkBundleIdentity,
@@ -18,6 +19,10 @@ from robo_trader.bootstrap_evidence_receivers import (
     assert_protective_mark_receiver_capability,
 )
 from robo_trader.config import RuntimeContract
+from robo_trader.financial_state_bootstrap import (
+    ExactStateBootstrapEvidence,
+    assert_verified_exact_state_reconciliation_evidence,
+)
 from robo_trader.safety.sqlite_identity import SQLitePathBinding
 
 from .domain import (
@@ -28,6 +33,12 @@ from .domain import (
     canonical_timestamp,
 )
 from .identity import RuntimeSafetyContext, assert_validated_runtime_safety_context
+from .policy import (
+    ExpectedTimingLagProof,
+    ReconciliationCoverage,
+    ReconciliationDifference,
+    ReconciliationStatus,
+)
 
 _CAPABILITY_MARKER = object()
 _CAPABILITY_KEY = secrets.token_bytes(32)
@@ -36,6 +47,8 @@ _CAPABILITIES: dict[
     int,
     tuple[weakref.ReferenceType["VerifiedRuntimeReconciliationEvidence"], str],
 ] = {}
+_COMPARISON_CONSUMPTION_LOCK = threading.Lock()
+_CONSUMED_COMPARISON_LINEAGES: set[tuple[str, str, str]] = set()
 
 
 class RuntimeReconciliationEvidenceError(ReconciliationDomainError):
@@ -65,13 +78,53 @@ def _strict_text(value: object, field_name: str) -> str:
     return value
 
 
-@dataclass(frozen=True, slots=True, weakref_slot=True, repr=False)
+@dataclass(frozen=True, repr=False)
 class VerifiedRuntimeReconciliationEvidence:
     """One exact core-authenticated broker generation and runtime ledger binding."""
+
+    # Python 3.10 predates dataclass(weakref_slot=True). Explicit slots keep the
+    # capability immutable, dictionary-free, and weak-referenceable throughout
+    # the supported 3.10+ interpreter range.
+    __slots__ = (
+        "snapshot",
+        "snapshot_id",
+        "snapshot_hash",
+        "comparison_coverage",
+        "differences",
+        "timing_lag_proofs",
+        "bundle_id",
+        "runtime_fingerprint",
+        "account_scope",
+        "account_alias",
+        "database_path",
+        "database_identity",
+        "database_device",
+        "database_inode",
+        "broker_artifact_hash",
+        "broker_receipt_id",
+        "broker_public_key_fingerprint",
+        "broker_evidence_expires_at",
+        "reconciliation_snapshot_id",
+        "reconciliation_artifact_path",
+        "reconciliation_artifact_hash",
+        "reconciliation_receipt_id",
+        "reconciliation_public_key_fingerprint",
+        "reconciliation_signature_ed25519",
+        "reconciliation_evidence_issued_at",
+        "reconciliation_evidence_expires_at",
+        "issued_at",
+        "expires_at",
+        "_runtime_context",
+        "_marker",
+        "__weakref__",
+    )
 
     snapshot: NormalizedBrokerSnapshot
     snapshot_id: str
     snapshot_hash: str
+    comparison_coverage: ReconciliationCoverage
+    differences: tuple[ReconciliationDifference, ...]
+    timing_lag_proofs: tuple[ExpectedTimingLagProof, ...]
     bundle_id: str
     runtime_fingerprint: str
     account_scope: str
@@ -83,10 +136,19 @@ class VerifiedRuntimeReconciliationEvidence:
     broker_artifact_hash: str
     broker_receipt_id: str
     broker_public_key_fingerprint: str
+    broker_evidence_expires_at: datetime
+    reconciliation_snapshot_id: str
+    reconciliation_artifact_path: str
+    reconciliation_artifact_hash: str
+    reconciliation_receipt_id: str
+    reconciliation_public_key_fingerprint: str
+    reconciliation_signature_ed25519: str
+    reconciliation_evidence_issued_at: datetime
+    reconciliation_evidence_expires_at: datetime
     issued_at: datetime
     expires_at: datetime
-    _runtime_context: RuntimeSafetyContext = field(repr=False, compare=False)
-    _marker: object = field(repr=False, compare=False)
+    _runtime_context: RuntimeSafetyContext
+    _marker: object
 
     def __post_init__(self) -> None:
         if self._marker is not _CAPABILITY_MARKER:
@@ -101,13 +163,29 @@ class VerifiedRuntimeReconciliationEvidence:
             "broker_artifact_hash": self.broker_artifact_hash,
             "broker_public_key_fingerprint": self.broker_public_key_fingerprint,
             "broker_receipt_id": self.broker_receipt_id,
+            "broker_evidence_expires_at": canonical_timestamp(self.broker_evidence_expires_at),
             "bundle_id": self.bundle_id,
+            "comparison_coverage": self.comparison_coverage.canonical_dict(),
             "database_device": self.database_device,
             "database_identity": self.database_identity,
             "database_inode": self.database_inode,
             "database_path": self.database_path,
             "expires_at": canonical_timestamp(self.expires_at),
             "issued_at": canonical_timestamp(self.issued_at),
+            "differences": [value.canonical_dict() for value in self.differences],
+            "timing_lag_proofs": [value.canonical_dict() for value in self.timing_lag_proofs],
+            "reconciliation_artifact_hash": self.reconciliation_artifact_hash,
+            "reconciliation_artifact_path": self.reconciliation_artifact_path,
+            "reconciliation_evidence_expires_at": canonical_timestamp(
+                self.reconciliation_evidence_expires_at
+            ),
+            "reconciliation_evidence_issued_at": canonical_timestamp(
+                self.reconciliation_evidence_issued_at
+            ),
+            "reconciliation_public_key_fingerprint": (self.reconciliation_public_key_fingerprint),
+            "reconciliation_receipt_id": self.reconciliation_receipt_id,
+            "reconciliation_signature_ed25519": self.reconciliation_signature_ed25519,
+            "reconciliation_snapshot_id": self.reconciliation_snapshot_id,
             "runtime_fingerprint": self.runtime_fingerprint,
             "snapshot_hash": self.snapshot_hash,
             "snapshot_id": self.snapshot_id,
@@ -121,6 +199,10 @@ class VerifiedRuntimeReconciliationEvidence:
         raise TypeError("runtime reconciliation evidence cannot be copied")
 
     def __reduce__(self) -> str:
+        raise TypeError("runtime reconciliation evidence cannot be pickled")
+
+    def __reduce_ex__(self, protocol: SupportsIndex) -> str:
+        del protocol
         raise TypeError("runtime reconciliation evidence cannot be pickled")
 
 
@@ -166,6 +248,7 @@ def _database_binding(runtime_contract: RuntimeContract) -> SQLitePathBinding:
 
 def bind_verified_runtime_reconciliation_evidence(
     verified_broker_evidence: object,
+    verified_exact_state_evidence: object,
     runtime_context: object,
     protective_mark_receiver: object,
 ) -> VerifiedRuntimeReconciliationEvidence:
@@ -182,6 +265,10 @@ def bind_verified_runtime_reconciliation_evidence(
         raise RuntimeReconciliationEvidenceError("exact RuntimeContract is required")
     try:
         broker = assert_and_consume_verified_broker_evidence(verified_broker_evidence)
+        exact_state = assert_verified_exact_state_reconciliation_evidence(
+            verified_exact_state_evidence,
+            contract,
+        )
         bundle = assert_protective_mark_receiver_capability(
             protective_mark_receiver,
             runtime_contract=contract,
@@ -193,8 +280,31 @@ def bind_verified_runtime_reconciliation_evidence(
     if (
         type(broker) is not VerifiedBrokerEvidenceEnvelope
         or type(bundle) is not ProtectiveMarkBundleIdentity
+        or type(exact_state) is not ExactStateBootstrapEvidence
     ):
         raise RuntimeReconciliationEvidenceError("core evidence types are not exact")
+
+    reconciliation_receipts = tuple(
+        receipt
+        for receipt in exact_state.authentication_receipts
+        if receipt.artifact_kind == "reconciliation_report"
+    )
+    if len(reconciliation_receipts) != 1:
+        raise RuntimeReconciliationEvidenceError(
+            "signed reconciliation receipt lineage is incomplete"
+        )
+    reconciliation_receipt = reconciliation_receipts[0]
+    comparison_lineage = (
+        exact_state.reconciliation_snapshot_id,
+        reconciliation_receipt.receipt_id,
+        reconciliation_receipt.signature_ed25519,
+    )
+    with _COMPARISON_CONSUMPTION_LOCK:
+        if comparison_lineage in _CONSUMED_COMPARISON_LINEAGES:
+            raise RuntimeReconciliationEvidenceError(
+                "signed reconciliation comparison was already consumed"
+            )
+        _CONSUMED_COMPARISON_LINEAGES.add(comparison_lineage)
 
     snapshot = broker.snapshot
     snapshot_hash = hashlib.sha256(snapshot.canonical_payload().encode("utf-8")).hexdigest()
@@ -216,11 +326,40 @@ def bind_verified_runtime_reconciliation_evidence(
             bundle.broker_public_key_fingerprint,
             broker.public_key_fingerprint,
         )
+        or exact_state.reconciliation_status is not ReconciliationStatus.PASSED
+        or type(exact_state.reconciliation_coverage) is not ReconciliationCoverage
+        or exact_state.reconciliation_snapshot_id != bundle.reconciliation_snapshot_id
+        or exact_state.bundle_id != bundle.bundle_id
+        or exact_state.runtime_fingerprint != contract.fingerprint
+        or exact_state.account_scope != broker.account_scope
+        or exact_state.database_path != contract.database_path
+        or exact_state.database_identity != contract.database_identity
+        or (exact_state.database_device, exact_state.database_inode)
+        != (bundle.database_device, bundle.database_inode)
+        or exact_state.broker_snapshot_id != broker.snapshot_id
+        or not hmac.compare_digest(exact_state.broker_snapshot_hash, broker.artifact_hash)
+        or reconciliation_receipt.artifact_sha256 != exact_state.reconciliation_report_hash
+        or reconciliation_receipt.runtime_fingerprint != contract.fingerprint
+        or reconciliation_receipt.account_scope != broker.account_scope
     ):
         raise RuntimeReconciliationEvidenceError("core evidence bindings disagree")
     issued_at = _timestamp(broker.issued_at, "broker evidence issued_at")
-    expires_at = _timestamp(broker.expires_at, "broker evidence expires_at")
-    if not snapshot.retrieved_at <= issued_at <= expires_at:
+    broker_expires_at = _timestamp(broker.expires_at, "broker evidence expires_at")
+    reconciliation_issued_at = _timestamp(
+        reconciliation_receipt.issued_at,
+        "reconciliation evidence issued_at",
+    )
+    reconciliation_expires_at = _timestamp(
+        reconciliation_receipt.expires_at,
+        "reconciliation evidence expires_at",
+    )
+    expires_at = min(broker_expires_at, reconciliation_expires_at)
+    if (
+        not snapshot.retrieved_at <= issued_at <= broker_expires_at
+        or not exact_state.reconciliation_generated_at
+        <= reconciliation_issued_at
+        <= reconciliation_expires_at
+    ):
         raise RuntimeReconciliationEvidenceError("broker evidence chronology is invalid")
     binding = _database_binding(contract)
     try:
@@ -236,6 +375,11 @@ def bind_verified_runtime_reconciliation_evidence(
         (broker.artifact_hash, "broker artifact hash"),
         (broker.public_key_fingerprint, "broker public-key fingerprint"),
         (broker.snapshot_hash, "broker snapshot hash"),
+        (exact_state.reconciliation_report_hash, "reconciliation artifact hash"),
+        (
+            reconciliation_receipt.public_key_fingerprint,
+            "reconciliation public-key fingerprint",
+        ),
     ):
         _hash(value, field_name)
     for value, field_name in (
@@ -243,6 +387,9 @@ def bind_verified_runtime_reconciliation_evidence(
         (broker.receipt_id, "broker receipt_id"),
         (contract.database_identity, "database_identity"),
         (contract.fingerprint, "runtime_fingerprint"),
+        (exact_state.reconciliation_snapshot_id, "reconciliation_snapshot_id"),
+        (reconciliation_receipt.receipt_id, "reconciliation receipt_id"),
+        (reconciliation_receipt.signature_ed25519, "reconciliation signature"),
     ):
         _strict_text(value, field_name)
     if type(bundle.database_device) is not int or type(bundle.database_inode) is not int:
@@ -253,6 +400,9 @@ def bind_verified_runtime_reconciliation_evidence(
             snapshot=snapshot,
             snapshot_id=snapshot.snapshot_id,
             snapshot_hash=snapshot_hash,
+            comparison_coverage=exact_state.reconciliation_coverage,
+            differences=(),
+            timing_lag_proofs=(),
             bundle_id=bundle.bundle_id,
             runtime_fingerprint=contract.fingerprint,
             account_scope=broker.account_scope,
@@ -264,6 +414,15 @@ def bind_verified_runtime_reconciliation_evidence(
             broker_artifact_hash=broker.artifact_hash,
             broker_receipt_id=broker.receipt_id,
             broker_public_key_fingerprint=broker.public_key_fingerprint,
+            broker_evidence_expires_at=broker_expires_at,
+            reconciliation_snapshot_id=exact_state.reconciliation_snapshot_id,
+            reconciliation_artifact_path=exact_state.reconciliation_artifact_path,
+            reconciliation_artifact_hash=exact_state.reconciliation_report_hash,
+            reconciliation_receipt_id=reconciliation_receipt.receipt_id,
+            reconciliation_public_key_fingerprint=(reconciliation_receipt.public_key_fingerprint),
+            reconciliation_signature_ed25519=reconciliation_receipt.signature_ed25519,
+            reconciliation_evidence_issued_at=reconciliation_issued_at,
+            reconciliation_evidence_expires_at=reconciliation_expires_at,
             issued_at=issued_at,
             expires_at=expires_at,
             _runtime_context=context,

--- a/robo_trader/reconciliation/runtime_evidence.py
+++ b/robo_trader/reconciliation/runtime_evidence.py
@@ -1,0 +1,327 @@
+"""Exact one-shot binding for runtime reconciliation evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+import threading
+import weakref
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+from robo_trader.bootstrap_evidence_receivers import (
+    ProtectiveMarkBundleIdentity,
+    VerifiedBrokerEvidenceEnvelope,
+    assert_and_consume_verified_broker_evidence,
+    assert_protective_mark_receiver_capability,
+)
+from robo_trader.config import RuntimeContract
+from robo_trader.safety.sqlite_identity import SQLitePathBinding
+
+from .domain import (
+    NormalizedBrokerSnapshot,
+    ReconciliationDomainError,
+    _timestamp,
+    canonical_json,
+    canonical_timestamp,
+)
+from .identity import RuntimeSafetyContext, assert_validated_runtime_safety_context
+
+_CAPABILITY_MARKER = object()
+_CAPABILITY_KEY = secrets.token_bytes(32)
+_CAPABILITY_LOCK = threading.Lock()
+_CAPABILITIES: dict[
+    int,
+    tuple[weakref.ReferenceType["VerifiedRuntimeReconciliationEvidence"], str],
+] = {}
+
+
+class RuntimeReconciliationEvidenceError(ReconciliationDomainError):
+    """Core evidence is forged, cross-bound, stale, or attached to another database."""
+
+
+def _hash(value: object, field_name: str) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or value != value.lower()
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise RuntimeReconciliationEvidenceError(f"{field_name} is malformed")
+    return value
+
+
+def _strict_text(value: object, field_name: str) -> str:
+    if (
+        not isinstance(value, str)
+        or value != value.strip()
+        or not value
+        or len(value) > 256
+        or any(ord(character) < 32 for character in value)
+    ):
+        raise RuntimeReconciliationEvidenceError(f"{field_name} is malformed")
+    return value
+
+
+@dataclass(frozen=True, slots=True, weakref_slot=True, repr=False)
+class VerifiedRuntimeReconciliationEvidence:
+    """One exact core-authenticated broker generation and runtime ledger binding."""
+
+    snapshot: NormalizedBrokerSnapshot
+    snapshot_id: str
+    snapshot_hash: str
+    bundle_id: str
+    runtime_fingerprint: str
+    account_scope: str
+    account_alias: str
+    database_path: str
+    database_identity: str
+    database_device: int
+    database_inode: int
+    broker_artifact_hash: str
+    broker_receipt_id: str
+    broker_public_key_fingerprint: str
+    issued_at: datetime
+    expires_at: datetime
+    _runtime_context: RuntimeSafetyContext = field(repr=False, compare=False)
+    _marker: object = field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if self._marker is not _CAPABILITY_MARKER:
+            raise RuntimeReconciliationEvidenceError(
+                "runtime reconciliation evidence is factory-only"
+            )
+
+    def canonical_dict(self) -> dict[str, object]:
+        return {
+            "account_alias": self.account_alias,
+            "account_scope": self.account_scope,
+            "broker_artifact_hash": self.broker_artifact_hash,
+            "broker_public_key_fingerprint": self.broker_public_key_fingerprint,
+            "broker_receipt_id": self.broker_receipt_id,
+            "bundle_id": self.bundle_id,
+            "database_device": self.database_device,
+            "database_identity": self.database_identity,
+            "database_inode": self.database_inode,
+            "database_path": self.database_path,
+            "expires_at": canonical_timestamp(self.expires_at),
+            "issued_at": canonical_timestamp(self.issued_at),
+            "runtime_fingerprint": self.runtime_fingerprint,
+            "snapshot_hash": self.snapshot_hash,
+            "snapshot_id": self.snapshot_id,
+        }
+
+    def __copy__(self) -> "VerifiedRuntimeReconciliationEvidence":
+        raise TypeError("runtime reconciliation evidence cannot be copied")
+
+    def __deepcopy__(self, memo: object) -> "VerifiedRuntimeReconciliationEvidence":
+        del memo
+        raise TypeError("runtime reconciliation evidence cannot be copied")
+
+    def __reduce__(self) -> str:
+        raise TypeError("runtime reconciliation evidence cannot be pickled")
+
+
+def _digest(evidence: VerifiedRuntimeReconciliationEvidence) -> str:
+    payload = canonical_json(evidence.canonical_dict())
+    return hmac.new(
+        _CAPABILITY_KEY,
+        payload.encode("utf-8") + b"\0" + evidence.snapshot.canonical_payload().encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def _register(
+    evidence: VerifiedRuntimeReconciliationEvidence,
+) -> VerifiedRuntimeReconciliationEvidence:
+    object_id = id(evidence)
+
+    def discard(reference: weakref.ReferenceType[VerifiedRuntimeReconciliationEvidence]) -> None:
+        with _CAPABILITY_LOCK:
+            current = _CAPABILITIES.get(object_id)
+            if current is not None and current[0] is reference:
+                _CAPABILITIES.pop(object_id, None)
+
+    reference = weakref.ref(evidence, discard)
+    with _CAPABILITY_LOCK:
+        if object_id in _CAPABILITIES:
+            raise RuntimeReconciliationEvidenceError("runtime evidence registration collided")
+        _CAPABILITIES[object_id] = (reference, _digest(evidence))
+    return evidence
+
+
+def _database_binding(runtime_contract: RuntimeContract) -> SQLitePathBinding:
+    path = Path(runtime_contract.database_path)
+    if not path.is_absolute() or str(path) != runtime_contract.database_path:
+        raise RuntimeReconciliationEvidenceError("runtime database path is not absolute lexical")
+    try:
+        return SQLitePathBinding.open_readonly(path)
+    except Exception as exc:
+        raise RuntimeReconciliationEvidenceError(
+            "runtime database identity cannot be bound"
+        ) from exc
+
+
+def bind_verified_runtime_reconciliation_evidence(
+    verified_broker_evidence: object,
+    runtime_context: object,
+    protective_mark_receiver: object,
+) -> VerifiedRuntimeReconciliationEvidence:
+    """Consume core broker evidence and bind it to one exact runtime/database bundle."""
+
+    try:
+        context = assert_validated_runtime_safety_context(runtime_context)
+    except Exception as exc:
+        raise RuntimeReconciliationEvidenceError(
+            "runtime safety context is not core-validated"
+        ) from exc
+    contract = context.runtime_contract
+    if type(contract) is not RuntimeContract:
+        raise RuntimeReconciliationEvidenceError("exact RuntimeContract is required")
+    try:
+        broker = assert_and_consume_verified_broker_evidence(verified_broker_evidence)
+        bundle = assert_protective_mark_receiver_capability(
+            protective_mark_receiver,
+            runtime_contract=contract,
+        )
+    except Exception as exc:
+        raise RuntimeReconciliationEvidenceError(
+            "runtime reconciliation evidence is not core-authenticated"
+        ) from exc
+    if (
+        type(broker) is not VerifiedBrokerEvidenceEnvelope
+        or type(bundle) is not ProtectiveMarkBundleIdentity
+    ):
+        raise RuntimeReconciliationEvidenceError("core evidence types are not exact")
+
+    snapshot = broker.snapshot
+    snapshot_hash = hashlib.sha256(snapshot.canonical_payload().encode("utf-8")).hexdigest()
+    if (
+        broker.snapshot_id != snapshot.snapshot_id
+        or not hmac.compare_digest(broker.snapshot_hash, snapshot_hash)
+        or broker.runtime_fingerprint != contract.fingerprint
+        or broker.account_scope != contract.safety_account_scope
+        or broker.account_scope != snapshot.account.account_scope
+        or snapshot.account.account_alias != context.account_alias
+        or bundle.runtime_fingerprint != contract.fingerprint
+        or bundle.account_scope != broker.account_scope
+        or bundle.database_identity != contract.database_identity
+        or bundle.broker_snapshot_id != broker.snapshot_id
+        or not hmac.compare_digest(bundle.broker_snapshot_hash, broker.snapshot_hash)
+        or not hmac.compare_digest(bundle.broker_artifact_hash, broker.artifact_hash)
+        or bundle.broker_receipt_id != broker.receipt_id
+        or not hmac.compare_digest(
+            bundle.broker_public_key_fingerprint,
+            broker.public_key_fingerprint,
+        )
+    ):
+        raise RuntimeReconciliationEvidenceError("core evidence bindings disagree")
+    issued_at = _timestamp(broker.issued_at, "broker evidence issued_at")
+    expires_at = _timestamp(broker.expires_at, "broker evidence expires_at")
+    if not snapshot.retrieved_at <= issued_at <= expires_at:
+        raise RuntimeReconciliationEvidenceError("broker evidence chronology is invalid")
+    binding = _database_binding(contract)
+    try:
+        if (binding.device, binding.inode) != (
+            bundle.database_device,
+            bundle.database_inode,
+        ):
+            raise RuntimeReconciliationEvidenceError("core bundle belongs to a replaced database")
+    finally:
+        binding.close()
+
+    for value, field_name in (
+        (broker.artifact_hash, "broker artifact hash"),
+        (broker.public_key_fingerprint, "broker public-key fingerprint"),
+        (broker.snapshot_hash, "broker snapshot hash"),
+    ):
+        _hash(value, field_name)
+    for value, field_name in (
+        (bundle.bundle_id, "bundle_id"),
+        (broker.receipt_id, "broker receipt_id"),
+        (contract.database_identity, "database_identity"),
+        (contract.fingerprint, "runtime_fingerprint"),
+    ):
+        _strict_text(value, field_name)
+    if type(bundle.database_device) is not int or type(bundle.database_inode) is not int:
+        raise RuntimeReconciliationEvidenceError("database identity numbers are malformed")
+
+    return _register(
+        VerifiedRuntimeReconciliationEvidence(
+            snapshot=snapshot,
+            snapshot_id=snapshot.snapshot_id,
+            snapshot_hash=snapshot_hash,
+            bundle_id=bundle.bundle_id,
+            runtime_fingerprint=contract.fingerprint,
+            account_scope=broker.account_scope,
+            account_alias=snapshot.account.account_alias,
+            database_path=contract.database_path,
+            database_identity=contract.database_identity,
+            database_device=bundle.database_device,
+            database_inode=bundle.database_inode,
+            broker_artifact_hash=broker.artifact_hash,
+            broker_receipt_id=broker.receipt_id,
+            broker_public_key_fingerprint=broker.public_key_fingerprint,
+            issued_at=issued_at,
+            expires_at=expires_at,
+            _runtime_context=context,
+            _marker=_CAPABILITY_MARKER,
+        )
+    )
+
+
+def assert_and_consume_verified_runtime_reconciliation_evidence(
+    evidence: object,
+) -> VerifiedRuntimeReconciliationEvidence:
+    """Consume one exact capability and revalidate its runtime database inode."""
+
+    if type(evidence) is not VerifiedRuntimeReconciliationEvidence:
+        raise RuntimeReconciliationEvidenceError(
+            "exact verified runtime reconciliation evidence is required"
+        )
+    with _CAPABILITY_LOCK:
+        registered = _CAPABILITIES.pop(id(evidence), None)
+    if (
+        registered is None
+        or registered[0]() is not evidence
+        or evidence._marker is not _CAPABILITY_MARKER
+        or not hmac.compare_digest(registered[1], _digest(evidence))
+    ):
+        raise RuntimeReconciliationEvidenceError(
+            "runtime reconciliation evidence is forged, changed, or already consumed"
+        )
+    try:
+        context = assert_validated_runtime_safety_context(evidence._runtime_context)
+    except Exception as exc:
+        raise RuntimeReconciliationEvidenceError("runtime context changed after binding") from exc
+    contract = context.runtime_contract
+    if (
+        type(contract) is not RuntimeContract
+        or contract.fingerprint != evidence.runtime_fingerprint
+        or contract.database_identity != evidence.database_identity
+        or contract.database_path != evidence.database_path
+        or contract.safety_account_scope != evidence.account_scope
+    ):
+        raise RuntimeReconciliationEvidenceError("runtime binding changed after production")
+    binding = _database_binding(contract)
+    try:
+        if (binding.device, binding.inode) != (
+            evidence.database_device,
+            evidence.database_inode,
+        ):
+            raise RuntimeReconciliationEvidenceError(
+                "runtime database was replaced after evidence production"
+            )
+    finally:
+        binding.close()
+    return evidence
+
+
+__all__ = [
+    "RuntimeReconciliationEvidenceError",
+    "VerifiedRuntimeReconciliationEvidence",
+    "assert_and_consume_verified_runtime_reconciliation_evidence",
+    "bind_verified_runtime_reconciliation_evidence",
+]

--- a/robo_trader/reconciliation/runtime_evidence.py
+++ b/robo_trader/reconciliation/runtime_evidence.py
@@ -45,7 +45,13 @@ _CAPABILITY_KEY = secrets.token_bytes(32)
 _CAPABILITY_LOCK = threading.Lock()
 _CAPABILITIES: dict[
     int,
-    tuple[weakref.ReferenceType["VerifiedRuntimeReconciliationEvidence"], str],
+    tuple[
+        weakref.ReferenceType["VerifiedRuntimeReconciliationEvidence"],
+        str,
+        ExactStateBootstrapEvidence,
+        str,
+        bool,
+    ],
 ] = {}
 _COMPARISON_CONSUMPTION_LOCK = threading.Lock()
 _MAX_CONSUMED_COMPARISON_LINEAGES = 1024
@@ -155,7 +161,7 @@ class VerifiedRuntimeReconciliationEvidence:
     issued_at: datetime
     expires_at: datetime
     _runtime_context: RuntimeSafetyContext
-    _exact_state_evidence: ExactStateBootstrapEvidence | None
+    _exact_state_evidence: ExactStateBootstrapEvidence
     _marker: object
 
     def __post_init__(self) -> None:
@@ -214,11 +220,34 @@ class VerifiedRuntimeReconciliationEvidence:
         raise TypeError("runtime reconciliation evidence cannot be pickled")
 
 
+def _exact_state_source_binding(
+    evidence: VerifiedRuntimeReconciliationEvidence,
+) -> tuple[ExactStateBootstrapEvidence, str]:
+    source = evidence._exact_state_evidence
+    if type(source) is not ExactStateBootstrapEvidence:
+        raise RuntimeReconciliationEvidenceError(
+            "runtime reconciliation exact-state source is missing or substituted"
+        )
+    try:
+        producer_digest = _hash(source._producer_digest, "exact-state producer digest")
+    except (AttributeError, RuntimeReconciliationEvidenceError) as exc:
+        raise RuntimeReconciliationEvidenceError(
+            "runtime reconciliation exact-state source is not producer-sealed"
+        ) from exc
+    return source, producer_digest
+
+
 def _digest(evidence: VerifiedRuntimeReconciliationEvidence) -> str:
     payload = canonical_json(evidence.canonical_dict())
+    source, source_digest = _exact_state_source_binding(evidence)
+    source_binding = f"{id(source):x}:{source_digest}".encode("ascii")
     return hmac.new(
         _CAPABILITY_KEY,
-        payload.encode("utf-8") + b"\0" + evidence.snapshot.canonical_payload().encode("utf-8"),
+        payload.encode("utf-8")
+        + b"\0"
+        + evidence.snapshot.canonical_payload().encode("utf-8")
+        + b"\0"
+        + source_binding,
         hashlib.sha256,
     ).hexdigest()
 
@@ -227,6 +256,7 @@ def _register(
     evidence: VerifiedRuntimeReconciliationEvidence,
 ) -> VerifiedRuntimeReconciliationEvidence:
     object_id = id(evidence)
+    source, source_digest = _exact_state_source_binding(evidence)
 
     def discard(reference: weakref.ReferenceType[VerifiedRuntimeReconciliationEvidence]) -> None:
         with _CAPABILITY_LOCK:
@@ -238,7 +268,13 @@ def _register(
     with _CAPABILITY_LOCK:
         if object_id in _CAPABILITIES:
             raise RuntimeReconciliationEvidenceError("runtime evidence registration collided")
-        _CAPABILITIES[object_id] = (reference, _digest(evidence))
+        _CAPABILITIES[object_id] = (
+            reference,
+            _digest(evidence),
+            source,
+            source_digest,
+            False,
+        )
     return evidence
 
 
@@ -252,6 +288,31 @@ def _database_binding(runtime_contract: RuntimeContract) -> SQLitePathBinding:
         raise RuntimeReconciliationEvidenceError(
             "runtime database identity cannot be bound"
         ) from exc
+
+
+def _assert_consumed_source_binding(
+    evidence: VerifiedRuntimeReconciliationEvidence,
+    *,
+    changed_message: str,
+) -> ExactStateBootstrapEvidence:
+    try:
+        source, source_digest = _exact_state_source_binding(evidence)
+        current_digest = _digest(evidence)
+    except RuntimeReconciliationEvidenceError as exc:
+        raise RuntimeReconciliationEvidenceError(changed_message) from exc
+    with _CAPABILITY_LOCK:
+        registered = _CAPABILITIES.get(id(evidence))
+    if (
+        registered is None
+        or registered[0]() is not evidence
+        or evidence._marker is not _CAPABILITY_MARKER
+        or not registered[4]
+        or not hmac.compare_digest(registered[1], current_digest)
+        or registered[2] is not source
+        or not hmac.compare_digest(registered[3], source_digest)
+    ):
+        raise RuntimeReconciliationEvidenceError(changed_message)
+    return source
 
 
 def _consume_comparison_lineage(
@@ -469,26 +530,19 @@ def bind_verified_runtime_reconciliation_evidence(
     )
 
 
-def assert_and_consume_verified_runtime_reconciliation_evidence(
-    evidence: object,
-) -> VerifiedRuntimeReconciliationEvidence:
-    """Consume one exact capability and revalidate its runtime database inode."""
+def assert_runtime_reconciliation_evidence_sources_current(
+    evidence: VerifiedRuntimeReconciliationEvidence,
+) -> None:
+    """Revalidate one consumed capability's sealed sources and database inode."""
 
     if type(evidence) is not VerifiedRuntimeReconciliationEvidence:
         raise RuntimeReconciliationEvidenceError(
             "exact verified runtime reconciliation evidence is required"
         )
-    with _CAPABILITY_LOCK:
-        registered = _CAPABILITIES.pop(id(evidence), None)
-    if (
-        registered is None
-        or registered[0]() is not evidence
-        or evidence._marker is not _CAPABILITY_MARKER
-        or not hmac.compare_digest(registered[1], _digest(evidence))
-    ):
-        raise RuntimeReconciliationEvidenceError(
-            "runtime reconciliation evidence is forged, changed, or already consumed"
-        )
+    source = _assert_consumed_source_binding(
+        evidence,
+        changed_message="consumed runtime reconciliation binding changed",
+    )
     try:
         context = assert_validated_runtime_safety_context(evidence._runtime_context)
     except Exception as exc:
@@ -502,16 +556,12 @@ def assert_and_consume_verified_runtime_reconciliation_evidence(
         or contract.safety_account_scope != evidence.account_scope
     ):
         raise RuntimeReconciliationEvidenceError("runtime binding changed after production")
-    if evidence._exact_state_evidence is not None:
-        try:
-            assert_exact_state_runtime_sources_unchanged(
-                evidence._exact_state_evidence,
-                contract,
-            )
-        except Exception as exc:
-            raise RuntimeReconciliationEvidenceError(
-                "signed reconciliation source state changed before comparison"
-            ) from exc
+    try:
+        assert_exact_state_runtime_sources_unchanged(source, contract)
+    except Exception as exc:
+        raise RuntimeReconciliationEvidenceError(
+            "signed reconciliation source state changed before comparison"
+        ) from exc
     binding = _database_binding(contract)
     try:
         if (binding.device, binding.inode) != (
@@ -523,6 +573,50 @@ def assert_and_consume_verified_runtime_reconciliation_evidence(
             )
     finally:
         binding.close()
+    _assert_consumed_source_binding(
+        evidence,
+        changed_message=("consumed runtime reconciliation binding changed during revalidation"),
+    )
+
+
+def assert_and_consume_verified_runtime_reconciliation_evidence(
+    evidence: object,
+) -> VerifiedRuntimeReconciliationEvidence:
+    """Consume one exact capability and revalidate all sealed runtime sources."""
+
+    if type(evidence) is not VerifiedRuntimeReconciliationEvidence:
+        raise RuntimeReconciliationEvidenceError(
+            "exact verified runtime reconciliation evidence is required"
+        )
+    try:
+        source, source_digest = _exact_state_source_binding(evidence)
+        current_digest = _digest(evidence)
+    except RuntimeReconciliationEvidenceError as exc:
+        raise RuntimeReconciliationEvidenceError(
+            "runtime reconciliation evidence is forged, changed, or already consumed"
+        ) from exc
+    with _CAPABILITY_LOCK:
+        registered = _CAPABILITIES.get(id(evidence))
+        if (
+            registered is None
+            or registered[0]() is not evidence
+            or evidence._marker is not _CAPABILITY_MARKER
+            or registered[4]
+            or not hmac.compare_digest(registered[1], current_digest)
+            or registered[2] is not source
+            or not hmac.compare_digest(registered[3], source_digest)
+        ):
+            raise RuntimeReconciliationEvidenceError(
+                "runtime reconciliation evidence is forged, changed, or already consumed"
+            )
+        _CAPABILITIES[id(evidence)] = (
+            registered[0],
+            registered[1],
+            registered[2],
+            registered[3],
+            True,
+        )
+    assert_runtime_reconciliation_evidence_sources_current(evidence)
     return evidence
 
 
@@ -530,5 +624,6 @@ __all__ = [
     "RuntimeReconciliationEvidenceError",
     "VerifiedRuntimeReconciliationEvidence",
     "assert_and_consume_verified_runtime_reconciliation_evidence",
+    "assert_runtime_reconciliation_evidence_sources_current",
     "bind_verified_runtime_reconciliation_evidence",
 ]

--- a/robo_trader/reconciliation/runtime_evidence.py
+++ b/robo_trader/reconciliation/runtime_evidence.py
@@ -8,7 +8,7 @@ import secrets
 import threading
 import weakref
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import SupportsIndex
 
@@ -21,6 +21,7 @@ from robo_trader.bootstrap_evidence_receivers import (
 from robo_trader.config import RuntimeContract
 from robo_trader.financial_state_bootstrap import (
     ExactStateBootstrapEvidence,
+    assert_exact_state_runtime_sources_unchanged,
     assert_verified_exact_state_reconciliation_evidence,
 )
 from robo_trader.safety.sqlite_identity import SQLitePathBinding
@@ -37,7 +38,6 @@ from .policy import (
     ExpectedTimingLagProof,
     ReconciliationCoverage,
     ReconciliationDifference,
-    ReconciliationStatus,
 )
 
 _CAPABILITY_MARKER = object()
@@ -48,7 +48,13 @@ _CAPABILITIES: dict[
     tuple[weakref.ReferenceType["VerifiedRuntimeReconciliationEvidence"], str],
 ] = {}
 _COMPARISON_CONSUMPTION_LOCK = threading.Lock()
-_CONSUMED_COMPARISON_LINEAGES: set[tuple[str, str, str]] = set()
+_MAX_CONSUMED_COMPARISON_LINEAGES = 1024
+_CONSUMED_COMPARISON_LINEAGES: dict[tuple[str, str, str], datetime] = {}
+_COMPARISON_LAST_CLOCK: datetime | None = None
+
+
+def _comparison_clock() -> datetime:
+    return datetime.now(timezone.utc)
 
 
 class RuntimeReconciliationEvidenceError(ReconciliationDomainError):
@@ -115,6 +121,7 @@ class VerifiedRuntimeReconciliationEvidence:
         "issued_at",
         "expires_at",
         "_runtime_context",
+        "_exact_state_evidence",
         "_marker",
         "__weakref__",
     )
@@ -148,6 +155,7 @@ class VerifiedRuntimeReconciliationEvidence:
     issued_at: datetime
     expires_at: datetime
     _runtime_context: RuntimeSafetyContext
+    _exact_state_evidence: ExactStateBootstrapEvidence | None
     _marker: object
 
     def __post_init__(self) -> None:
@@ -246,6 +254,39 @@ def _database_binding(runtime_contract: RuntimeContract) -> SQLitePathBinding:
         ) from exc
 
 
+def _consume_comparison_lineage(
+    lineage: tuple[str, str, str],
+    *,
+    expires_at: datetime,
+) -> None:
+    global _COMPARISON_LAST_CLOCK
+
+    checked_at = _timestamp(_comparison_clock(), "comparison replay clock")
+    expiry = _timestamp(expires_at, "comparison replay expires_at")
+    with _COMPARISON_CONSUMPTION_LOCK:
+        if _COMPARISON_LAST_CLOCK is not None and checked_at < _COMPARISON_LAST_CLOCK:
+            raise RuntimeReconciliationEvidenceError("comparison replay clock moved backwards")
+        _COMPARISON_LAST_CLOCK = checked_at
+        expired = tuple(
+            key
+            for key, cached_expiry in _CONSUMED_COMPARISON_LINEAGES.items()
+            if cached_expiry < checked_at
+        )
+        for key in expired:
+            _CONSUMED_COMPARISON_LINEAGES.pop(key, None)
+        if expiry < checked_at:
+            raise RuntimeReconciliationEvidenceError("signed reconciliation comparison expired")
+        if lineage in _CONSUMED_COMPARISON_LINEAGES:
+            raise RuntimeReconciliationEvidenceError(
+                "signed reconciliation comparison was already consumed"
+            )
+        if len(_CONSUMED_COMPARISON_LINEAGES) >= _MAX_CONSUMED_COMPARISON_LINEAGES:
+            raise RuntimeReconciliationEvidenceError(
+                "signed reconciliation replay cache is at its safety bound"
+            )
+        _CONSUMED_COMPARISON_LINEAGES[lineage] = expiry
+
+
 def bind_verified_runtime_reconciliation_evidence(
     verified_broker_evidence: object,
     verified_exact_state_evidence: object,
@@ -294,18 +335,6 @@ def bind_verified_runtime_reconciliation_evidence(
             "signed reconciliation receipt lineage is incomplete"
         )
     reconciliation_receipt = reconciliation_receipts[0]
-    comparison_lineage = (
-        exact_state.reconciliation_snapshot_id,
-        reconciliation_receipt.receipt_id,
-        reconciliation_receipt.signature_ed25519,
-    )
-    with _COMPARISON_CONSUMPTION_LOCK:
-        if comparison_lineage in _CONSUMED_COMPARISON_LINEAGES:
-            raise RuntimeReconciliationEvidenceError(
-                "signed reconciliation comparison was already consumed"
-            )
-        _CONSUMED_COMPARISON_LINEAGES.add(comparison_lineage)
-
     snapshot = broker.snapshot
     snapshot_hash = hashlib.sha256(snapshot.canonical_payload().encode("utf-8")).hexdigest()
     if (
@@ -326,7 +355,6 @@ def bind_verified_runtime_reconciliation_evidence(
             bundle.broker_public_key_fingerprint,
             broker.public_key_fingerprint,
         )
-        or exact_state.reconciliation_status is not ReconciliationStatus.PASSED
         or type(exact_state.reconciliation_coverage) is not ReconciliationCoverage
         or exact_state.reconciliation_snapshot_id != bundle.reconciliation_snapshot_id
         or exact_state.bundle_id != bundle.bundle_id
@@ -395,14 +423,23 @@ def bind_verified_runtime_reconciliation_evidence(
     if type(bundle.database_device) is not int or type(bundle.database_inode) is not int:
         raise RuntimeReconciliationEvidenceError("database identity numbers are malformed")
 
+    _consume_comparison_lineage(
+        (
+            exact_state.reconciliation_snapshot_id,
+            reconciliation_receipt.receipt_id,
+            reconciliation_receipt.signature_ed25519,
+        ),
+        expires_at=reconciliation_expires_at,
+    )
+
     return _register(
         VerifiedRuntimeReconciliationEvidence(
             snapshot=snapshot,
             snapshot_id=snapshot.snapshot_id,
             snapshot_hash=snapshot_hash,
             comparison_coverage=exact_state.reconciliation_coverage,
-            differences=(),
-            timing_lag_proofs=(),
+            differences=exact_state.reconciliation_differences,
+            timing_lag_proofs=exact_state.reconciliation_timing_lag_proofs,
             bundle_id=bundle.bundle_id,
             runtime_fingerprint=contract.fingerprint,
             account_scope=broker.account_scope,
@@ -426,6 +463,7 @@ def bind_verified_runtime_reconciliation_evidence(
             issued_at=issued_at,
             expires_at=expires_at,
             _runtime_context=context,
+            _exact_state_evidence=exact_state,
             _marker=_CAPABILITY_MARKER,
         )
     )
@@ -464,6 +502,16 @@ def assert_and_consume_verified_runtime_reconciliation_evidence(
         or contract.safety_account_scope != evidence.account_scope
     ):
         raise RuntimeReconciliationEvidenceError("runtime binding changed after production")
+    if evidence._exact_state_evidence is not None:
+        try:
+            assert_exact_state_runtime_sources_unchanged(
+                evidence._exact_state_evidence,
+                contract,
+            )
+        except Exception as exc:
+            raise RuntimeReconciliationEvidenceError(
+                "signed reconciliation source state changed before comparison"
+            ) from exc
     binding = _database_binding(contract)
     try:
         if (binding.device, binding.inode) != (

--- a/robo_trader/reconciliation/service.py
+++ b/robo_trader/reconciliation/service.py
@@ -317,6 +317,16 @@ class ReconciliationService:
                 eligible_until=eligible_until,
             )
             assert_runtime_reconciliation_evidence_sources_current(runtime_evidence)
+            publication_at = self._clock_value("post-persistence clock")
+            if publication_at < completed_at:
+                raise ReconciliationServiceBlocked("post-persistence clock moved backwards")
+            if (
+                verdict.status in {ReconciliationStatus.PASSED, ReconciliationStatus.DEGRADED}
+                and publication_at > eligible_until
+            ):
+                raise ReconciliationServiceBlocked(
+                    "post-persistence eligibility expired before outcome publication"
+                )
         except BaseException as exc:
             self._quarantine()
             if isinstance(exc, asyncio.CancelledError):

--- a/robo_trader/reconciliation/service.py
+++ b/robo_trader/reconciliation/service.py
@@ -1,0 +1,319 @@
+"""Dormant trigger-aware reconciliation service with fail-closed eligibility."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import math
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import Awaitable, Callable, Protocol
+
+from .domain import NormalizedBrokerSnapshot, ReconciliationDomainError, _timestamp
+from .persistence import PersistedReconciliation, ReconciliationPersistence
+from .policy import (
+    ExpectedTimingLagProof,
+    ReconciliationCoverage,
+    ReconciliationDifference,
+    ReconciliationStatus,
+    ReconciliationVerdict,
+    evaluate_paper_simulator_reconciliation,
+)
+
+
+class ReconciliationServiceBlocked(ReconciliationDomainError):
+    """Reconciliation could not produce and persist trusted entry evidence."""
+
+
+class ReconciliationTrigger(str, Enum):
+    STARTUP = "startup"
+    RECONNECT = "reconnect"
+    PERIODIC = "periodic"
+    BEFORE_LIVE = "before_live"
+    AMBIGUOUS_ORDER = "ambiguous_order"
+
+
+class ReconciliationServiceState(str, Enum):
+    UNINITIALIZED = "uninitialized"
+    IDLE = "idle"
+    RUNNING = "running"
+    READY = "ready"
+    DEGRADED = "degraded"
+    QUARANTINED = "quarantined"
+    CLOSED = "closed"
+
+
+@dataclass(frozen=True, slots=True)
+class ReconciliationComparison:
+    coverage: ReconciliationCoverage
+    differences: tuple[ReconciliationDifference, ...] = ()
+    timing_lag_proofs: tuple[ExpectedTimingLagProof, ...] = ()
+
+    def __post_init__(self) -> None:
+        if type(self.coverage) is not ReconciliationCoverage:
+            raise ReconciliationServiceBlocked("comparison coverage is not normalized")
+        if any(type(value) is not ReconciliationDifference for value in self.differences):
+            raise ReconciliationServiceBlocked("comparison differences are not normalized")
+        if any(type(value) is not ExpectedTimingLagProof for value in self.timing_lag_proofs):
+            raise ReconciliationServiceBlocked("comparison timing proofs are not normalized")
+
+
+@dataclass(frozen=True, slots=True)
+class ReconciliationServiceOutcome:
+    trigger: ReconciliationTrigger
+    verdict: ReconciliationVerdict
+    persisted: PersistedReconciliation
+    state: ReconciliationServiceState
+    entry_eligible: bool
+
+
+class NormalizedSnapshotSource(Protocol):
+    """Narrow source implemented by the existing read-only provider pipeline.
+
+    Runtime composition must supply the provider's authenticated normalized
+    evidence handoff. The service intentionally receives no transport or order
+    capability and cannot reach around that handoff.
+    """
+
+    async def collect_normalized_snapshot(
+        self, *, max_age_seconds: float
+    ) -> NormalizedBrokerSnapshot:
+        """Collect one bounded read-only broker snapshot."""
+
+    async def close(self) -> None:
+        """Close only the diagnostic read-only transport."""
+
+
+class ReconciliationComparisonSource(Protocol):
+    def __call__(
+        self,
+        snapshot: NormalizedBrokerSnapshot,
+        trigger: ReconciliationTrigger,
+    ) -> ReconciliationComparison | Awaitable[ReconciliationComparison]:
+        """Compare immutable local evidence without repairing or replacing it."""
+
+
+def _system_clock() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class ReconciliationService:
+    """Serialize startup, reconnect, and periodic reconciliation generations.
+
+    The service never repairs broker or local state. It only collects evidence,
+    evaluates the merged pure policy, appends durable records, and reports
+    whether new entry eligibility remains quarantined.
+    """
+
+    def __init__(
+        self,
+        *,
+        snapshot_source: NormalizedSnapshotSource,
+        comparison_source: ReconciliationComparisonSource,
+        persistence: ReconciliationPersistence,
+        expected_account_scope: str,
+        max_age_seconds: float = 30.0,
+        periodic_interval_seconds: float = 15.0,
+        clock: Callable[[], datetime] = _system_clock,
+    ) -> None:
+        if not isinstance(max_age_seconds, (int, float)) or isinstance(max_age_seconds, bool):
+            raise ReconciliationServiceBlocked("maximum evidence age must be numeric")
+        if not isinstance(periodic_interval_seconds, (int, float)) or isinstance(
+            periodic_interval_seconds, bool
+        ):
+            raise ReconciliationServiceBlocked("periodic interval must be numeric")
+        if (
+            not math.isfinite(float(max_age_seconds))
+            or float(max_age_seconds) <= 0
+            or not math.isfinite(float(periodic_interval_seconds))
+            or float(periodic_interval_seconds) <= 0
+            or float(periodic_interval_seconds) > float(max_age_seconds)
+        ):
+            raise ReconciliationServiceBlocked(
+                "periodic interval must be positive and no longer than evidence age"
+            )
+        if not callable(getattr(snapshot_source, "collect_normalized_snapshot", None)):
+            raise ReconciliationServiceBlocked("normalized snapshot source is unavailable")
+        if not callable(getattr(snapshot_source, "close", None)):
+            raise ReconciliationServiceBlocked("snapshot source cleanup is unavailable")
+        if not callable(comparison_source):
+            raise ReconciliationServiceBlocked("comparison source is unavailable")
+        self._snapshot_source = snapshot_source
+        self._comparison_source = comparison_source
+        self._persistence = persistence
+        self._expected_account_scope = expected_account_scope
+        self._max_age_seconds = float(max_age_seconds)
+        self._periodic_interval = timedelta(seconds=float(periodic_interval_seconds))
+        self._clock = clock
+        self._lock = asyncio.Lock()
+        self._initialized = False
+        self._state = ReconciliationServiceState.UNINITIALIZED
+        self._latest_outcome: ReconciliationServiceOutcome | None = None
+        self._last_completed_at: datetime | None = None
+
+    @property
+    def state(self) -> ReconciliationServiceState:
+        return self._state
+
+    @property
+    def latest_outcome(self) -> ReconciliationServiceOutcome | None:
+        return self._latest_outcome
+
+    def entry_eligible(self, *, at: datetime | None = None) -> bool:
+        """Return false once durable evidence is quarantined, missing, or stale."""
+
+        outcome = self._latest_outcome
+        if (
+            outcome is None
+            or not outcome.entry_eligible
+            or self._state
+            not in {ReconciliationServiceState.READY, ReconciliationServiceState.DEGRADED}
+        ):
+            return False
+        try:
+            checked_at = _timestamp(at if at is not None else self._clock(), "eligibility clock")
+        except Exception:
+            return False
+        return checked_at <= outcome.verdict.fresh_until
+
+    async def initialize(self) -> None:
+        async with self._lock:
+            self._assert_not_closed()
+            await self._initialize_locked()
+
+    async def reconcile_startup(self) -> ReconciliationServiceOutcome:
+        return await self._run(ReconciliationTrigger.STARTUP)
+
+    async def reconcile_reconnect(self) -> ReconciliationServiceOutcome:
+        return await self._run(ReconciliationTrigger.RECONNECT)
+
+    async def reconcile_before_live(self) -> ReconciliationServiceOutcome:
+        return await self._run(ReconciliationTrigger.BEFORE_LIVE)
+
+    async def reconcile_ambiguous_order(self) -> ReconciliationServiceOutcome:
+        return await self._run(ReconciliationTrigger.AMBIGUOUS_ORDER)
+
+    async def reconcile_periodic_if_due(self) -> ReconciliationServiceOutcome | None:
+        async with self._lock:
+            self._assert_not_closed()
+            await self._initialize_locked()
+            now = self._clock_value("periodic clock")
+            if self._last_completed_at is not None:
+                if now < self._last_completed_at:
+                    self._quarantine()
+                    raise ReconciliationServiceBlocked("periodic clock moved backwards")
+                if now - self._last_completed_at < self._periodic_interval:
+                    return None
+            return await self._run_locked(ReconciliationTrigger.PERIODIC, started_at=now)
+
+    async def close(self) -> None:
+        async with self._lock:
+            if self._state is ReconciliationServiceState.CLOSED:
+                return
+            self._quarantine()
+            try:
+                await self._snapshot_source.close()
+            finally:
+                self._state = ReconciliationServiceState.CLOSED
+
+    async def _run(self, trigger: ReconciliationTrigger) -> ReconciliationServiceOutcome:
+        async with self._lock:
+            self._assert_not_closed()
+            await self._initialize_locked()
+            return await self._run_locked(trigger, started_at=self._clock_value("run clock"))
+
+    async def _initialize_locked(self) -> None:
+        if self._initialized:
+            return
+        try:
+            await self._persistence.initialize()
+        except BaseException as exc:
+            self._quarantine()
+            if isinstance(exc, asyncio.CancelledError):
+                raise
+            raise ReconciliationServiceBlocked(
+                "reconciliation persistence initialization failed"
+            ) from exc
+        self._initialized = True
+        self._state = ReconciliationServiceState.IDLE
+
+    async def _run_locked(
+        self,
+        trigger: ReconciliationTrigger,
+        *,
+        started_at: datetime,
+    ) -> ReconciliationServiceOutcome:
+        self._state = ReconciliationServiceState.RUNNING
+        try:
+            snapshot = await self._snapshot_source.collect_normalized_snapshot(
+                max_age_seconds=self._max_age_seconds
+            )
+            if type(snapshot) is not NormalizedBrokerSnapshot:
+                raise ReconciliationServiceBlocked("snapshot source returned invalid evidence")
+            comparison_result = self._comparison_source(snapshot, trigger)
+            if inspect.isawaitable(comparison_result):
+                comparison_result = await comparison_result
+            if type(comparison_result) is not ReconciliationComparison:
+                raise ReconciliationServiceBlocked("comparison source returned invalid evidence")
+            checked_at = self._clock_value("policy clock")
+            if checked_at < started_at:
+                raise ReconciliationServiceBlocked("policy clock moved backwards")
+            verdict = evaluate_paper_simulator_reconciliation(
+                snapshot,
+                comparison_result.coverage,
+                comparison_result.differences,
+                comparison_result.timing_lag_proofs,
+                expected_account_scope=self._expected_account_scope,
+                now=checked_at,
+                max_age_seconds=self._max_age_seconds,
+            )
+            completed_at = self._clock_value("completion clock")
+            if completed_at < checked_at:
+                raise ReconciliationServiceBlocked("completion clock moved backwards")
+            persisted = await self._persistence.append_reconciliation(
+                trigger_type=trigger.value,
+                snapshot=snapshot,
+                verdict=verdict,
+                started_at=started_at,
+                completed_at=completed_at,
+            )
+        except BaseException as exc:
+            self._quarantine()
+            if isinstance(exc, asyncio.CancelledError):
+                raise
+            if isinstance(exc, ReconciliationServiceBlocked):
+                raise
+            raise ReconciliationServiceBlocked("reconciliation generation failed closed") from exc
+
+        state = {
+            ReconciliationStatus.PASSED: ReconciliationServiceState.READY,
+            ReconciliationStatus.DEGRADED: ReconciliationServiceState.DEGRADED,
+            ReconciliationStatus.QUARANTINED: ReconciliationServiceState.QUARANTINED,
+        }[verdict.status]
+        outcome = ReconciliationServiceOutcome(
+            trigger=trigger,
+            verdict=verdict,
+            persisted=persisted,
+            state=state,
+            entry_eligible=persisted.entry_eligible,
+        )
+        self._state = state
+        self._latest_outcome = outcome
+        self._last_completed_at = completed_at
+        return outcome
+
+    def _clock_value(self, label: str) -> datetime:
+        try:
+            return _timestamp(self._clock(), label)
+        except Exception as exc:
+            raise ReconciliationServiceBlocked(f"{label} is unavailable") from exc
+
+    def _quarantine(self) -> None:
+        self._latest_outcome = None
+        self._last_completed_at = None
+        self._state = ReconciliationServiceState.QUARANTINED
+
+    def _assert_not_closed(self) -> None:
+        if self._state is ReconciliationServiceState.CLOSED:
+            raise ReconciliationServiceBlocked("reconciliation service is closed")

--- a/robo_trader/reconciliation/service.py
+++ b/robo_trader/reconciliation/service.py
@@ -11,6 +11,7 @@ from enum import Enum
 from typing import Awaitable, Callable, Protocol
 
 from .domain import NormalizedBrokerSnapshot, ReconciliationDomainError, _timestamp
+from .ibkr_adapter import await_cleanup_required
 from .persistence import PersistedReconciliation, ReconciliationPersistence
 from .policy import (
     ExpectedTimingLagProof,
@@ -19,6 +20,10 @@ from .policy import (
     ReconciliationStatus,
     ReconciliationVerdict,
     evaluate_paper_simulator_reconciliation,
+)
+from .runtime_evidence import (
+    VerifiedRuntimeReconciliationEvidence,
+    assert_and_consume_verified_runtime_reconciliation_evidence,
 )
 
 
@@ -41,6 +46,7 @@ class ReconciliationServiceState(str, Enum):
     READY = "ready"
     DEGRADED = "degraded"
     QUARANTINED = "quarantined"
+    CLOSING = "closing"
     CLOSED = "closed"
 
 
@@ -66,20 +72,21 @@ class ReconciliationServiceOutcome:
     persisted: PersistedReconciliation
     state: ReconciliationServiceState
     entry_eligible: bool
+    eligible_until: datetime
 
 
-class NormalizedSnapshotSource(Protocol):
-    """Narrow source implemented by the existing read-only provider pipeline.
+class VerifiedEvidenceSource(Protocol):
+    """Narrow source implemented by the core-authenticated provider pipeline.
 
-    Runtime composition must supply the provider's authenticated normalized
-    evidence handoff. The service intentionally receives no transport or order
-    capability and cannot reach around that handoff.
+    A structurally compatible source is not trusted: every result is consumed
+    through the exact one-shot runtime evidence assertion before any field is
+    inspected.
     """
 
-    async def collect_normalized_snapshot(
+    async def collect_verified_evidence(
         self, *, max_age_seconds: float
-    ) -> NormalizedBrokerSnapshot:
-        """Collect one bounded read-only broker snapshot."""
+    ) -> VerifiedRuntimeReconciliationEvidence:
+        """Collect one exact core-bound read-only broker generation."""
 
     async def close(self) -> None:
         """Close only the diagnostic read-only transport."""
@@ -109,7 +116,7 @@ class ReconciliationService:
     def __init__(
         self,
         *,
-        snapshot_source: NormalizedSnapshotSource,
+        evidence_source: VerifiedEvidenceSource,
         comparison_source: ReconciliationComparisonSource,
         persistence: ReconciliationPersistence,
         expected_account_scope: str,
@@ -133,13 +140,13 @@ class ReconciliationService:
             raise ReconciliationServiceBlocked(
                 "periodic interval must be positive and no longer than evidence age"
             )
-        if not callable(getattr(snapshot_source, "collect_normalized_snapshot", None)):
-            raise ReconciliationServiceBlocked("normalized snapshot source is unavailable")
-        if not callable(getattr(snapshot_source, "close", None)):
-            raise ReconciliationServiceBlocked("snapshot source cleanup is unavailable")
+        if not callable(getattr(evidence_source, "collect_verified_evidence", None)):
+            raise ReconciliationServiceBlocked("verified evidence source is unavailable")
+        if not callable(getattr(evidence_source, "close", None)):
+            raise ReconciliationServiceBlocked("evidence source cleanup is unavailable")
         if not callable(comparison_source):
             raise ReconciliationServiceBlocked("comparison source is unavailable")
-        self._snapshot_source = snapshot_source
+        self._evidence_source = evidence_source
         self._comparison_source = comparison_source
         self._persistence = persistence
         self._expected_account_scope = expected_account_scope
@@ -174,8 +181,19 @@ class ReconciliationService:
         try:
             checked_at = _timestamp(at if at is not None else self._clock(), "eligibility clock")
         except Exception:
+            self._quarantine()
             return False
-        return checked_at <= outcome.verdict.fresh_until
+        if (
+            checked_at < outcome.verdict.checked_at
+            or self._last_completed_at is None
+            or checked_at < self._last_completed_at
+        ):
+            self._quarantine()
+            return False
+        if checked_at > outcome.eligible_until:
+            self._state = ReconciliationServiceState.QUARANTINED
+            return False
+        return True
 
     async def initialize(self) -> None:
         async with self._lock:
@@ -211,11 +229,17 @@ class ReconciliationService:
         async with self._lock:
             if self._state is ReconciliationServiceState.CLOSED:
                 return
-            self._quarantine()
+            self._latest_outcome = None
+            self._last_completed_at = None
+            self._state = ReconciliationServiceState.CLOSING
             try:
-                await self._snapshot_source.close()
-            finally:
-                self._state = ReconciliationServiceState.CLOSED
+                cancellation_received = await await_cleanup_required(self._evidence_source.close())
+            except BaseException:
+                self._state = ReconciliationServiceState.CLOSING
+                raise
+            self._state = ReconciliationServiceState.CLOSED
+            if cancellation_received:
+                raise asyncio.CancelledError
 
     async def _run(self, trigger: ReconciliationTrigger) -> ReconciliationServiceOutcome:
         async with self._lock:
@@ -246,11 +270,11 @@ class ReconciliationService:
     ) -> ReconciliationServiceOutcome:
         self._state = ReconciliationServiceState.RUNNING
         try:
-            snapshot = await self._snapshot_source.collect_normalized_snapshot(
+            produced = await self._evidence_source.collect_verified_evidence(
                 max_age_seconds=self._max_age_seconds
             )
-            if type(snapshot) is not NormalizedBrokerSnapshot:
-                raise ReconciliationServiceBlocked("snapshot source returned invalid evidence")
+            runtime_evidence = assert_and_consume_verified_runtime_reconciliation_evidence(produced)
+            snapshot = runtime_evidence.snapshot
             comparison_result = self._comparison_source(snapshot, trigger)
             if inspect.isawaitable(comparison_result):
                 comparison_result = await comparison_result
@@ -271,12 +295,36 @@ class ReconciliationService:
             completed_at = self._clock_value("completion clock")
             if completed_at < checked_at:
                 raise ReconciliationServiceBlocked("completion clock moved backwards")
+            relied_on_proof_expiries = []
+            proofs_by_key = {
+                proof.binding_key: proof for proof in comparison_result.timing_lag_proofs
+            }
+            for difference in verdict.differences:
+                if difference.kind.value != "expected_timing_lag":
+                    continue
+                proof = proofs_by_key.get(
+                    (
+                        snapshot.snapshot_id,
+                        difference.kind.value,
+                        difference.reason_code,
+                        difference.subject,
+                        difference.evidence_ids[0],
+                    )
+                )
+                if proof is not None:
+                    relied_on_proof_expiries.append(proof.expires_at)
+            eligible_until = min(
+                verdict.fresh_until,
+                runtime_evidence.expires_at,
+                *relied_on_proof_expiries,
+            )
             persisted = await self._persistence.append_reconciliation(
                 trigger_type=trigger.value,
-                snapshot=snapshot,
+                runtime_evidence=runtime_evidence,
                 verdict=verdict,
                 started_at=started_at,
                 completed_at=completed_at,
+                eligible_until=eligible_until,
             )
         except BaseException as exc:
             self._quarantine()
@@ -297,6 +345,7 @@ class ReconciliationService:
             persisted=persisted,
             state=state,
             entry_eligible=persisted.entry_eligible,
+            eligible_until=eligible_until,
         )
         self._state = state
         self._latest_outcome = outcome
@@ -317,3 +366,5 @@ class ReconciliationService:
     def _assert_not_closed(self) -> None:
         if self._state is ReconciliationServiceState.CLOSED:
             raise ReconciliationServiceBlocked("reconciliation service is closed")
+        if self._state is ReconciliationServiceState.CLOSING:
+            raise ReconciliationServiceBlocked("reconciliation source cleanup is incomplete")

--- a/robo_trader/reconciliation/service.py
+++ b/robo_trader/reconciliation/service.py
@@ -23,6 +23,7 @@ from .policy import (
 from .runtime_evidence import (
     VerifiedRuntimeReconciliationEvidence,
     assert_and_consume_verified_runtime_reconciliation_evidence,
+    assert_runtime_reconciliation_evidence_sources_current,
 )
 
 
@@ -315,6 +316,7 @@ class ReconciliationService:
                 completed_at=completed_at,
                 eligible_until=eligible_until,
             )
+            assert_runtime_reconciliation_evidence_sources_current(runtime_evidence)
         except BaseException as exc:
             self._quarantine()
             if isinstance(exc, asyncio.CancelledError):

--- a/robo_trader/reconciliation/service.py
+++ b/robo_trader/reconciliation/service.py
@@ -3,20 +3,19 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
 import math
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from typing import Awaitable, Callable, Protocol
+from pathlib import Path
+from typing import Callable, Protocol
 
-from .domain import NormalizedBrokerSnapshot, ReconciliationDomainError, _timestamp
+from robo_trader.safety.sqlite_identity import SQLitePathBinding
+
+from .domain import ReconciliationDomainError, _timestamp
 from .ibkr_adapter import await_cleanup_required
 from .persistence import PersistedReconciliation, ReconciliationPersistence
 from .policy import (
-    ExpectedTimingLagProof,
-    ReconciliationCoverage,
-    ReconciliationDifference,
     ReconciliationStatus,
     ReconciliationVerdict,
     evaluate_paper_simulator_reconciliation,
@@ -51,21 +50,6 @@ class ReconciliationServiceState(str, Enum):
 
 
 @dataclass(frozen=True, slots=True)
-class ReconciliationComparison:
-    coverage: ReconciliationCoverage
-    differences: tuple[ReconciliationDifference, ...] = ()
-    timing_lag_proofs: tuple[ExpectedTimingLagProof, ...] = ()
-
-    def __post_init__(self) -> None:
-        if type(self.coverage) is not ReconciliationCoverage:
-            raise ReconciliationServiceBlocked("comparison coverage is not normalized")
-        if any(type(value) is not ReconciliationDifference for value in self.differences):
-            raise ReconciliationServiceBlocked("comparison differences are not normalized")
-        if any(type(value) is not ExpectedTimingLagProof for value in self.timing_lag_proofs):
-            raise ReconciliationServiceBlocked("comparison timing proofs are not normalized")
-
-
-@dataclass(frozen=True, slots=True)
 class ReconciliationServiceOutcome:
     trigger: ReconciliationTrigger
     verdict: ReconciliationVerdict
@@ -92,15 +76,6 @@ class VerifiedEvidenceSource(Protocol):
         """Close only the diagnostic read-only transport."""
 
 
-class ReconciliationComparisonSource(Protocol):
-    def __call__(
-        self,
-        snapshot: NormalizedBrokerSnapshot,
-        trigger: ReconciliationTrigger,
-    ) -> ReconciliationComparison | Awaitable[ReconciliationComparison]:
-        """Compare immutable local evidence without repairing or replacing it."""
-
-
 def _system_clock() -> datetime:
     return datetime.now(timezone.utc)
 
@@ -117,7 +92,6 @@ class ReconciliationService:
         self,
         *,
         evidence_source: VerifiedEvidenceSource,
-        comparison_source: ReconciliationComparisonSource,
         persistence: ReconciliationPersistence,
         expected_account_scope: str,
         max_age_seconds: float = 30.0,
@@ -144,10 +118,7 @@ class ReconciliationService:
             raise ReconciliationServiceBlocked("verified evidence source is unavailable")
         if not callable(getattr(evidence_source, "close", None)):
             raise ReconciliationServiceBlocked("evidence source cleanup is unavailable")
-        if not callable(comparison_source):
-            raise ReconciliationServiceBlocked("comparison source is unavailable")
         self._evidence_source = evidence_source
-        self._comparison_source = comparison_source
         self._persistence = persistence
         self._expected_account_scope = expected_account_scope
         self._max_age_seconds = float(max_age_seconds)
@@ -158,6 +129,7 @@ class ReconciliationService:
         self._state = ReconciliationServiceState.UNINITIALIZED
         self._latest_outcome: ReconciliationServiceOutcome | None = None
         self._last_completed_at: datetime | None = None
+        self._latest_database_binding: tuple[str, int, int] | None = None
 
     @property
     def state(self) -> ReconciliationServiceState:
@@ -191,8 +163,29 @@ class ReconciliationService:
             self._quarantine()
             return False
         if checked_at > outcome.eligible_until:
-            self._state = ReconciliationServiceState.QUARANTINED
+            self._quarantine()
             return False
+        database_binding = self._latest_database_binding
+        if database_binding is None:
+            self._quarantine()
+            return False
+        path, expected_device, expected_inode = database_binding
+        binding: SQLitePathBinding | None = None
+        try:
+            binding = SQLitePathBinding.open_readonly(Path(path))
+            binding.assert_path_identity()
+            if (binding.device, binding.inode) != (expected_device, expected_inode):
+                raise ReconciliationServiceBlocked("runtime database identity changed")
+        except Exception:
+            self._quarantine()
+            return False
+        finally:
+            if binding is not None:
+                try:
+                    binding.close()
+                except Exception:
+                    self._quarantine()
+                    return False
         return True
 
     async def initialize(self) -> None:
@@ -231,6 +224,7 @@ class ReconciliationService:
                 return
             self._latest_outcome = None
             self._last_completed_at = None
+            self._latest_database_binding = None
             self._state = ReconciliationServiceState.CLOSING
             try:
                 cancellation_received = await await_cleanup_required(self._evidence_source.close())
@@ -275,19 +269,14 @@ class ReconciliationService:
             )
             runtime_evidence = assert_and_consume_verified_runtime_reconciliation_evidence(produced)
             snapshot = runtime_evidence.snapshot
-            comparison_result = self._comparison_source(snapshot, trigger)
-            if inspect.isawaitable(comparison_result):
-                comparison_result = await comparison_result
-            if type(comparison_result) is not ReconciliationComparison:
-                raise ReconciliationServiceBlocked("comparison source returned invalid evidence")
             checked_at = self._clock_value("policy clock")
             if checked_at < started_at:
                 raise ReconciliationServiceBlocked("policy clock moved backwards")
             verdict = evaluate_paper_simulator_reconciliation(
                 snapshot,
-                comparison_result.coverage,
-                comparison_result.differences,
-                comparison_result.timing_lag_proofs,
+                runtime_evidence.comparison_coverage,
+                runtime_evidence.differences,
+                runtime_evidence.timing_lag_proofs,
                 expected_account_scope=self._expected_account_scope,
                 now=checked_at,
                 max_age_seconds=self._max_age_seconds,
@@ -297,7 +286,7 @@ class ReconciliationService:
                 raise ReconciliationServiceBlocked("completion clock moved backwards")
             relied_on_proof_expiries = []
             proofs_by_key = {
-                proof.binding_key: proof for proof in comparison_result.timing_lag_proofs
+                proof.binding_key: proof for proof in runtime_evidence.timing_lag_proofs
             }
             for difference in verdict.differences:
                 if difference.kind.value != "expected_timing_lag":
@@ -350,6 +339,11 @@ class ReconciliationService:
         self._state = state
         self._latest_outcome = outcome
         self._last_completed_at = completed_at
+        self._latest_database_binding = (
+            runtime_evidence.database_path,
+            runtime_evidence.database_device,
+            runtime_evidence.database_inode,
+        )
         return outcome
 
     def _clock_value(self, label: str) -> datetime:
@@ -361,6 +355,7 @@ class ReconciliationService:
     def _quarantine(self) -> None:
         self._latest_outcome = None
         self._last_completed_at = None
+        self._latest_database_binding = None
         self._state = ReconciliationServiceState.QUARANTINED
 
     def _assert_not_closed(self) -> None:

--- a/robo_trader/reconciliation_migrations.py
+++ b/robo_trader/reconciliation_migrations.py
@@ -147,12 +147,10 @@ async def _migration_v1(connection: aiosqlite.Connection) -> None:
         """)
 
 
-async def _migration_v2(connection: aiosqlite.Connection) -> None:
-    """Add exact runtime lineage without rewriting any v1 table or row."""
-
-    await connection.execute("""
+_V2_TABLE_SQL = {
+    "rt_reconciliation_snapshot_lineage": """
         CREATE TABLE IF NOT EXISTS rt_reconciliation_snapshot_lineage (
-            snapshot_id TEXT PRIMARY KEY,
+            snapshot_id TEXT PRIMARY KEY NOT NULL,
             schema_version INTEGER NOT NULL CHECK (schema_version = 2),
             account_alias TEXT NOT NULL,
             snapshot_hash TEXT NOT NULL CHECK (
@@ -192,23 +190,18 @@ async def _migration_v2(connection: aiosqlite.Connection) -> None:
             persisted_at TEXT NOT NULL,
             FOREIGN KEY(snapshot_id) REFERENCES rt_reconciliation_snapshots(snapshot_id)
         )
-    """)
-    await connection.execute("""
+    """,
+    "rt_reconciliation_run_eligibility": """
         CREATE TABLE IF NOT EXISTS rt_reconciliation_run_eligibility (
-            run_id TEXT PRIMARY KEY,
+            run_id TEXT PRIMARY KEY NOT NULL,
             schema_version INTEGER NOT NULL CHECK (schema_version = 2),
             eligible_until TEXT NOT NULL,
             FOREIGN KEY(run_id) REFERENCES rt_reconciliation_runs(run_id)
         )
-    """)
-    await connection.execute("""
-        CREATE UNIQUE INDEX IF NOT EXISTS
-            rt_reconciliation_differences_run_difference_uq
-        ON rt_reconciliation_differences(run_id, difference_id)
-    """)
-    await connection.execute("""
+    """,
+    "rt_reconciliation_operator_resolution_bindings": """
         CREATE TABLE IF NOT EXISTS rt_reconciliation_operator_resolution_bindings (
-            resolution_id TEXT PRIMARY KEY,
+            resolution_id TEXT PRIMARY KEY NOT NULL,
             run_id TEXT NOT NULL,
             difference_id TEXT NOT NULL,
             FOREIGN KEY(resolution_id)
@@ -216,7 +209,21 @@ async def _migration_v2(connection: aiosqlite.Connection) -> None:
             FOREIGN KEY(run_id, difference_id)
                 REFERENCES rt_reconciliation_differences(run_id, difference_id)
         )
+    """,
+}
+
+
+async def _migration_v2(connection: aiosqlite.Connection) -> None:
+    """Add exact runtime lineage without rewriting any v1 table or row."""
+
+    await connection.execute(_V2_TABLE_SQL["rt_reconciliation_snapshot_lineage"])
+    await connection.execute(_V2_TABLE_SQL["rt_reconciliation_run_eligibility"])
+    await connection.execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS
+            rt_reconciliation_differences_run_difference_uq
+        ON rt_reconciliation_differences(run_id, difference_id)
     """)
+    await connection.execute(_V2_TABLE_SQL["rt_reconciliation_operator_resolution_bindings"])
     await connection.execute("""
         INSERT INTO rt_reconciliation_operator_resolution_bindings(
             resolution_id, run_id, difference_id
@@ -373,21 +380,86 @@ _REQUIRED_TABLE_SQL = {
         "foreign key(run_id) references rt_reconciliation_runs(run_id)",
         "foreign key(difference_id) references rt_reconciliation_differences(difference_id)",
     ),
-    "rt_reconciliation_snapshot_lineage": (
-        "schema_version integer not null check (schema_version = 2)",
-        "foreign key(snapshot_id) references rt_reconciliation_snapshots(snapshot_id)",
-        "length(reconciliation_artifact_hash) = 64",
-    ),
-    "rt_reconciliation_run_eligibility": (
-        "schema_version integer not null check (schema_version = 2)",
-        "foreign key(run_id) references rt_reconciliation_runs(run_id)",
-    ),
-    "rt_reconciliation_operator_resolution_bindings": (
-        "foreign key(resolution_id) references "
-        "rt_reconciliation_operator_resolutions(resolution_id)",
-        "foreign key(run_id, difference_id) references "
-        "rt_reconciliation_differences(run_id, difference_id)",
-    ),
+}
+
+_EXPECTED_V2_COLUMN_SHAPES = {
+    table: {
+        column: (
+            (
+                "INTEGER"
+                if column in {"schema_version", "database_device", "database_inode"}
+                else "TEXT"
+            ),
+            1,
+            None,
+            int(column == primary_key),
+        )
+        for column in columns
+    }
+    for table, columns, primary_key in (
+        (
+            "rt_reconciliation_snapshot_lineage",
+            _EXPECTED_COLUMNS["rt_reconciliation_snapshot_lineage"],
+            "snapshot_id",
+        ),
+        (
+            "rt_reconciliation_run_eligibility",
+            _EXPECTED_COLUMNS["rt_reconciliation_run_eligibility"],
+            "run_id",
+        ),
+        (
+            "rt_reconciliation_operator_resolution_bindings",
+            _EXPECTED_COLUMNS["rt_reconciliation_operator_resolution_bindings"],
+            "resolution_id",
+        ),
+    )
+}
+
+_EXPECTED_V2_FOREIGN_KEYS = {
+    "rt_reconciliation_snapshot_lineage": {
+        (
+            "rt_reconciliation_snapshots",
+            ("snapshot_id",),
+            ("snapshot_id",),
+            "NO ACTION",
+            "NO ACTION",
+            "NONE",
+        )
+    },
+    "rt_reconciliation_run_eligibility": {
+        (
+            "rt_reconciliation_runs",
+            ("run_id",),
+            ("run_id",),
+            "NO ACTION",
+            "NO ACTION",
+            "NONE",
+        )
+    },
+    "rt_reconciliation_operator_resolution_bindings": {
+        (
+            "rt_reconciliation_operator_resolutions",
+            ("resolution_id",),
+            ("resolution_id",),
+            "NO ACTION",
+            "NO ACTION",
+            "NONE",
+        ),
+        (
+            "rt_reconciliation_differences",
+            ("run_id", "difference_id"),
+            ("run_id", "difference_id"),
+            "NO ACTION",
+            "NO ACTION",
+            "NONE",
+        ),
+    },
+}
+
+_EXPECTED_V2_INDEXES = {
+    "rt_reconciliation_snapshot_lineage": {(1, "pk", 0, ("snapshot_id",))},
+    "rt_reconciliation_run_eligibility": {(1, "pk", 0, ("run_id",))},
+    "rt_reconciliation_operator_resolution_bindings": {(1, "pk", 0, ("resolution_id",))},
 }
 
 
@@ -404,6 +476,58 @@ def _canonical_schema_sql(value: object) -> str:
 async def _table_columns(connection: aiosqlite.Connection, table: str) -> set[str]:
     cursor = await connection.execute(f"PRAGMA table_info({table})")
     return {str(row[1]) for row in await cursor.fetchall()}
+
+
+async def _table_shape(
+    connection: aiosqlite.Connection, table: str
+) -> dict[str, tuple[str, int, object, int]]:
+    cursor = await connection.execute(f"PRAGMA table_info({table})")
+    return {
+        str(row[1]): (str(row[2]).upper(), int(row[3]), row[4], int(row[5]))
+        for row in await cursor.fetchall()
+    }
+
+
+async def _foreign_key_shape(
+    connection: aiosqlite.Connection, table: str
+) -> set[tuple[str, tuple[str, ...], tuple[str, ...], str, str, str]]:
+    def sequence(row: tuple[object, ...]) -> int:
+        value = row[1]
+        if type(value) is not int:
+            raise RuntimeError(f"reconciliation table {table} foreign keys are malformed")
+        return value
+
+    cursor = await connection.execute(f"PRAGMA foreign_key_list({table})")
+    grouped: dict[int, list[tuple[object, ...]]] = {}
+    for row in await cursor.fetchall():
+        grouped.setdefault(int(row[0]), []).append(row)
+    return {
+        (
+            str(rows[0][2]),
+            tuple(str(row[3]) for row in sorted(rows, key=sequence)),
+            tuple(str(row[4]) for row in sorted(rows, key=sequence)),
+            str(rows[0][5]).upper(),
+            str(rows[0][6]).upper(),
+            str(rows[0][7]).upper(),
+        )
+        for rows in grouped.values()
+    }
+
+
+async def _index_shape(
+    connection: aiosqlite.Connection, table: str
+) -> set[tuple[int, str, int, tuple[str, ...]]]:
+    cursor = await connection.execute(f"PRAGMA index_list({table})")
+    result: set[tuple[int, str, int, tuple[str, ...]]] = set()
+    for row in await cursor.fetchall():
+        index_name = str(row[1])
+        columns = await connection.execute(
+            "SELECT name FROM pragma_index_info(?) ORDER BY seqno",
+            (index_name,),
+        )
+        column_names = tuple(str(item[0]) for item in await columns.fetchall())
+        result.add((int(row[2]), str(row[3]), int(row[4]), column_names))
+    return result
 
 
 async def apply_reconciliation_migrations(connection: aiosqlite.Connection) -> None:
@@ -478,6 +602,15 @@ async def assert_reconciliation_schema(connection: aiosqlite.Connection) -> None
     for table, fragments in _REQUIRED_TABLE_SQL.items():
         if any(_normalized_sql(fragment) not in table_sql.get(table, "") for fragment in fragments):
             raise RuntimeError(f"reconciliation table {table} constraints are malformed")
+    for table, expected_sql in _V2_TABLE_SQL.items():
+        if table_sql.get(table) != _canonical_schema_sql(expected_sql):
+            raise RuntimeError(f"reconciliation table {table} definition is malformed")
+        if await _table_shape(connection, table) != _EXPECTED_V2_COLUMN_SHAPES[table]:
+            raise RuntimeError(f"reconciliation table {table} column shape is malformed")
+        if await _foreign_key_shape(connection, table) != _EXPECTED_V2_FOREIGN_KEYS[table]:
+            raise RuntimeError(f"reconciliation table {table} foreign keys are malformed")
+        if await _index_shape(connection, table) != _EXPECTED_V2_INDEXES[table]:
+            raise RuntimeError(f"reconciliation table {table} indexes are malformed")
     trigger_rows = await connection.execute(
         "SELECT name, sql FROM sqlite_master "
         "WHERE type = 'trigger' AND tbl_name LIKE 'rt_reconciliation_%'"
@@ -538,3 +671,35 @@ async def assert_reconciliation_schema(connection: aiosqlite.Connection) -> None
         """)
     if await unbound_resolutions.fetchone() is not None:
         raise RuntimeError("reconciliation resolution lacks composite run binding")
+    for table, query in (
+        (
+            "rt_reconciliation_snapshot_lineage",
+            """
+            SELECT 1 FROM rt_reconciliation_snapshot_lineage
+            GROUP BY snapshot_id
+            HAVING snapshot_id IS NULL OR COUNT(*) > 1
+            LIMIT 1
+            """,
+        ),
+        (
+            "rt_reconciliation_run_eligibility",
+            """
+            SELECT 1 FROM rt_reconciliation_run_eligibility
+            GROUP BY run_id
+            HAVING run_id IS NULL OR COUNT(*) > 1
+            LIMIT 1
+            """,
+        ),
+        (
+            "rt_reconciliation_operator_resolution_bindings",
+            """
+            SELECT 1 FROM rt_reconciliation_operator_resolution_bindings
+            GROUP BY resolution_id
+            HAVING resolution_id IS NULL OR COUNT(*) > 1
+            LIMIT 1
+            """,
+        ),
+    ):
+        invalid_identity = await connection.execute(query)
+        if await invalid_identity.fetchone() is not None:
+            raise RuntimeError(f"reconciliation table {table} identity is malformed")

--- a/robo_trader/reconciliation_migrations.py
+++ b/robo_trader/reconciliation_migrations.py
@@ -28,6 +28,26 @@ async def _migration_v1(connection: aiosqlite.Connection) -> None:
                 AND substr(account_scope, 1, 8) = 'acct_v1_'
                 AND substr(account_scope, 9) NOT GLOB '*[^0-9a-f]*'
             ),
+            account_alias TEXT NOT NULL,
+            snapshot_hash TEXT NOT NULL CHECK (
+                length(snapshot_hash) = 64 AND snapshot_hash = lower(snapshot_hash)
+            ),
+            bundle_id TEXT NOT NULL,
+            runtime_fingerprint TEXT NOT NULL,
+            database_path TEXT NOT NULL,
+            database_identity TEXT NOT NULL,
+            database_device INTEGER NOT NULL,
+            database_inode INTEGER NOT NULL,
+            broker_artifact_hash TEXT NOT NULL CHECK (
+                length(broker_artifact_hash) = 64
+                AND broker_artifact_hash = lower(broker_artifact_hash)
+            ),
+            broker_receipt_id TEXT NOT NULL,
+            broker_public_key_fingerprint TEXT NOT NULL CHECK (
+                length(broker_public_key_fingerprint) = 64
+                AND broker_public_key_fingerprint = lower(broker_public_key_fingerprint)
+            ),
+            broker_evidence_expires_at TEXT NOT NULL,
             observed_from TEXT NOT NULL,
             observed_through TEXT NOT NULL,
             retrieved_at TEXT NOT NULL,
@@ -56,6 +76,7 @@ async def _migration_v1(connection: aiosqlite.Connection) -> None:
             ),
             started_at TEXT NOT NULL,
             completed_at TEXT NOT NULL,
+            eligible_until TEXT NOT NULL,
             status TEXT NOT NULL CHECK (status IN ('passed', 'degraded', 'quarantined')),
             evidence_fresh INTEGER NOT NULL CHECK (evidence_fresh IN (0, 1)),
             comparison_complete INTEGER NOT NULL CHECK (comparison_complete IN (0, 1)),
@@ -103,6 +124,7 @@ async def _migration_v1(connection: aiosqlite.Connection) -> None:
                     AND materiality = 'material')
             ),
             UNIQUE(run_id, ordinal),
+            UNIQUE(run_id, difference_id),
             FOREIGN KEY(run_id) REFERENCES rt_reconciliation_runs(run_id)
         )
     """)
@@ -121,7 +143,8 @@ async def _migration_v1(connection: aiosqlite.Connection) -> None:
             evidence_reference TEXT,
             created_at TEXT NOT NULL,
             FOREIGN KEY(run_id) REFERENCES rt_reconciliation_runs(run_id),
-            FOREIGN KEY(difference_id) REFERENCES rt_reconciliation_differences(difference_id)
+            FOREIGN KEY(run_id, difference_id)
+                REFERENCES rt_reconciliation_differences(run_id, difference_id)
         )
     """)
     for table in _TABLES:
@@ -150,6 +173,18 @@ _EXPECTED_COLUMNS = {
         "snapshot_id",
         "schema_version",
         "account_scope",
+        "account_alias",
+        "snapshot_hash",
+        "bundle_id",
+        "runtime_fingerprint",
+        "database_path",
+        "database_identity",
+        "database_device",
+        "database_inode",
+        "broker_artifact_hash",
+        "broker_receipt_id",
+        "broker_public_key_fingerprint",
+        "broker_evidence_expires_at",
         "observed_from",
         "observed_through",
         "retrieved_at",
@@ -167,6 +202,7 @@ _EXPECTED_COLUMNS = {
         "expected_account_scope",
         "started_at",
         "completed_at",
+        "eligible_until",
         "status",
         "evidence_fresh",
         "comparison_complete",
@@ -206,12 +242,16 @@ _REQUIRED_TABLE_SQL = {
     "rt_reconciliation_snapshots": (
         "schema_version integer not null check (schema_version = 1)",
         "length(account_scope) = 72",
+        "length(snapshot_hash) = 64 and snapshot_hash = lower(snapshot_hash)",
+        "length(broker_artifact_hash) = 64 and broker_artifact_hash = "
+        "lower(broker_artifact_hash)",
         "check (json_valid(payload_json))",
         "length(payload_sha256) = 64 and payload_sha256 = lower(payload_sha256)",
     ),
     "rt_reconciliation_runs": (
         "trigger_type in ('startup', 'reconnect', 'periodic', 'before_live', " "'ambiguous_order')",
         "status in ('passed', 'degraded', 'quarantined')",
+        "eligible_until text not null",
         "status = 'quarantined' and quarantine_required = 1 and entry_eligible = 0",
         "foreign key(snapshot_id) references rt_reconciliation_snapshots(snapshot_id)",
     ),
@@ -219,6 +259,7 @@ _REQUIRED_TABLE_SQL = {
         "kind = 'expected_timing_lag' and materiality = 'informational'",
         "kind = 'unknown' and materiality = 'unknown'",
         "unique(run_id, ordinal)",
+        "unique(run_id, difference_id)",
         "foreign key(run_id) references rt_reconciliation_runs(run_id)",
     ),
     "rt_reconciliation_operator_resolutions": (
@@ -226,7 +267,8 @@ _REQUIRED_TABLE_SQL = {
         "'investigation_note')",
         "length(trim(reason)) >= 10",
         "foreign key(run_id) references rt_reconciliation_runs(run_id)",
-        "foreign key(difference_id) references rt_reconciliation_differences(difference_id)",
+        "foreign key(run_id, difference_id) references "
+        "rt_reconciliation_differences(run_id, difference_id)",
     ),
 }
 
@@ -331,14 +373,14 @@ async def assert_reconciliation_schema(connection: aiosqlite.Connection) -> None
     for table in _TABLES:
         for suffix, operation in (("no_update", "update"), ("no_delete", "delete")):
             name = f"{table}_{suffix}"
-            expected = _normalized_sql(f"""
+            expected_trigger = _normalized_sql(f"""
                 CREATE TRIGGER {name}
                 BEFORE {operation.upper()} ON {table}
                 BEGIN
                     SELECT RAISE(ABORT, 'reconciliation evidence is append-only');
                 END
                 """)
-            if triggers[name] != expected:
+            if triggers[name] != expected_trigger:
                 raise RuntimeError(f"reconciliation trigger {name} is malformed")
     violations = await connection.execute("PRAGMA foreign_key_check")
     if await violations.fetchone() is not None:

--- a/robo_trader/reconciliation_migrations.py
+++ b/robo_trader/reconciliation_migrations.py
@@ -1,0 +1,345 @@
+"""Component-scoped, append-only schema for durable reconciliation evidence."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Awaitable, Callable
+
+import aiosqlite
+
+RECONCILIATION_COMPONENT = "broker_reconciliation"
+RECONCILIATION_SCHEMA_VERSION = 1
+
+_TABLES = (
+    "rt_reconciliation_snapshots",
+    "rt_reconciliation_runs",
+    "rt_reconciliation_differences",
+    "rt_reconciliation_operator_resolutions",
+)
+
+
+async def _migration_v1(connection: aiosqlite.Connection) -> None:
+    await connection.execute("""
+        CREATE TABLE IF NOT EXISTS rt_reconciliation_snapshots (
+            snapshot_id TEXT PRIMARY KEY,
+            schema_version INTEGER NOT NULL CHECK (schema_version = 1),
+            account_scope TEXT NOT NULL CHECK (
+                length(account_scope) = 72
+                AND substr(account_scope, 1, 8) = 'acct_v1_'
+                AND substr(account_scope, 9) NOT GLOB '*[^0-9a-f]*'
+            ),
+            observed_from TEXT NOT NULL,
+            observed_through TEXT NOT NULL,
+            retrieved_at TEXT NOT NULL,
+            complete INTEGER NOT NULL CHECK (complete IN (0, 1)),
+            payload_json TEXT NOT NULL CHECK (json_valid(payload_json)),
+            payload_sha256 TEXT NOT NULL CHECK (
+                length(payload_sha256) = 64 AND payload_sha256 = lower(payload_sha256)
+            ),
+            persisted_at TEXT NOT NULL
+        )
+    """)
+    await connection.execute("""
+        CREATE TABLE IF NOT EXISTS rt_reconciliation_runs (
+            run_id TEXT PRIMARY KEY,
+            schema_version INTEGER NOT NULL CHECK (schema_version = 1),
+            trigger_type TEXT NOT NULL CHECK (
+                trigger_type IN ('startup', 'reconnect', 'periodic',
+                                 'before_live', 'ambiguous_order')
+            ),
+            snapshot_id TEXT NOT NULL,
+            verdict_id TEXT NOT NULL,
+            expected_account_scope TEXT NOT NULL CHECK (
+                length(expected_account_scope) = 72
+                AND substr(expected_account_scope, 1, 8) = 'acct_v1_'
+                AND substr(expected_account_scope, 9) NOT GLOB '*[^0-9a-f]*'
+            ),
+            started_at TEXT NOT NULL,
+            completed_at TEXT NOT NULL,
+            status TEXT NOT NULL CHECK (status IN ('passed', 'degraded', 'quarantined')),
+            evidence_fresh INTEGER NOT NULL CHECK (evidence_fresh IN (0, 1)),
+            comparison_complete INTEGER NOT NULL CHECK (comparison_complete IN (0, 1)),
+            quarantine_required INTEGER NOT NULL CHECK (quarantine_required IN (0, 1)),
+            entry_eligible INTEGER NOT NULL CHECK (entry_eligible IN (0, 1)),
+            coverage_json TEXT NOT NULL CHECK (json_valid(coverage_json)),
+            verdict_payload_json TEXT NOT NULL CHECK (json_valid(verdict_payload_json)),
+            verdict_sha256 TEXT NOT NULL CHECK (
+                length(verdict_sha256) = 64 AND verdict_sha256 = lower(verdict_sha256)
+            ),
+            CHECK (completed_at >= started_at),
+            CHECK (
+                (status = 'quarantined' AND quarantine_required = 1 AND entry_eligible = 0)
+                OR
+                (status != 'quarantined' AND quarantine_required = 0 AND entry_eligible = 1)
+            ),
+            FOREIGN KEY(snapshot_id) REFERENCES rt_reconciliation_snapshots(snapshot_id)
+        )
+    """)
+    await connection.execute("""
+        CREATE TABLE IF NOT EXISTS rt_reconciliation_differences (
+            difference_id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            ordinal INTEGER NOT NULL CHECK (ordinal >= 0),
+            kind TEXT NOT NULL CHECK (
+                kind IN ('expected_timing_lag', 'recoverable_missing_event',
+                         'duplicate_event', 'account_mismatch', 'quantity_mismatch',
+                         'cash_mismatch', 'unknown')
+            ),
+            materiality TEXT NOT NULL CHECK (
+                materiality IN ('informational', 'material', 'unknown')
+            ),
+            reason_code TEXT NOT NULL,
+            subject TEXT NOT NULL,
+            evidence_ids_json TEXT NOT NULL CHECK (json_valid(evidence_ids_json)),
+            payload_json TEXT NOT NULL CHECK (json_valid(payload_json)),
+            payload_sha256 TEXT NOT NULL CHECK (
+                length(payload_sha256) = 64 AND payload_sha256 = lower(payload_sha256)
+            ),
+            persisted_at TEXT NOT NULL,
+            CHECK (
+                (kind = 'expected_timing_lag' AND materiality = 'informational')
+                OR (kind = 'unknown' AND materiality = 'unknown')
+                OR (kind NOT IN ('expected_timing_lag', 'unknown')
+                    AND materiality = 'material')
+            ),
+            UNIQUE(run_id, ordinal),
+            FOREIGN KEY(run_id) REFERENCES rt_reconciliation_runs(run_id)
+        )
+    """)
+    await connection.execute("""
+        CREATE TABLE IF NOT EXISTS rt_reconciliation_operator_resolutions (
+            resolution_id TEXT PRIMARY KEY,
+            schema_version INTEGER NOT NULL CHECK (schema_version = 1),
+            run_id TEXT NOT NULL,
+            difference_id TEXT NOT NULL,
+            resolution_kind TEXT NOT NULL CHECK (
+                resolution_kind IN ('acknowledged', 'external_remediation_recorded',
+                                    'investigation_note')
+            ),
+            operator_id TEXT NOT NULL CHECK (length(trim(operator_id)) BETWEEN 1 AND 64),
+            reason TEXT NOT NULL CHECK (length(trim(reason)) >= 10),
+            evidence_reference TEXT,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY(run_id) REFERENCES rt_reconciliation_runs(run_id),
+            FOREIGN KEY(difference_id) REFERENCES rt_reconciliation_differences(difference_id)
+        )
+    """)
+    for table in _TABLES:
+        await connection.execute(f"""
+            CREATE TRIGGER IF NOT EXISTS {table}_no_update
+            BEFORE UPDATE ON {table}
+            BEGIN
+                SELECT RAISE(ABORT, 'reconciliation evidence is append-only');
+            END
+        """)
+        await connection.execute(f"""
+            CREATE TRIGGER IF NOT EXISTS {table}_no_delete
+            BEFORE DELETE ON {table}
+            BEGIN
+                SELECT RAISE(ABORT, 'reconciliation evidence is append-only');
+            END
+        """)
+
+
+_MIGRATIONS: tuple[tuple[int, Callable[[aiosqlite.Connection], Awaitable[None]]], ...] = (
+    (1, _migration_v1),
+)
+
+_EXPECTED_COLUMNS = {
+    "rt_reconciliation_snapshots": {
+        "snapshot_id",
+        "schema_version",
+        "account_scope",
+        "observed_from",
+        "observed_through",
+        "retrieved_at",
+        "complete",
+        "payload_json",
+        "payload_sha256",
+        "persisted_at",
+    },
+    "rt_reconciliation_runs": {
+        "run_id",
+        "schema_version",
+        "trigger_type",
+        "snapshot_id",
+        "verdict_id",
+        "expected_account_scope",
+        "started_at",
+        "completed_at",
+        "status",
+        "evidence_fresh",
+        "comparison_complete",
+        "quarantine_required",
+        "entry_eligible",
+        "coverage_json",
+        "verdict_payload_json",
+        "verdict_sha256",
+    },
+    "rt_reconciliation_differences": {
+        "difference_id",
+        "run_id",
+        "ordinal",
+        "kind",
+        "materiality",
+        "reason_code",
+        "subject",
+        "evidence_ids_json",
+        "payload_json",
+        "payload_sha256",
+        "persisted_at",
+    },
+    "rt_reconciliation_operator_resolutions": {
+        "resolution_id",
+        "schema_version",
+        "run_id",
+        "difference_id",
+        "resolution_kind",
+        "operator_id",
+        "reason",
+        "evidence_reference",
+        "created_at",
+    },
+}
+
+_REQUIRED_TABLE_SQL = {
+    "rt_reconciliation_snapshots": (
+        "schema_version integer not null check (schema_version = 1)",
+        "length(account_scope) = 72",
+        "check (json_valid(payload_json))",
+        "length(payload_sha256) = 64 and payload_sha256 = lower(payload_sha256)",
+    ),
+    "rt_reconciliation_runs": (
+        "trigger_type in ('startup', 'reconnect', 'periodic', 'before_live', " "'ambiguous_order')",
+        "status in ('passed', 'degraded', 'quarantined')",
+        "status = 'quarantined' and quarantine_required = 1 and entry_eligible = 0",
+        "foreign key(snapshot_id) references rt_reconciliation_snapshots(snapshot_id)",
+    ),
+    "rt_reconciliation_differences": (
+        "kind = 'expected_timing_lag' and materiality = 'informational'",
+        "kind = 'unknown' and materiality = 'unknown'",
+        "unique(run_id, ordinal)",
+        "foreign key(run_id) references rt_reconciliation_runs(run_id)",
+    ),
+    "rt_reconciliation_operator_resolutions": (
+        "resolution_kind in ('acknowledged', 'external_remediation_recorded', "
+        "'investigation_note')",
+        "length(trim(reason)) >= 10",
+        "foreign key(run_id) references rt_reconciliation_runs(run_id)",
+        "foreign key(difference_id) references rt_reconciliation_differences(difference_id)",
+    ),
+}
+
+
+def _normalized_sql(value: object) -> str:
+    if not isinstance(value, str) or not value.strip():
+        return ""
+    return re.sub(r"\s+", " ", value.strip().lower())
+
+
+def _canonical_schema_sql(value: object) -> str:
+    return _normalized_sql(value).replace("if not exists ", "")
+
+
+async def _table_columns(connection: aiosqlite.Connection, table: str) -> set[str]:
+    cursor = await connection.execute(f"PRAGMA table_info({table})")
+    return {str(row[1]) for row in await cursor.fetchall()}
+
+
+async def apply_reconciliation_migrations(connection: aiosqlite.Connection) -> None:
+    """Apply missing reconciliation migrations in the caller-owned transaction."""
+
+    await connection.execute("PRAGMA foreign_keys = ON")
+    foreign_keys = await connection.execute("PRAGMA foreign_keys")
+    if await foreign_keys.fetchone() != (1,):
+        raise RuntimeError("reconciliation schema requires foreign-key enforcement")
+    await connection.execute("""
+        CREATE TABLE IF NOT EXISTS rt_schema_migrations (
+            component TEXT NOT NULL,
+            version INTEGER NOT NULL,
+            description TEXT NOT NULL,
+            applied_at TEXT NOT NULL,
+            PRIMARY KEY(component, version)
+        )
+    """)
+    cursor = await connection.execute(
+        "SELECT version FROM rt_schema_migrations WHERE component = ? ORDER BY version",
+        (RECONCILIATION_COMPONENT,),
+    )
+    applied = [int(row[0]) for row in await cursor.fetchall()]
+    if any(version < 1 or version > RECONCILIATION_SCHEMA_VERSION for version in applied):
+        raise RuntimeError("reconciliation migration version is unknown")
+    for version, migration in _MIGRATIONS:
+        if version in applied:
+            continue
+        await migration(connection)
+        await connection.execute(
+            """
+            INSERT INTO rt_schema_migrations(component, version, description, applied_at)
+            VALUES (?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+            """,
+            (RECONCILIATION_COMPONENT, version, "append-only broker reconciliation evidence"),
+        )
+
+
+async def assert_reconciliation_schema(connection: aiosqlite.Connection) -> None:
+    """Fail closed when registered schema evidence or append-only guards drift."""
+
+    foreign_keys = await connection.execute("PRAGMA foreign_keys")
+    if await foreign_keys.fetchone() != (1,):
+        raise RuntimeError("reconciliation schema requires foreign-key enforcement")
+    migrations = await connection.execute(
+        "SELECT version FROM rt_schema_migrations WHERE component = ? ORDER BY version",
+        (RECONCILIATION_COMPONENT,),
+    )
+    if [int(row[0]) for row in await migrations.fetchall()] != list(
+        range(1, RECONCILIATION_SCHEMA_VERSION + 1)
+    ):
+        raise RuntimeError("reconciliation migration evidence is incomplete or unknown")
+    migration_columns = await connection.execute("PRAGMA table_info(rt_schema_migrations)")
+    migration_shape = {
+        str(row[1]): (str(row[2]).upper(), int(row[3]), int(row[5]))
+        for row in await migration_columns.fetchall()
+    }
+    if migration_shape != {
+        "component": ("TEXT", 1, 1),
+        "version": ("INTEGER", 1, 2),
+        "description": ("TEXT", 1, 0),
+        "applied_at": ("TEXT", 1, 0),
+    }:
+        raise RuntimeError("shared component migration registry is malformed")
+    for table, expected in _EXPECTED_COLUMNS.items():
+        if await _table_columns(connection, table) != expected:
+            raise RuntimeError(f"reconciliation table {table} is malformed")
+    table_rows = await connection.execute(
+        "SELECT name, sql FROM sqlite_master WHERE type = 'table'"
+    )
+    table_sql = {str(row[0]): _canonical_schema_sql(row[1]) for row in await table_rows.fetchall()}
+    for table, fragments in _REQUIRED_TABLE_SQL.items():
+        if any(_normalized_sql(fragment) not in table_sql.get(table, "") for fragment in fragments):
+            raise RuntimeError(f"reconciliation table {table} constraints are malformed")
+    trigger_rows = await connection.execute(
+        "SELECT name, sql FROM sqlite_master WHERE type = 'trigger' AND tbl_name IN (?, ?, ?, ?)",
+        _TABLES,
+    )
+    triggers = {str(row[0]): _canonical_schema_sql(row[1]) for row in await trigger_rows.fetchall()}
+    expected_names = {
+        f"{table}_{suffix}" for table in _TABLES for suffix in ("no_update", "no_delete")
+    }
+    if set(triggers) != expected_names:
+        raise RuntimeError("reconciliation append-only trigger set is malformed")
+    for table in _TABLES:
+        for suffix, operation in (("no_update", "update"), ("no_delete", "delete")):
+            name = f"{table}_{suffix}"
+            expected = _normalized_sql(f"""
+                CREATE TRIGGER {name}
+                BEFORE {operation.upper()} ON {table}
+                BEGIN
+                    SELECT RAISE(ABORT, 'reconciliation evidence is append-only');
+                END
+                """)
+            if triggers[name] != expected:
+                raise RuntimeError(f"reconciliation trigger {name} is malformed")
+    violations = await connection.execute("PRAGMA foreign_key_check")
+    if await violations.fetchone() is not None:
+        raise RuntimeError("reconciliation schema contains foreign-key violations")

--- a/robo_trader/reconciliation_migrations.py
+++ b/robo_trader/reconciliation_migrations.py
@@ -8,7 +8,7 @@ from collections.abc import Awaitable, Callable
 import aiosqlite
 
 RECONCILIATION_COMPONENT = "broker_reconciliation"
-RECONCILIATION_SCHEMA_VERSION = 1
+RECONCILIATION_SCHEMA_VERSION = 2
 
 _TABLES = (
     "rt_reconciliation_snapshots",
@@ -16,6 +16,12 @@ _TABLES = (
     "rt_reconciliation_differences",
     "rt_reconciliation_operator_resolutions",
 )
+_V2_TABLES = (
+    "rt_reconciliation_snapshot_lineage",
+    "rt_reconciliation_run_eligibility",
+    "rt_reconciliation_operator_resolution_bindings",
+)
+_ALL_TABLES = _TABLES + _V2_TABLES
 
 
 async def _migration_v1(connection: aiosqlite.Connection) -> None:
@@ -28,26 +34,6 @@ async def _migration_v1(connection: aiosqlite.Connection) -> None:
                 AND substr(account_scope, 1, 8) = 'acct_v1_'
                 AND substr(account_scope, 9) NOT GLOB '*[^0-9a-f]*'
             ),
-            account_alias TEXT NOT NULL,
-            snapshot_hash TEXT NOT NULL CHECK (
-                length(snapshot_hash) = 64 AND snapshot_hash = lower(snapshot_hash)
-            ),
-            bundle_id TEXT NOT NULL,
-            runtime_fingerprint TEXT NOT NULL,
-            database_path TEXT NOT NULL,
-            database_identity TEXT NOT NULL,
-            database_device INTEGER NOT NULL,
-            database_inode INTEGER NOT NULL,
-            broker_artifact_hash TEXT NOT NULL CHECK (
-                length(broker_artifact_hash) = 64
-                AND broker_artifact_hash = lower(broker_artifact_hash)
-            ),
-            broker_receipt_id TEXT NOT NULL,
-            broker_public_key_fingerprint TEXT NOT NULL CHECK (
-                length(broker_public_key_fingerprint) = 64
-                AND broker_public_key_fingerprint = lower(broker_public_key_fingerprint)
-            ),
-            broker_evidence_expires_at TEXT NOT NULL,
             observed_from TEXT NOT NULL,
             observed_through TEXT NOT NULL,
             retrieved_at TEXT NOT NULL,
@@ -76,7 +62,6 @@ async def _migration_v1(connection: aiosqlite.Connection) -> None:
             ),
             started_at TEXT NOT NULL,
             completed_at TEXT NOT NULL,
-            eligible_until TEXT NOT NULL,
             status TEXT NOT NULL CHECK (status IN ('passed', 'degraded', 'quarantined')),
             evidence_fresh INTEGER NOT NULL CHECK (evidence_fresh IN (0, 1)),
             comparison_complete INTEGER NOT NULL CHECK (comparison_complete IN (0, 1)),
@@ -124,7 +109,6 @@ async def _migration_v1(connection: aiosqlite.Connection) -> None:
                     AND materiality = 'material')
             ),
             UNIQUE(run_id, ordinal),
-            UNIQUE(run_id, difference_id),
             FOREIGN KEY(run_id) REFERENCES rt_reconciliation_runs(run_id)
         )
     """)
@@ -143,8 +127,7 @@ async def _migration_v1(connection: aiosqlite.Connection) -> None:
             evidence_reference TEXT,
             created_at TEXT NOT NULL,
             FOREIGN KEY(run_id) REFERENCES rt_reconciliation_runs(run_id),
-            FOREIGN KEY(run_id, difference_id)
-                REFERENCES rt_reconciliation_differences(run_id, difference_id)
+            FOREIGN KEY(difference_id) REFERENCES rt_reconciliation_differences(difference_id)
         )
     """)
     for table in _TABLES:
@@ -164,8 +147,112 @@ async def _migration_v1(connection: aiosqlite.Connection) -> None:
         """)
 
 
+async def _migration_v2(connection: aiosqlite.Connection) -> None:
+    """Add exact runtime lineage without rewriting any v1 table or row."""
+
+    await connection.execute("""
+        CREATE TABLE IF NOT EXISTS rt_reconciliation_snapshot_lineage (
+            snapshot_id TEXT PRIMARY KEY,
+            schema_version INTEGER NOT NULL CHECK (schema_version = 2),
+            account_alias TEXT NOT NULL,
+            snapshot_hash TEXT NOT NULL CHECK (
+                length(snapshot_hash) = 64 AND snapshot_hash = lower(snapshot_hash)
+            ),
+            bundle_id TEXT NOT NULL,
+            runtime_fingerprint TEXT NOT NULL,
+            database_path TEXT NOT NULL,
+            database_identity TEXT NOT NULL,
+            database_device INTEGER NOT NULL,
+            database_inode INTEGER NOT NULL,
+            broker_artifact_hash TEXT NOT NULL CHECK (
+                length(broker_artifact_hash) = 64
+                AND broker_artifact_hash = lower(broker_artifact_hash)
+            ),
+            broker_receipt_id TEXT NOT NULL,
+            broker_public_key_fingerprint TEXT NOT NULL CHECK (
+                length(broker_public_key_fingerprint) = 64
+                AND broker_public_key_fingerprint = lower(broker_public_key_fingerprint)
+            ),
+            broker_evidence_expires_at TEXT NOT NULL,
+            reconciliation_snapshot_id TEXT NOT NULL,
+            reconciliation_artifact_path TEXT NOT NULL,
+            reconciliation_artifact_hash TEXT NOT NULL CHECK (
+                length(reconciliation_artifact_hash) = 64
+                AND reconciliation_artifact_hash = lower(reconciliation_artifact_hash)
+            ),
+            reconciliation_receipt_id TEXT NOT NULL,
+            reconciliation_public_key_fingerprint TEXT NOT NULL CHECK (
+                length(reconciliation_public_key_fingerprint) = 64
+                AND reconciliation_public_key_fingerprint =
+                    lower(reconciliation_public_key_fingerprint)
+            ),
+            reconciliation_signature_ed25519 TEXT NOT NULL,
+            reconciliation_evidence_issued_at TEXT NOT NULL,
+            reconciliation_evidence_expires_at TEXT NOT NULL,
+            persisted_at TEXT NOT NULL,
+            FOREIGN KEY(snapshot_id) REFERENCES rt_reconciliation_snapshots(snapshot_id)
+        )
+    """)
+    await connection.execute("""
+        CREATE TABLE IF NOT EXISTS rt_reconciliation_run_eligibility (
+            run_id TEXT PRIMARY KEY,
+            schema_version INTEGER NOT NULL CHECK (schema_version = 2),
+            eligible_until TEXT NOT NULL,
+            FOREIGN KEY(run_id) REFERENCES rt_reconciliation_runs(run_id)
+        )
+    """)
+    await connection.execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS
+            rt_reconciliation_differences_run_difference_uq
+        ON rt_reconciliation_differences(run_id, difference_id)
+    """)
+    await connection.execute("""
+        CREATE TABLE IF NOT EXISTS rt_reconciliation_operator_resolution_bindings (
+            resolution_id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            difference_id TEXT NOT NULL,
+            FOREIGN KEY(resolution_id)
+                REFERENCES rt_reconciliation_operator_resolutions(resolution_id),
+            FOREIGN KEY(run_id, difference_id)
+                REFERENCES rt_reconciliation_differences(run_id, difference_id)
+        )
+    """)
+    await connection.execute("""
+        INSERT INTO rt_reconciliation_operator_resolution_bindings(
+            resolution_id, run_id, difference_id
+        )
+        SELECT resolution_id, run_id, difference_id
+        FROM rt_reconciliation_operator_resolutions
+    """)
+    await connection.execute("""
+        CREATE TRIGGER IF NOT EXISTS rt_reconciliation_operator_resolution_bind
+        AFTER INSERT ON rt_reconciliation_operator_resolutions
+        BEGIN
+            INSERT INTO rt_reconciliation_operator_resolution_bindings(
+                resolution_id, run_id, difference_id
+            ) VALUES (NEW.resolution_id, NEW.run_id, NEW.difference_id);
+        END
+    """)
+    for table in _V2_TABLES:
+        await connection.execute(f"""
+            CREATE TRIGGER IF NOT EXISTS {table}_no_update
+            BEFORE UPDATE ON {table}
+            BEGIN
+                SELECT RAISE(ABORT, 'reconciliation evidence is append-only');
+            END
+        """)
+        await connection.execute(f"""
+            CREATE TRIGGER IF NOT EXISTS {table}_no_delete
+            BEFORE DELETE ON {table}
+            BEGIN
+                SELECT RAISE(ABORT, 'reconciliation evidence is append-only');
+            END
+        """)
+
+
 _MIGRATIONS: tuple[tuple[int, Callable[[aiosqlite.Connection], Awaitable[None]]], ...] = (
     (1, _migration_v1),
+    (2, _migration_v2),
 )
 
 _EXPECTED_COLUMNS = {
@@ -173,18 +260,6 @@ _EXPECTED_COLUMNS = {
         "snapshot_id",
         "schema_version",
         "account_scope",
-        "account_alias",
-        "snapshot_hash",
-        "bundle_id",
-        "runtime_fingerprint",
-        "database_path",
-        "database_identity",
-        "database_device",
-        "database_inode",
-        "broker_artifact_hash",
-        "broker_receipt_id",
-        "broker_public_key_fingerprint",
-        "broker_evidence_expires_at",
         "observed_from",
         "observed_through",
         "retrieved_at",
@@ -202,7 +277,6 @@ _EXPECTED_COLUMNS = {
         "expected_account_scope",
         "started_at",
         "completed_at",
-        "eligible_until",
         "status",
         "evidence_fresh",
         "comparison_complete",
@@ -236,22 +310,53 @@ _EXPECTED_COLUMNS = {
         "evidence_reference",
         "created_at",
     },
+    "rt_reconciliation_snapshot_lineage": {
+        "snapshot_id",
+        "schema_version",
+        "account_alias",
+        "snapshot_hash",
+        "bundle_id",
+        "runtime_fingerprint",
+        "database_path",
+        "database_identity",
+        "database_device",
+        "database_inode",
+        "broker_artifact_hash",
+        "broker_receipt_id",
+        "broker_public_key_fingerprint",
+        "broker_evidence_expires_at",
+        "reconciliation_snapshot_id",
+        "reconciliation_artifact_path",
+        "reconciliation_artifact_hash",
+        "reconciliation_receipt_id",
+        "reconciliation_public_key_fingerprint",
+        "reconciliation_signature_ed25519",
+        "reconciliation_evidence_issued_at",
+        "reconciliation_evidence_expires_at",
+        "persisted_at",
+    },
+    "rt_reconciliation_run_eligibility": {
+        "run_id",
+        "schema_version",
+        "eligible_until",
+    },
+    "rt_reconciliation_operator_resolution_bindings": {
+        "resolution_id",
+        "run_id",
+        "difference_id",
+    },
 }
 
 _REQUIRED_TABLE_SQL = {
     "rt_reconciliation_snapshots": (
         "schema_version integer not null check (schema_version = 1)",
         "length(account_scope) = 72",
-        "length(snapshot_hash) = 64 and snapshot_hash = lower(snapshot_hash)",
-        "length(broker_artifact_hash) = 64 and broker_artifact_hash = "
-        "lower(broker_artifact_hash)",
         "check (json_valid(payload_json))",
         "length(payload_sha256) = 64 and payload_sha256 = lower(payload_sha256)",
     ),
     "rt_reconciliation_runs": (
         "trigger_type in ('startup', 'reconnect', 'periodic', 'before_live', " "'ambiguous_order')",
         "status in ('passed', 'degraded', 'quarantined')",
-        "eligible_until text not null",
         "status = 'quarantined' and quarantine_required = 1 and entry_eligible = 0",
         "foreign key(snapshot_id) references rt_reconciliation_snapshots(snapshot_id)",
     ),
@@ -259,7 +364,6 @@ _REQUIRED_TABLE_SQL = {
         "kind = 'expected_timing_lag' and materiality = 'informational'",
         "kind = 'unknown' and materiality = 'unknown'",
         "unique(run_id, ordinal)",
-        "unique(run_id, difference_id)",
         "foreign key(run_id) references rt_reconciliation_runs(run_id)",
     ),
     "rt_reconciliation_operator_resolutions": (
@@ -267,6 +371,20 @@ _REQUIRED_TABLE_SQL = {
         "'investigation_note')",
         "length(trim(reason)) >= 10",
         "foreign key(run_id) references rt_reconciliation_runs(run_id)",
+        "foreign key(difference_id) references rt_reconciliation_differences(difference_id)",
+    ),
+    "rt_reconciliation_snapshot_lineage": (
+        "schema_version integer not null check (schema_version = 2)",
+        "foreign key(snapshot_id) references rt_reconciliation_snapshots(snapshot_id)",
+        "length(reconciliation_artifact_hash) = 64",
+    ),
+    "rt_reconciliation_run_eligibility": (
+        "schema_version integer not null check (schema_version = 2)",
+        "foreign key(run_id) references rt_reconciliation_runs(run_id)",
+    ),
+    "rt_reconciliation_operator_resolution_bindings": (
+        "foreign key(resolution_id) references "
+        "rt_reconciliation_operator_resolutions(resolution_id)",
         "foreign key(run_id, difference_id) references "
         "rt_reconciliation_differences(run_id, difference_id)",
     ),
@@ -361,16 +479,17 @@ async def assert_reconciliation_schema(connection: aiosqlite.Connection) -> None
         if any(_normalized_sql(fragment) not in table_sql.get(table, "") for fragment in fragments):
             raise RuntimeError(f"reconciliation table {table} constraints are malformed")
     trigger_rows = await connection.execute(
-        "SELECT name, sql FROM sqlite_master WHERE type = 'trigger' AND tbl_name IN (?, ?, ?, ?)",
-        _TABLES,
+        "SELECT name, sql FROM sqlite_master "
+        "WHERE type = 'trigger' AND tbl_name LIKE 'rt_reconciliation_%'"
     )
     triggers = {str(row[0]): _canonical_schema_sql(row[1]) for row in await trigger_rows.fetchall()}
     expected_names = {
-        f"{table}_{suffix}" for table in _TABLES for suffix in ("no_update", "no_delete")
+        f"{table}_{suffix}" for table in _ALL_TABLES for suffix in ("no_update", "no_delete")
     }
+    expected_names.add("rt_reconciliation_operator_resolution_bind")
     if set(triggers) != expected_names:
         raise RuntimeError("reconciliation append-only trigger set is malformed")
-    for table in _TABLES:
+    for table in _ALL_TABLES:
         for suffix, operation in (("no_update", "update"), ("no_delete", "delete")):
             name = f"{table}_{suffix}"
             expected_trigger = _normalized_sql(f"""
@@ -382,6 +501,40 @@ async def assert_reconciliation_schema(connection: aiosqlite.Connection) -> None
                 """)
             if triggers[name] != expected_trigger:
                 raise RuntimeError(f"reconciliation trigger {name} is malformed")
+    expected_bind_trigger = _normalized_sql("""
+        CREATE TRIGGER rt_reconciliation_operator_resolution_bind
+        AFTER INSERT ON rt_reconciliation_operator_resolutions
+        BEGIN
+            INSERT INTO rt_reconciliation_operator_resolution_bindings(
+                resolution_id, run_id, difference_id
+            ) VALUES (NEW.resolution_id, NEW.run_id, NEW.difference_id);
+        END
+        """)
+    if triggers["rt_reconciliation_operator_resolution_bind"] != expected_bind_trigger:
+        raise RuntimeError("reconciliation resolution binding trigger is malformed")
+    index = await connection.execute(
+        "SELECT sql FROM sqlite_master WHERE type='index' "
+        "AND name='rt_reconciliation_differences_run_difference_uq'"
+    )
+    index_row = await index.fetchone()
+    expected_index = _normalized_sql("""
+        CREATE UNIQUE INDEX rt_reconciliation_differences_run_difference_uq
+        ON rt_reconciliation_differences(run_id, difference_id)
+        """)
+    if index_row is None or _canonical_schema_sql(index_row[0]) != expected_index:
+        raise RuntimeError("reconciliation composite identity index is malformed")
     violations = await connection.execute("PRAGMA foreign_key_check")
     if await violations.fetchone() is not None:
         raise RuntimeError("reconciliation schema contains foreign-key violations")
+    unbound_resolutions = await connection.execute("""
+        SELECT 1
+        FROM rt_reconciliation_operator_resolutions AS resolution
+        LEFT JOIN rt_reconciliation_operator_resolution_bindings AS binding
+          ON binding.resolution_id = resolution.resolution_id
+         AND binding.run_id = resolution.run_id
+         AND binding.difference_id = resolution.difference_id
+        WHERE binding.resolution_id IS NULL
+        LIMIT 1
+        """)
+    if await unbound_resolutions.fetchone() is not None:
+        raise RuntimeError("reconciliation resolution lacks composite run binding")

--- a/robo_trader/reconciliation_migrations.py
+++ b/robo_trader/reconciliation_migrations.py
@@ -147,6 +147,115 @@ async def _migration_v1(connection: aiosqlite.Connection) -> None:
         """)
 
 
+_V1_TABLE_SQL = {
+    "rt_reconciliation_snapshots": """
+        CREATE TABLE rt_reconciliation_snapshots (
+            snapshot_id TEXT PRIMARY KEY,
+            schema_version INTEGER NOT NULL CHECK (schema_version = 1),
+            account_scope TEXT NOT NULL CHECK (
+                length(account_scope) = 72
+                AND substr(account_scope, 1, 8) = 'acct_v1_'
+                AND substr(account_scope, 9) NOT GLOB '*[^0-9a-f]*'
+            ),
+            observed_from TEXT NOT NULL,
+            observed_through TEXT NOT NULL,
+            retrieved_at TEXT NOT NULL,
+            complete INTEGER NOT NULL CHECK (complete IN (0, 1)),
+            payload_json TEXT NOT NULL CHECK (json_valid(payload_json)),
+            payload_sha256 TEXT NOT NULL CHECK (
+                length(payload_sha256) = 64 AND payload_sha256 = lower(payload_sha256)
+            ),
+            persisted_at TEXT NOT NULL
+        )
+    """,
+    "rt_reconciliation_runs": """
+        CREATE TABLE rt_reconciliation_runs (
+            run_id TEXT PRIMARY KEY,
+            schema_version INTEGER NOT NULL CHECK (schema_version = 1),
+            trigger_type TEXT NOT NULL CHECK (
+                trigger_type IN ('startup', 'reconnect', 'periodic',
+                                 'before_live', 'ambiguous_order')
+            ),
+            snapshot_id TEXT NOT NULL,
+            verdict_id TEXT NOT NULL,
+            expected_account_scope TEXT NOT NULL CHECK (
+                length(expected_account_scope) = 72
+                AND substr(expected_account_scope, 1, 8) = 'acct_v1_'
+                AND substr(expected_account_scope, 9) NOT GLOB '*[^0-9a-f]*'
+            ),
+            started_at TEXT NOT NULL,
+            completed_at TEXT NOT NULL,
+            status TEXT NOT NULL CHECK (status IN ('passed', 'degraded', 'quarantined')),
+            evidence_fresh INTEGER NOT NULL CHECK (evidence_fresh IN (0, 1)),
+            comparison_complete INTEGER NOT NULL CHECK (comparison_complete IN (0, 1)),
+            quarantine_required INTEGER NOT NULL CHECK (quarantine_required IN (0, 1)),
+            entry_eligible INTEGER NOT NULL CHECK (entry_eligible IN (0, 1)),
+            coverage_json TEXT NOT NULL CHECK (json_valid(coverage_json)),
+            verdict_payload_json TEXT NOT NULL CHECK (json_valid(verdict_payload_json)),
+            verdict_sha256 TEXT NOT NULL CHECK (
+                length(verdict_sha256) = 64 AND verdict_sha256 = lower(verdict_sha256)
+            ),
+            CHECK (completed_at >= started_at),
+            CHECK (
+                (status = 'quarantined' AND quarantine_required = 1 AND entry_eligible = 0)
+                OR
+                (status != 'quarantined' AND quarantine_required = 0 AND entry_eligible = 1)
+            ),
+            FOREIGN KEY(snapshot_id) REFERENCES rt_reconciliation_snapshots(snapshot_id)
+        )
+    """,
+    "rt_reconciliation_differences": """
+        CREATE TABLE rt_reconciliation_differences (
+            difference_id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            ordinal INTEGER NOT NULL CHECK (ordinal >= 0),
+            kind TEXT NOT NULL CHECK (
+                kind IN ('expected_timing_lag', 'recoverable_missing_event',
+                         'duplicate_event', 'account_mismatch', 'quantity_mismatch',
+                         'cash_mismatch', 'unknown')
+            ),
+            materiality TEXT NOT NULL CHECK (
+                materiality IN ('informational', 'material', 'unknown')
+            ),
+            reason_code TEXT NOT NULL,
+            subject TEXT NOT NULL,
+            evidence_ids_json TEXT NOT NULL CHECK (json_valid(evidence_ids_json)),
+            payload_json TEXT NOT NULL CHECK (json_valid(payload_json)),
+            payload_sha256 TEXT NOT NULL CHECK (
+                length(payload_sha256) = 64 AND payload_sha256 = lower(payload_sha256)
+            ),
+            persisted_at TEXT NOT NULL,
+            CHECK (
+                (kind = 'expected_timing_lag' AND materiality = 'informational')
+                OR (kind = 'unknown' AND materiality = 'unknown')
+                OR (kind NOT IN ('expected_timing_lag', 'unknown')
+                    AND materiality = 'material')
+            ),
+            UNIQUE(run_id, ordinal),
+            FOREIGN KEY(run_id) REFERENCES rt_reconciliation_runs(run_id)
+        )
+    """,
+    "rt_reconciliation_operator_resolutions": """
+        CREATE TABLE rt_reconciliation_operator_resolutions (
+            resolution_id TEXT PRIMARY KEY,
+            schema_version INTEGER NOT NULL CHECK (schema_version = 1),
+            run_id TEXT NOT NULL,
+            difference_id TEXT NOT NULL,
+            resolution_kind TEXT NOT NULL CHECK (
+                resolution_kind IN ('acknowledged', 'external_remediation_recorded',
+                                    'investigation_note')
+            ),
+            operator_id TEXT NOT NULL CHECK (length(trim(operator_id)) BETWEEN 1 AND 64),
+            reason TEXT NOT NULL CHECK (length(trim(reason)) >= 10),
+            evidence_reference TEXT,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY(run_id) REFERENCES rt_reconciliation_runs(run_id),
+            FOREIGN KEY(difference_id) REFERENCES rt_reconciliation_differences(difference_id)
+        )
+    """,
+}
+
+
 _V2_TABLE_SQL = {
     "rt_reconciliation_snapshot_lineage": """
         CREATE TABLE IF NOT EXISTS rt_reconciliation_snapshot_lineage (
@@ -352,6 +461,96 @@ _EXPECTED_COLUMNS = {
         "run_id",
         "difference_id",
     },
+}
+
+_V1_INTEGER_COLUMNS = {
+    "rt_reconciliation_snapshots": {"schema_version", "complete"},
+    "rt_reconciliation_runs": {
+        "schema_version",
+        "evidence_fresh",
+        "comparison_complete",
+        "quarantine_required",
+        "entry_eligible",
+    },
+    "rt_reconciliation_differences": {"ordinal"},
+    "rt_reconciliation_operator_resolutions": {"schema_version"},
+}
+_V1_PRIMARY_KEYS = {
+    "rt_reconciliation_snapshots": "snapshot_id",
+    "rt_reconciliation_runs": "run_id",
+    "rt_reconciliation_differences": "difference_id",
+    "rt_reconciliation_operator_resolutions": "resolution_id",
+}
+_EXPECTED_V1_COLUMN_SHAPES = {
+    table: {
+        column: (
+            "INTEGER" if column in _V1_INTEGER_COLUMNS[table] else "TEXT",
+            int(
+                column != _V1_PRIMARY_KEYS[table]
+                and not (
+                    table == "rt_reconciliation_operator_resolutions"
+                    and column == "evidence_reference"
+                )
+            ),
+            None,
+            int(column == _V1_PRIMARY_KEYS[table]),
+        )
+        for column in _EXPECTED_COLUMNS[table]
+    }
+    for table in _TABLES
+}
+
+_EXPECTED_V1_FOREIGN_KEYS = {
+    "rt_reconciliation_snapshots": set(),
+    "rt_reconciliation_runs": {
+        (
+            "rt_reconciliation_snapshots",
+            ("snapshot_id",),
+            ("snapshot_id",),
+            "NO ACTION",
+            "NO ACTION",
+            "NONE",
+        )
+    },
+    "rt_reconciliation_differences": {
+        (
+            "rt_reconciliation_runs",
+            ("run_id",),
+            ("run_id",),
+            "NO ACTION",
+            "NO ACTION",
+            "NONE",
+        )
+    },
+    "rt_reconciliation_operator_resolutions": {
+        (
+            "rt_reconciliation_runs",
+            ("run_id",),
+            ("run_id",),
+            "NO ACTION",
+            "NO ACTION",
+            "NONE",
+        ),
+        (
+            "rt_reconciliation_differences",
+            ("difference_id",),
+            ("difference_id",),
+            "NO ACTION",
+            "NO ACTION",
+            "NONE",
+        ),
+    },
+}
+
+_EXPECTED_V1_INDEXES = {
+    "rt_reconciliation_snapshots": {(1, "pk", 0, ("snapshot_id",))},
+    "rt_reconciliation_runs": {(1, "pk", 0, ("run_id",))},
+    "rt_reconciliation_differences": {
+        (1, "pk", 0, ("difference_id",)),
+        (1, "u", 0, ("run_id", "ordinal")),
+        (1, "c", 0, ("run_id", "difference_id")),
+    },
+    "rt_reconciliation_operator_resolutions": {(1, "pk", 0, ("resolution_id",))},
 }
 
 _REQUIRED_TABLE_SQL = {
@@ -599,6 +798,15 @@ async def assert_reconciliation_schema(connection: aiosqlite.Connection) -> None
         "SELECT name, sql FROM sqlite_master WHERE type = 'table'"
     )
     table_sql = {str(row[0]): _canonical_schema_sql(row[1]) for row in await table_rows.fetchall()}
+    for table, expected_sql in _V1_TABLE_SQL.items():
+        if table_sql.get(table) != _canonical_schema_sql(expected_sql):
+            raise RuntimeError(f"reconciliation table {table} definition is malformed")
+        if await _table_shape(connection, table) != _EXPECTED_V1_COLUMN_SHAPES[table]:
+            raise RuntimeError(f"reconciliation table {table} column shape is malformed")
+        if await _foreign_key_shape(connection, table) != _EXPECTED_V1_FOREIGN_KEYS[table]:
+            raise RuntimeError(f"reconciliation table {table} foreign keys are malformed")
+        if await _index_shape(connection, table) != _EXPECTED_V1_INDEXES[table]:
+            raise RuntimeError(f"reconciliation table {table} indexes are malformed")
     for table, fragments in _REQUIRED_TABLE_SQL.items():
         if any(_normalized_sql(fragment) not in table_sql.get(table, "") for fragment in fragments):
             raise RuntimeError(f"reconciliation table {table} constraints are malformed")

--- a/tests/test_exact_state_bootstrap.py
+++ b/tests/test_exact_state_bootstrap.py
@@ -30,6 +30,7 @@ from robo_trader.financial_state_bootstrap import (
     ExactStateBootstrapCommittedBackupInvalid,
     ExactStateBootstrapError,
     acquire_exact_state_safety_journal_guard,
+    assert_exact_state_runtime_sources_unchanged,
     inspect_legacy_state,
     load_exact_state_bootstrap_evidence,
     sqlite_table_evidence,
@@ -477,6 +478,8 @@ def _candidate_bundle(
         "mutated_state": False,
         "portfolio_ids": ["default"],
         "reconciliation_status": "passed",
+        "reconciliation_differences": [],
+        "reconciliation_timing_lag_proofs": [],
         "runtime_fingerprint": runtime_contract.fingerprint,
         "safety_journal_device": journal_metadata.st_dev,
         "safety_journal_identity": runtime_contract.safety_journal_identity,
@@ -735,6 +738,58 @@ def test_safety_journal_guard_blocks_mutation_and_releases_writer_lock(
         writer.close()
 
 
+@pytest.mark.parametrize("journal_mode", ["DELETE", "WAL"])
+def test_runtime_source_revalidation_rejects_same_inode_ledger_content_change(
+    tmp_path: Path,
+    journal_mode: str,
+) -> None:
+    path = tmp_path / "legacy.db"
+    _legacy_database(path)
+    _candidate, evidence, runtime_contract = _candidate_bundle(path, tmp_path)
+    original_inode = path.stat().st_ino
+    writer = sqlite3.connect(path)
+    try:
+        assert writer.execute(f"PRAGMA journal_mode={journal_mode}").fetchone()[0].upper() == (
+            journal_mode
+        )
+        writer.execute("UPDATE account SET cash = cash + 1 WHERE portfolio_id='default'")
+        writer.commit()
+        assert path.stat().st_ino == original_inode
+        with pytest.raises(ExactStateBootstrapError, match="ledger content changed"):
+            assert_exact_state_runtime_sources_unchanged(evidence, runtime_contract)
+    finally:
+        writer.close()
+
+
+def test_runtime_source_revalidation_rejects_same_inode_safety_journal_change(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "legacy.db"
+    _legacy_database(path)
+    _candidate, evidence, runtime_contract = _candidate_bundle(path, tmp_path)
+    journal_path = Path(str(runtime_contract.safety_journal_path))
+    original_inode = journal_path.stat().st_ino
+    with sqlite3.connect(journal_path) as connection:
+        connection.execute(
+            """
+            INSERT INTO safety_journal_events(
+                sequence, event_id, event_type, occurred_at, idempotency_key,
+                execution_domain_scope, account_scope, portfolio_id, con_id,
+                intent_fingerprint, claim_id, payload_json, previous_chain_hash,
+                payload_hash, chain_hash, schema_version
+            ) VALUES (1, 'tampered-event', 'RESERVED', '2026-07-28T14:00:00Z',
+                      'tampered-key', 'paper-simulator-v1', ?, 'default', 1,
+                      'tampered-intent', NULL, '{}', ?, ?, ?, 1)
+            """,
+            (ACCOUNT_SCOPE, "0" * 64, "1" * 64, "2" * 64),
+        )
+        connection.commit()
+    assert journal_path.stat().st_ino == original_inode
+
+    with pytest.raises(ExactStateBootstrapError, match="journal"):
+        assert_exact_state_runtime_sources_unchanged(evidence, runtime_contract)
+
+
 @pytest.mark.asyncio
 async def test_offline_schema_failure_rolls_back_to_byte_identical_raw_legacy_database(
     tmp_path: Path,
@@ -989,7 +1044,7 @@ def test_evidence_loader_rejects_tampered_broker_and_wrong_runtime_scope(
         account_scope=ACCOUNT_SCOPE,
     )
 
-    with pytest.raises(ExactStateBootstrapError, match="zero paper exposure"):
+    with pytest.raises(ExactStateBootstrapError, match="collection evidence counts"):
         load_exact_state_bootstrap_evidence(
             reconciliation_path=tmp_path / "reconciliation.json",
             broker_snapshot_path=broker_path,

--- a/tests/test_pr5_bootstrap_reconciliation_producer.py
+++ b/tests/test_pr5_bootstrap_reconciliation_producer.py
@@ -614,14 +614,11 @@ def test_completed_broker_history_remains_diagnostic_not_simulator_equality(
 @pytest.mark.parametrize(
     "snapshot",
     [
-        _snapshot(positions=(_position(),)),
-        _snapshot(orders=(_order(),)),
         _snapshot(complete=False),
-        _snapshot(retrieved_at=NOW - timedelta(minutes=5)),
         _snapshot(scope=OTHER_ACCOUNT_SCOPE),
     ],
 )
-def test_exposure_incomplete_stale_or_wrong_account_blocks(
+def test_incomplete_or_wrong_account_blocks(
     database: Path,
     snapshot: NormalizedBrokerSnapshot,
 ) -> None:
@@ -631,6 +628,39 @@ def test_exposure_incomplete_stale_or_wrong_account_blocks(
         _produce(database, snapshot=snapshot, receiver=receiver)
 
     assert receiver.results == []
+
+
+@pytest.mark.parametrize(
+    ("snapshot", "reason_code"),
+    [
+        (
+            _snapshot(positions=(_position(),)),
+            "UNEXPECTED_IBKR_POSITION_IN_PAPER_SIMULATOR",
+        ),
+        (
+            _snapshot(orders=(_order(),)),
+            "UNEXPECTED_IBKR_OPEN_ORDER_IN_PAPER_SIMULATOR",
+        ),
+        (
+            _snapshot(retrieved_at=NOW - timedelta(minutes=5)),
+            "BROKER_EVIDENCE_STALE",
+        ),
+    ],
+)
+def test_authenticated_mismatch_is_signed_for_quarantine_persistence(
+    database: Path,
+    snapshot: NormalizedBrokerSnapshot,
+    reason_code: str,
+) -> None:
+    _, receiver, _ = _produce(database, snapshot=snapshot)
+
+    result = receiver.results[0]
+    assert result.reconciliation_status is ReconciliationStatus.QUARANTINED
+    assert reason_code in {
+        difference.reason_code for difference in result.reconciliation_differences
+    }
+    assert result.authorizes_startup is False
+    assert result.mutated_state is False
 
 
 def test_stale_internal_clock_blocks_without_receiver_call(database: Path) -> None:

--- a/tests/test_pr5_reconciliation_runtime.py
+++ b/tests/test_pr5_reconciliation_runtime.py
@@ -1,31 +1,51 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
+import os
 import sqlite3
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
+from types import SimpleNamespace
 
 import aiosqlite
 import pytest
 
+from robo_trader import bootstrap_evidence_receivers as receiver_module
+from robo_trader.bootstrap_evidence_receivers import (
+    ProtectiveMarkBundleIdentity,
+    VerifiedBrokerEvidenceEnvelope,
+)
+from robo_trader.config import RuntimeContract
+from robo_trader.reconciliation import runtime_evidence as runtime_evidence_module
 from robo_trader.reconciliation.domain import (
     BrokerCollectionEvidence,
     BrokerCollectionKind,
     BrokerEvidenceCompleteness,
     NormalizedBrokerAccount,
     NormalizedBrokerSnapshot,
+    canonical_timestamp,
+    fingerprint,
 )
 from robo_trader.reconciliation.persistence import (
     OperatorResolutionKind,
     ReconciliationPersistence,
+    ReconciliationPersistenceError,
 )
 from robo_trader.reconciliation.policy import (
     DifferenceKind,
     DifferenceMateriality,
+    ExpectedTimingLagProof,
     ReconciliationCoverage,
     ReconciliationDifference,
     ReconciliationStatus,
     evaluate_paper_simulator_reconciliation,
+)
+from robo_trader.reconciliation.runtime_evidence import (
+    RuntimeReconciliationEvidenceError,
+    VerifiedRuntimeReconciliationEvidence,
+    assert_and_consume_verified_runtime_reconciliation_evidence,
+    bind_verified_runtime_reconciliation_evidence,
 )
 from robo_trader.reconciliation.service import (
     ReconciliationComparison,
@@ -107,23 +127,104 @@ def _coverage(**changes: bool) -> ReconciliationCoverage:
     return ReconciliationCoverage(**values)
 
 
-class _SnapshotSource:
-    def __init__(self, snapshot: NormalizedBrokerSnapshot) -> None:
+@pytest.fixture(autouse=True)
+def _accept_registered_test_runtime_context(monkeypatch) -> None:
+    monkeypatch.setattr(
+        runtime_evidence_module,
+        "assert_validated_runtime_safety_context",
+        lambda context: context,
+    )
+
+
+def _registered_evidence(
+    database_path,
+    *,
+    snapshot: NormalizedBrokerSnapshot | None = None,
+    expires_at: datetime = NOW + timedelta(seconds=29),
+) -> VerifiedRuntimeReconciliationEvidence:
+    path = database_path.resolve()
+    path.touch(exist_ok=True)
+    metadata = os.lstat(path)
+    broker_snapshot = snapshot or _snapshot()
+    contract = RuntimeContract(
+        environment="development",
+        execution_mode="paper",
+        execution_source="paper_simulator",
+        ibkr_host="127.0.0.1",
+        ibkr_port=4002,
+        ibkr_readonly=True,
+        database_path=str(path),
+        account_alias="***1234",
+        account_type="paper",
+        model_artifact_set="test-models",
+        build_id="test-build",
+        state_namespace="paper",
+        safety_account_scope=ACCOUNT_SCOPE,
+        safety_execution_domain_scope="paper-simulator-v1",
+    )
+    context = SimpleNamespace(runtime_contract=contract, account_alias="***1234")
+    snapshot_hash = hashlib.sha256(broker_snapshot.canonical_payload().encode("utf-8")).hexdigest()
+    return runtime_evidence_module._register(
+        VerifiedRuntimeReconciliationEvidence(
+            snapshot=broker_snapshot,
+            snapshot_id=broker_snapshot.snapshot_id,
+            snapshot_hash=snapshot_hash,
+            bundle_id="bootstrap-evidence-bundle-v1-" + "a1" * 32,
+            runtime_fingerprint=contract.fingerprint,
+            account_scope=ACCOUNT_SCOPE,
+            account_alias="***1234",
+            database_path=str(path),
+            database_identity=contract.database_identity,
+            database_device=metadata.st_dev,
+            database_inode=metadata.st_ino,
+            broker_artifact_hash="b2" * 32,
+            broker_receipt_id="receipt-v1-" + "c3" * 32,
+            broker_public_key_fingerprint="d4" * 32,
+            issued_at=NOW - timedelta(microseconds=1),
+            expires_at=expires_at,
+            _runtime_context=context,
+            _marker=runtime_evidence_module._CAPABILITY_MARKER,
+        )
+    )
+
+
+class _EvidenceSource:
+    def __init__(self, database_path, snapshot: NormalizedBrokerSnapshot) -> None:
+        self.database_path = database_path
         self.snapshot = snapshot
         self.calls = 0
         self.closed = False
         self.error: Exception | None = None
+        self.close_error: Exception | None = None
+        self.close_started = None
+        self.close_release = None
+        self.expires_at = NOW + timedelta(seconds=29)
+        self.prepared_evidence: object | None = None
 
-    async def collect_normalized_snapshot(
+    async def collect_verified_evidence(
         self, *, max_age_seconds: float
-    ) -> NormalizedBrokerSnapshot:
+    ) -> VerifiedRuntimeReconciliationEvidence:
         assert max_age_seconds == 30.0
         self.calls += 1
         if self.error is not None:
             raise self.error
-        return self.snapshot
+        if self.prepared_evidence is not None:
+            evidence = self.prepared_evidence
+            self.prepared_evidence = None
+            return evidence  # type: ignore[return-value]
+        return _registered_evidence(
+            self.database_path,
+            snapshot=self.snapshot,
+            expires_at=self.expires_at,
+        )
 
     async def close(self) -> None:
+        if self.close_started is not None:
+            self.close_started.set()
+        if self.close_release is not None:
+            await self.close_release.wait()
+        if self.close_error is not None:
+            raise self.close_error
         self.closed = True
 
 
@@ -142,6 +243,7 @@ def _comparison(
     differences: tuple[ReconciliationDifference, ...] = (),
     *,
     coverage: ReconciliationCoverage | None = None,
+    timing_lag_proofs: tuple[ExpectedTimingLagProof, ...] = (),
 ):
     def compare(
         snapshot: NormalizedBrokerSnapshot,
@@ -149,7 +251,11 @@ def _comparison(
     ) -> ReconciliationComparison:
         assert snapshot.account.account_scope == ACCOUNT_SCOPE
         assert type(trigger) is ReconciliationTrigger
-        return ReconciliationComparison(coverage or _coverage(), differences)
+        return ReconciliationComparison(
+            coverage or _coverage(),
+            differences,
+            timing_lag_proofs,
+        )
 
     return compare
 
@@ -174,11 +280,12 @@ async def _service(
     snapshot: NormalizedBrokerSnapshot | None = None,
     comparison=None,
     clock: _Clock | None = None,
-) -> tuple[ReconciliationService, _SnapshotSource, ReconciliationPersistence]:
-    source = _SnapshotSource(snapshot or _snapshot())
-    persistence = ReconciliationPersistence((tmp_path / "reconciliation.sqlite3").resolve())
+) -> tuple[ReconciliationService, _EvidenceSource, ReconciliationPersistence]:
+    database_path = (tmp_path / "reconciliation.sqlite3").resolve()
+    source = _EvidenceSource(database_path, snapshot or _snapshot())
+    persistence = ReconciliationPersistence(database_path)
     service = ReconciliationService(
-        snapshot_source=source,
+        evidence_source=source,
         comparison_source=comparison or _comparison(),
         persistence=persistence,
         expected_account_scope=ACCOUNT_SCOPE,
@@ -345,9 +452,9 @@ async def test_partial_migration_fails_closed_without_using_runtime_state(tmp_pa
             (RECONCILIATION_COMPONENT, "2026-07-28T14:00:00Z"),
         )
         await connection.commit()
-    source = _SnapshotSource(_snapshot())
+    source = _EvidenceSource(database_path, _snapshot())
     service = ReconciliationService(
-        snapshot_source=source,
+        evidence_source=source,
         comparison_source=_comparison(),
         persistence=ReconciliationPersistence(database_path),
         expected_account_scope=ACCOUNT_SCOPE,
@@ -373,20 +480,26 @@ async def test_duplicate_append_is_idempotent_not_a_duplicate_callback(tmp_path)
         now=NOW,
         max_age_seconds=30,
     )
+    runtime_evidence = _registered_evidence(
+        tmp_path / "reconciliation.sqlite3",
+        snapshot=snapshot,
+    )
 
     first = await persistence.append_reconciliation(
         trigger_type="startup",
-        snapshot=snapshot,
+        runtime_evidence=runtime_evidence,
         verdict=verdict,
         started_at=NOW,
         completed_at=NOW,
+        eligible_until=NOW + timedelta(seconds=29),
     )
     second = await persistence.append_reconciliation(
         trigger_type="startup",
-        snapshot=snapshot,
+        runtime_evidence=runtime_evidence,
         verdict=verdict,
         started_at=NOW,
         completed_at=NOW,
+        eligible_until=NOW + timedelta(seconds=29),
     )
 
     assert second == first
@@ -443,3 +556,328 @@ async def test_service_failure_clears_prior_entry_eligibility(tmp_path) -> None:
     assert service.state is ReconciliationServiceState.QUARANTINED
     assert service.latest_outcome is None
     assert service.entry_eligible(at=NOW) is False
+
+
+@pytest.mark.asyncio
+async def test_fabricated_snapshot_source_is_rejected_before_comparison(tmp_path) -> None:
+    service, source, _ = await _service(tmp_path)
+    source.prepared_evidence = _snapshot()
+
+    with pytest.raises(ReconciliationServiceBlocked, match="failed closed"):
+        await service.reconcile_startup()
+
+    assert service.state is ReconciliationServiceState.QUARANTINED
+    assert service.entry_eligible(at=NOW) is False
+
+
+def test_core_broker_and_bundle_assertions_issue_one_shot_runtime_evidence(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    database_path = (tmp_path / "reconciliation.sqlite3").resolve()
+    sqlite3.connect(database_path).close()
+    metadata = os.lstat(database_path)
+    snapshot = _snapshot()
+    snapshot_hash = hashlib.sha256(snapshot.canonical_payload().encode("utf-8")).hexdigest()
+    contract = RuntimeContract(
+        environment="development",
+        execution_mode="paper",
+        execution_source="paper_simulator",
+        ibkr_host="127.0.0.1",
+        ibkr_port=4002,
+        ibkr_readonly=True,
+        database_path=str(database_path),
+        account_alias="***1234",
+        account_type="paper",
+        model_artifact_set="test-models",
+        build_id="test-build",
+        state_namespace="paper",
+        safety_account_scope=ACCOUNT_SCOPE,
+        safety_execution_domain_scope="paper-simulator-v1",
+    )
+    context = SimpleNamespace(runtime_contract=contract, account_alias="***1234")
+    broker = VerifiedBrokerEvidenceEnvelope(
+        snapshot=snapshot,
+        snapshot_id=snapshot.snapshot_id,
+        snapshot_hash=snapshot_hash,
+        runtime_fingerprint=contract.fingerprint,
+        account_scope=ACCOUNT_SCOPE,
+        receipt_id="receipt-v1-" + "c3" * 32,
+        public_key_fingerprint="d4" * 32,
+        artifact_hash="b2" * 32,
+        issued_at=NOW - timedelta(microseconds=1),
+        expires_at=NOW + timedelta(seconds=29),
+        _marker=receiver_module._VERIFIED_BROKER_MARKER,
+    )
+    bundle = ProtectiveMarkBundleIdentity(
+        receiver_type=object,
+        bundle_id="bootstrap-evidence-bundle-v1-" + "a1" * 32,
+        reconciliation_snapshot_id="reconciliation-v1-" + "f6" * 32,
+        broker_snapshot_id=snapshot.snapshot_id,
+        broker_snapshot_hash=snapshot_hash,
+        broker_artifact_hash=broker.artifact_hash,
+        broker_receipt_id=broker.receipt_id,
+        broker_public_key_fingerprint=broker.public_key_fingerprint,
+        runtime_fingerprint=contract.fingerprint,
+        account_scope=ACCOUNT_SCOPE,
+        database_identity=contract.database_identity,
+        database_device=metadata.st_dev,
+        database_inode=metadata.st_ino,
+    )
+    asserted = []
+
+    def assert_broker(value):
+        asserted.append("broker")
+        assert value is broker
+        return broker
+
+    def assert_bundle(value, *, runtime_contract):
+        asserted.append("bundle")
+        assert value is marker
+        assert runtime_contract is contract
+        return bundle
+
+    marker = object()
+    monkeypatch.setattr(
+        runtime_evidence_module,
+        "assert_and_consume_verified_broker_evidence",
+        assert_broker,
+    )
+    monkeypatch.setattr(
+        runtime_evidence_module,
+        "assert_protective_mark_receiver_capability",
+        assert_bundle,
+    )
+
+    evidence = bind_verified_runtime_reconciliation_evidence(broker, context, marker)
+
+    assert asserted == ["broker", "bundle"]
+    assert evidence.database_device == metadata.st_dev
+    assert evidence.database_inode == metadata.st_ino
+    assert assert_and_consume_verified_runtime_reconciliation_evidence(evidence) is evidence
+    with pytest.raises(RuntimeReconciliationEvidenceError, match="already consumed"):
+        assert_and_consume_verified_runtime_reconciliation_evidence(evidence)
+
+
+@pytest.mark.asyncio
+async def test_replaced_database_blocks_exact_prepared_evidence(tmp_path) -> None:
+    service, source, _ = await _service(tmp_path)
+    await service.initialize()
+    database_path = tmp_path / "reconciliation.sqlite3"
+    source.prepared_evidence = _registered_evidence(database_path)
+    replacement = tmp_path / "replacement.sqlite3"
+    sqlite3.connect(replacement).close()
+    os.replace(replacement, database_path)
+
+    with pytest.raises(ReconciliationServiceBlocked, match="failed closed"):
+        await service.reconcile_startup()
+
+    assert service.state is ReconciliationServiceState.QUARANTINED
+
+
+@pytest.mark.asyncio
+async def test_persisted_snapshot_contains_full_runtime_and_broker_binding(tmp_path) -> None:
+    service, _, _ = await _service(tmp_path)
+    outcome = await service.reconcile_startup()
+
+    with sqlite3.connect(tmp_path / "reconciliation.sqlite3") as connection:
+        row = connection.execute(
+            """
+            SELECT runtime_fingerprint, account_scope, account_alias,
+                   database_identity, database_device, database_inode,
+                   broker_artifact_hash, broker_receipt_id,
+                   broker_public_key_fingerprint, bundle_id, snapshot_hash
+            FROM rt_reconciliation_snapshots WHERE snapshot_id = ?
+            """,
+            (outcome.persisted.snapshot_id,),
+        ).fetchone()
+
+    assert row is not None
+    assert row[0]
+    assert row[1:3] == (ACCOUNT_SCOPE, "***1234")
+    assert row[3]
+    assert type(row[4]) is int and type(row[5]) is int
+    assert row[6] == "b2" * 32
+    assert row[7] == "receipt-v1-" + "c3" * 32
+    assert row[8] == "d4" * 32
+    assert row[9].startswith("bootstrap-evidence-bundle-v1-")
+    assert len(row[10]) == 64
+
+
+@pytest.mark.asyncio
+async def test_eligibility_expires_at_relied_on_timing_proof(tmp_path) -> None:
+    snapshot = _snapshot()
+    broker_event_id = "broker-event-v1-" + "e5" * 32
+    lag = ReconciliationDifference(
+        kind=DifferenceKind.EXPECTED_TIMING_LAG,
+        materiality=DifferenceMateriality.INFORMATIONAL,
+        reason_code="BROKER_ORDER_EVENT_PENDING",
+        subject="AAPL",
+        evidence_ids=(broker_event_id,),
+    )
+    proof = ExpectedTimingLagProof.from_trusted_producer(
+        broker_snapshot_id=snapshot.snapshot_id,
+        reason_code=lag.reason_code,
+        subject=lag.subject,
+        broker_event_id=broker_event_id,
+        started_at=NOW - timedelta(seconds=1),
+        expires_at=NOW + timedelta(seconds=5),
+    )
+    service, _, _ = await _service(
+        tmp_path,
+        snapshot=snapshot,
+        comparison=_comparison((lag,), timing_lag_proofs=(proof,)),
+    )
+
+    outcome = await service.reconcile_startup()
+
+    assert outcome.state is ReconciliationServiceState.DEGRADED
+    assert outcome.eligible_until == proof.expires_at
+    assert service.entry_eligible(at=NOW + timedelta(seconds=5)) is True
+    assert service.entry_eligible(at=NOW + timedelta(seconds=5, microseconds=1)) is False
+    assert service.state is ReconciliationServiceState.QUARANTINED
+
+
+@pytest.mark.asyncio
+async def test_clock_rollback_quarantines_entry_eligibility(tmp_path) -> None:
+    service, _, _ = await _service(tmp_path)
+    outcome = await service.reconcile_startup()
+
+    assert service.entry_eligible(at=outcome.verdict.checked_at) is True
+    assert (
+        service.entry_eligible(at=outcome.verdict.checked_at - timedelta(microseconds=1)) is False
+    )
+    assert service.state is ReconciliationServiceState.QUARANTINED
+
+
+@pytest.mark.asyncio
+async def test_resolution_composite_fk_rejects_difference_from_another_run(tmp_path) -> None:
+    clock = _Clock()
+    service, _, _ = await _service(
+        tmp_path,
+        comparison=_comparison((_difference(DifferenceKind.UNKNOWN),)),
+        clock=clock,
+    )
+    first = await service.reconcile_startup()
+    clock.advance(1)
+    second = await service.reconcile_reconnect()
+
+    with sqlite3.connect(tmp_path / "reconciliation.sqlite3") as connection:
+        connection.execute("PRAGMA foreign_keys = ON")
+        with pytest.raises(sqlite3.IntegrityError, match="FOREIGN KEY"):
+            connection.execute(
+                """
+                INSERT INTO rt_reconciliation_operator_resolutions(
+                    resolution_id, schema_version, run_id, difference_id,
+                    resolution_kind, operator_id, reason, evidence_reference, created_at
+                ) VALUES (?, 1, ?, ?, 'investigation_note', 'operator',
+                          'cross-run target must fail', NULL, ?)
+                """,
+                (
+                    "reconciliation-resolution-v1-cross-run",
+                    first.persisted.run_id,
+                    second.persisted.difference_ids[0],
+                    canonical_timestamp(NOW + timedelta(seconds=2)),
+                ),
+            )
+
+
+@pytest.mark.asyncio
+async def test_close_cancellation_shields_cleanup_before_closing(tmp_path) -> None:
+    service, source, _ = await _service(tmp_path)
+    source.close_started = asyncio.Event()
+    source.close_release = asyncio.Event()
+    close_task = asyncio.create_task(service.close())
+    await source.close_started.wait()
+
+    close_task.cancel()
+    await asyncio.sleep(0)
+    assert service.state is ReconciliationServiceState.CLOSING
+    assert source.closed is False
+    source.close_release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await close_task
+    assert source.closed is True
+    assert service.state is ReconciliationServiceState.CLOSED
+
+
+@pytest.mark.asyncio
+async def test_close_failure_remains_retryable(tmp_path) -> None:
+    service, source, _ = await _service(tmp_path)
+    source.close_error = RuntimeError("cleanup failed")
+
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        await service.close()
+    assert service.state is ReconciliationServiceState.CLOSING
+
+    source.close_error = None
+    await service.close()
+    assert source.closed is True
+    assert service.state is ReconciliationServiceState.CLOSED
+
+
+@pytest.mark.asyncio
+async def test_operator_resolution_retry_is_idempotent_and_conflict_fails(tmp_path) -> None:
+    service, _, persistence = await _service(
+        tmp_path,
+        comparison=_comparison((_difference(DifferenceKind.UNKNOWN),)),
+    )
+    outcome = await service.reconcile_startup()
+    difference_id = outcome.persisted.difference_ids[0]
+    arguments = {
+        "run_id": outcome.persisted.run_id,
+        "difference_id": difference_id,
+        "resolution_kind": OperatorResolutionKind.INVESTIGATION_NOTE,
+        "operator_id": "operator@example.com",
+        "reason": "Reviewed once and retained for another reconciliation.",
+        "evidence_reference": "ticket/RT-206",
+        "created_at": NOW + timedelta(seconds=1),
+    }
+
+    first = await persistence.append_operator_resolution(**arguments)
+    second = await persistence.append_operator_resolution(**arguments)
+
+    assert second == first
+    conflict_arguments = {
+        **arguments,
+        "reason": "A different deterministic resolution payload for conflict testing.",
+        "created_at": NOW + timedelta(seconds=2),
+    }
+    payload = {
+        "created_at": canonical_timestamp(conflict_arguments["created_at"]),
+        "difference_id": difference_id,
+        "evidence_reference": conflict_arguments["evidence_reference"],
+        "operator_id": conflict_arguments["operator_id"],
+        "reason": conflict_arguments["reason"],
+        "resolution_kind": OperatorResolutionKind.INVESTIGATION_NOTE.value,
+        "run_id": outcome.persisted.run_id,
+        "schema_version": 1,
+    }
+    conflict_id = fingerprint("reconciliation-resolution-v1", payload)
+    with sqlite3.connect(tmp_path / "reconciliation.sqlite3") as connection:
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute(
+            """
+            INSERT INTO rt_reconciliation_operator_resolutions(
+                resolution_id, schema_version, run_id, difference_id,
+                resolution_kind, operator_id, reason, evidence_reference, created_at
+            ) VALUES (?, 1, ?, ?, 'investigation_note', 'other-operator',
+                      'conflicting stored evidence', ?, ?)
+            """,
+            (
+                conflict_id,
+                outcome.persisted.run_id,
+                difference_id,
+                conflict_arguments["evidence_reference"],
+                canonical_timestamp(conflict_arguments["created_at"]),
+            ),
+        )
+        connection.commit()
+
+    with pytest.raises(ReconciliationPersistenceError, match="conflicting evidence"):
+        await persistence.append_operator_resolution(**conflict_arguments)
+    with sqlite3.connect(tmp_path / "reconciliation.sqlite3") as connection:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM rt_reconciliation_operator_resolutions"
+        ).fetchone() == (2,)

--- a/tests/test_pr5_reconciliation_runtime.py
+++ b/tests/test_pr5_reconciliation_runtime.py
@@ -464,6 +464,225 @@ async def test_exact_old_v1_schema_upgrades_additively_without_row_loss(tmp_path
         ).fetchall() == [(1,), (2,)]
 
 
+def _rewrite_schema_definition(
+    database_path,
+    object_type: str,
+    name: str,
+    old: str,
+    new: str,
+) -> None:
+    assert object_type in {"table", "trigger"}
+    with sqlite3.connect(database_path) as connection:
+        definition = connection.execute(
+            "SELECT sql FROM sqlite_master WHERE type=? AND name=?",
+            (object_type, name),
+        ).fetchone()
+        assert definition is not None
+        assert definition[0].count(old) == 1
+        replacement = definition[0].replace(old, new, 1)
+        schema_version = connection.execute("PRAGMA schema_version").fetchone()[0]
+        connection.execute("PRAGMA writable_schema = ON")
+        connection.execute(
+            "UPDATE sqlite_master SET sql=? WHERE type=? AND name=?",
+            (replacement, object_type, name),
+        )
+        connection.execute(f"PRAGMA schema_version = {schema_version + 1}")
+        connection.execute("PRAGMA writable_schema = OFF")
+        connection.commit()
+
+
+def _rewrite_table_definition(
+    database_path,
+    table: str,
+    old: str,
+    new: str,
+) -> None:
+    _rewrite_schema_definition(database_path, "table", table, old, new)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("table", "old", "new"),
+    [
+        (
+            "rt_reconciliation_snapshot_lineage",
+            "snapshot_id TEXT PRIMARY KEY NOT NULL",
+            "snapshot_id TEXT UNIQUE NOT NULL",
+        ),
+        (
+            "rt_reconciliation_snapshot_lineage",
+            "schema_version INTEGER NOT NULL CHECK (schema_version = 2)",
+            "schema_version INTEGER NOT NULL",
+        ),
+        (
+            "rt_reconciliation_snapshot_lineage",
+            "length(snapshot_hash) = 64",
+            "length(snapshot_hash) >= 1",
+        ),
+        (
+            "rt_reconciliation_snapshot_lineage",
+            "broker_receipt_id TEXT NOT NULL",
+            "broker_receipt_id TEXT",
+        ),
+        (
+            "rt_reconciliation_snapshot_lineage",
+            "broker_public_key_fingerprint TEXT NOT NULL",
+            "broker_public_key_fingerprint TEXT",
+        ),
+        (
+            "rt_reconciliation_snapshot_lineage",
+            "REFERENCES rt_reconciliation_snapshots(snapshot_id)",
+            "REFERENCES rt_reconciliation_snapshots(snapshot_id) ON DELETE CASCADE",
+        ),
+        (
+            "rt_reconciliation_snapshot_lineage",
+            "persisted_at TEXT NOT NULL,",
+            "persisted_at TEXT NOT NULL, unexpected_column TEXT,",
+        ),
+        (
+            "rt_reconciliation_run_eligibility",
+            "run_id TEXT PRIMARY KEY NOT NULL",
+            "run_id TEXT PRIMARY KEY",
+        ),
+        (
+            "rt_reconciliation_run_eligibility",
+            "eligible_until TEXT NOT NULL",
+            "eligible_until TEXT",
+        ),
+        (
+            "rt_reconciliation_operator_resolution_bindings",
+            "resolution_id TEXT PRIMARY KEY NOT NULL",
+            "resolution_id TEXT PRIMARY KEY",
+        ),
+        (
+            "rt_reconciliation_operator_resolution_bindings",
+            "FOREIGN KEY(run_id, difference_id)",
+            "FOREIGN KEY(difference_id, run_id)",
+        ),
+    ],
+)
+async def test_v2_constraint_mutation_matrix_fails_closed(
+    tmp_path,
+    table: str,
+    old: str,
+    new: str,
+) -> None:
+    database_path = (tmp_path / "reconciliation.sqlite3").resolve()
+    persistence = ReconciliationPersistence(database_path)
+    await persistence.initialize()
+    _rewrite_table_definition(database_path, table, old, new)
+
+    with pytest.raises((RuntimeError, sqlite3.DatabaseError), match="malformed"):
+        await persistence.initialize()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "table",
+    [
+        "rt_reconciliation_snapshot_lineage",
+        "rt_reconciliation_run_eligibility",
+        "rt_reconciliation_operator_resolution_bindings",
+    ],
+)
+@pytest.mark.parametrize(
+    ("suffix", "old", "new"),
+    [
+        ("no_update", "BEFORE UPDATE", "AFTER UPDATE"),
+        ("no_delete", "BEFORE DELETE", "AFTER DELETE"),
+    ],
+)
+async def test_every_v2_append_only_trigger_is_exact(
+    tmp_path,
+    table: str,
+    suffix: str,
+    old: str,
+    new: str,
+) -> None:
+    database_path = (tmp_path / "reconciliation.sqlite3").resolve()
+    persistence = ReconciliationPersistence(database_path)
+    await persistence.initialize()
+    trigger = f"{table}_{suffix}"
+    _rewrite_schema_definition(
+        database_path,
+        "trigger",
+        trigger,
+        old,
+        new,
+    )
+
+    with pytest.raises(RuntimeError, match=f"trigger {trigger} is malformed"):
+        await persistence.initialize()
+
+
+@pytest.mark.asyncio
+async def test_v2_composite_identity_index_mutation_fails_closed(tmp_path) -> None:
+    database_path = (tmp_path / "reconciliation.sqlite3").resolve()
+    persistence = ReconciliationPersistence(database_path)
+    await persistence.initialize()
+    with sqlite3.connect(database_path) as connection:
+        connection.execute("DROP INDEX rt_reconciliation_differences_run_difference_uq")
+        connection.execute(
+            "CREATE UNIQUE INDEX rt_reconciliation_differences_run_difference_uq "
+            "ON rt_reconciliation_differences(difference_id, run_id)"
+        )
+        connection.commit()
+
+    with pytest.raises(RuntimeError, match="composite identity index is malformed"):
+        await persistence.initialize()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("table", "identity_column"),
+    [
+        ("rt_reconciliation_snapshot_lineage", "snapshot_id"),
+        ("rt_reconciliation_run_eligibility", "run_id"),
+    ],
+)
+async def test_v2_duplicate_null_identity_probe_fails_closed(
+    tmp_path,
+    table: str,
+    identity_column: str,
+) -> None:
+    database_path = (tmp_path / "reconciliation.sqlite3").resolve()
+    persistence = ReconciliationPersistence(database_path)
+    await persistence.initialize()
+    constrained = f"{identity_column} TEXT PRIMARY KEY NOT NULL"
+    nullable = f"{identity_column} TEXT PRIMARY KEY"
+    _rewrite_table_definition(database_path, table, constrained, nullable)
+
+    with sqlite3.connect(database_path) as connection:
+        columns = connection.execute(f"PRAGMA table_info({table})").fetchall()
+        names = [str(row[1]) for row in columns]
+        values = []
+        for row in columns:
+            name = str(row[1])
+            if name == identity_column:
+                values.append(None)
+            elif name == "schema_version":
+                values.append(2)
+            elif str(row[2]).upper() == "INTEGER":
+                values.append(1)
+            elif name.endswith("hash") or name.endswith("fingerprint"):
+                values.append("a" * 64)
+            else:
+                values.append("probe")
+        placeholders = ", ".join("?" for _ in names)
+        connection.executemany(
+            f"INSERT INTO {table} ({', '.join(names)}) VALUES ({placeholders})",
+            (values, values),
+        )
+        connection.commit()
+        assert connection.execute(
+            f"SELECT COUNT(*) FROM {table} WHERE {identity_column} IS NULL"
+        ).fetchone() == (2,)
+
+    _rewrite_table_definition(database_path, table, nullable, constrained)
+    with pytest.raises(RuntimeError, match="identity is malformed"):
+        await persistence.initialize()
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("snapshot", "comparison", "reason_code"),

--- a/tests/test_pr5_reconciliation_runtime.py
+++ b/tests/test_pr5_reconciliation_runtime.py
@@ -139,9 +139,20 @@ def _accept_registered_test_runtime_context(monkeypatch) -> None:
         lambda context: context,
     )
     monkeypatch.setattr(runtime_evidence_module, "_comparison_clock", lambda: NOW)
+    monkeypatch.setattr(
+        runtime_evidence_module,
+        "assert_exact_state_runtime_sources_unchanged",
+        lambda evidence, runtime_contract: None,
+    )
     with runtime_evidence_module._COMPARISON_CONSUMPTION_LOCK:
         runtime_evidence_module._CONSUMED_COMPARISON_LINEAGES.clear()
         runtime_evidence_module._COMPARISON_LAST_CLOCK = None
+
+
+def _exact_state_source() -> runtime_evidence_module.ExactStateBootstrapEvidence:
+    source = object.__new__(runtime_evidence_module.ExactStateBootstrapEvidence)
+    object.__setattr__(source, "_producer_digest", "91" * 32)
+    return source
 
 
 def _registered_evidence(
@@ -206,7 +217,7 @@ def _registered_evidence(
             issued_at=NOW - timedelta(microseconds=1),
             expires_at=expires_at,
             _runtime_context=context,
-            _exact_state_evidence=None,
+            _exact_state_evidence=_exact_state_source(),
             _marker=runtime_evidence_module._CAPABILITY_MARKER,
         )
     )
@@ -1096,6 +1107,7 @@ async def test_authenticated_mismatch_is_persisted_with_timing_expiry(
         )
         signed_status = ReconciliationStatus.DEGRADED
     exact_state = SimpleNamespace(
+        _producer_digest="91" * 32,
         authentication_receipts=(reconciliation_receipt,),
         reconciliation_status=signed_status,
         reconciliation_coverage=_coverage(),
@@ -1190,7 +1202,7 @@ async def test_authenticated_mismatch_is_persisted_with_timing_expiry(
     )
     assert outcome.state is expected_state
     assert outcome.entry_eligible is (mismatch_kind == "timing_lag")
-    assert revalidated == [(exact_state, contract)]
+    assert revalidated == [(exact_state, contract), (exact_state, contract)]
     with sqlite3.connect(database_path) as connection:
         persisted_rows = connection.execute(
             "SELECT kind, materiality, reason_code FROM rt_reconciliation_differences"
@@ -1225,6 +1237,31 @@ def test_runtime_capability_is_python310_compatible_immutable_and_nonserializabl
         copy.deepcopy(evidence)
     with pytest.raises(TypeError, match="cannot be pickled"):
         pickle.dumps(evidence)
+
+
+@pytest.mark.parametrize("mutation", ["missing", "substituted"])
+def test_runtime_capability_rejects_raw_exact_state_reference_mutation(
+    tmp_path,
+    monkeypatch,
+    mutation: str,
+) -> None:
+    evidence = _registered_evidence(tmp_path / "reconciliation.sqlite3")
+    revalidated = []
+    monkeypatch.setattr(
+        runtime_evidence_module,
+        "assert_exact_state_runtime_sources_unchanged",
+        lambda source, contract: revalidated.append((source, contract)),
+    )
+    replacement = None if mutation == "missing" else _exact_state_source()
+
+    object.__setattr__(evidence, "_exact_state_evidence", replacement)
+
+    with pytest.raises(
+        RuntimeReconciliationEvidenceError,
+        match="forged, changed, or already consumed",
+    ):
+        assert_and_consume_verified_runtime_reconciliation_evidence(evidence)
+    assert revalidated == []
 
 
 def test_consumed_comparison_cache_is_bounded_and_evicts_only_expired(
@@ -1313,6 +1350,40 @@ async def test_entry_eligibility_revalidates_database_inode_every_time(tmp_path)
 
     assert service.entry_eligible(at=NOW) is False
     assert service.state is ReconciliationServiceState.QUARANTINED
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("replacement_kind", ["database", "exact_state"])
+async def test_post_commit_replacement_blocks_outcome(tmp_path, replacement_kind: str) -> None:
+    service, _, persistence = await _service(tmp_path)
+    database_path = (tmp_path / "reconciliation.sqlite3").resolve()
+
+    class _ReplaceAfterCommitPersistence:
+        async def initialize(self) -> None:
+            await persistence.initialize()
+
+        async def append_reconciliation(self, **kwargs):
+            result = await persistence.append_reconciliation(**kwargs)
+            if replacement_kind == "database":
+                replacement = tmp_path / "replacement-after-commit.sqlite3"
+                sqlite3.connect(replacement).close()
+                os.replace(replacement, database_path)
+            else:
+                object.__setattr__(
+                    kwargs["runtime_evidence"],
+                    "_exact_state_evidence",
+                    _exact_state_source(),
+                )
+            return result
+
+    service._persistence = _ReplaceAfterCommitPersistence()  # type: ignore[assignment]
+
+    with pytest.raises(ReconciliationServiceBlocked, match="failed closed"):
+        await service.reconcile_startup()
+
+    assert service.state is ReconciliationServiceState.QUARANTINED
+    assert service.latest_outcome is None
+    assert service.entry_eligible(at=NOW) is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_pr5_reconciliation_runtime.py
+++ b/tests/test_pr5_reconciliation_runtime.py
@@ -1,0 +1,445 @@
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import aiosqlite
+import pytest
+
+from robo_trader.reconciliation.domain import (
+    BrokerCollectionEvidence,
+    BrokerCollectionKind,
+    BrokerEvidenceCompleteness,
+    NormalizedBrokerAccount,
+    NormalizedBrokerSnapshot,
+)
+from robo_trader.reconciliation.persistence import (
+    OperatorResolutionKind,
+    ReconciliationPersistence,
+)
+from robo_trader.reconciliation.policy import (
+    DifferenceKind,
+    DifferenceMateriality,
+    ReconciliationCoverage,
+    ReconciliationDifference,
+    ReconciliationStatus,
+    evaluate_paper_simulator_reconciliation,
+)
+from robo_trader.reconciliation.service import (
+    ReconciliationComparison,
+    ReconciliationService,
+    ReconciliationServiceBlocked,
+    ReconciliationServiceState,
+    ReconciliationTrigger,
+)
+from robo_trader.reconciliation_migrations import RECONCILIATION_COMPONENT
+
+NOW = datetime(2026, 7, 28, 14, 0, tzinfo=timezone.utc)
+ACCOUNT_SCOPE = "acct_v1_" + "0123456789abcdef" * 4
+
+
+def _collection_evidence(
+    collection: BrokerCollectionKind,
+    observed_at: datetime,
+) -> BrokerCollectionEvidence:
+    digest = hashlib.sha256(f"{collection.value}:{observed_at.isoformat()}".encode()).hexdigest()
+    return BrokerCollectionEvidence(
+        account_scope=ACCOUNT_SCOPE,
+        collection=collection,
+        evidence_id=f"broker-collection-v1-{digest}",
+        result_count=0,
+        observed_at=observed_at,
+    )
+
+
+def _snapshot(
+    *,
+    retrieved_at: datetime = NOW - timedelta(seconds=1),
+    complete: bool = True,
+) -> NormalizedBrokerSnapshot:
+    completeness = BrokerEvidenceCompleteness(
+        account=True,
+        positions=True,
+        open_orders=True,
+        completed_orders=True,
+        executions=True,
+        commissions=complete,
+    )
+    evidence = tuple(
+        _collection_evidence(kind, retrieved_at)
+        for kind in BrokerCollectionKind
+        if complete or kind is not BrokerCollectionKind.COMMISSIONS
+    )
+    return NormalizedBrokerSnapshot(
+        account=NormalizedBrokerAccount(
+            account_scope=ACCOUNT_SCOPE,
+            account_alias="***1234",
+            account_type="paper",
+            base_currency="USD",
+            total_cash=Decimal("25000.00"),
+            buying_power=Decimal("100000.00"),
+            observed_at=retrieved_at,
+        ),
+        observed_from=retrieved_at - timedelta(seconds=1),
+        observed_through=retrieved_at,
+        retrieved_at=retrieved_at,
+        completeness=completeness,
+        collection_evidence=evidence,
+    )
+
+
+def _coverage(**changes: bool) -> ReconciliationCoverage:
+    values = {
+        "broker_account": True,
+        "broker_positions": True,
+        "broker_open_orders": True,
+        "broker_completed_orders": True,
+        "broker_executions": True,
+        "broker_commissions": True,
+        "ledger_positions": True,
+        "ledger_orders": True,
+        "ledger_executions": True,
+        "ledger_cash": True,
+    }
+    values.update(changes)
+    return ReconciliationCoverage(**values)
+
+
+class _SnapshotSource:
+    def __init__(self, snapshot: NormalizedBrokerSnapshot) -> None:
+        self.snapshot = snapshot
+        self.calls = 0
+        self.closed = False
+        self.error: Exception | None = None
+
+    async def collect_normalized_snapshot(
+        self, *, max_age_seconds: float
+    ) -> NormalizedBrokerSnapshot:
+        assert max_age_seconds == 30.0
+        self.calls += 1
+        if self.error is not None:
+            raise self.error
+        return self.snapshot
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _Clock:
+    def __init__(self, current: datetime = NOW) -> None:
+        self.current = current
+
+    def __call__(self) -> datetime:
+        return self.current
+
+    def advance(self, seconds: float) -> None:
+        self.current += timedelta(seconds=seconds)
+
+
+def _comparison(
+    differences: tuple[ReconciliationDifference, ...] = (),
+    *,
+    coverage: ReconciliationCoverage | None = None,
+):
+    def compare(
+        snapshot: NormalizedBrokerSnapshot,
+        trigger: ReconciliationTrigger,
+    ) -> ReconciliationComparison:
+        assert snapshot.account.account_scope == ACCOUNT_SCOPE
+        assert type(trigger) is ReconciliationTrigger
+        return ReconciliationComparison(coverage or _coverage(), differences)
+
+    return compare
+
+
+def _difference(kind: DifferenceKind) -> ReconciliationDifference:
+    materiality = (
+        DifferenceMateriality.UNKNOWN
+        if kind is DifferenceKind.UNKNOWN
+        else DifferenceMateriality.MATERIAL
+    )
+    return ReconciliationDifference(
+        kind=kind,
+        materiality=materiality,
+        reason_code=f"TEST_{kind.value.upper()}",
+        subject="AAPL",
+    )
+
+
+async def _service(
+    tmp_path,
+    *,
+    snapshot: NormalizedBrokerSnapshot | None = None,
+    comparison=None,
+    clock: _Clock | None = None,
+) -> tuple[ReconciliationService, _SnapshotSource, ReconciliationPersistence]:
+    source = _SnapshotSource(snapshot or _snapshot())
+    persistence = ReconciliationPersistence((tmp_path / "reconciliation.sqlite3").resolve())
+    service = ReconciliationService(
+        snapshot_source=source,
+        comparison_source=comparison or _comparison(),
+        persistence=persistence,
+        expected_account_scope=ACCOUNT_SCOPE,
+        max_age_seconds=30,
+        periodic_interval_seconds=15,
+        clock=clock or _Clock(),
+    )
+    return service, source, persistence
+
+
+@pytest.mark.asyncio
+async def test_clean_startup_is_durable_and_entry_eligible(tmp_path) -> None:
+    service, _, _ = await _service(tmp_path)
+
+    outcome = await service.reconcile_startup()
+
+    assert outcome.trigger is ReconciliationTrigger.STARTUP
+    assert outcome.state is ReconciliationServiceState.READY
+    assert outcome.verdict.status is ReconciliationStatus.PASSED
+    assert outcome.entry_eligible is True
+    assert service.entry_eligible(at=NOW) is True
+    with sqlite3.connect(tmp_path / "reconciliation.sqlite3") as connection:
+        assert connection.execute(
+            "SELECT component, version FROM rt_schema_migrations"
+        ).fetchall() == [(RECONCILIATION_COMPONENT, 1)]
+        assert connection.execute(
+            "SELECT trigger_type, status, entry_eligible FROM rt_reconciliation_runs"
+        ).fetchall() == [("startup", "passed", 1)]
+        assert connection.execute(
+            "SELECT COUNT(*) FROM rt_reconciliation_snapshots"
+        ).fetchone() == (1,)
+
+
+@pytest.mark.asyncio
+async def test_component_migration_preserves_unrelated_schema_and_rows(tmp_path) -> None:
+    database_path = (tmp_path / "reconciliation.sqlite3").resolve()
+    async with aiosqlite.connect(database_path) as connection:
+        await connection.execute(
+            "CREATE TABLE legacy_user_history (event_id TEXT PRIMARY KEY, payload TEXT NOT NULL)"
+        )
+        await connection.execute(
+            "INSERT INTO legacy_user_history VALUES ('event-1', 'irreplaceable')"
+        )
+        await connection.commit()
+    persistence = ReconciliationPersistence(database_path)
+
+    await persistence.initialize()
+    await persistence.initialize()
+
+    with sqlite3.connect(database_path) as connection:
+        assert connection.execute("SELECT * FROM legacy_user_history").fetchall() == [
+            ("event-1", "irreplaceable")
+        ]
+        assert connection.execute(
+            "SELECT component, version FROM rt_schema_migrations"
+        ).fetchall() == [(RECONCILIATION_COMPONENT, 1)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("snapshot", "comparison", "reason_code"),
+    [
+        (
+            _snapshot(retrieved_at=NOW - timedelta(minutes=1)),
+            _comparison(),
+            "BROKER_EVIDENCE_STALE",
+        ),
+        (_snapshot(complete=False), _comparison(), "BROKER_EVIDENCE_INCOMPLETE"),
+        (
+            _snapshot(),
+            _comparison((_difference(DifferenceKind.QUANTITY_MISMATCH),)),
+            "TEST_QUANTITY_MISMATCH",
+        ),
+        (
+            _snapshot(),
+            _comparison((_difference(DifferenceKind.UNKNOWN),)),
+            "TEST_UNKNOWN",
+        ),
+        (
+            _snapshot(),
+            _comparison(coverage=_coverage(ledger_cash=False)),
+            "LOCAL_COMPARISON_INCOMPLETE",
+        ),
+    ],
+)
+async def test_stale_incomplete_material_and_unknown_evidence_quarantine(
+    tmp_path,
+    snapshot: NormalizedBrokerSnapshot,
+    comparison,
+    reason_code: str,
+) -> None:
+    service, _, _ = await _service(
+        tmp_path,
+        snapshot=snapshot,
+        comparison=comparison,
+    )
+
+    outcome = await service.reconcile_startup()
+
+    assert outcome.state is ReconciliationServiceState.QUARANTINED
+    assert outcome.entry_eligible is False
+    assert service.entry_eligible(at=NOW) is False
+    assert reason_code in {difference.reason_code for difference in outcome.verdict.differences}
+    with sqlite3.connect(tmp_path / "reconciliation.sqlite3") as connection:
+        assert connection.execute(
+            "SELECT status, entry_eligible FROM rt_reconciliation_runs"
+        ).fetchone() == ("quarantined", 0)
+        assert reason_code in {
+            row[0]
+            for row in connection.execute(
+                "SELECT reason_code FROM rt_reconciliation_differences"
+            ).fetchall()
+        }
+
+
+@pytest.mark.asyncio
+async def test_reconnect_and_due_periodic_generations_are_serialized(tmp_path) -> None:
+    clock = _Clock()
+    service, source, _ = await _service(tmp_path, clock=clock)
+    await service.reconcile_startup()
+    clock.advance(1)
+    await service.reconcile_reconnect()
+    clock.advance(5)
+
+    assert await service.reconcile_periodic_if_due() is None
+    clock.advance(10)
+    periodic = await service.reconcile_periodic_if_due()
+
+    assert periodic is not None
+    assert periodic.trigger is ReconciliationTrigger.PERIODIC
+    assert source.calls == 3
+    with sqlite3.connect(tmp_path / "reconciliation.sqlite3") as connection:
+        assert connection.execute(
+            "SELECT trigger_type FROM rt_reconciliation_runs ORDER BY completed_at, rowid"
+        ).fetchall() == [("startup",), ("reconnect",), ("periodic",)]
+
+
+@pytest.mark.asyncio
+async def test_eligibility_expires_without_waiting_for_another_periodic_run(tmp_path) -> None:
+    clock = _Clock()
+    service, _, _ = await _service(tmp_path, clock=clock)
+    await service.reconcile_startup()
+
+    clock.advance(31)
+
+    assert service.entry_eligible() is False
+
+
+@pytest.mark.asyncio
+async def test_partial_migration_fails_closed_without_using_runtime_state(tmp_path) -> None:
+    database_path = (tmp_path / "reconciliation.sqlite3").resolve()
+    async with aiosqlite.connect(database_path) as connection:
+        await connection.execute("""
+            CREATE TABLE rt_schema_migrations (
+                component TEXT NOT NULL,
+                version INTEGER NOT NULL,
+                description TEXT NOT NULL,
+                applied_at TEXT NOT NULL,
+                PRIMARY KEY(component, version)
+            )
+        """)
+        await connection.execute(
+            "INSERT INTO rt_schema_migrations VALUES (?, 1, 'incomplete', ?)",
+            (RECONCILIATION_COMPONENT, "2026-07-28T14:00:00Z"),
+        )
+        await connection.commit()
+    source = _SnapshotSource(_snapshot())
+    service = ReconciliationService(
+        snapshot_source=source,
+        comparison_source=_comparison(),
+        persistence=ReconciliationPersistence(database_path),
+        expected_account_scope=ACCOUNT_SCOPE,
+    )
+
+    with pytest.raises(ReconciliationServiceBlocked, match="initialization failed"):
+        await service.reconcile_startup()
+
+    assert service.state is ReconciliationServiceState.QUARANTINED
+    assert service.entry_eligible(at=NOW) is False
+    assert source.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_duplicate_append_is_idempotent_not_a_duplicate_callback(tmp_path) -> None:
+    persistence = ReconciliationPersistence((tmp_path / "reconciliation.sqlite3").resolve())
+    await persistence.initialize()
+    snapshot = _snapshot()
+    verdict = evaluate_paper_simulator_reconciliation(
+        snapshot,
+        _coverage(),
+        expected_account_scope=ACCOUNT_SCOPE,
+        now=NOW,
+        max_age_seconds=30,
+    )
+
+    first = await persistence.append_reconciliation(
+        trigger_type="startup",
+        snapshot=snapshot,
+        verdict=verdict,
+        started_at=NOW,
+        completed_at=NOW,
+    )
+    second = await persistence.append_reconciliation(
+        trigger_type="startup",
+        snapshot=snapshot,
+        verdict=verdict,
+        started_at=NOW,
+        completed_at=NOW,
+    )
+
+    assert second == first
+    with sqlite3.connect(tmp_path / "reconciliation.sqlite3") as connection:
+        assert connection.execute("SELECT COUNT(*) FROM rt_reconciliation_runs").fetchone() == (1,)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM rt_reconciliation_snapshots"
+        ).fetchone() == (1,)
+
+
+@pytest.mark.asyncio
+async def test_operator_resolution_appends_without_replacing_quarantine(tmp_path) -> None:
+    service, _, persistence = await _service(
+        tmp_path,
+        comparison=_comparison((_difference(DifferenceKind.UNKNOWN),)),
+    )
+    outcome = await service.reconcile_startup()
+    difference_id = outcome.persisted.difference_ids[0]
+
+    event = await persistence.append_operator_resolution(
+        run_id=outcome.persisted.run_id,
+        difference_id=difference_id,
+        resolution_kind=OperatorResolutionKind.INVESTIGATION_NOTE,
+        operator_id="operator@example.com",
+        reason="Broker evidence reviewed; external investigation remains open.",
+        evidence_reference="ticket/RT-205",
+        created_at=NOW + timedelta(seconds=1),
+    )
+
+    assert event.difference_id == difference_id
+    assert service.state is ReconciliationServiceState.QUARANTINED
+    assert service.entry_eligible(at=NOW + timedelta(seconds=1)) is False
+    with sqlite3.connect(tmp_path / "reconciliation.sqlite3") as connection:
+        assert connection.execute(
+            "SELECT status, entry_eligible FROM rt_reconciliation_runs"
+        ).fetchone() == ("quarantined", 0)
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            connection.execute(
+                "UPDATE rt_reconciliation_operator_resolutions SET reason = 'replacement'"
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            connection.execute("DELETE FROM rt_reconciliation_differences")
+
+
+@pytest.mark.asyncio
+async def test_service_failure_clears_prior_entry_eligibility(tmp_path) -> None:
+    service, source, _ = await _service(tmp_path)
+    await service.reconcile_startup()
+    source.error = RuntimeError("diagnostic collection failed")
+
+    with pytest.raises(ReconciliationServiceBlocked, match="failed closed"):
+        await service.reconcile_reconnect()
+
+    assert service.state is ReconciliationServiceState.QUARANTINED
+    assert service.latest_outcome is None
+    assert service.entry_eligible(at=NOW) is False

--- a/tests/test_pr5_reconciliation_runtime.py
+++ b/tests/test_pr5_reconciliation_runtime.py
@@ -1387,6 +1387,76 @@ async def test_post_commit_replacement_blocks_outcome(tmp_path, replacement_kind
 
 
 @pytest.mark.asyncio
+async def test_post_persistence_timing_proof_deadline_blocks_positive_outcome(tmp_path) -> None:
+    clock = _Clock()
+    snapshot = _snapshot()
+    broker_event_id = "broker-event-v1-" + "e5" * 32
+    lag = ReconciliationDifference(
+        kind=DifferenceKind.EXPECTED_TIMING_LAG,
+        materiality=DifferenceMateriality.INFORMATIONAL,
+        reason_code="BROKER_ORDER_EVENT_PENDING",
+        subject="AAPL",
+        evidence_ids=(broker_event_id,),
+    )
+    proof = ExpectedTimingLagProof.from_trusted_producer(
+        broker_snapshot_id=snapshot.snapshot_id,
+        reason_code=lag.reason_code,
+        subject=lag.subject,
+        broker_event_id=broker_event_id,
+        started_at=NOW - timedelta(seconds=1),
+        expires_at=NOW + timedelta(seconds=5),
+    )
+    service, _, persistence = await _service(
+        tmp_path,
+        snapshot=snapshot,
+        comparison=_comparison((lag,), timing_lag_proofs=(proof,)),
+        clock=clock,
+    )
+
+    class _AdvancePastDeadlineAfterPersistence:
+        async def initialize(self) -> None:
+            await persistence.initialize()
+
+        async def append_reconciliation(self, **kwargs):
+            result = await persistence.append_reconciliation(**kwargs)
+            clock.current = proof.expires_at + timedelta(microseconds=1)
+            return result
+
+    service._persistence = _AdvancePastDeadlineAfterPersistence()  # type: ignore[assignment]
+
+    with pytest.raises(ReconciliationServiceBlocked, match="eligibility expired"):
+        await service.reconcile_startup()
+
+    assert service.state is ReconciliationServiceState.QUARANTINED
+    assert service.latest_outcome is None
+    assert service.entry_eligible(at=clock.current) is False
+
+
+@pytest.mark.asyncio
+async def test_post_persistence_clock_rollback_blocks_positive_outcome(tmp_path) -> None:
+    clock = _Clock()
+    service, _, persistence = await _service(tmp_path, clock=clock)
+
+    class _RollBackClockAfterPersistence:
+        async def initialize(self) -> None:
+            await persistence.initialize()
+
+        async def append_reconciliation(self, **kwargs):
+            result = await persistence.append_reconciliation(**kwargs)
+            clock.current = kwargs["completed_at"] - timedelta(microseconds=1)
+            return result
+
+    service._persistence = _RollBackClockAfterPersistence()  # type: ignore[assignment]
+
+    with pytest.raises(ReconciliationServiceBlocked, match="clock moved backwards"):
+        await service.reconcile_startup()
+
+    assert service.state is ReconciliationServiceState.QUARANTINED
+    assert service.latest_outcome is None
+    assert service.entry_eligible(at=NOW) is False
+
+
+@pytest.mark.asyncio
 async def test_comparison_substitution_and_capability_reuse_are_rejected(tmp_path) -> None:
     service, source, _ = await _service(tmp_path)
     evidence = _registered_evidence(tmp_path / "reconciliation.sqlite3")

--- a/tests/test_pr5_reconciliation_runtime.py
+++ b/tests/test_pr5_reconciliation_runtime.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import hashlib
 import os
+import pickle
 import sqlite3
+import weakref
+from dataclasses import FrozenInstanceError
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from types import SimpleNamespace
@@ -12,6 +16,7 @@ import aiosqlite
 import pytest
 
 from robo_trader import bootstrap_evidence_receivers as receiver_module
+from robo_trader import reconciliation_migrations as migrations_module
 from robo_trader.bootstrap_evidence_receivers import (
     ProtectiveMarkBundleIdentity,
     VerifiedBrokerEvidenceEnvelope,
@@ -48,7 +53,6 @@ from robo_trader.reconciliation.runtime_evidence import (
     bind_verified_runtime_reconciliation_evidence,
 )
 from robo_trader.reconciliation.service import (
-    ReconciliationComparison,
     ReconciliationService,
     ReconciliationServiceBlocked,
     ReconciliationServiceState,
@@ -141,6 +145,9 @@ def _registered_evidence(
     *,
     snapshot: NormalizedBrokerSnapshot | None = None,
     expires_at: datetime = NOW + timedelta(seconds=29),
+    coverage: ReconciliationCoverage | None = None,
+    differences: tuple[ReconciliationDifference, ...] = (),
+    timing_lag_proofs: tuple[ExpectedTimingLagProof, ...] = (),
 ) -> VerifiedRuntimeReconciliationEvidence:
     path = database_path.resolve()
     path.touch(exist_ok=True)
@@ -169,6 +176,9 @@ def _registered_evidence(
             snapshot=broker_snapshot,
             snapshot_id=broker_snapshot.snapshot_id,
             snapshot_hash=snapshot_hash,
+            comparison_coverage=coverage or _coverage(),
+            differences=differences,
+            timing_lag_proofs=timing_lag_proofs,
             bundle_id="bootstrap-evidence-bundle-v1-" + "a1" * 32,
             runtime_fingerprint=contract.fingerprint,
             account_scope=ACCOUNT_SCOPE,
@@ -180,6 +190,15 @@ def _registered_evidence(
             broker_artifact_hash="b2" * 32,
             broker_receipt_id="receipt-v1-" + "c3" * 32,
             broker_public_key_fingerprint="d4" * 32,
+            broker_evidence_expires_at=expires_at,
+            reconciliation_snapshot_id="bootstrap-reconciliation-v1-" + "e5" * 32,
+            reconciliation_artifact_path=str(path.parent / "reconciliation_report.json"),
+            reconciliation_artifact_hash="f6" * 32,
+            reconciliation_receipt_id="bevr-v2-" + "a7" * 32,
+            reconciliation_public_key_fingerprint="b8" * 32,
+            reconciliation_signature_ed25519="c2lnbmF0dXJl",
+            reconciliation_evidence_issued_at=NOW - timedelta(microseconds=1),
+            reconciliation_evidence_expires_at=expires_at,
             issued_at=NOW - timedelta(microseconds=1),
             expires_at=expires_at,
             _runtime_context=context,
@@ -189,7 +208,7 @@ def _registered_evidence(
 
 
 class _EvidenceSource:
-    def __init__(self, database_path, snapshot: NormalizedBrokerSnapshot) -> None:
+    def __init__(self, database_path, snapshot: NormalizedBrokerSnapshot, comparison) -> None:
         self.database_path = database_path
         self.snapshot = snapshot
         self.calls = 0
@@ -200,6 +219,7 @@ class _EvidenceSource:
         self.close_release = None
         self.expires_at = NOW + timedelta(seconds=29)
         self.prepared_evidence: object | None = None
+        self.comparison = comparison
 
     async def collect_verified_evidence(
         self, *, max_age_seconds: float
@@ -216,6 +236,9 @@ class _EvidenceSource:
             self.database_path,
             snapshot=self.snapshot,
             expires_at=self.expires_at,
+            coverage=self.comparison.coverage,
+            differences=self.comparison.differences,
+            timing_lag_proofs=self.comparison.timing_lag_proofs,
         )
 
     async def close(self) -> None:
@@ -245,19 +268,11 @@ def _comparison(
     coverage: ReconciliationCoverage | None = None,
     timing_lag_proofs: tuple[ExpectedTimingLagProof, ...] = (),
 ):
-    def compare(
-        snapshot: NormalizedBrokerSnapshot,
-        trigger: ReconciliationTrigger,
-    ) -> ReconciliationComparison:
-        assert snapshot.account.account_scope == ACCOUNT_SCOPE
-        assert type(trigger) is ReconciliationTrigger
-        return ReconciliationComparison(
-            coverage or _coverage(),
-            differences,
-            timing_lag_proofs,
-        )
-
-    return compare
+    return SimpleNamespace(
+        coverage=coverage or _coverage(),
+        differences=differences,
+        timing_lag_proofs=timing_lag_proofs,
+    )
 
 
 def _difference(kind: DifferenceKind) -> ReconciliationDifference:
@@ -282,11 +297,10 @@ async def _service(
     clock: _Clock | None = None,
 ) -> tuple[ReconciliationService, _EvidenceSource, ReconciliationPersistence]:
     database_path = (tmp_path / "reconciliation.sqlite3").resolve()
-    source = _EvidenceSource(database_path, snapshot or _snapshot())
+    source = _EvidenceSource(database_path, snapshot or _snapshot(), comparison or _comparison())
     persistence = ReconciliationPersistence(database_path)
     service = ReconciliationService(
         evidence_source=source,
-        comparison_source=comparison or _comparison(),
         persistence=persistence,
         expected_account_scope=ACCOUNT_SCOPE,
         max_age_seconds=30,
@@ -310,7 +324,7 @@ async def test_clean_startup_is_durable_and_entry_eligible(tmp_path) -> None:
     with sqlite3.connect(tmp_path / "reconciliation.sqlite3") as connection:
         assert connection.execute(
             "SELECT component, version FROM rt_schema_migrations"
-        ).fetchall() == [(RECONCILIATION_COMPONENT, 1)]
+        ).fetchall() == [(RECONCILIATION_COMPONENT, 1), (RECONCILIATION_COMPONENT, 2)]
         assert connection.execute(
             "SELECT trigger_type, status, entry_eligible FROM rt_reconciliation_runs"
         ).fetchall() == [("startup", "passed", 1)]
@@ -341,7 +355,113 @@ async def test_component_migration_preserves_unrelated_schema_and_rows(tmp_path)
         ]
         assert connection.execute(
             "SELECT component, version FROM rt_schema_migrations"
-        ).fetchall() == [(RECONCILIATION_COMPONENT, 1)]
+        ).fetchall() == [(RECONCILIATION_COMPONENT, 1), (RECONCILIATION_COMPONENT, 2)]
+
+
+@pytest.mark.asyncio
+async def test_exact_old_v1_schema_upgrades_additively_without_row_loss(tmp_path) -> None:
+    database_path = (tmp_path / "reconciliation.sqlite3").resolve()
+    account_scope = ACCOUNT_SCOPE
+    payload = "{}"
+    digest = hashlib.sha256(payload.encode()).hexdigest()
+    async with aiosqlite.connect(database_path) as connection:
+        await connection.execute("PRAGMA foreign_keys = ON")
+        await connection.execute("BEGIN IMMEDIATE")
+        await migrations_module._migration_v1(connection)
+        await connection.execute("""
+            CREATE TABLE rt_schema_migrations (
+                component TEXT NOT NULL,
+                version INTEGER NOT NULL,
+                description TEXT NOT NULL,
+                applied_at TEXT NOT NULL,
+                PRIMARY KEY(component, version)
+            )
+        """)
+        await connection.execute(
+            "INSERT INTO rt_schema_migrations VALUES (?, 1, 'old-v1', ?)",
+            (RECONCILIATION_COMPONENT, canonical_timestamp(NOW)),
+        )
+        await connection.execute(
+            "INSERT INTO rt_reconciliation_snapshots VALUES (?, 1, ?, ?, ?, ?, 1, ?, ?, ?)",
+            (
+                "snapshot-old-v1",
+                account_scope,
+                canonical_timestamp(NOW),
+                canonical_timestamp(NOW),
+                canonical_timestamp(NOW),
+                payload,
+                digest,
+                canonical_timestamp(NOW),
+            ),
+        )
+        await connection.execute(
+            """
+            INSERT INTO rt_reconciliation_runs VALUES (
+                ?, 1, 'startup', ?, ?, ?, ?, ?, 'quarantined',
+                1, 1, 1, 0, ?, ?, ?
+            )
+            """,
+            (
+                "run-old-v1",
+                "snapshot-old-v1",
+                "verdict-old-v1",
+                account_scope,
+                canonical_timestamp(NOW),
+                canonical_timestamp(NOW),
+                payload,
+                payload,
+                digest,
+            ),
+        )
+        await connection.execute(
+            """
+            INSERT INTO rt_reconciliation_differences VALUES (
+                ?, ?, 0, 'unknown', 'unknown', 'OLD_V1_UNKNOWN',
+                'AAPL', '[]', ?, ?, ?
+            )
+            """,
+            (
+                "difference-old-v1",
+                "run-old-v1",
+                payload,
+                digest,
+                canonical_timestamp(NOW),
+            ),
+        )
+        await connection.execute(
+            "INSERT INTO rt_reconciliation_operator_resolutions VALUES (?, 1, ?, ?, ?, ?, ?, NULL, ?)",
+            (
+                "resolution-old-v1",
+                "run-old-v1",
+                "difference-old-v1",
+                "investigation_note",
+                "operator",
+                "preserve exact old v1 evidence",
+                canonical_timestamp(NOW),
+            ),
+        )
+        await connection.commit()
+
+    await ReconciliationPersistence(database_path).initialize()
+
+    with sqlite3.connect(database_path) as connection:
+        assert connection.execute(
+            "SELECT snapshot_id FROM rt_reconciliation_snapshots"
+        ).fetchall() == [("snapshot-old-v1",)]
+        assert connection.execute("SELECT run_id FROM rt_reconciliation_runs").fetchall() == [
+            ("run-old-v1",)
+        ]
+        assert connection.execute(
+            "SELECT difference_id FROM rt_reconciliation_differences"
+        ).fetchall() == [("difference-old-v1",)]
+        assert connection.execute(
+            "SELECT resolution_id, run_id, difference_id "
+            "FROM rt_reconciliation_operator_resolution_bindings"
+        ).fetchall() == [("resolution-old-v1", "run-old-v1", "difference-old-v1")]
+        assert connection.execute(
+            "SELECT version FROM rt_schema_migrations WHERE component=? ORDER BY version",
+            (RECONCILIATION_COMPONENT,),
+        ).fetchall() == [(1,), (2,)]
 
 
 @pytest.mark.asyncio
@@ -452,10 +572,9 @@ async def test_partial_migration_fails_closed_without_using_runtime_state(tmp_pa
             (RECONCILIATION_COMPONENT, "2026-07-28T14:00:00Z"),
         )
         await connection.commit()
-    source = _EvidenceSource(database_path, _snapshot())
+    source = _EvidenceSource(database_path, _snapshot(), _comparison())
     service = ReconciliationService(
         evidence_source=source,
-        comparison_source=_comparison(),
         persistence=ReconciliationPersistence(database_path),
         expected_account_scope=ACCOUNT_SCOPE,
     )
@@ -612,7 +731,7 @@ def test_core_broker_and_bundle_assertions_issue_one_shot_runtime_evidence(
     bundle = ProtectiveMarkBundleIdentity(
         receiver_type=object,
         bundle_id="bootstrap-evidence-bundle-v1-" + "a1" * 32,
-        reconciliation_snapshot_id="reconciliation-v1-" + "f6" * 32,
+        reconciliation_snapshot_id="bootstrap-reconciliation-v1-" + "e5" * 32,
         broker_snapshot_id=snapshot.snapshot_id,
         broker_snapshot_hash=snapshot_hash,
         broker_artifact_hash=broker.artifact_hash,
@@ -625,6 +744,35 @@ def test_core_broker_and_bundle_assertions_issue_one_shot_runtime_evidence(
         database_inode=metadata.st_ino,
     )
     asserted = []
+    reconciliation_receipt = SimpleNamespace(
+        artifact_kind="reconciliation_report",
+        artifact_sha256="f6" * 32,
+        runtime_fingerprint=contract.fingerprint,
+        account_scope=ACCOUNT_SCOPE,
+        issued_at=NOW - timedelta(microseconds=1),
+        expires_at=NOW + timedelta(seconds=29),
+        receipt_id="bevr-v2-" + "a7" * 32,
+        public_key_fingerprint="b8" * 32,
+        signature_ed25519="c2lnbmF0dXJl",
+    )
+    exact_state = SimpleNamespace(
+        authentication_receipts=(reconciliation_receipt,),
+        reconciliation_status=ReconciliationStatus.PASSED,
+        reconciliation_coverage=_coverage(),
+        reconciliation_snapshot_id=bundle.reconciliation_snapshot_id,
+        reconciliation_artifact_path=str(database_path.parent / "reconciliation_report.json"),
+        reconciliation_report_hash=reconciliation_receipt.artifact_sha256,
+        reconciliation_generated_at=NOW - timedelta(microseconds=2),
+        bundle_id=bundle.bundle_id,
+        runtime_fingerprint=contract.fingerprint,
+        account_scope=ACCOUNT_SCOPE,
+        database_path=str(database_path),
+        database_identity=contract.database_identity,
+        database_device=metadata.st_dev,
+        database_inode=metadata.st_ino,
+        broker_snapshot_id=broker.snapshot_id,
+        broker_snapshot_hash=broker.artifact_hash,
+    )
 
     def assert_broker(value):
         asserted.append("broker")
@@ -637,6 +785,12 @@ def test_core_broker_and_bundle_assertions_issue_one_shot_runtime_evidence(
         assert runtime_contract is contract
         return bundle
 
+    def assert_exact(value, runtime_contract):
+        asserted.append("reconciliation")
+        assert value is exact_state
+        assert runtime_contract is contract
+        return exact_state
+
     marker = object()
     monkeypatch.setattr(
         runtime_evidence_module,
@@ -648,15 +802,67 @@ def test_core_broker_and_bundle_assertions_issue_one_shot_runtime_evidence(
         "assert_protective_mark_receiver_capability",
         assert_bundle,
     )
+    monkeypatch.setattr(
+        runtime_evidence_module,
+        "assert_verified_exact_state_reconciliation_evidence",
+        assert_exact,
+    )
+    monkeypatch.setattr(
+        runtime_evidence_module,
+        "ExactStateBootstrapEvidence",
+        SimpleNamespace,
+    )
 
-    evidence = bind_verified_runtime_reconciliation_evidence(broker, context, marker)
+    evidence = bind_verified_runtime_reconciliation_evidence(
+        broker,
+        exact_state,
+        context,
+        marker,
+    )
 
-    assert asserted == ["broker", "bundle"]
+    assert asserted == ["broker", "reconciliation", "bundle"]
     assert evidence.database_device == metadata.st_dev
     assert evidence.database_inode == metadata.st_ino
+    with pytest.raises(RuntimeReconciliationEvidenceError, match="already consumed"):
+        bind_verified_runtime_reconciliation_evidence(
+            broker,
+            exact_state,
+            context,
+            marker,
+        )
     assert assert_and_consume_verified_runtime_reconciliation_evidence(evidence) is evidence
     with pytest.raises(RuntimeReconciliationEvidenceError, match="already consumed"):
         assert_and_consume_verified_runtime_reconciliation_evidence(evidence)
+
+
+def test_runtime_capability_is_python310_compatible_immutable_and_nonserializable(
+    tmp_path,
+) -> None:
+    evidence = _registered_evidence(tmp_path / "reconciliation.sqlite3")
+
+    assert weakref.ref(evidence)() is evidence
+    assert not hasattr(evidence, "__dict__")
+    with pytest.raises(FrozenInstanceError):
+        evidence.bundle_id = "changed"  # type: ignore[misc]
+    with pytest.raises(TypeError, match="cannot be copied"):
+        copy.copy(evidence)
+    with pytest.raises(TypeError, match="cannot be copied"):
+        copy.deepcopy(evidence)
+    with pytest.raises(TypeError, match="cannot be pickled"):
+        pickle.dumps(evidence)
+
+
+@pytest.mark.asyncio
+async def test_public_comparison_callable_is_not_an_accepted_service_boundary(tmp_path) -> None:
+    database_path = (tmp_path / "reconciliation.sqlite3").resolve()
+    source = _EvidenceSource(database_path, _snapshot(), _comparison())
+    with pytest.raises(TypeError, match="comparison_source"):
+        ReconciliationService(  # type: ignore[call-arg]
+            evidence_source=source,
+            comparison_source=lambda *_: _comparison(),
+            persistence=ReconciliationPersistence(database_path),
+            expected_account_scope=ACCOUNT_SCOPE,
+        )
 
 
 @pytest.mark.asyncio
@@ -676,6 +882,42 @@ async def test_replaced_database_blocks_exact_prepared_evidence(tmp_path) -> Non
 
 
 @pytest.mark.asyncio
+async def test_entry_eligibility_revalidates_database_inode_every_time(tmp_path) -> None:
+    service, _, _ = await _service(tmp_path)
+    await service.reconcile_startup()
+    assert service.entry_eligible(at=NOW) is True
+    database_path = tmp_path / "reconciliation.sqlite3"
+    replacement = tmp_path / "replacement-after-reconcile.sqlite3"
+    sqlite3.connect(replacement).close()
+    os.replace(replacement, database_path)
+
+    assert service.entry_eligible(at=NOW) is False
+    assert service.state is ReconciliationServiceState.QUARANTINED
+
+
+@pytest.mark.asyncio
+async def test_comparison_substitution_and_capability_reuse_are_rejected(tmp_path) -> None:
+    service, source, _ = await _service(tmp_path)
+    evidence = _registered_evidence(tmp_path / "reconciliation.sqlite3")
+    object.__setattr__(evidence, "comparison_coverage", _coverage(ledger_cash=False))
+    source.prepared_evidence = evidence
+
+    with pytest.raises(ReconciliationServiceBlocked, match="failed closed"):
+        await service.reconcile_startup()
+    assert service.state is ReconciliationServiceState.QUARANTINED
+
+    replay_directory = tmp_path / "replay"
+    replay_directory.mkdir()
+    replay_service, replay_source, _ = await _service(replay_directory)
+    replay = _registered_evidence(replay_directory / "reconciliation.sqlite3")
+    replay_source.prepared_evidence = replay
+    await replay_service.reconcile_startup()
+    replay_source.prepared_evidence = replay
+    with pytest.raises(ReconciliationServiceBlocked, match="failed closed"):
+        await replay_service.reconcile_reconnect()
+
+
+@pytest.mark.asyncio
 async def test_persisted_snapshot_contains_full_runtime_and_broker_binding(tmp_path) -> None:
     service, _, _ = await _service(tmp_path)
     outcome = await service.reconcile_startup()
@@ -686,8 +928,14 @@ async def test_persisted_snapshot_contains_full_runtime_and_broker_binding(tmp_p
             SELECT runtime_fingerprint, account_scope, account_alias,
                    database_identity, database_device, database_inode,
                    broker_artifact_hash, broker_receipt_id,
-                   broker_public_key_fingerprint, bundle_id, snapshot_hash
-            FROM rt_reconciliation_snapshots WHERE snapshot_id = ?
+                   broker_public_key_fingerprint, bundle_id, snapshot_hash,
+                   reconciliation_snapshot_id, reconciliation_artifact_hash,
+                   reconciliation_receipt_id,
+                   reconciliation_public_key_fingerprint,
+                   reconciliation_signature_ed25519
+            FROM rt_reconciliation_snapshots AS snapshots
+            JOIN rt_reconciliation_snapshot_lineage AS lineage USING(snapshot_id)
+            WHERE snapshot_id = ?
             """,
             (outcome.persisted.snapshot_id,),
         ).fetchone()
@@ -702,6 +950,11 @@ async def test_persisted_snapshot_contains_full_runtime_and_broker_binding(tmp_p
     assert row[8] == "d4" * 32
     assert row[9].startswith("bootstrap-evidence-bundle-v1-")
     assert len(row[10]) == 64
+    assert row[11].startswith("bootstrap-reconciliation-v1-")
+    assert row[12] == "f6" * 32
+    assert row[13] == "bevr-v2-" + "a7" * 32
+    assert row[14] == "b8" * 32
+    assert row[15] == "c2lnbmF0dXJl"
 
 
 @pytest.mark.asyncio

--- a/tests/test_pr5_reconciliation_runtime.py
+++ b/tests/test_pr5_reconciliation_runtime.py
@@ -138,6 +138,10 @@ def _accept_registered_test_runtime_context(monkeypatch) -> None:
         "assert_validated_runtime_safety_context",
         lambda context: context,
     )
+    monkeypatch.setattr(runtime_evidence_module, "_comparison_clock", lambda: NOW)
+    with runtime_evidence_module._COMPARISON_CONSUMPTION_LOCK:
+        runtime_evidence_module._CONSUMED_COMPARISON_LINEAGES.clear()
+        runtime_evidence_module._COMPARISON_LAST_CLOCK = None
 
 
 def _registered_evidence(
@@ -202,6 +206,7 @@ def _registered_evidence(
             issued_at=NOW - timedelta(microseconds=1),
             expires_at=expires_at,
             _runtime_context=context,
+            _exact_state_evidence=None,
             _marker=runtime_evidence_module._CAPABILITY_MARKER,
         )
     )
@@ -578,6 +583,95 @@ async def test_v2_constraint_mutation_matrix_fails_closed(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    ("table", "old", "new"),
+    [
+        (
+            "rt_reconciliation_snapshots",
+            "schema_version INTEGER NOT NULL CHECK (schema_version = 1)",
+            "schema_version INTEGER NOT NULL",
+        ),
+        (
+            "rt_reconciliation_snapshots",
+            "payload_json TEXT NOT NULL CHECK (json_valid(payload_json))",
+            "payload_json TEXT NOT NULL",
+        ),
+        (
+            "rt_reconciliation_runs",
+            "evidence_fresh INTEGER NOT NULL CHECK (evidence_fresh IN (0, 1))",
+            "evidence_fresh INTEGER NOT NULL",
+        ),
+        (
+            "rt_reconciliation_runs",
+            "FOREIGN KEY(snapshot_id) REFERENCES rt_reconciliation_snapshots(snapshot_id)",
+            "FOREIGN KEY(snapshot_id) REFERENCES rt_reconciliation_snapshots(snapshot_id) "
+            "ON DELETE CASCADE",
+        ),
+        (
+            "rt_reconciliation_differences",
+            "ordinal INTEGER NOT NULL CHECK (ordinal >= 0)",
+            "ordinal INTEGER NOT NULL",
+        ),
+        (
+            "rt_reconciliation_differences",
+            "UNIQUE(run_id, ordinal)",
+            "UNIQUE(ordinal, run_id)",
+        ),
+        (
+            "rt_reconciliation_operator_resolutions",
+            "reason TEXT NOT NULL CHECK (length(trim(reason)) >= 10)",
+            "reason TEXT NOT NULL",
+        ),
+        (
+            "rt_reconciliation_operator_resolutions",
+            "evidence_reference TEXT,",
+            "evidence_reference TEXT, unexpected_column TEXT,",
+        ),
+    ],
+)
+async def test_v1_constraint_mutation_matrix_fails_closed(
+    tmp_path,
+    table: str,
+    old: str,
+    new: str,
+) -> None:
+    database_path = (tmp_path / "reconciliation.sqlite3").resolve()
+    persistence = ReconciliationPersistence(database_path)
+    await persistence.initialize()
+    _rewrite_table_definition(database_path, table, old, new)
+
+    with pytest.raises((RuntimeError, sqlite3.DatabaseError), match="malformed"):
+        await persistence.initialize()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "table",
+    [
+        "rt_reconciliation_snapshots",
+        "rt_reconciliation_runs",
+        "rt_reconciliation_differences",
+        "rt_reconciliation_operator_resolutions",
+    ],
+)
+async def test_every_v1_append_only_trigger_is_exact(tmp_path, table: str) -> None:
+    database_path = (tmp_path / "reconciliation.sqlite3").resolve()
+    persistence = ReconciliationPersistence(database_path)
+    await persistence.initialize()
+    trigger = f"{table}_no_delete"
+    _rewrite_schema_definition(
+        database_path,
+        "trigger",
+        trigger,
+        "BEFORE DELETE",
+        "AFTER DELETE",
+    )
+
+    with pytest.raises(RuntimeError, match=f"trigger {trigger} is malformed"):
+        await persistence.initialize()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     "table",
     [
         "rt_reconciliation_snapshot_lineage",
@@ -628,7 +722,7 @@ async def test_v2_composite_identity_index_mutation_fails_closed(tmp_path) -> No
         )
         connection.commit()
 
-    with pytest.raises(RuntimeError, match="composite identity index is malformed"):
+    with pytest.raises(RuntimeError, match="indexes are malformed"):
         await persistence.initialize()
 
 
@@ -908,9 +1002,12 @@ async def test_fabricated_snapshot_source_is_rejected_before_comparison(tmp_path
     assert service.entry_eligible(at=NOW) is False
 
 
-def test_core_broker_and_bundle_assertions_issue_one_shot_runtime_evidence(
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mismatch_kind", ["material", "timing_lag"])
+async def test_authenticated_mismatch_is_persisted_with_timing_expiry(
     tmp_path,
     monkeypatch,
+    mismatch_kind: str,
 ) -> None:
     database_path = (tmp_path / "reconciliation.sqlite3").resolve()
     sqlite3.connect(database_path).close()
@@ -974,9 +1071,33 @@ def test_core_broker_and_bundle_assertions_issue_one_shot_runtime_evidence(
         public_key_fingerprint="b8" * 32,
         signature_ed25519="c2lnbmF0dXJl",
     )
+    if mismatch_kind == "material":
+        signed_difference = _difference(DifferenceKind.QUANTITY_MISMATCH)
+        signed_proofs: tuple[ExpectedTimingLagProof, ...] = ()
+        signed_status = ReconciliationStatus.QUARANTINED
+    else:
+        broker_event_id = "broker-event-v1-" + "e5" * 32
+        signed_difference = ReconciliationDifference(
+            kind=DifferenceKind.EXPECTED_TIMING_LAG,
+            materiality=DifferenceMateriality.INFORMATIONAL,
+            reason_code="BROKER_ORDER_EVENT_PENDING",
+            subject="AAPL",
+            evidence_ids=(broker_event_id,),
+        )
+        signed_proofs = (
+            ExpectedTimingLagProof.from_trusted_producer(
+                broker_snapshot_id=snapshot.snapshot_id,
+                reason_code=signed_difference.reason_code,
+                subject=signed_difference.subject,
+                broker_event_id=broker_event_id,
+                started_at=NOW - timedelta(seconds=1),
+                expires_at=NOW + timedelta(seconds=5),
+            ),
+        )
+        signed_status = ReconciliationStatus.DEGRADED
     exact_state = SimpleNamespace(
         authentication_receipts=(reconciliation_receipt,),
-        reconciliation_status=ReconciliationStatus.PASSED,
+        reconciliation_status=signed_status,
         reconciliation_coverage=_coverage(),
         reconciliation_snapshot_id=bundle.reconciliation_snapshot_id,
         reconciliation_artifact_path=str(database_path.parent / "reconciliation_report.json"),
@@ -991,6 +1112,8 @@ def test_core_broker_and_bundle_assertions_issue_one_shot_runtime_evidence(
         database_inode=metadata.st_ino,
         broker_snapshot_id=broker.snapshot_id,
         broker_snapshot_hash=broker.artifact_hash,
+        reconciliation_differences=(signed_difference,),
+        reconciliation_timing_lag_proofs=signed_proofs,
     )
 
     def assert_broker(value):
@@ -1031,6 +1154,12 @@ def test_core_broker_and_bundle_assertions_issue_one_shot_runtime_evidence(
         "ExactStateBootstrapEvidence",
         SimpleNamespace,
     )
+    revalidated = []
+    monkeypatch.setattr(
+        runtime_evidence_module,
+        "assert_exact_state_runtime_sources_unchanged",
+        lambda evidence, runtime_contract: revalidated.append((evidence, runtime_contract)),
+    )
 
     evidence = bind_verified_runtime_reconciliation_evidence(
         broker,
@@ -1042,6 +1171,7 @@ def test_core_broker_and_bundle_assertions_issue_one_shot_runtime_evidence(
     assert asserted == ["broker", "reconciliation", "bundle"]
     assert evidence.database_device == metadata.st_dev
     assert evidence.database_inode == metadata.st_ino
+    assert evidence.differences == (signed_difference,)
     with pytest.raises(RuntimeReconciliationEvidenceError, match="already consumed"):
         bind_verified_runtime_reconciliation_evidence(
             broker,
@@ -1049,7 +1179,33 @@ def test_core_broker_and_bundle_assertions_issue_one_shot_runtime_evidence(
             context,
             marker,
         )
-    assert assert_and_consume_verified_runtime_reconciliation_evidence(evidence) is evidence
+    service, source, _ = await _service(tmp_path)
+    source.prepared_evidence = evidence
+    outcome = await service.reconcile_startup()
+
+    expected_state = (
+        ReconciliationServiceState.QUARANTINED
+        if mismatch_kind == "material"
+        else ReconciliationServiceState.DEGRADED
+    )
+    assert outcome.state is expected_state
+    assert outcome.entry_eligible is (mismatch_kind == "timing_lag")
+    assert revalidated == [(exact_state, contract)]
+    with sqlite3.connect(database_path) as connection:
+        persisted_rows = connection.execute(
+            "SELECT kind, materiality, reason_code FROM rt_reconciliation_differences"
+        ).fetchall()
+    assert persisted_rows == [
+        (
+            signed_difference.kind.value,
+            signed_difference.materiality.value,
+            signed_difference.reason_code,
+        )
+    ]
+    if mismatch_kind == "timing_lag":
+        assert service.entry_eligible(at=NOW + timedelta(seconds=5)) is True
+        assert service.entry_eligible(at=NOW + timedelta(seconds=5, microseconds=1)) is False
+        assert service.state is ReconciliationServiceState.QUARANTINED
     with pytest.raises(RuntimeReconciliationEvidenceError, match="already consumed"):
         assert_and_consume_verified_runtime_reconciliation_evidence(evidence)
 
@@ -1069,6 +1225,51 @@ def test_runtime_capability_is_python310_compatible_immutable_and_nonserializabl
         copy.deepcopy(evidence)
     with pytest.raises(TypeError, match="cannot be pickled"):
         pickle.dumps(evidence)
+
+
+def test_consumed_comparison_cache_is_bounded_and_evicts_only_expired(
+    monkeypatch,
+) -> None:
+    current = [NOW]
+    monkeypatch.setattr(runtime_evidence_module, "_MAX_CONSUMED_COMPARISON_LINEAGES", 3)
+    monkeypatch.setattr(runtime_evidence_module, "_comparison_clock", lambda: current[0])
+    for ordinal in range(3):
+        runtime_evidence_module._consume_comparison_lineage(
+            (f"snapshot-{ordinal}", f"receipt-{ordinal}", f"signature-{ordinal}"),
+            expires_at=NOW + timedelta(seconds=10),
+        )
+    with pytest.raises(RuntimeReconciliationEvidenceError, match="safety bound"):
+        runtime_evidence_module._consume_comparison_lineage(
+            ("snapshot-full", "receipt-full", "signature-full"),
+            expires_at=NOW + timedelta(seconds=10),
+        )
+    assert len(runtime_evidence_module._CONSUMED_COMPARISON_LINEAGES) == 3
+
+    current[0] = NOW + timedelta(seconds=11)
+    runtime_evidence_module._consume_comparison_lineage(
+        ("snapshot-new", "receipt-new", "signature-new"),
+        expires_at=NOW + timedelta(seconds=20),
+    )
+    assert runtime_evidence_module._CONSUMED_COMPARISON_LINEAGES == {
+        ("snapshot-new", "receipt-new", "signature-new"): NOW + timedelta(seconds=20)
+    }
+
+
+def test_consumed_comparison_cache_fails_closed_on_clock_rollback(monkeypatch) -> None:
+    current = [NOW]
+    monkeypatch.setattr(runtime_evidence_module, "_comparison_clock", lambda: current[0])
+    runtime_evidence_module._consume_comparison_lineage(
+        ("snapshot-first", "receipt-first", "signature-first"),
+        expires_at=NOW + timedelta(seconds=10),
+    )
+    current[0] = NOW - timedelta(microseconds=1)
+
+    with pytest.raises(RuntimeReconciliationEvidenceError, match="clock moved backwards"):
+        runtime_evidence_module._consume_comparison_lineage(
+            ("snapshot-rollback", "receipt-rollback", "signature-rollback"),
+            expires_at=NOW + timedelta(seconds=10),
+        )
+    assert len(runtime_evidence_module._CONSUMED_COMPARISON_LINEAGES) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Outcome

Adds the dormant PR5 reconciliation persistence/service layer with fail-closed runtime evidence binding. It grants no startup or order authority.

## Safety contract

- append-only reconciliation runs, differences, eligibility verdicts, and operator-resolution events
- exact one-shot verified broker/runtime/protective-bundle evidence; no duck-typed snapshot acceptance
- persisted account, runtime fingerprint, database path/device/inode, signed artifact/receipt/key, bundle, and snapshot lineage
- material/unknown mismatches quarantine eligibility
- timing-lag eligibility cannot outlive its proof and rejects clock rollback
- composite run/difference attribution and exact-idempotent resolution retries
- cancellation-safe, retryable service cleanup
- no repair, delete, trade, broker-write, or startup authority

## Verification

- 164 focused reconciliation/bootstrap tests passed
- 2,675 full tests passed, 5 skipped
- Black, isort, Flake8, targeted MyPy, compileall, Bandit, diff, and secret-pattern checks passed
- independent re-review is in progress on this exact head

## Remediation scope

PR 5 / Gate A in `docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md`. Production startup/reconnect/periodic wiring, dashboard/preflight exposure, and operational broker-vs-ledger evidence remain follow-ups.

Gate A remains closed. The trader remains stopped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches auth receipts, bootstrap gating, quarantine/eligibility, and durable safety evidence; bugs could mis-classify broker/ledger drift or treat expired evidence as entry-eligible.
> 
> **Overview**
> Adds a **fail-closed reconciliation stack** that binds signed broker/bootstrap artifacts to the runtime database, evaluates policy, and **append-only persists** runs, differences, eligibility windows, and non-authorizing operator notes—without granting startup or trading authority.
> 
> **Evidence & bootstrap path:** `AuthenticatedEvidenceReceipt` now carries **`signature_ed25519`**. Exact-state bootstrap evidence/loaders accept **reconciliation differences, timing-lag proofs, coverage, and `quarantined` status** (derived from materiality), plus broker snapshot lineage paths/IDs. Bootstrap reconciliation **no longer hard-requires zero IBKR exposure**; it checks collection counts against snapshot contents and **signs mismatches for quarantine** instead of blocking production. New **`assert_verified_exact_state_reconciliation_evidence`** and **`assert_exact_state_runtime_sources_unchanged`** re-read signed reconciliation artifacts and SQLite/journal bytes before use.
> 
> **Runtime layer:** **`VerifiedRuntimeReconciliationEvidence`** is a one-shot, non-copyable capability that consumes core broker + exact-state + protective-mark bindings, tracks **comparison replay consumption**, and revalidates DB inode/journal/ledger stability. **`ReconciliationService`** runs startup/reconnect/periodic/before-live/ambiguous-order flows, consumes verified evidence, evaluates policy (including pre-signed differences), persists atomically, and exposes **`entry_eligible`** that quarantines on stale evidence, clock rollback, or DB identity drift.
> 
> **Persistence:** New **`reconciliation_migrations` (v2)** and **`ReconciliationPersistence`** with append-only triggers, snapshot/run/difference tables, **v2 lineage** (fingerprints, receipt IDs, ed25519 signature), and run eligibility expiry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f20fc20d4a44ca899ff09d59a4c2a503a6a2450. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->