### PR TITLE
feat(risk): persist daily gross filled notional

### DIFF
--- a/robo_trader/risk/filled_notional/MIGRATION.md
+++ b/robo_trader/risk/filled_notional/MIGRATION.md
@@ -19,11 +19,19 @@ Future schema versions also fail closed. Downgrade and in-place rewrite are not
 supported. No migration may delete or overwrite the only copy of any ledger,
 anchor, execution evidence, or conflict marker.
 
-The anchor must live in a separate non-group/world-writable directory. Protect
-and version it independently from the SQLite database. The HMAC key must not be
-stored with either artifact. A coordinated rollback of the database, anchor,
-and external key/monotonic authority is outside the local module's threat
-boundary and requires an independently operated monotonic service.
+The anchor must live in a separate non-group/world-writable directory. The
+service binds that directory by device/inode and performs anchor operations
+relative to an `O_DIRECTORY`/no-follow descriptor. Replacing or redirecting the
+directory does not transfer anchor authority.
+
+The HMAC key must not be stored with either local artifact, but key separation
+alone does **not** prove freshness. An attacker can replay an older valid
+database and its matching older valid anchor while leaving the HMAC key
+unchanged. Every authoritative service construction, read, and append therefore
+requires an independent monotonic verifier. Its accepted state must live
+outside the database/anchor failure domain and reject any state older than the
+last accepted fill/conflict heads and counts. Without such an independently
+operated monotonic state or service, this ledger is non-authoritative.
 
 Each append first fsyncs an authenticated pending transition to the anchor,
 then commits SQLite, then atomically replaces and directory-fsyncs the stable
@@ -32,3 +40,9 @@ read-only validation. A pending anchor may resolve only to its authenticated
 old or new state; a stable anchor is never advanced heuristically. Therefore an
 old stable anchor, ledger tail truncation, database rollback, or replacement
 fails closed instead of being mistaken for a process-crash window.
+
+For an existing database, schema version detection is immutable and read-only
+before any read-write recovery. A legacy v1 hot journal is preserved byte for
+byte; it is never opened in a mode that can recover, remove, or rewrite the
+database or sidecar. If the version cannot be established without recovery, the
+service raises unavailable and leaves all evidence untouched.

--- a/robo_trader/risk/filled_notional/MIGRATION.md
+++ b/robo_trader/risk/filled_notional/MIGRATION.md
@@ -75,9 +75,9 @@ cannot be trusted, reconstruct on a reviewed copy or restart to force the full
 audit before relying on the ledger.
 
 Schema validation inventories every trigger whose target is a protected ledger
-table, regardless of the trigger's name, and rejects anything beyond the exact
-versioned trigger set. This prevents a foreign trigger such as
-`RAISE(IGNORE)` from silently suppressing an append.
+table, regardless of the trigger's name or the target identifier's ASCII case,
+and rejects anything beyond the exact versioned trigger set. This prevents a
+foreign trigger such as `RAISE(IGNORE)` from silently suppressing an append.
 
 For an existing database, schema version detection is immutable and read-only
 before any read-write recovery. Read-write recovery of a hot rollback journal

--- a/robo_trader/risk/filled_notional/MIGRATION.md
+++ b/robo_trader/risk/filled_notional/MIGRATION.md
@@ -1,23 +1,27 @@
 # Filled-notional ledger migration
 
-Schema version 2 adds authenticated fill records, an account-level broker
-execution identity, durable conflict quarantine, and a separately protected
-chain-head/count anchor.
+Schema version 3 adds an append-only HMAC checkpoint chain and authenticated
+per-scope cumulative fill counts and totals. The service performs a full,
+streaming validation of the fill, conflict, and checkpoint chains at startup.
+After that audit, appends and authoritative reads validate the latest
+checkpoint, the relevant authenticated scope-total record, the independent
+anchor, and the external monotonic state without rescanning all history.
 
-Version 1 ledgers are never changed in place. Opening one raises
-`FilledNotionalMigrationRequired` before an anchor is created. The safe path is:
+Version 1 and version 2 ledgers are never changed in place. Opening either one
+raises `FilledNotionalMigrationRequired` before an anchor is created. The safe
+path is:
 
-1. Preserve and checksum the version 1 database and all SQLite sidecars.
+1. Preserve and checksum the legacy database and all SQLite sidecars.
 2. Reconcile every execution against a reviewed broker execution export.
-3. Create a new version 2 ledger and anchor in new paths with an HMAC key from
+3. Create a new version 3 ledger and anchor in new paths with an HMAC key from
    an independent secret authority.
 4. Replay only confirmed executions using their immutable broker execution IDs.
 5. Compare per-account, per-portfolio, per-currency, and New York trading-date
-   totals, then retain the original version 1 files as read-only evidence.
+   totals, then retain the legacy files as read-only evidence.
 
 Future schema versions also fail closed. Downgrade and in-place rewrite are not
 supported. No migration may delete or overwrite the only copy of any ledger,
-anchor, execution evidence, or conflict marker.
+anchor, execution evidence, conflict marker, or SQLite sidecar.
 
 The anchor must live in a separate non-group/world-writable directory. The
 service binds that directory by device/inode and performs anchor operations
@@ -27,22 +31,37 @@ directory does not transfer anchor authority.
 The HMAC key must not be stored with either local artifact, but key separation
 alone does **not** prove freshness. An attacker can replay an older valid
 database and its matching older valid anchor while leaving the HMAC key
-unchanged. Every authoritative service construction, read, and append therefore
-requires an independent monotonic verifier. Its accepted state must live
-outside the database/anchor failure domain and reject any state older than the
-last accepted fill/conflict heads and counts. Without such an independently
+unchanged. Every authoritative service construction, read, append, and review
+therefore requires an independent monotonic verifier. Its accepted state must
+live outside the database/anchor failure domain and reject any state older than
+the last accepted fill/conflict heads and counts. Without such an independently
 operated monotonic state or service, this ledger is non-authoritative.
 
 Each append first fsyncs an authenticated pending transition to the anchor,
 then commits SQLite, then atomically replaces and directory-fsyncs the stable
-anchor. On restart, identity-bound read-write SQLite recovery runs before any
-read-only validation. A pending anchor may resolve only to its authenticated
-old or new state; a stable anchor is never advanced heuristically. Therefore an
-old stable anchor, ledger tail truncation, database rollback, or replacement
-fails closed instead of being mistaken for a process-crash window.
+anchor. A pending anchor may resolve only to its authenticated old or new
+state; a stable anchor is never advanced heuristically. Authoritative reads and
+reviews use one SQLite snapshot and re-check both the exact anchor and external
+monotonic state immediately before returning.
+
+The hot path is deliberately bounded: the latest cumulative scope total is
+found through the scope/date/sequence index, each append adds one checkpoint,
+and no scope may exceed 100,000 fills for one New York trading date. Exceeding
+that limit rejects the append before any durable mutation. Full history and
+checkpoint-chain validation is startup-only and streams rows instead of
+materializing them. The hot path detects forged or truncated tails and invalid
+authenticated totals; the startup audit additionally detects interior record
+tampering. This assumes the process and ledger paths retain their configured OS
+access controls between startup and use. If that local-file integrity boundary
+cannot be trusted, reconstruct on a reviewed copy or restart to force the full
+audit before relying on the ledger.
 
 For an existing database, schema version detection is immutable and read-only
-before any read-write recovery. A legacy v1 hot journal is preserved byte for
-byte; it is never opened in a mode that can recover, remove, or rewrite the
-database or sidecar. If the version cannot be established without recovery, the
-service raises unavailable and leaves all evidence untouched.
+before any read-write recovery. Read-write recovery of a hot rollback journal
+is authorized only by a valid current-version anchor bound to that exact
+database device/inode. A legacy or otherwise ambiguous hot journal without
+that authority is preserved byte for byte and the service raises unavailable.
+This is required because SQLite cache spill can place an uncommitted future
+schema marker in the main database while the rollback journal still contains
+the authoritative legacy image; trusting that marker and recovering would
+destroy migration evidence.

--- a/robo_trader/risk/filled_notional/MIGRATION.md
+++ b/robo_trader/risk/filled_notional/MIGRATION.md
@@ -44,6 +44,14 @@ state; a stable anchor is never advanced heuristically. Authoritative reads and
 reviews use one SQLite snapshot and re-check both the exact anchor and external
 monotonic state immediately before returning.
 
+Writers also hold an owner-only, inode-checked transition lock in the protected
+anchor directory from checkpoint validation through stable-anchor publication
+and the final monotonic verification. This closes the post-commit interval in
+which a second writer could otherwise advance the anchor and cause the first
+writer to report failure after its fill was already durable. Exact execution
+replays perform the same return-boundary anchor and monotonic checks even though
+they do not append a row.
+
 The hot path is deliberately bounded: the latest cumulative scope total is
 found through the scope/date/sequence index, each append adds one checkpoint,
 and no scope may exceed 100,000 fills for one New York trading date. Exceeding
@@ -65,3 +73,11 @@ This is required because SQLite cache spill can place an uncommitted future
 schema marker in the main database while the rollback journal still contains
 the authoritative legacy image; trusting that marker and recovering would
 destroy migration evidence.
+
+Version 3 requires SQLite rollback-journal mode (header read/write versions
+`1/1`) and does not accept WAL mode. Existing `-wal` or `-shm` files are
+preserved and rejected before SQLite opens them. A rollback `-journal` is
+eligible for authenticated recovery only when it is a non-symlink regular file
+with one link; hardlinked journals are preserved and rejected. These checks
+prevent read-only construction and accounting writes from following or
+mutating unbound SQLite sidecar targets.

--- a/robo_trader/risk/filled_notional/MIGRATION.md
+++ b/robo_trader/risk/filled_notional/MIGRATION.md
@@ -79,20 +79,23 @@ table, regardless of the trigger's name or the target identifier's ASCII case,
 and rejects anything beyond the exact versioned trigger set. This prevents a
 foreign trigger such as `RAISE(IGNORE)` from silently suppressing an append.
 
-For an existing database, schema version detection is immutable and read-only
-before any read-write recovery. Read-write recovery of a hot rollback journal
-is authorized only by a valid current-version anchor bound to that exact
-database device/inode. A legacy or otherwise ambiguous hot journal without
-that authority is preserved byte for byte and the service raises unavailable.
-This is required because SQLite cache spill can place an uncommitted future
-schema marker in the main database while the rollback journal still contains
-the authoritative legacy image; trusting that marker and recovering would
-destroy migration evidence.
+For an existing database, schema version detection is immutable and read-only.
+Any hot rollback journal, including one whose isolated-copy recovery validates
+against a current-version anchor, is preserved and the service raises
+unavailable. SQLite derives and reopens the journal by pathname during recovery;
+there is no portable way to bind the validated journal inode through SQLite's
+first mutation if another local process can replace that pathname. Reviewed
+recovery must therefore operate on an isolated copy and install a separately
+authenticated ledger generation. This also protects legacy evidence because
+SQLite cache spill can place an uncommitted future schema marker in the main
+database while the rollback journal still contains the authoritative legacy
+image; trusting that marker and recovering would destroy migration evidence.
 
 Version 3 requires SQLite rollback-journal mode (header read/write versions
 `1/1`) and does not accept WAL mode. Existing `-wal` or `-shm` files are
 preserved and rejected before SQLite opens them. A rollback `-journal` is
-eligible for authenticated recovery only when it is a non-symlink regular file
-with one link; hardlinked journals are preserved and rejected. These checks
-prevent read-only construction and accounting writes from following or
-mutating unbound SQLite sidecar targets.
+inspected on an isolated copy only when it is a non-symlink regular file with
+one link, but automatic recovery is still rejected; hardlinked journals are
+preserved and rejected before copying. These checks prevent read-only
+construction and accounting writes from following or mutating unbound SQLite
+sidecar targets.

--- a/robo_trader/risk/filled_notional/MIGRATION.md
+++ b/robo_trader/risk/filled_notional/MIGRATION.md
@@ -40,9 +40,19 @@ operated monotonic state or service, this ledger is non-authoritative.
 Each append first fsyncs an authenticated pending transition to the anchor,
 then commits SQLite, then atomically replaces and directory-fsyncs the stable
 anchor. A pending anchor may resolve only to its authenticated old or new
-state; a stable anchor is never advanced heuristically. Authoritative reads and
-reviews use one SQLite snapshot and re-check both the exact anchor and external
-monotonic state immediately before returning.
+state; a stable anchor is never advanced heuristically. Before publishing that
+pending anchor, the writer re-reads the uncommitted checkpoint and fill/conflict
+tails and requires them to equal the expected advanced state. A suppressed
+insert or checkpoint therefore rolls back without changing the durable anchor.
+Authoritative reads use one SQLite snapshot and re-check both the exact anchor
+and external monotonic state immediately before returning.
+
+Quarantine review requires both the main database and anchor to be existing,
+exclusive, non-symlink regular files. It opens the database through immutable
+read-only SQLite snapshots, does not initialize or recover the database, does
+not reconcile or replace the anchor, and does not create the anchor transition
+lock. Missing, mistyped, or concurrently removed artifacts fail unavailable
+without recreating either artifact or otherwise mutating disk.
 
 Writers also hold an owner-only, inode-checked transition lock in the protected
 anchor directory from checkpoint validation through stable-anchor publication
@@ -63,6 +73,11 @@ tampering. This assumes the process and ledger paths retain their configured OS
 access controls between startup and use. If that local-file integrity boundary
 cannot be trusted, reconstruct on a reviewed copy or restart to force the full
 audit before relying on the ledger.
+
+Schema validation inventories every trigger whose target is a protected ledger
+table, regardless of the trigger's name, and rejects anything beyond the exact
+versioned trigger set. This prevents a foreign trigger such as
+`RAISE(IGNORE)` from silently suppressing an append.
 
 For an existing database, schema version detection is immutable and read-only
 before any read-write recovery. Read-write recovery of a hot rollback journal

--- a/robo_trader/risk/filled_notional/MIGRATION.md
+++ b/robo_trader/risk/filled_notional/MIGRATION.md
@@ -1,0 +1,34 @@
+# Filled-notional ledger migration
+
+Schema version 2 adds authenticated fill records, an account-level broker
+execution identity, durable conflict quarantine, and a separately protected
+chain-head/count anchor.
+
+Version 1 ledgers are never changed in place. Opening one raises
+`FilledNotionalMigrationRequired` before an anchor is created. The safe path is:
+
+1. Preserve and checksum the version 1 database and all SQLite sidecars.
+2. Reconcile every execution against a reviewed broker execution export.
+3. Create a new version 2 ledger and anchor in new paths with an HMAC key from
+   an independent secret authority.
+4. Replay only confirmed executions using their immutable broker execution IDs.
+5. Compare per-account, per-portfolio, per-currency, and New York trading-date
+   totals, then retain the original version 1 files as read-only evidence.
+
+Future schema versions also fail closed. Downgrade and in-place rewrite are not
+supported. No migration may delete or overwrite the only copy of any ledger,
+anchor, execution evidence, or conflict marker.
+
+The anchor must live in a separate non-group/world-writable directory. Protect
+and version it independently from the SQLite database. The HMAC key must not be
+stored with either artifact. A coordinated rollback of the database, anchor,
+and external key/monotonic authority is outside the local module's threat
+boundary and requires an independently operated monotonic service.
+
+Each append first fsyncs an authenticated pending transition to the anchor,
+then commits SQLite, then atomically replaces and directory-fsyncs the stable
+anchor. On restart, identity-bound read-write SQLite recovery runs before any
+read-only validation. A pending anchor may resolve only to its authenticated
+old or new state; a stable anchor is never advanced heuristically. Therefore an
+old stable anchor, ledger tail truncation, database rollback, or replacement
+fails closed instead of being mistaken for a process-crash window.

--- a/robo_trader/risk/filled_notional/__init__.py
+++ b/robo_trader/risk/filled_notional/__init__.py
@@ -15,6 +15,7 @@ from .ledger import (
     FilledNotionalMigrationRequired,
     FilledNotionalUnavailable,
     FillSide,
+    MonotonicLedgerState,
 )
 
 __all__ = [
@@ -23,6 +24,7 @@ __all__ = [
     "ExecutedFill",
     "FillAccountingResult",
     "FillSide",
+    "MonotonicLedgerState",
     "FilledNotionalConflict",
     "FilledNotionalError",
     "FilledNotionalIntegrityError",

--- a/robo_trader/risk/filled_notional/__init__.py
+++ b/robo_trader/risk/filled_notional/__init__.py
@@ -1,0 +1,27 @@
+"""Durable gross-filled-notional accounting.
+
+This package is deliberately dormant.  It exposes accounting primitives but
+does not connect them to the runner, order submission, or startup paths.
+"""
+
+from .ledger import (
+    DailyFilledNotional,
+    ExecutedFill,
+    FillAccountingResult,
+    FilledNotionalConflict,
+    FilledNotionalError,
+    FilledNotionalIntegrityError,
+    FilledNotionalUnavailable,
+    FillSide,
+)
+
+__all__ = [
+    "DailyFilledNotional",
+    "ExecutedFill",
+    "FillAccountingResult",
+    "FillSide",
+    "FilledNotionalConflict",
+    "FilledNotionalError",
+    "FilledNotionalIntegrityError",
+    "FilledNotionalUnavailable",
+]

--- a/robo_trader/risk/filled_notional/__init__.py
+++ b/robo_trader/risk/filled_notional/__init__.py
@@ -5,17 +5,20 @@ does not connect them to the runner, order submission, or startup paths.
 """
 
 from .ledger import (
+    ConflictEvidence,
     DailyFilledNotional,
     ExecutedFill,
     FillAccountingResult,
     FilledNotionalConflict,
     FilledNotionalError,
     FilledNotionalIntegrityError,
+    FilledNotionalMigrationRequired,
     FilledNotionalUnavailable,
     FillSide,
 )
 
 __all__ = [
+    "ConflictEvidence",
     "DailyFilledNotional",
     "ExecutedFill",
     "FillAccountingResult",
@@ -23,5 +26,6 @@ __all__ = [
     "FilledNotionalConflict",
     "FilledNotionalError",
     "FilledNotionalIntegrityError",
+    "FilledNotionalMigrationRequired",
     "FilledNotionalUnavailable",
 ]

--- a/robo_trader/risk/filled_notional/ledger.py
+++ b/robo_trader/risk/filled_notional/ledger.py
@@ -27,6 +27,7 @@ The package is dormant: it grants no order, broker, runner, or startup authority
 
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import hmac
 import json
@@ -685,22 +686,25 @@ class DailyFilledNotional:
             created = self._initialize_if_missing()
             if not created:
                 recovery_required = self._preflight_existing_schema()
+            else:
+                recovery_required = False
+            with self._anchor_transition_lock():
                 if recovery_required:
                     self._recover_hot_journal()
-            with self._connection(readonly=True) as connection:
-                connection.execute("BEGIN")
-                state = self._validate_ledger(connection)
-                if created:
-                    anchor = self._create_initial_anchor(state)
-                else:
-                    anchor = self._reconcile_anchor(state)
-                self._verify_monotonic_state(state)
-                self._ledger_id = state.ledger_id
-                current_day = self._current_trading_date()
-                total = self._total_for_date(connection, current_day)
-                anchor = self._require_exact_anchor(state)
-                self._verify_monotonic_state(state)
-                connection.commit()
+                with self._connection(readonly=True) as connection:
+                    connection.execute("BEGIN")
+                    state = self._validate_ledger(connection)
+                    if created:
+                        anchor = self._create_initial_anchor(state)
+                    else:
+                        anchor = self._reconcile_anchor(state)
+                    self._verify_monotonic_state(state)
+                    self._ledger_id = state.ledger_id
+                    current_day = self._current_trading_date()
+                    total = self._total_for_date(connection, current_day)
+                    anchor = self._require_exact_anchor(state)
+                    self._verify_monotonic_state(state)
+                    connection.commit()
         except FilledNotionalError:
             raise
         except DecimalException as exc:
@@ -753,6 +757,7 @@ class DailyFilledNotional:
         ):
             raise FilledNotionalError("anchor directory is not safely bindable")
         self._anchor_name = self._anchor_path.name
+        self._anchor_lock_name = f".{self._anchor_name}.lock"
         self._anchor_directory_device = metadata.st_dev
         self._anchor_directory_inode = metadata.st_ino
 
@@ -775,6 +780,17 @@ class DailyFilledNotional:
                 path_metadata.st_ino,
             ) != expected:
                 raise FilledNotionalIntegrityError("anchor directory identity changed")
+        except FilledNotionalError:
+            if descriptor is not None:
+                os.close(descriptor)
+            raise
+        except OSError as exc:
+            if descriptor is not None:
+                os.close(descriptor)
+            raise FilledNotionalIntegrityError(
+                "anchor directory cannot be accessed safely"
+            ) from exc
+        try:
             yield descriptor
             metadata = os.fstat(descriptor)
             path_metadata = os.lstat(self._anchor_path.parent)
@@ -785,15 +801,72 @@ class DailyFilledNotional:
                 raise FilledNotionalIntegrityError(
                     "anchor directory identity changed during operation"
                 )
-        except FilledNotionalError:
-            raise
-        except OSError as exc:
-            raise FilledNotionalIntegrityError(
-                "anchor directory cannot be accessed safely"
-            ) from exc
         finally:
             if descriptor is not None:
                 os.close(descriptor)
+
+    @contextmanager
+    def _anchor_transition_lock(self) -> Iterator[None]:
+        """Serialize database commits through stable-anchor publication."""
+
+        descriptor: Optional[int] = None
+        with self._anchor_directory_descriptor() as directory_descriptor:
+            try:
+                descriptor = os.open(
+                    self._anchor_lock_name,
+                    os.O_RDWR
+                    | os.O_CREAT
+                    | getattr(os, "O_NOFOLLOW", 0)
+                    | getattr(os, "O_CLOEXEC", 0),
+                    0o600,
+                    dir_fd=directory_descriptor,
+                )
+                metadata = os.fstat(descriptor)
+                path_metadata = os.stat(
+                    self._anchor_lock_name,
+                    dir_fd=directory_descriptor,
+                    follow_symlinks=False,
+                )
+                if (
+                    not stat.S_ISREG(metadata.st_mode)
+                    or metadata.st_mode & 0o077
+                    or metadata.st_nlink != 1
+                    or (metadata.st_dev, metadata.st_ino)
+                    != (path_metadata.st_dev, path_metadata.st_ino)
+                ):
+                    raise FilledNotionalIntegrityError(
+                        "anchor transition lock is not safely bindable"
+                    )
+                fcntl.flock(descriptor, fcntl.LOCK_EX)
+            except FilledNotionalError:
+                if descriptor is not None:
+                    os.close(descriptor)
+                raise
+            except OSError as exc:
+                if descriptor is not None:
+                    os.close(descriptor)
+                raise FilledNotionalIntegrityError(
+                    "anchor transition lock cannot be used safely"
+                ) from exc
+            try:
+                yield
+                final_metadata = os.fstat(descriptor)
+                final_path_metadata = os.stat(
+                    self._anchor_lock_name,
+                    dir_fd=directory_descriptor,
+                    follow_symlinks=False,
+                )
+                if final_metadata.st_nlink != 1 or (
+                    final_metadata.st_dev,
+                    final_metadata.st_ino,
+                ) != (final_path_metadata.st_dev, final_path_metadata.st_ino):
+                    raise FilledNotionalIntegrityError("anchor transition lock identity changed")
+            finally:
+                if descriptor is not None:
+                    try:
+                        fcntl.flock(descriptor, fcntl.LOCK_UN)
+                    finally:
+                        os.close(descriptor)
 
     @property
     def database_path(self) -> Path:
@@ -826,101 +899,106 @@ class DailyFilledNotional:
 
         conflict: Optional[FilledNotionalConflict] = None
         try:
-            with self._connection(readonly=False) as connection:
-                connection.execute("BEGIN IMMEDIATE")
-                before = self._validate_checkpointed_state(connection)
-                anchor = self._reconcile_anchor(before)
-                self._assert_no_conflicts(before)
-                self._verify_monotonic_state(before)
-                existing = connection.execute(
-                    """
-                    SELECT portfolio_id, side, quantity_text, price_text, currency,
-                           executed_at_utc, trading_date, notional_text, record_hash
-                    FROM daily_filled_notional_records
-                    WHERE account_id = ? AND broker_execution_id = ?
-                    """,
-                    (self._account_id, canonical.broker_execution_id),
-                ).fetchone()
-                recorded = existing is None
-                mutated = recorded
-                raw_after = before
-                if existing is not None:
-                    stored = tuple(str(value) for value in existing[:8])
-                    expected = (
-                        self._portfolio_id,
-                        canonical.side,
-                        canonical.quantity_text,
-                        canonical.price_text,
-                        canonical.currency,
-                        canonical.executed_at_utc,
-                        canonical.trading_date,
-                        canonical.notional_text,
-                    )
-                    if stored != expected:
-                        conflict_head = self._append_conflict(
+            with self._anchor_transition_lock():
+                with self._connection(readonly=False) as connection:
+                    connection.execute("BEGIN IMMEDIATE")
+                    before = self._validate_checkpointed_state(connection)
+                    anchor = self._reconcile_anchor(before)
+                    self._assert_no_conflicts(before)
+                    self._verify_monotonic_state(before)
+                    existing = connection.execute(
+                        """
+                        SELECT portfolio_id, side, quantity_text, price_text, currency,
+                               executed_at_utc, trading_date, notional_text, record_hash
+                        FROM daily_filled_notional_records
+                        WHERE account_id = ? AND broker_execution_id = ?
+                        """,
+                        (self._account_id, canonical.broker_execution_id),
+                    ).fetchone()
+                    recorded = existing is None
+                    mutated = recorded
+                    raw_after = before
+                    if existing is not None:
+                        stored = tuple(str(value) for value in existing[:8])
+                        expected = (
+                            self._portfolio_id,
+                            canonical.side,
+                            canonical.quantity_text,
+                            canonical.price_text,
+                            canonical.currency,
+                            canonical.executed_at_utc,
+                            canonical.trading_date,
+                            canonical.notional_text,
+                        )
+                        if stored != expected:
+                            conflict_head = self._append_conflict(
+                                connection,
+                                before,
+                                canonical,
+                                existing_portfolio_id=str(existing[0]),
+                                existing_record_hash=str(existing[8]),
+                                observed_at_utc=observed_at_utc,
+                            )
+                            conflict = FilledNotionalConflict(
+                                "broker execution identity has durable conflicting evidence"
+                            )
+                            raw_after = replace(
+                                before,
+                                conflict_count=before.conflict_count + 1,
+                                conflict_head=conflict_head,
+                            )
+                            mutated = True
+                    else:
+                        prior_count, prior_total = self._scope_total_for_date(
+                            connection, date.fromisoformat(canonical.trading_date)
+                        )
+                        if prior_count >= _MAX_DAILY_FILL_ROWS:
+                            raise FilledNotionalUnavailable(
+                                "daily fill count exceeds the bounded accounting limit"
+                            )
+                        scope_fill_count = prior_count + 1
+                        scope_total = _exact_add(prior_total, canonical.notional)
+                        scope_total_text = _canonical_positive_decimal(
+                            scope_total,
+                            "scope_total",
+                            max_digits=96,
+                            max_abs_exponent=54,
+                        )
+                        fill_head = self._append_fill(
                             connection,
                             before,
                             canonical,
-                            existing_portfolio_id=str(existing[0]),
-                            existing_record_hash=str(existing[8]),
-                            observed_at_utc=observed_at_utc,
-                        )
-                        conflict = FilledNotionalConflict(
-                            "broker execution identity has durable conflicting evidence"
+                            scope_fill_count=scope_fill_count,
+                            scope_total_text=scope_total_text,
                         )
                         raw_after = replace(
                             before,
-                            conflict_count=before.conflict_count + 1,
-                            conflict_head=conflict_head,
+                            fill_count=before.fill_count + 1,
+                            fill_head=fill_head,
                         )
-                        mutated = True
-                else:
-                    prior_count, prior_total = self._scope_total_for_date(
-                        connection, date.fromisoformat(canonical.trading_date)
+                    after = (
+                        self._append_checkpoint(connection, before, raw_after)
+                        if mutated
+                        else before
                     )
-                    if prior_count >= _MAX_DAILY_FILL_ROWS:
-                        raise FilledNotionalUnavailable(
-                            "daily fill count exceeds the bounded accounting limit"
+                    trading_day = date.fromisoformat(canonical.trading_date)
+                    total = self._total_for_date(connection, trading_day)
+                    if mutated:
+                        pending = self._replace_anchor(
+                            self._anchor_for_state(before, pending_state=after),
+                            expected=anchor,
                         )
-                    scope_fill_count = prior_count + 1
-                    scope_total = _exact_add(prior_total, canonical.notional)
-                    scope_total_text = _canonical_positive_decimal(
-                        scope_total,
-                        "scope_total",
-                        max_digits=96,
-                        max_abs_exponent=54,
-                    )
-                    fill_head = self._append_fill(
-                        connection,
-                        before,
-                        canonical,
-                        scope_fill_count=scope_fill_count,
-                        scope_total_text=scope_total_text,
-                    )
-                    raw_after = replace(
-                        before,
-                        fill_count=before.fill_count + 1,
-                        fill_head=fill_head,
-                    )
-                after = (
-                    self._append_checkpoint(connection, before, raw_after) if mutated else before
-                )
-                trading_day = date.fromisoformat(canonical.trading_date)
-                total = self._total_for_date(connection, trading_day)
-                if mutated:
-                    pending = self._replace_anchor(
-                        self._anchor_for_state(before, pending_state=after),
-                        expected=anchor,
-                    )
-                    self._commit_database(connection)
-                    self._anchor = self._replace_anchor(
-                        self._anchor_for_state(after),
-                        expected=pending,
-                    )
-                    self._verify_monotonic_state(after)
-                else:
-                    self._commit_database(connection)
-                    self._anchor = anchor
+                        self._commit_database(connection)
+                        self._anchor = self._replace_anchor(
+                            self._anchor_for_state(after),
+                            expected=pending,
+                        )
+                        self._anchor = self._require_exact_anchor(after)
+                        self._verify_monotonic_state(after)
+                    else:
+                        self._commit_database(connection)
+                        self._anchor = self._require_exact_anchor(before)
+                        self._verify_monotonic_state(before)
         except FilledNotionalIntegrityError as exc:
             self._latch_failure(str(exc))
             raise
@@ -1314,16 +1392,92 @@ class DailyFilledNotional:
             connection.execute("SELECT count(*) FROM sqlite_master").fetchone()
             connection.commit()
 
+    def _reject_wal_sidecars(self) -> None:
+        """Reject WAL state before SQLite can open or mutate WAL/SHM artifacts."""
+
+        for suffix in ("-wal", "-shm"):
+            sidecar = Path(f"{self._path}{suffix}")
+            try:
+                os.lstat(sidecar)
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                raise FilledNotionalUnavailable(
+                    "SQLite sidecar identity cannot be inspected safely"
+                ) from exc
+            raise FilledNotionalUnavailable(
+                "WAL/SHM sidecars are unsupported; preserve them for reviewed recovery"
+            )
+
+    def _validate_existing_rollback_journal(self) -> None:
+        """Ensure a rollback journal cannot redirect mutations through another inode name."""
+
+        journal = Path(f"{self._path}-journal")
+        try:
+            metadata = os.lstat(journal)
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            raise FilledNotionalUnavailable(
+                "SQLite rollback-journal identity cannot be inspected safely"
+            ) from exc
+        if (
+            stat.S_ISLNK(metadata.st_mode)
+            or not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+        ):
+            raise FilledNotionalUnavailable(
+                "SQLite rollback journal is not an exclusive regular file"
+            )
+        try:
+            anchor = self._load_anchor()
+            database_metadata = os.lstat(self._path)
+        except (FilledNotionalError, OSError) as exc:
+            raise FilledNotionalUnavailable(
+                "hot journal lacks an authenticated current-schema recovery anchor"
+            ) from exc
+        if (
+            stat.S_ISLNK(database_metadata.st_mode)
+            or not stat.S_ISREG(database_metadata.st_mode)
+            or anchor.state.database_device != database_metadata.st_dev
+            or anchor.state.database_inode != database_metadata.st_ino
+        ):
+            raise FilledNotionalUnavailable(
+                "hot journal recovery anchor does not bind this database"
+            )
+
+    @staticmethod
+    def _require_rollback_journal_header(binding: SQLitePathBinding) -> None:
+        try:
+            header = os.pread(binding.guardian_file_descriptor, 20, 0)
+        except OSError as exc:
+            raise FilledNotionalUnavailable(
+                "SQLite journal mode cannot be inspected safely"
+            ) from exc
+        if len(header) != 20 or header[:16] != b"SQLite format 3\x00":
+            raise FilledNotionalUnavailable(
+                "existing schema cannot be detected without SQLite recovery"
+            )
+        if header[18:20] != b"\x01\x01":
+            raise FilledNotionalUnavailable(
+                "SQLite ledger must use rollback-journal mode; WAL is unsupported"
+            )
+
     def _preflight_existing_schema(self) -> bool:
         """Identify legacy state without permitting SQLite journal recovery."""
 
+        self._reject_wal_sidecars()
         journal = Path(f"{self._path}-journal")
         try:
             journal_metadata = os.lstat(journal)
         except FileNotFoundError:
             journal_metadata = None
         if journal_metadata is not None:
-            if stat.S_ISLNK(journal_metadata.st_mode) or not stat.S_ISREG(journal_metadata.st_mode):
+            if (
+                stat.S_ISLNK(journal_metadata.st_mode)
+                or not stat.S_ISREG(journal_metadata.st_mode)
+                or journal_metadata.st_nlink != 1
+            ):
                 raise FilledNotionalUnavailable(
                     "SQLite journal prevents safe read-only schema detection"
                 )
@@ -1366,6 +1520,9 @@ class DailyFilledNotional:
         connection: Optional[sqlite3.Connection] = None
         try:
             binding = SQLitePathBinding.open_for_initialization(self._path, create=False)
+            self._require_rollback_journal_header(binding)
+            self._reject_wal_sidecars()
+            self._validate_existing_rollback_journal()
             mode = "ro" if readonly else "rw"
             immutable_query = "&immutable=1" if immutable else ""
             connection = sqlite3.connect(
@@ -1376,6 +1533,9 @@ class DailyFilledNotional:
             )
             connection.row_factory = sqlite3.Row
             bound = binding.bind_sqlite_connection(sqlite_connection_file_identity(connection))
+            journal_mode = connection.execute("PRAGMA journal_mode").fetchone()
+            if journal_mode is None or str(journal_mode[0]).lower() != "delete":
+                raise FilledNotionalUnavailable("SQLite ledger journal mode changed while opening")
             connection.execute("PRAGMA busy_timeout=1000")
             connection.execute("PRAGMA foreign_keys=ON")
             connection.set_authorizer(_append_only_authorizer)
@@ -2008,11 +2168,12 @@ class DailyFilledNotional:
     def _resolve_pending_anchor(self) -> None:
         """Serialize behind a writer and reconcile only authenticated endpoints."""
 
-        with self._connection(readonly=False) as connection:
-            connection.execute("BEGIN IMMEDIATE")
-            state = self._validate_ledger(connection)
-            self._anchor = self._reconcile_anchor(state)
-            connection.commit()
+        with self._anchor_transition_lock():
+            with self._connection(readonly=False) as connection:
+                connection.execute("BEGIN IMMEDIATE")
+                state = self._validate_ledger(connection)
+                self._anchor = self._reconcile_anchor(state)
+                connection.commit()
 
     def _replace_anchor(self, desired: _Anchor, *, expected: _Anchor) -> _Anchor:
         current = self._load_anchor()

--- a/robo_trader/risk/filled_notional/ledger.py
+++ b/robo_trader/risk/filled_notional/ledger.py
@@ -8,11 +8,12 @@ Durability boundary
 The SQLite ledger is checked against an atomic HMAC-protected anchor file in a
 different directory. The caller must obtain the 32-byte-or-longer HMAC key from
 an independent secret authority; the key is never stored in the database or
-anchor. The anchor binds the ledger UUID, database device/inode, fill count and
-head, and quarantine count and head. This detects ledger rollback, replacement,
-and tail deletion. One authenticated database event ahead of the anchor is the
-only recoverable crash window (SQLite committed and the atomic anchor replace
-did not finish).
+anchor. The anchor binds the ledger UUID, database device/inode, fill and
+quarantine heads/counts, and the latest append-only checkpoint. Each fill also
+contains an authenticated cumulative count and total for its accounting scope
+and New York trading date. Startup streams and audits the complete history;
+later operations validate bounded checkpoint, tail, and indexed scope state.
+This detects ledger rollback, replacement, tail deletion, and forged totals.
 
 An HMAC does not prove freshness: an attacker who replays an older valid
 database and matching older valid anchor can pass all local checks while the
@@ -36,7 +37,7 @@ import sqlite3
 import stat
 import uuid
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import date, datetime, timezone
 from decimal import (
     MAX_EMAX,
@@ -63,8 +64,9 @@ from robo_trader.safety.sqlite_identity import (
 
 _NEW_YORK = ZoneInfo("America/New_York")
 _ZERO_HASH = "0" * 64
-_SCHEMA_VERSION = 2
-_ANCHOR_VERSION = 1
+_SCHEMA_VERSION = 3
+_ANCHOR_VERSION = 2
+_MAX_DAILY_FILL_ROWS = 100_000
 _IDENTIFIER_RE = re.compile(r"[\x21-\x7e]{1,128}\Z")
 _CURRENCY_RE = re.compile(r"[A-Z]{3}\Z")
 _LEDGER_ID_RE = re.compile(r"[0-9a-f]{32}\Z")
@@ -105,7 +107,7 @@ _DENIED_SQLITE_ACTIONS = frozenset(
 _SCHEMA_TABLE_SQL = """
 CREATE TABLE daily_filled_notional_schema (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
-    schema_version INTEGER NOT NULL CHECK (schema_version = 2),
+    schema_version INTEGER NOT NULL CHECK (schema_version = 3),
     ledger_id TEXT NOT NULL CHECK (length(ledger_id) = 32)
 )
 """
@@ -125,6 +127,8 @@ CREATE TABLE daily_filled_notional_records (
     executed_at_utc TEXT NOT NULL,
     trading_date TEXT NOT NULL,
     notional_text TEXT NOT NULL,
+    scope_fill_count INTEGER NOT NULL CHECK (scope_fill_count > 0),
+    scope_total_text TEXT NOT NULL,
     previous_hash TEXT NOT NULL CHECK (length(previous_hash) = 64),
     record_hash TEXT NOT NULL CHECK (length(record_hash) = 64)
 )
@@ -145,6 +149,21 @@ CREATE TABLE daily_filled_notional_conflicts (
 )
 """
 
+_CHECKPOINTS_TABLE_SQL = """
+CREATE TABLE daily_filled_notional_checkpoints (
+    event_sequence INTEGER PRIMARY KEY,
+    ledger_id TEXT NOT NULL CHECK (length(ledger_id) = 32),
+    database_device INTEGER NOT NULL CHECK (database_device >= 0),
+    database_inode INTEGER NOT NULL CHECK (database_inode >= 0),
+    fill_count INTEGER NOT NULL CHECK (fill_count >= 0),
+    fill_head TEXT NOT NULL CHECK (length(fill_head) = 64),
+    conflict_count INTEGER NOT NULL CHECK (conflict_count >= 0),
+    conflict_head TEXT NOT NULL CHECK (length(conflict_head) = 64),
+    previous_checkpoint_hash TEXT NOT NULL CHECK (length(previous_checkpoint_hash) = 64),
+    checkpoint_hash TEXT NOT NULL CHECK (length(checkpoint_hash) = 64)
+)
+"""
+
 _UNIQUE_EXECUTION_SQL = """
 CREATE UNIQUE INDEX daily_filled_notional_execution_identity
 ON daily_filled_notional_records(account_id, broker_execution_id)
@@ -152,7 +171,9 @@ ON daily_filled_notional_records(account_id, broker_execution_id)
 
 _SCOPE_DATE_SQL = """
 CREATE INDEX daily_filled_notional_scope_date
-ON daily_filled_notional_records(account_id, portfolio_id, currency, trading_date)
+ON daily_filled_notional_records(
+    account_id, portfolio_id, currency, trading_date, sequence DESC
+)
 """
 
 _TRIGGER_SQL = {
@@ -238,6 +259,37 @@ _TRIGGER_SQL = {
         WHEN EXISTS (SELECT 1 FROM daily_filled_notional_schema)
         BEGIN
             SELECT RAISE(ABORT, 'filled-notional schema is immutable');
+        END
+    """,
+    "daily_filled_notional_checkpoints_insert_guard": """
+        CREATE TRIGGER daily_filled_notional_checkpoints_insert_guard
+        BEFORE INSERT ON daily_filled_notional_checkpoints
+        WHEN NEW.event_sequence != COALESCE(
+                 (SELECT MAX(event_sequence) + 1 FROM daily_filled_notional_checkpoints), 0
+             )
+          OR NEW.previous_checkpoint_hash != COALESCE(
+                 (
+                     SELECT checkpoint_hash
+                     FROM daily_filled_notional_checkpoints
+                     ORDER BY event_sequence DESC LIMIT 1
+                 ), '0000000000000000000000000000000000000000000000000000000000000000'
+             )
+        BEGIN
+            SELECT RAISE(ABORT, 'filled-notional checkpoints must append to the chain');
+        END
+    """,
+    "daily_filled_notional_checkpoints_no_update": """
+        CREATE TRIGGER daily_filled_notional_checkpoints_no_update
+        BEFORE UPDATE ON daily_filled_notional_checkpoints
+        BEGIN
+            SELECT RAISE(ABORT, 'filled-notional checkpoints are append-only');
+        END
+    """,
+    "daily_filled_notional_checkpoints_no_delete": """
+        CREATE TRIGGER daily_filled_notional_checkpoints_no_delete
+        BEFORE DELETE ON daily_filled_notional_checkpoints
+        BEGIN
+            SELECT RAISE(ABORT, 'filled-notional checkpoints are append-only');
         END
     """,
 }
@@ -356,6 +408,8 @@ class _LedgerState:
     fill_head: str
     conflict_count: int
     conflict_head: str
+    checkpoint_sequence: int
+    checkpoint_head: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -420,6 +474,11 @@ def _canonical_nonzero_decimal_magnitude(value: object, field_name: str) -> str:
 def _exact_multiply(left: Decimal, right: Decimal) -> Decimal:
     with _isolated_decimal_context() as context:
         return context.multiply(left, right)
+
+
+def _exact_add(left: Decimal, right: Decimal) -> Decimal:
+    with _isolated_decimal_context() as context:
+        return context.add(left, right)
 
 
 def _parse_canonical_positive_decimal(
@@ -514,6 +573,8 @@ def _fill_hash(
     account_id: str,
     portfolio_id: str,
     fill: _CanonicalFill,
+    scope_fill_count: int,
+    scope_total_text: str,
     previous_hash: str,
 ) -> str:
     return _keyed_hash(
@@ -524,6 +585,8 @@ def _fill_hash(
             "ledger_id": ledger_id,
             "portfolio_id": portfolio_id,
             "previous_hash": previous_hash,
+            "scope_fill_count": scope_fill_count,
+            "scope_total_text": scope_total_text,
             "sequence": sequence,
         },
     )
@@ -531,6 +594,37 @@ def _fill_hash(
 
 def _conflict_hash(key: bytes, ledger_id: str, payload: dict[str, object]) -> str:
     return _keyed_hash(key, {"conflict": payload, "ledger_id": ledger_id})
+
+
+def _checkpoint_hash(
+    key: bytes,
+    *,
+    ledger_id: str,
+    database_device: int,
+    database_inode: int,
+    fill_count: int,
+    fill_head: str,
+    conflict_count: int,
+    conflict_head: str,
+    event_sequence: int,
+    previous_checkpoint_hash: str,
+) -> str:
+    return _keyed_hash(
+        key,
+        {
+            "checkpoint": {
+                "conflict_count": conflict_count,
+                "conflict_head": conflict_head,
+                "database_device": database_device,
+                "database_inode": database_inode,
+                "event_sequence": event_sequence,
+                "fill_count": fill_count,
+                "fill_head": fill_head,
+                "ledger_id": ledger_id,
+                "previous_checkpoint_hash": previous_checkpoint_hash,
+            }
+        },
+    )
 
 
 def _append_only_authorizer(
@@ -590,17 +684,23 @@ class DailyFilledNotional:
         try:
             created = self._initialize_if_missing()
             if not created:
-                self._preflight_existing_schema()
-            self._recover_hot_journal()
+                recovery_required = self._preflight_existing_schema()
+                if recovery_required:
+                    self._recover_hot_journal()
             with self._connection(readonly=True) as connection:
+                connection.execute("BEGIN")
                 state = self._validate_ledger(connection)
                 if created:
                     anchor = self._create_initial_anchor(state)
                 else:
                     anchor = self._reconcile_anchor(state)
                 self._verify_monotonic_state(state)
+                self._ledger_id = state.ledger_id
                 current_day = self._current_trading_date()
                 total = self._total_for_date(connection, current_day)
+                anchor = self._require_exact_anchor(state)
+                self._verify_monotonic_state(state)
+                connection.commit()
         except FilledNotionalError:
             raise
         except DecimalException as exc:
@@ -611,6 +711,7 @@ class DailyFilledNotional:
             raise FilledNotionalUnavailable("filled-notional ledger startup failed closed") from exc
 
         self._ledger_id = state.ledger_id
+        self._state = state
         self._anchor = anchor
         self._restored_trading_date = current_day
         self._restored_total = total
@@ -727,7 +828,7 @@ class DailyFilledNotional:
         try:
             with self._connection(readonly=False) as connection:
                 connection.execute("BEGIN IMMEDIATE")
-                before = self._validate_ledger(connection)
+                before = self._validate_checkpointed_state(connection)
                 anchor = self._reconcile_anchor(before)
                 self._assert_no_conflicts(before)
                 self._verify_monotonic_state(before)
@@ -742,6 +843,7 @@ class DailyFilledNotional:
                 ).fetchone()
                 recorded = existing is None
                 mutated = recorded
+                raw_after = before
                 if existing is not None:
                     stored = tuple(str(value) for value in existing[:8])
                     expected = (
@@ -755,7 +857,7 @@ class DailyFilledNotional:
                         canonical.notional_text,
                     )
                     if stored != expected:
-                        self._append_conflict(
+                        conflict_head = self._append_conflict(
                             connection,
                             before,
                             canonical,
@@ -766,12 +868,45 @@ class DailyFilledNotional:
                         conflict = FilledNotionalConflict(
                             "broker execution identity has durable conflicting evidence"
                         )
+                        raw_after = replace(
+                            before,
+                            conflict_count=before.conflict_count + 1,
+                            conflict_head=conflict_head,
+                        )
                         mutated = True
                 else:
-                    self._append_fill(connection, before, canonical)
+                    prior_count, prior_total = self._scope_total_for_date(
+                        connection, date.fromisoformat(canonical.trading_date)
+                    )
+                    if prior_count >= _MAX_DAILY_FILL_ROWS:
+                        raise FilledNotionalUnavailable(
+                            "daily fill count exceeds the bounded accounting limit"
+                        )
+                    scope_fill_count = prior_count + 1
+                    scope_total = _exact_add(prior_total, canonical.notional)
+                    scope_total_text = _canonical_positive_decimal(
+                        scope_total,
+                        "scope_total",
+                        max_digits=96,
+                        max_abs_exponent=54,
+                    )
+                    fill_head = self._append_fill(
+                        connection,
+                        before,
+                        canonical,
+                        scope_fill_count=scope_fill_count,
+                        scope_total_text=scope_total_text,
+                    )
+                    raw_after = replace(
+                        before,
+                        fill_count=before.fill_count + 1,
+                        fill_head=fill_head,
+                    )
+                after = (
+                    self._append_checkpoint(connection, before, raw_after) if mutated else before
+                )
                 trading_day = date.fromisoformat(canonical.trading_date)
                 total = self._total_for_date(connection, trading_day)
-                after = self._validate_ledger(connection)
                 if mutated:
                     pending = self._replace_anchor(
                         self._anchor_for_state(before, pending_state=after),
@@ -816,11 +951,17 @@ class DailyFilledNotional:
             while True:
                 try:
                     with self._connection(readonly=True) as connection:
-                        state = self._validate_ledger(connection)
+                        connection.execute("BEGIN")
+                        state = self._validate_checkpointed_state(connection)
                         self._anchor = self._require_exact_anchor(state)
                         self._assert_no_conflicts(state)
                         self._verify_monotonic_state(state)
-                        return self._total_for_date(connection, trading_day)
+                        total = self._total_for_date(connection, trading_day)
+                        self._anchor = self._require_exact_anchor(state)
+                        self._verify_monotonic_state(state)
+                        connection.commit()
+                        self._state = state
+                        return total
                 except _PendingAnchorInProgress:
                     pending_attempts += 1
                     if pending_attempts > 3:
@@ -870,12 +1011,14 @@ class DailyFilledNotional:
         )
         try:
             with reviewer._connection(readonly=True) as connection:
-                state = reviewer._validate_ledger(connection)
+                connection.execute("BEGIN")
+                state = reviewer._validate_checkpointed_state(connection)
                 reviewer._require_exact_anchor(state)
+                reviewer._verify_monotonic_state(state)
                 rows = connection.execute(
                     "SELECT * FROM daily_filled_notional_conflicts ORDER BY sequence"
                 ).fetchall()
-                return tuple(
+                evidence = tuple(
                     ConflictEvidence(
                         sequence=int(row["sequence"]),
                         account_id=str(row["account_id"]),
@@ -888,6 +1031,10 @@ class DailyFilledNotional:
                     )
                     for row in rows
                 )
+                reviewer._require_exact_anchor(state)
+                reviewer._verify_monotonic_state(state)
+                connection.commit()
+                return evidence
         finally:
             reviewer._latch_failure("review-only instance cannot perform accounting")
 
@@ -896,7 +1043,10 @@ class DailyFilledNotional:
         connection: sqlite3.Connection,
         state: _LedgerState,
         fill: _CanonicalFill,
-    ) -> None:
+        *,
+        scope_fill_count: int,
+        scope_total_text: str,
+    ) -> str:
         sequence = state.fill_count + 1
         digest = _fill_hash(
             self._key,
@@ -905,6 +1055,8 @@ class DailyFilledNotional:
             self._account_id,
             self._portfolio_id,
             fill,
+            scope_fill_count,
+            scope_total_text,
             state.fill_head,
         )
         connection.execute(
@@ -912,8 +1064,9 @@ class DailyFilledNotional:
             INSERT INTO daily_filled_notional_records (
                 sequence, account_id, portfolio_id, broker_execution_id,
                 side, quantity_text, price_text, currency, executed_at_utc,
-                trading_date, notional_text, previous_hash, record_hash
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                trading_date, notional_text, scope_fill_count, scope_total_text,
+                previous_hash, record_hash
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 sequence,
@@ -927,10 +1080,13 @@ class DailyFilledNotional:
                 fill.executed_at_utc,
                 fill.trading_date,
                 fill.notional_text,
+                scope_fill_count,
+                scope_total_text,
                 state.fill_head,
                 digest,
             ),
         )
+        return digest
 
     def _append_conflict(
         self,
@@ -941,7 +1097,7 @@ class DailyFilledNotional:
         existing_portfolio_id: str,
         existing_record_hash: str,
         observed_at_utc: str,
-    ) -> None:
+    ) -> str:
         sequence = state.conflict_count + 1
         claimed_fill_json = _canonical_json(fill.as_dict())
         payload: dict[str, object] = {
@@ -977,6 +1133,55 @@ class DailyFilledNotional:
                 state.conflict_head,
                 digest,
             ),
+        )
+        return digest
+
+    def _append_checkpoint(
+        self,
+        connection: sqlite3.Connection,
+        before: _LedgerState,
+        after: _LedgerState,
+    ) -> _LedgerState:
+        event_sequence = before.checkpoint_sequence + 1
+        if event_sequence != after.fill_count + after.conflict_count:
+            raise FilledNotionalIntegrityError("checkpoint event sequence is invalid")
+        digest = _checkpoint_hash(
+            self._key,
+            ledger_id=after.ledger_id,
+            database_device=after.database_device,
+            database_inode=after.database_inode,
+            fill_count=after.fill_count,
+            fill_head=after.fill_head,
+            conflict_count=after.conflict_count,
+            conflict_head=after.conflict_head,
+            event_sequence=event_sequence,
+            previous_checkpoint_hash=before.checkpoint_head,
+        )
+        connection.execute(
+            """
+            INSERT INTO daily_filled_notional_checkpoints (
+                event_sequence, ledger_id, database_device, database_inode,
+                fill_count, fill_head, conflict_count, conflict_head,
+                previous_checkpoint_hash, checkpoint_hash
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                event_sequence,
+                after.ledger_id,
+                after.database_device,
+                after.database_inode,
+                after.fill_count,
+                after.fill_head,
+                after.conflict_count,
+                after.conflict_head,
+                before.checkpoint_head,
+                digest,
+            ),
+        )
+        return replace(
+            after,
+            checkpoint_sequence=event_sequence,
+            checkpoint_head=digest,
         )
 
     @staticmethod
@@ -1051,13 +1256,43 @@ class DailyFilledNotional:
             connection.execute(_SCHEMA_TABLE_SQL)
             connection.execute(_RECORDS_TABLE_SQL)
             connection.execute(_CONFLICTS_TABLE_SQL)
+            connection.execute(_CHECKPOINTS_TABLE_SQL)
             connection.execute(_UNIQUE_EXECUTION_SQL)
             connection.execute(_SCOPE_DATE_SQL)
             for statement in _TRIGGER_SQL.values():
                 connection.execute(statement)
+            ledger_id = uuid.uuid4().hex
             connection.execute(
                 "INSERT INTO daily_filled_notional_schema VALUES (1, ?, ?)",
-                (_SCHEMA_VERSION, uuid.uuid4().hex),
+                (_SCHEMA_VERSION, ledger_id),
+            )
+            initial_checkpoint = _checkpoint_hash(
+                self._key,
+                ledger_id=ledger_id,
+                database_device=bound.device,
+                database_inode=bound.inode,
+                fill_count=0,
+                fill_head=_ZERO_HASH,
+                conflict_count=0,
+                conflict_head=_ZERO_HASH,
+                event_sequence=0,
+                previous_checkpoint_hash=_ZERO_HASH,
+            )
+            connection.execute(
+                """
+                INSERT INTO daily_filled_notional_checkpoints VALUES (
+                    0, ?, ?, ?, 0, ?, 0, ?, ?, ?
+                )
+                """,
+                (
+                    ledger_id,
+                    bound.device,
+                    bound.inode,
+                    _ZERO_HASH,
+                    _ZERO_HASH,
+                    _ZERO_HASH,
+                    initial_checkpoint,
+                ),
             )
             connection.commit()
             bound.assert_connection_identity(sqlite_connection_file_identity(connection))
@@ -1079,7 +1314,7 @@ class DailyFilledNotional:
             connection.execute("SELECT count(*) FROM sqlite_master").fetchone()
             connection.commit()
 
-    def _preflight_existing_schema(self) -> None:
+    def _preflight_existing_schema(self) -> bool:
         """Identify legacy state without permitting SQLite journal recovery."""
 
         journal = Path(f"{self._path}-journal")
@@ -1092,6 +1327,21 @@ class DailyFilledNotional:
                 raise FilledNotionalUnavailable(
                     "SQLite journal prevents safe read-only schema detection"
                 )
+            try:
+                anchor = self._load_anchor()
+                database_metadata = os.lstat(self._path)
+            except (FilledNotionalError, OSError) as exc:
+                raise FilledNotionalUnavailable(
+                    "hot journal lacks an authenticated current-schema recovery anchor"
+                ) from exc
+            if (
+                anchor.state.database_device != database_metadata.st_dev
+                or anchor.state.database_inode != database_metadata.st_ino
+            ):
+                raise FilledNotionalUnavailable(
+                    "hot journal recovery anchor does not bind this database"
+                )
+            return True
         try:
             with self._connection(readonly=True, immutable=True) as connection:
                 self._schema_version(connection)
@@ -1103,6 +1353,7 @@ class DailyFilledNotional:
             raise FilledNotionalUnavailable(
                 "existing schema cannot be detected without SQLite recovery"
             ) from exc
+        return False
 
     @contextmanager
     def _connection(
@@ -1159,7 +1410,7 @@ class DailyFilledNotional:
         version = int(rows[0][0])
         if version < _SCHEMA_VERSION:
             raise FilledNotionalMigrationRequired(
-                f"filled-notional schema v{version} requires reviewed copy migration to v2"
+                f"filled-notional schema v{version} requires reviewed copy migration to v3"
             )
         if version > _SCHEMA_VERSION:
             raise FilledNotionalIntegrityError(
@@ -1167,15 +1418,13 @@ class DailyFilledNotional:
             )
         return version
 
-    def _validate_ledger(self, connection: sqlite3.Connection) -> _LedgerState:
-        integrity = connection.execute("PRAGMA integrity_check").fetchall()
-        if len(integrity) != 1 or str(integrity[0][0]) != "ok":
-            raise FilledNotionalIntegrityError("SQLite integrity_check failed")
+    def _validate_schema(self, connection: sqlite3.Connection) -> str:
         self._schema_version(connection)
         expected_sql = {
             ("table", "daily_filled_notional_schema"): _SCHEMA_TABLE_SQL,
             ("table", "daily_filled_notional_records"): _RECORDS_TABLE_SQL,
             ("table", "daily_filled_notional_conflicts"): _CONFLICTS_TABLE_SQL,
+            ("table", "daily_filled_notional_checkpoints"): _CHECKPOINTS_TABLE_SQL,
             ("index", "daily_filled_notional_execution_identity"): _UNIQUE_EXECUTION_SQL,
             ("index", "daily_filled_notional_scope_date"): _SCOPE_DATE_SQL,
             **{("trigger", name): sql for name, sql in _TRIGGER_SQL.items()},
@@ -1201,13 +1450,26 @@ class DailyFilledNotional:
         ledger_id = str(schema_rows[0][2])
         if _LEDGER_ID_RE.fullmatch(ledger_id) is None:
             raise FilledNotionalIntegrityError("filled-notional ledger identity is invalid")
+        return ledger_id
+
+    def _validate_ledger(self, connection: sqlite3.Connection) -> _LedgerState:
+        integrity = connection.execute("PRAGMA integrity_check")
+        first_integrity = integrity.fetchone()
+        if (
+            first_integrity is None
+            or str(first_integrity[0]) != "ok"
+            or integrity.fetchone() is not None
+        ):
+            raise FilledNotionalIntegrityError("SQLite integrity_check failed")
+        ledger_id = self._validate_schema(connection)
 
         fill_count, fill_head = self._validate_fills(connection, ledger_id)
         conflict_count, conflict_head = self._validate_conflicts(connection, ledger_id)
         metadata = os.lstat(self._path)
         if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
             raise FilledNotionalIntegrityError("ledger path identity is invalid")
-        return _LedgerState(
+        checkpoint_sequence, checkpoint_head = self._validate_checkpoints(
+            connection,
             ledger_id=ledger_id,
             database_device=metadata.st_dev,
             database_inode=metadata.st_ino,
@@ -1216,14 +1478,124 @@ class DailyFilledNotional:
             conflict_count=conflict_count,
             conflict_head=conflict_head,
         )
+        return _LedgerState(
+            ledger_id=ledger_id,
+            database_device=metadata.st_dev,
+            database_inode=metadata.st_ino,
+            fill_count=fill_count,
+            fill_head=fill_head,
+            conflict_count=conflict_count,
+            conflict_head=conflict_head,
+            checkpoint_sequence=checkpoint_sequence,
+            checkpoint_head=checkpoint_head,
+        )
+
+    def _validate_checkpointed_state(self, connection: sqlite3.Connection) -> _LedgerState:
+        """Validate bounded authenticated state after the startup full audit."""
+
+        ledger_id = self._validate_schema(connection)
+        row = connection.execute(
+            "SELECT * FROM daily_filled_notional_checkpoints "
+            "ORDER BY event_sequence DESC LIMIT 1"
+        ).fetchone()
+        if row is None:
+            raise FilledNotionalIntegrityError("checkpoint state is missing")
+        integer_names = (
+            "event_sequence",
+            "database_device",
+            "database_inode",
+            "fill_count",
+            "conflict_count",
+        )
+        if any(type(row[name]) is not int or row[name] < 0 for name in integer_names):
+            raise FilledNotionalIntegrityError("checkpoint counters are invalid")
+        checkpoint_ledger_id = str(row["ledger_id"])
+        database_device = int(row["database_device"])
+        database_inode = int(row["database_inode"])
+        fill_count = int(row["fill_count"])
+        fill_head = str(row["fill_head"])
+        conflict_count = int(row["conflict_count"])
+        conflict_head = str(row["conflict_head"])
+        event_sequence = int(row["event_sequence"])
+        previous_checkpoint_hash = str(row["previous_checkpoint_hash"])
+        if (
+            checkpoint_ledger_id != ledger_id
+            or event_sequence != fill_count + conflict_count
+            or conflict_count > 1
+            or _HASH_RE.fullmatch(fill_head) is None
+            or _HASH_RE.fullmatch(conflict_head) is None
+            or _HASH_RE.fullmatch(previous_checkpoint_hash) is None
+        ):
+            raise FilledNotionalIntegrityError("checkpoint state is inconsistent")
+        expected_hash = _checkpoint_hash(
+            self._key,
+            ledger_id=checkpoint_ledger_id,
+            database_device=database_device,
+            database_inode=database_inode,
+            fill_count=fill_count,
+            fill_head=fill_head,
+            conflict_count=conflict_count,
+            conflict_head=conflict_head,
+            event_sequence=event_sequence,
+            previous_checkpoint_hash=previous_checkpoint_hash,
+        )
+        checkpoint_head = str(row["checkpoint_hash"])
+        if not hmac.compare_digest(checkpoint_head, expected_hash):
+            raise FilledNotionalIntegrityError("checkpoint HMAC is invalid")
+        metadata = os.lstat(self._path)
+        if (
+            stat.S_ISLNK(metadata.st_mode)
+            or not stat.S_ISREG(metadata.st_mode)
+            or (metadata.st_dev, metadata.st_ino) != (database_device, database_inode)
+        ):
+            raise FilledNotionalIntegrityError("checkpoint database identity changed")
+        fill_tail = connection.execute(
+            "SELECT sequence, record_hash FROM daily_filled_notional_records "
+            "ORDER BY sequence DESC LIMIT 1"
+        ).fetchone()
+        conflict_tail = connection.execute(
+            "SELECT sequence, conflict_hash FROM daily_filled_notional_conflicts "
+            "ORDER BY sequence DESC LIMIT 1"
+        ).fetchone()
+        if fill_count == 0:
+            fill_matches = fill_tail is None and fill_head == _ZERO_HASH
+        else:
+            fill_matches = (
+                fill_tail is not None
+                and type(fill_tail[0]) is int
+                and int(fill_tail[0]) == fill_count
+                and str(fill_tail[1]) == fill_head
+            )
+        if conflict_count == 0:
+            conflict_matches = conflict_tail is None and conflict_head == _ZERO_HASH
+        else:
+            conflict_matches = (
+                conflict_tail is not None
+                and type(conflict_tail[0]) is int
+                and int(conflict_tail[0]) == conflict_count
+                and str(conflict_tail[1]) == conflict_head
+            )
+        if not fill_matches or not conflict_matches:
+            raise FilledNotionalIntegrityError("checkpoint tails do not match ledger rows")
+        return _LedgerState(
+            ledger_id=ledger_id,
+            database_device=database_device,
+            database_inode=database_inode,
+            fill_count=fill_count,
+            fill_head=fill_head,
+            conflict_count=conflict_count,
+            conflict_head=conflict_head,
+            checkpoint_sequence=event_sequence,
+            checkpoint_head=checkpoint_head,
+        )
 
     def _validate_fills(self, connection: sqlite3.Connection, ledger_id: str) -> tuple[int, str]:
         previous_hash = _ZERO_HASH
         expected_sequence = 1
-        identities: set[tuple[str, str]] = set()
+        scope_states: dict[tuple[str, str, str, str], tuple[int, Decimal]] = {}
         for row in connection.execute(
             "SELECT * FROM daily_filled_notional_records ORDER BY sequence"
-        ).fetchall():
+        ):
             if int(row["sequence"]) != expected_sequence:
                 raise FilledNotionalIntegrityError("filled-notional sequence is not contiguous")
             account_id = _validate_stored_identifier(row["account_id"], "account_id")
@@ -1231,10 +1603,6 @@ class DailyFilledNotional:
             execution_id = _validate_stored_identifier(
                 row["broker_execution_id"], "broker_execution_id"
             )
-            identity = (account_id, execution_id)
-            if identity in identities:
-                raise FilledNotionalIntegrityError("duplicate account execution identity")
-            identities.add(identity)
             side = str(row["side"])
             if side not in {candidate.value for candidate in FillSide}:
                 raise FilledNotionalIntegrityError("stored fill side is invalid")
@@ -1266,6 +1634,24 @@ class DailyFilledNotional:
                 trading_date=str(row["trading_date"]),
                 notional_text=str(row["notional_text"]),
             )
+            scope_key = (account_id, portfolio_id, currency, str(row["trading_date"]))
+            prior_scope_count, prior_scope_total = scope_states.get(scope_key, (0, Decimal("0")))
+            scope_fill_count = int(row["scope_fill_count"])
+            if (
+                type(row["scope_fill_count"]) is not int
+                or scope_fill_count != prior_scope_count + 1
+                or scope_fill_count > _MAX_DAILY_FILL_ROWS
+            ):
+                raise FilledNotionalIntegrityError("stored scope fill count is invalid")
+            scope_total = _parse_canonical_positive_decimal(
+                row["scope_total_text"],
+                "scope total",
+                max_digits=96,
+                max_abs_exponent=54,
+            )
+            expected_scope_total = _exact_add(prior_scope_total, notional)
+            if scope_total != expected_scope_total:
+                raise FilledNotionalIntegrityError("stored scope total is inconsistent")
             expected_hash = _fill_hash(
                 self._key,
                 ledger_id,
@@ -1273,12 +1659,15 @@ class DailyFilledNotional:
                 account_id,
                 portfolio_id,
                 canonical,
+                scope_fill_count,
+                str(row["scope_total_text"]),
                 previous_hash,
             )
             stored_hash = str(row["record_hash"])
             if not hmac.compare_digest(stored_hash, expected_hash):
                 raise FilledNotionalIntegrityError("filled-notional record HMAC is invalid")
             previous_hash = stored_hash
+            scope_states[scope_key] = (scope_fill_count, scope_total)
             expected_sequence += 1
         return expected_sequence - 1, previous_hash
 
@@ -1289,7 +1678,7 @@ class DailyFilledNotional:
         expected_sequence = 1
         for row in connection.execute(
             "SELECT * FROM daily_filled_notional_conflicts ORDER BY sequence"
-        ).fetchall():
+        ):
             if int(row["sequence"]) != expected_sequence:
                 raise FilledNotionalIntegrityError("conflict sequence is not contiguous")
             payload: dict[str, object] = {
@@ -1328,9 +1717,85 @@ class DailyFilledNotional:
             expected_sequence += 1
         return expected_sequence - 1, previous_hash
 
+    def _validate_checkpoints(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        ledger_id: str,
+        database_device: int,
+        database_inode: int,
+        fill_count: int,
+        fill_head: str,
+        conflict_count: int,
+        conflict_head: str,
+    ) -> tuple[int, str]:
+        expected_sequence = 0
+        previous_hash = _ZERO_HASH
+        final_row: Optional[sqlite3.Row] = None
+        for row in connection.execute(
+            "SELECT * FROM daily_filled_notional_checkpoints ORDER BY event_sequence"
+        ):
+            if int(row["event_sequence"]) != expected_sequence:
+                raise FilledNotionalIntegrityError("checkpoint sequence is not contiguous")
+            if str(row["ledger_id"]) != ledger_id:
+                raise FilledNotionalIntegrityError("checkpoint ledger identity changed")
+            checkpoint_database_device = int(row["database_device"])
+            checkpoint_database_inode = int(row["database_inode"])
+            checkpoint_fill_count = int(row["fill_count"])
+            checkpoint_fill_head = str(row["fill_head"])
+            checkpoint_conflict_count = int(row["conflict_count"])
+            checkpoint_conflict_head = str(row["conflict_head"])
+            if str(row["previous_checkpoint_hash"]) != previous_hash:
+                raise FilledNotionalIntegrityError("checkpoint hash chain is broken")
+            expected_hash = _checkpoint_hash(
+                self._key,
+                ledger_id=ledger_id,
+                database_device=checkpoint_database_device,
+                database_inode=checkpoint_database_inode,
+                fill_count=checkpoint_fill_count,
+                fill_head=checkpoint_fill_head,
+                conflict_count=checkpoint_conflict_count,
+                conflict_head=checkpoint_conflict_head,
+                event_sequence=expected_sequence,
+                previous_checkpoint_hash=previous_hash,
+            )
+            stored_hash = str(row["checkpoint_hash"])
+            if not hmac.compare_digest(stored_hash, expected_hash):
+                raise FilledNotionalIntegrityError("checkpoint HMAC is invalid")
+            previous_hash = stored_hash
+            expected_sequence += 1
+            final_row = row
+        if final_row is None:
+            raise FilledNotionalIntegrityError("initial checkpoint is missing")
+        final_values = (
+            int(final_row["database_device"]),
+            int(final_row["database_inode"]),
+            int(final_row["fill_count"]),
+            str(final_row["fill_head"]),
+            int(final_row["conflict_count"]),
+            str(final_row["conflict_head"]),
+        )
+        if final_values != (
+            database_device,
+            database_inode,
+            fill_count,
+            fill_head,
+            conflict_count,
+            conflict_head,
+        ):
+            raise FilledNotionalIntegrityError(
+                "checkpoint does not match audited ledger state; rollback, tail deletion, "
+                "or tamper detected"
+            )
+        if expected_sequence - 1 != fill_count + conflict_count:
+            raise FilledNotionalIntegrityError("checkpoint event count is inconsistent")
+        return expected_sequence - 1, previous_hash
+
     @staticmethod
     def _state_payload(state: _LedgerState) -> dict[str, object]:
         return {
+            "checkpoint_head": state.checkpoint_head,
+            "checkpoint_sequence": state.checkpoint_sequence,
             "conflict_count": state.conflict_count,
             "conflict_head": state.conflict_head,
             "database_device": state.database_device,
@@ -1454,6 +1919,8 @@ class DailyFilledNotional:
     @staticmethod
     def _parse_anchor_state(value: object) -> _LedgerState:
         names = {
+            "checkpoint_head",
+            "checkpoint_sequence",
             "conflict_count",
             "conflict_head",
             "database_device",
@@ -1466,11 +1933,18 @@ class DailyFilledNotional:
             raise FilledNotionalIntegrityError("anchor state shape is invalid")
         if any(
             type(value[name]) is not int or value[name] < 0
-            for name in ("conflict_count", "database_device", "database_inode", "fill_count")
+            for name in (
+                "checkpoint_sequence",
+                "conflict_count",
+                "database_device",
+                "database_inode",
+                "fill_count",
+            )
         ):
             raise FilledNotionalIntegrityError("anchor counters or identity are invalid")
         if _LEDGER_ID_RE.fullmatch(str(value["ledger_id"])) is None or any(
-            _HASH_RE.fullmatch(str(value[name])) is None for name in ("fill_head", "conflict_head")
+            _HASH_RE.fullmatch(str(value[name])) is None
+            for name in ("checkpoint_head", "fill_head", "conflict_head")
         ):
             raise FilledNotionalIntegrityError("anchor identifiers are invalid")
         return _LedgerState(
@@ -1481,6 +1955,8 @@ class DailyFilledNotional:
             fill_head=str(value["fill_head"]),
             conflict_count=int(value["conflict_count"]),
             conflict_head=str(value["conflict_head"]),
+            checkpoint_sequence=int(value["checkpoint_sequence"]),
+            checkpoint_head=str(value["checkpoint_head"]),
         )
 
     def _reconcile_anchor(self, state: _LedgerState) -> _Anchor:
@@ -1616,13 +2092,15 @@ class DailyFilledNotional:
             raise FilledNotionalIntegrityError("atomic anchor verification failed")
         return loaded
 
-    def _total_for_date(self, connection: sqlite3.Connection, trading_day: date) -> Decimal:
-        rows = connection.execute(
+    def _scope_total_for_date(
+        self, connection: sqlite3.Connection, trading_day: date
+    ) -> tuple[int, Decimal]:
+        row = connection.execute(
             """
-            SELECT notional_text FROM daily_filled_notional_records
+            SELECT * FROM daily_filled_notional_records
             WHERE account_id = ? AND portfolio_id = ?
               AND currency = ? AND trading_date = ?
-            ORDER BY sequence
+            ORDER BY sequence DESC LIMIT 1
             """,
             (
                 self._account_id,
@@ -1630,15 +2108,58 @@ class DailyFilledNotional:
                 self._currency,
                 trading_day.isoformat(),
             ),
-        ).fetchall()
-        with _isolated_decimal_context() as context:
-            total = Decimal("0")
-            for row in rows:
-                total = context.add(
-                    total,
-                    _parse_canonical_positive_decimal(row[0], "notional"),
-                )
-            return total
+        ).fetchone()
+        if row is None:
+            return 0, Decimal("0")
+        sequence = int(row["sequence"])
+        scope_fill_count = int(row["scope_fill_count"])
+        if (
+            type(row["sequence"]) is not int
+            or type(row["scope_fill_count"]) is not int
+            or sequence < 1
+            or scope_fill_count < 1
+            or scope_fill_count > _MAX_DAILY_FILL_ROWS
+        ):
+            raise FilledNotionalIntegrityError("stored scope fill count is invalid")
+        account_id = _validate_stored_identifier(row["account_id"], "account_id")
+        portfolio_id = _validate_stored_identifier(row["portfolio_id"], "portfolio_id")
+        execution_id = _validate_stored_identifier(
+            row["broker_execution_id"], "broker_execution_id"
+        )
+        canonical = _CanonicalFill(
+            broker_execution_id=execution_id,
+            side=str(row["side"]),
+            quantity_text=str(row["quantity_text"]),
+            price_text=str(row["price_text"]),
+            currency=str(row["currency"]),
+            executed_at_utc=str(row["executed_at_utc"]),
+            trading_date=str(row["trading_date"]),
+            notional_text=str(row["notional_text"]),
+        )
+        scope_total_text = str(row["scope_total_text"])
+        total = _parse_canonical_positive_decimal(
+            scope_total_text,
+            "scope total",
+            max_digits=96,
+            max_abs_exponent=54,
+        )
+        expected_hash = _fill_hash(
+            self._key,
+            self._ledger_id,
+            sequence,
+            account_id,
+            portfolio_id,
+            canonical,
+            scope_fill_count,
+            scope_total_text,
+            str(row["previous_hash"]),
+        )
+        if not hmac.compare_digest(str(row["record_hash"]), expected_hash):
+            raise FilledNotionalIntegrityError("scope-total record HMAC is invalid")
+        return scope_fill_count, total
+
+    def _total_for_date(self, connection: sqlite3.Connection, trading_day: date) -> Decimal:
+        return self._scope_total_for_date(connection, trading_day)[1]
 
 
 def _validate_stored_identifier(value: object, field_name: str) -> str:

--- a/robo_trader/risk/filled_notional/ledger.py
+++ b/robo_trader/risk/filled_notional/ledger.py
@@ -1,17 +1,25 @@
-"""Append-only accounting for daily gross executed-fill notional.
+"""Authenticated, append-only daily gross executed-fill notional accounting.
 
-Only broker execution evidence belongs in this ledger.  An order being
-submitted, accepted, cancelled, or rejected is not an execution and cannot be
-represented by :class:`ExecutedFill`.
+Only actual broker executions belong here. Submitted, cancelled, rejected, and
+otherwise zero-fill order events cannot be represented by :class:`ExecutedFill`.
 
-The service is bound to one broker account and portfolio.  Each partial fill is
-recorded independently under its immutable broker execution identifier.  Exact
-replays are idempotent; a reuse of that identifier with different evidence is a
-fatal conflict.  Monetary arithmetic is performed entirely with ``Decimal``
-and persisted as canonical decimal text.
+Durability boundary
+-------------------
+The SQLite ledger is checked against an atomic HMAC-protected anchor file in a
+different directory. The caller must obtain the 32-byte-or-longer HMAC key from
+an independent secret authority; the key is never stored in the database or
+anchor. The anchor binds the ledger UUID, database device/inode, fill count and
+head, and quarantine count and head. This detects ledger rollback, replacement,
+and tail deletion. One authenticated database event ahead of the anchor is the
+only recoverable crash window (SQLite committed and the atomic anchor replace
+did not finish).
 
-This module grants no order or process-start authority and is not wired into
-the trading runner.
+No local-file design can prove a coordinated offline rollback of the database,
+anchor, *and* the external key/monotonic authority. Operators must protect and
+version the anchor independently (for example, immutable backup or a monotonic
+secret service). This module makes no claim beyond that explicit boundary.
+
+The package is dormant: it grants no order, broker, runner, or startup authority.
 """
 
 from __future__ import annotations
@@ -21,11 +29,24 @@ import hmac
 import json
 import os
 import re
+import secrets
 import sqlite3
+import stat
+import uuid
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
-from decimal import MAX_PREC, Decimal, Inexact, Rounded, localcontext
+from decimal import (
+    MAX_EMAX,
+    MAX_PREC,
+    MIN_EMIN,
+    Context,
+    Decimal,
+    DecimalException,
+    Inexact,
+    Rounded,
+    localcontext,
+)
 from enum import Enum
 from pathlib import Path
 from typing import Callable, Iterator, Optional
@@ -40,9 +61,13 @@ from robo_trader.safety.sqlite_identity import (
 
 _NEW_YORK = ZoneInfo("America/New_York")
 _ZERO_HASH = "0" * 64
-_SCHEMA_VERSION = 1
+_SCHEMA_VERSION = 2
+_ANCHOR_VERSION = 1
 _IDENTIFIER_RE = re.compile(r"[\x21-\x7e]{1,128}\Z")
 _CURRENCY_RE = re.compile(r"[A-Z]{3}\Z")
+_LEDGER_ID_RE = re.compile(r"[0-9a-f]{32}\Z")
+_HASH_RE = re.compile(r"[0-9a-f]{64}\Z")
+
 _DENIED_SQLITE_ACTIONS = frozenset(
     action
     for name in (
@@ -78,7 +103,8 @@ _DENIED_SQLITE_ACTIONS = frozenset(
 _SCHEMA_TABLE_SQL = """
 CREATE TABLE daily_filled_notional_schema (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
-    schema_version INTEGER NOT NULL CHECK (schema_version = 1)
+    schema_version INTEGER NOT NULL CHECK (schema_version = 2),
+    ledger_id TEXT NOT NULL CHECK (length(ledger_id) = 32)
 )
 """
 
@@ -102,9 +128,24 @@ CREATE TABLE daily_filled_notional_records (
 )
 """
 
+_CONFLICTS_TABLE_SQL = """
+CREATE TABLE daily_filled_notional_conflicts (
+    sequence INTEGER PRIMARY KEY,
+    account_id TEXT NOT NULL,
+    broker_execution_id TEXT NOT NULL,
+    existing_portfolio_id TEXT NOT NULL,
+    claimed_portfolio_id TEXT NOT NULL,
+    existing_record_hash TEXT NOT NULL CHECK (length(existing_record_hash) = 64),
+    claimed_fill_json TEXT NOT NULL,
+    observed_at_utc TEXT NOT NULL,
+    previous_hash TEXT NOT NULL CHECK (length(previous_hash) = 64),
+    conflict_hash TEXT NOT NULL CHECK (length(conflict_hash) = 64)
+)
+"""
+
 _UNIQUE_EXECUTION_SQL = """
 CREATE UNIQUE INDEX daily_filled_notional_execution_identity
-ON daily_filled_notional_records(account_id, portfolio_id, broker_execution_id)
+ON daily_filled_notional_records(account_id, broker_execution_id)
 """
 
 _SCOPE_DATE_SQL = """
@@ -144,6 +185,37 @@ _TRIGGER_SQL = {
             SELECT RAISE(ABORT, 'filled-notional records are append-only');
         END
     """,
+    "daily_filled_notional_conflicts_insert_guard": """
+        CREATE TRIGGER daily_filled_notional_conflicts_insert_guard
+        BEFORE INSERT ON daily_filled_notional_conflicts
+        WHEN NEW.sequence != COALESCE(
+                 (SELECT MAX(sequence) + 1 FROM daily_filled_notional_conflicts), 1
+             )
+          OR NEW.previous_hash != COALESCE(
+                 (
+                     SELECT conflict_hash
+                     FROM daily_filled_notional_conflicts
+                     ORDER BY sequence DESC LIMIT 1
+                 ), '0000000000000000000000000000000000000000000000000000000000000000'
+             )
+        BEGIN
+            SELECT RAISE(ABORT, 'filled-notional conflicts must append to the chain');
+        END
+    """,
+    "daily_filled_notional_conflicts_no_update": """
+        CREATE TRIGGER daily_filled_notional_conflicts_no_update
+        BEFORE UPDATE ON daily_filled_notional_conflicts
+        BEGIN
+            SELECT RAISE(ABORT, 'filled-notional conflicts are append-only');
+        END
+    """,
+    "daily_filled_notional_conflicts_no_delete": """
+        CREATE TRIGGER daily_filled_notional_conflicts_no_delete
+        BEFORE DELETE ON daily_filled_notional_conflicts
+        BEGIN
+            SELECT RAISE(ABORT, 'filled-notional conflicts are append-only');
+        END
+    """,
     "daily_filled_notional_schema_no_update": """
         CREATE TRIGGER daily_filled_notional_schema_no_update
         BEFORE UPDATE ON daily_filled_notional_schema
@@ -178,19 +250,19 @@ class FilledNotionalUnavailable(FilledNotionalError):
 
 
 class FilledNotionalIntegrityError(FilledNotionalUnavailable):
-    """The ledger schema or immutable record chain is invalid."""
+    """The ledger, anchor, schema, or authenticated chain is invalid."""
 
 
 class FilledNotionalConflict(FilledNotionalUnavailable):
-    """One immutable execution identifier has conflicting evidence."""
+    """Durable conflicting evidence requires operator review."""
+
+
+class FilledNotionalMigrationRequired(FilledNotionalUnavailable):
+    """A preserved older schema requires an explicit reviewed migration."""
 
 
 class FillSide(str, Enum):
-    """Economic direction of an executed fill.
-
-    Direction never changes gross-notional arithmetic: buys, sells, shorts,
-    and covers all add the absolute executed quantity multiplied by price.
-    """
+    """Economic direction of an actual executed fill."""
 
     BUY = "BUY"
     SELL = "SELL"
@@ -212,12 +284,22 @@ class ExecutedFill:
 
 @dataclass(frozen=True, slots=True)
 class FillAccountingResult:
-    """Result of appending or replaying one execution."""
-
     recorded: bool
     trading_date: date
     fill_notional: Decimal
     gross_filled_notional: Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class ConflictEvidence:
+    sequence: int
+    account_id: str
+    broker_execution_id: str
+    existing_portfolio_id: str
+    claimed_portfolio_id: str
+    claimed_fill_json: str
+    observed_at_utc: str
+    conflict_hash: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -235,6 +317,36 @@ class _CanonicalFill:
     def notional(self) -> Decimal:
         return Decimal(self.notional_text)
 
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "broker_execution_id": self.broker_execution_id,
+            "currency": self.currency,
+            "executed_at_utc": self.executed_at_utc,
+            "notional_text": self.notional_text,
+            "price_text": self.price_text,
+            "quantity_text": self.quantity_text,
+            "side": self.side,
+            "trading_date": self.trading_date,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class _LedgerState:
+    ledger_id: str
+    database_device: int
+    database_inode: int
+    fill_count: int
+    fill_head: str
+    conflict_count: int
+    conflict_head: str
+
+
+@dataclass(frozen=True, slots=True)
+class _Anchor:
+    state: _LedgerState
+    pending_state: Optional[_LedgerState]
+    mac: str
+
 
 def _normalized_sql(value: object) -> str:
     if not isinstance(value, str) or not value.strip():
@@ -248,6 +360,16 @@ def _validate_identifier(value: object, field_name: str) -> str:
             f"{field_name} must be 1-128 non-whitespace printable ASCII characters"
         )
     return value
+
+
+@contextmanager
+def _isolated_decimal_context() -> Iterator[Context]:
+    context = Context(prec=MAX_PREC, Emax=MAX_EMAX, Emin=MIN_EMIN, clamp=0)
+    context.traps[Inexact] = True
+    context.traps[Rounded] = True
+    context.clear_flags()
+    with localcontext(context) as active:
+        yield active
 
 
 def _canonical_positive_decimal(
@@ -269,9 +391,7 @@ def _canonical_positive_decimal(
     text = format(value, "f")
     if len(text) > max_digits + max_abs_exponent + 2:
         raise FilledNotionalError(f"{field_name} exceeds the exact-decimal storage bound")
-    if "." in text:
-        text = text.rstrip("0").rstrip(".")
-    return text
+    return text.rstrip("0").rstrip(".") if "." in text else text
 
 
 def _canonical_nonzero_decimal_magnitude(value: object, field_name: str) -> str:
@@ -281,11 +401,8 @@ def _canonical_nonzero_decimal_magnitude(value: object, field_name: str) -> str:
 
 
 def _exact_multiply(left: Decimal, right: Decimal) -> Decimal:
-    with localcontext() as context:
-        context.prec = MAX_PREC
-        context.traps[Inexact] = True
-        context.traps[Rounded] = True
-        return left * right
+    with _isolated_decimal_context() as context:
+        return context.multiply(left, right)
 
 
 def _parse_canonical_positive_decimal(
@@ -298,17 +415,15 @@ def _parse_canonical_positive_decimal(
     if type(value) is not str or not value:
         raise FilledNotionalIntegrityError(f"stored {field_name} is not canonical decimal text")
     try:
-        parsed = Decimal(value)
-    except Exception as exc:
-        raise FilledNotionalIntegrityError(f"stored {field_name} is malformed") from exc
-    try:
+        with _isolated_decimal_context() as context:
+            parsed = context.create_decimal(value)
         canonical = _canonical_positive_decimal(
             parsed,
             field_name,
             max_digits=max_digits,
             max_abs_exponent=max_abs_exponent,
         )
-    except FilledNotionalError as exc:
+    except (DecimalException, FilledNotionalError) as exc:
         raise FilledNotionalIntegrityError(f"stored {field_name} is invalid") from exc
     if canonical != value:
         raise FilledNotionalIntegrityError(f"stored {field_name} is not canonical decimal text")
@@ -317,7 +432,7 @@ def _parse_canonical_positive_decimal(
 
 def _canonical_utc(value: object) -> tuple[str, str]:
     if type(value) is not datetime or value.tzinfo is None or value.utcoffset() is None:
-        raise FilledNotionalError("executed_at must be an aware datetime")
+        raise FilledNotionalError("timestamp must be an aware datetime")
     instant = value.astimezone(timezone.utc)
     utc_text = instant.isoformat(timespec="microseconds").replace("+00:00", "Z")
     trading_day = instant.astimezone(_NEW_YORK).date().isoformat()
@@ -326,14 +441,14 @@ def _canonical_utc(value: object) -> tuple[str, str]:
 
 def _parse_canonical_utc(value: object) -> datetime:
     if type(value) is not str or not value.endswith("Z"):
-        raise FilledNotionalIntegrityError("stored execution timestamp is not canonical UTC")
+        raise FilledNotionalIntegrityError("stored timestamp is not canonical UTC")
     try:
         parsed = datetime.fromisoformat(value[:-1] + "+00:00")
     except ValueError as exc:
-        raise FilledNotionalIntegrityError("stored execution timestamp is malformed") from exc
+        raise FilledNotionalIntegrityError("stored timestamp is malformed") from exc
     canonical, _ = _canonical_utc(parsed)
     if canonical != value:
-        raise FilledNotionalIntegrityError("stored execution timestamp is not canonical UTC")
+        raise FilledNotionalIntegrityError("stored timestamp is not canonical UTC")
     return parsed
 
 
@@ -367,29 +482,38 @@ def _canonical_fill(fill: object) -> _CanonicalFill:
     )
 
 
-def _record_hash(
+def _canonical_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _keyed_hash(key: bytes, payload: object) -> str:
+    return hmac.new(key, _canonical_json(payload).encode("ascii"), hashlib.sha256).hexdigest()
+
+
+def _fill_hash(
+    key: bytes,
+    ledger_id: str,
     sequence: int,
     account_id: str,
     portfolio_id: str,
     fill: _CanonicalFill,
     previous_hash: str,
 ) -> str:
-    payload = {
-        "account_id": account_id,
-        "broker_execution_id": fill.broker_execution_id,
-        "currency": fill.currency,
-        "executed_at_utc": fill.executed_at_utc,
-        "notional_text": fill.notional_text,
-        "portfolio_id": portfolio_id,
-        "previous_hash": previous_hash,
-        "price_text": fill.price_text,
-        "quantity_text": fill.quantity_text,
-        "sequence": sequence,
-        "side": fill.side,
-        "trading_date": fill.trading_date,
-    }
-    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("ascii")
-    return hashlib.sha256(encoded).hexdigest()
+    return _keyed_hash(
+        key,
+        {
+            "account_id": account_id,
+            "fill": fill.as_dict(),
+            "ledger_id": ledger_id,
+            "portfolio_id": portfolio_id,
+            "previous_hash": previous_hash,
+            "sequence": sequence,
+        },
+    )
+
+
+def _conflict_hash(key: bytes, ledger_id: str, payload: dict[str, object]) -> str:
+    return _keyed_hash(key, {"conflict": payload, "ledger_id": ledger_id})
 
 
 def _append_only_authorizer(
@@ -402,24 +526,33 @@ def _append_only_authorizer(
     del argument_two, database_name, trigger_name
     if action in _DENIED_SQLITE_ACTIONS:
         return sqlite3.SQLITE_DENY
-    if action == sqlite3.SQLITE_PRAGMA and argument_one not in {"integrity_check"}:
+    if action == sqlite3.SQLITE_PRAGMA and argument_one not in {
+        "integrity_check",
+        "schema_version",
+    }:
         return sqlite3.SQLITE_DENY
     return sqlite3.SQLITE_OK
 
 
 class DailyFilledNotional:
-    """Scope-bound, durable accounting for gross executed-fill notional."""
+    """Scope-bound durable gross-filled-notional accounting."""
 
     def __init__(
         self,
         database_path: Path | str,
         *,
+        anchor_path: Path | str,
+        anchor_key: bytes,
         account_id: str,
         portfolio_id: str,
         currency: str = "USD",
         clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+        _review_only: bool = False,
     ) -> None:
         self._path = lexical_path_preserving_leaf(database_path)
+        self._anchor_path = lexical_path_preserving_leaf(anchor_path)
+        self._key = self._validate_anchor_key(anchor_key)
+        self._validate_independent_anchor_path()
         self._account_id = _validate_identifier(account_id, "account_id")
         self._portfolio_id = _validate_identifier(portfolio_id, "portfolio_id")
         if type(currency) is not str or _CURRENCY_RE.fullmatch(currency) is None:
@@ -429,68 +562,106 @@ class DailyFilledNotional:
         self._currency = currency
         self._clock = clock
         self._failed_reason: Optional[str] = None
-        self._restored_trading_date: date
-        self._restored_total: Decimal
+        self._review_only = _review_only
 
         try:
-            self._initialize_if_missing()
-            current_day = self._current_trading_date()
+            created = self._initialize_if_missing()
+            self._recover_hot_journal()
             with self._connection(readonly=True) as connection:
-                self._validate_ledger(connection)
+                state = self._validate_ledger(connection)
+                if created:
+                    anchor = self._create_initial_anchor(state)
+                else:
+                    anchor = self._reconcile_anchor(state)
+                current_day = self._current_trading_date()
                 total = self._total_for_date(connection, current_day)
         except FilledNotionalError:
             raise
+        except DecimalException as exc:
+            raise FilledNotionalUnavailable(
+                "filled-notional decimal restoration failed closed"
+            ) from exc
         except (OSError, sqlite3.Error, SQLiteIdentityError) as exc:
             raise FilledNotionalUnavailable("filled-notional ledger startup failed closed") from exc
+
+        self._ledger_id = state.ledger_id
+        self._anchor = anchor
         self._restored_trading_date = current_day
         self._restored_total = total
+        if state.conflict_count and not _review_only:
+            self._latch_failure("durable conflicting execution evidence requires review")
+            raise FilledNotionalConflict(self._failed_reason)
+
+    @staticmethod
+    def _validate_anchor_key(value: object) -> bytes:
+        if type(value) is not bytes or len(value) < 32:
+            raise FilledNotionalError("anchor_key must be at least 32 exact bytes")
+        return value
+
+    def _validate_independent_anchor_path(self) -> None:
+        if self._anchor_path == self._path:
+            raise FilledNotionalError("anchor path must differ from the SQLite ledger")
+        if self._anchor_path.parent == self._path.parent:
+            raise FilledNotionalError("anchor must be stored in a separate protected directory")
+        try:
+            metadata = os.lstat(self._anchor_path.parent)
+        except OSError as exc:
+            raise FilledNotionalError("anchor directory must already exist") from exc
+        if not stat.S_ISDIR(metadata.st_mode) or metadata.st_mode & 0o022:
+            raise FilledNotionalError(
+                "anchor directory must be a non-group/world-writable directory"
+            )
 
     @property
     def database_path(self) -> Path:
         return self._path
 
     @property
-    def restored_trading_date(self) -> date:
-        """Trading date restored during construction."""
+    def anchor_path(self) -> Path:
+        return self._anchor_path
 
+    @property
+    def restored_trading_date(self) -> date:
         return self._restored_trading_date
 
     @property
     def restored_gross_filled_notional(self) -> Decimal:
-        """Exact total restored from durable records during construction."""
-
         return self._restored_total
 
     def record_fill(self, fill: ExecutedFill) -> FillAccountingResult:
-        """Append one actual execution, or accept an exact replay idempotently."""
+        """Append one execution or accept an exact account-level replay."""
 
         self._require_available()
-        canonical = _canonical_fill(fill)
+        try:
+            canonical = _canonical_fill(fill)
+            observed_at_utc, _ = _canonical_utc(self._clock())
+        except DecimalException as exc:
+            self._latch_failure("decimal accounting failed")
+            raise FilledNotionalUnavailable("filled-notional decimal failed closed") from exc
         if canonical.currency != self._currency:
             raise FilledNotionalError("fill currency does not match the service scope")
 
+        conflict: Optional[FilledNotionalConflict] = None
         try:
             with self._connection(readonly=False) as connection:
                 connection.execute("BEGIN IMMEDIATE")
-                self._validate_ledger(connection)
+                before = self._validate_ledger(connection)
+                anchor = self._reconcile_anchor(before)
                 existing = connection.execute(
                     """
-                    SELECT side, quantity_text, price_text, currency,
-                           executed_at_utc, trading_date, notional_text
+                    SELECT portfolio_id, side, quantity_text, price_text, currency,
+                           executed_at_utc, trading_date, notional_text, record_hash
                     FROM daily_filled_notional_records
-                    WHERE account_id = ? AND portfolio_id = ?
-                      AND broker_execution_id = ?
+                    WHERE account_id = ? AND broker_execution_id = ?
                     """,
-                    (
-                        self._account_id,
-                        self._portfolio_id,
-                        canonical.broker_execution_id,
-                    ),
+                    (self._account_id, canonical.broker_execution_id),
                 ).fetchone()
                 recorded = existing is None
+                mutated = recorded
                 if existing is not None:
-                    stored = tuple(str(value) for value in existing)
+                    stored = tuple(str(value) for value in existing[:8])
                     expected = (
+                        self._portfolio_id,
                         canonical.side,
                         canonical.quantity_text,
                         canonical.price_text,
@@ -500,62 +671,49 @@ class DailyFilledNotional:
                         canonical.notional_text,
                     )
                     if stored != expected:
-                        raise FilledNotionalConflict(
-                            "broker execution identity has conflicting immutable evidence"
+                        self._append_conflict(
+                            connection,
+                            before,
+                            canonical,
+                            existing_portfolio_id=str(existing[0]),
+                            existing_record_hash=str(existing[8]),
+                            observed_at_utc=observed_at_utc,
                         )
+                        conflict = FilledNotionalConflict(
+                            "broker execution identity has durable conflicting evidence"
+                        )
+                        mutated = True
                 else:
-                    tail = connection.execute("""
-                        SELECT sequence, record_hash
-                        FROM daily_filled_notional_records
-                        ORDER BY sequence DESC LIMIT 1
-                        """).fetchone()
-                    sequence = 1 if tail is None else int(tail[0]) + 1
-                    previous_hash = _ZERO_HASH if tail is None else str(tail[1])
-                    digest = _record_hash(
-                        sequence,
-                        self._account_id,
-                        self._portfolio_id,
-                        canonical,
-                        previous_hash,
-                    )
-                    connection.execute(
-                        """
-                        INSERT INTO daily_filled_notional_records (
-                            sequence, account_id, portfolio_id, broker_execution_id,
-                            side, quantity_text, price_text, currency,
-                            executed_at_utc, trading_date, notional_text,
-                            previous_hash, record_hash
-                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                        """,
-                        (
-                            sequence,
-                            self._account_id,
-                            self._portfolio_id,
-                            canonical.broker_execution_id,
-                            canonical.side,
-                            canonical.quantity_text,
-                            canonical.price_text,
-                            canonical.currency,
-                            canonical.executed_at_utc,
-                            canonical.trading_date,
-                            canonical.notional_text,
-                            previous_hash,
-                            digest,
-                        ),
-                    )
+                    self._append_fill(connection, before, canonical)
                 trading_day = date.fromisoformat(canonical.trading_date)
                 total = self._total_for_date(connection, trading_day)
-                connection.commit()
-        except FilledNotionalConflict as exc:
-            self._latch_failure(str(exc))
-            raise
+                after = self._validate_ledger(connection)
+                if mutated:
+                    pending = self._replace_anchor(
+                        self._anchor_for_state(before, pending_state=after),
+                        expected=anchor,
+                    )
+                    self._commit_database(connection)
+                    self._anchor = self._replace_anchor(
+                        self._anchor_for_state(after),
+                        expected=pending,
+                    )
+                else:
+                    self._commit_database(connection)
+                    self._anchor = anchor
         except FilledNotionalIntegrityError as exc:
             self._latch_failure(str(exc))
             raise
+        except DecimalException as exc:
+            self._latch_failure("decimal accounting failed")
+            raise FilledNotionalUnavailable("filled-notional decimal failed closed") from exc
         except (OSError, sqlite3.Error, SQLiteIdentityError) as exc:
             self._latch_failure("filled-notional ledger write failed")
             raise FilledNotionalUnavailable("filled-notional ledger write failed closed") from exc
 
+        if conflict is not None:
+            self._latch_failure(str(conflict))
+            raise conflict
         return FillAccountingResult(
             recorded=recorded,
             trading_date=trading_day,
@@ -564,29 +722,163 @@ class DailyFilledNotional:
         )
 
     def current_gross_filled_notional(self, *, as_of: Optional[datetime] = None) -> Decimal:
-        """Read the exact total for the New York date containing ``as_of``.
-
-        This API performs no database mutation.  Omitting ``as_of`` uses the
-        injected clock, which also makes midnight and DST behavior testable.
-        """
+        """Return a read-only exact total for the containing New York date."""
 
         self._require_available()
         try:
             trading_day = self._trading_date(as_of if as_of is not None else self._clock())
             with self._connection(readonly=True) as connection:
-                self._validate_ledger(connection)
-                total = self._total_for_date(connection, trading_day)
+                state = self._validate_ledger(connection)
+                self._anchor = self._require_exact_anchor(state)
+                return self._total_for_date(connection, trading_day)
         except FilledNotionalIntegrityError as exc:
             self._latch_failure(str(exc))
             raise
+        except DecimalException as exc:
+            self._latch_failure("decimal accounting failed")
+            raise FilledNotionalUnavailable("filled-notional decimal failed closed") from exc
         except FilledNotionalError:
             raise
         except (OSError, sqlite3.Error, SQLiteIdentityError) as exc:
             self._latch_failure("filled-notional ledger read failed")
             raise FilledNotionalUnavailable("filled-notional ledger read failed closed") from exc
-        return total
+
+    @classmethod
+    def review_quarantine(
+        cls,
+        database_path: Path | str,
+        *,
+        anchor_path: Path | str,
+        anchor_key: bytes,
+    ) -> tuple[ConflictEvidence, ...]:
+        """Authenticate and return durable conflict markers without clearing them."""
+
+        reviewer = cls(
+            database_path,
+            anchor_path=anchor_path,
+            anchor_key=anchor_key,
+            account_id="__review__",
+            portfolio_id="__review__",
+            _review_only=True,
+        )
+        try:
+            with reviewer._connection(readonly=True) as connection:
+                state = reviewer._validate_ledger(connection)
+                reviewer._require_exact_anchor(state)
+                rows = connection.execute(
+                    "SELECT * FROM daily_filled_notional_conflicts ORDER BY sequence"
+                ).fetchall()
+                return tuple(
+                    ConflictEvidence(
+                        sequence=int(row["sequence"]),
+                        account_id=str(row["account_id"]),
+                        broker_execution_id=str(row["broker_execution_id"]),
+                        existing_portfolio_id=str(row["existing_portfolio_id"]),
+                        claimed_portfolio_id=str(row["claimed_portfolio_id"]),
+                        claimed_fill_json=str(row["claimed_fill_json"]),
+                        observed_at_utc=str(row["observed_at_utc"]),
+                        conflict_hash=str(row["conflict_hash"]),
+                    )
+                    for row in rows
+                )
+        finally:
+            reviewer._latch_failure("review-only instance cannot perform accounting")
+
+    def _append_fill(
+        self,
+        connection: sqlite3.Connection,
+        state: _LedgerState,
+        fill: _CanonicalFill,
+    ) -> None:
+        sequence = state.fill_count + 1
+        digest = _fill_hash(
+            self._key,
+            state.ledger_id,
+            sequence,
+            self._account_id,
+            self._portfolio_id,
+            fill,
+            state.fill_head,
+        )
+        connection.execute(
+            """
+            INSERT INTO daily_filled_notional_records (
+                sequence, account_id, portfolio_id, broker_execution_id,
+                side, quantity_text, price_text, currency, executed_at_utc,
+                trading_date, notional_text, previous_hash, record_hash
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                sequence,
+                self._account_id,
+                self._portfolio_id,
+                fill.broker_execution_id,
+                fill.side,
+                fill.quantity_text,
+                fill.price_text,
+                fill.currency,
+                fill.executed_at_utc,
+                fill.trading_date,
+                fill.notional_text,
+                state.fill_head,
+                digest,
+            ),
+        )
+
+    def _append_conflict(
+        self,
+        connection: sqlite3.Connection,
+        state: _LedgerState,
+        fill: _CanonicalFill,
+        *,
+        existing_portfolio_id: str,
+        existing_record_hash: str,
+        observed_at_utc: str,
+    ) -> None:
+        sequence = state.conflict_count + 1
+        claimed_fill_json = _canonical_json(fill.as_dict())
+        payload: dict[str, object] = {
+            "account_id": self._account_id,
+            "broker_execution_id": fill.broker_execution_id,
+            "claimed_fill_json": claimed_fill_json,
+            "claimed_portfolio_id": self._portfolio_id,
+            "existing_portfolio_id": existing_portfolio_id,
+            "existing_record_hash": existing_record_hash,
+            "observed_at_utc": observed_at_utc,
+            "previous_hash": state.conflict_head,
+            "sequence": sequence,
+        }
+        digest = _conflict_hash(self._key, state.ledger_id, payload)
+        connection.execute(
+            """
+            INSERT INTO daily_filled_notional_conflicts (
+                sequence, account_id, broker_execution_id,
+                existing_portfolio_id, claimed_portfolio_id,
+                existing_record_hash, claimed_fill_json, observed_at_utc,
+                previous_hash, conflict_hash
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                sequence,
+                self._account_id,
+                fill.broker_execution_id,
+                existing_portfolio_id,
+                self._portfolio_id,
+                existing_record_hash,
+                claimed_fill_json,
+                observed_at_utc,
+                state.conflict_head,
+                digest,
+            ),
+        )
+
+    @staticmethod
+    def _commit_database(connection: sqlite3.Connection) -> None:
+        connection.commit()
 
     def _require_available(self) -> None:
+        if self._review_only:
+            raise FilledNotionalUnavailable("review-only instance cannot perform accounting")
         if self._failed_reason is not None:
             raise FilledNotionalUnavailable(
                 f"filled-notional accounting is latched unavailable: {self._failed_reason}"
@@ -603,17 +895,17 @@ class DailyFilledNotional:
         _, trading_day = _canonical_utc(instant)
         return date.fromisoformat(trading_day)
 
-    def _initialize_if_missing(self) -> None:
+    def _initialize_if_missing(self) -> bool:
         try:
             os.lstat(self._path)
-            create = False
+            return False
         except FileNotFoundError:
-            create = True
+            pass
 
         binding: Optional[SQLitePathBinding] = None
         connection: Optional[sqlite3.Connection] = None
         try:
-            binding = SQLitePathBinding.open_for_initialization(self._path, create=create)
+            binding = SQLitePathBinding.open_for_initialization(self._path, create=True)
             connection = sqlite3.connect(
                 self._path.as_uri() + "?mode=rw",
                 uri=True,
@@ -622,22 +914,23 @@ class DailyFilledNotional:
             )
             connection.row_factory = sqlite3.Row
             bound = binding.bind_sqlite_connection(sqlite_connection_file_identity(connection))
-            if create:
-                connection.execute("PRAGMA journal_mode=DELETE")
-                connection.execute("PRAGMA synchronous=FULL")
-                connection.execute("BEGIN IMMEDIATE")
-                connection.execute(_SCHEMA_TABLE_SQL)
-                connection.execute(_RECORDS_TABLE_SQL)
-                connection.execute(_UNIQUE_EXECUTION_SQL)
-                connection.execute(_SCOPE_DATE_SQL)
-                for statement in _TRIGGER_SQL.values():
-                    connection.execute(statement)
-                connection.execute(
-                    "INSERT INTO daily_filled_notional_schema VALUES (1, ?)",
-                    (_SCHEMA_VERSION,),
-                )
-                connection.commit()
+            connection.execute("PRAGMA journal_mode=DELETE")
+            connection.execute("PRAGMA synchronous=FULL")
+            connection.execute("BEGIN IMMEDIATE")
+            connection.execute(_SCHEMA_TABLE_SQL)
+            connection.execute(_RECORDS_TABLE_SQL)
+            connection.execute(_CONFLICTS_TABLE_SQL)
+            connection.execute(_UNIQUE_EXECUTION_SQL)
+            connection.execute(_SCOPE_DATE_SQL)
+            for statement in _TRIGGER_SQL.values():
+                connection.execute(statement)
+            connection.execute(
+                "INSERT INTO daily_filled_notional_schema VALUES (1, ?, ?)",
+                (_SCHEMA_VERSION, uuid.uuid4().hex),
+            )
+            connection.commit()
             bound.assert_connection_identity(sqlite_connection_file_identity(connection))
+            return True
         finally:
             if connection is not None:
                 if connection.in_transaction:
@@ -645,6 +938,15 @@ class DailyFilledNotional:
                 connection.close()
             if binding is not None:
                 binding.close()
+
+    def _recover_hot_journal(self) -> None:
+        """Force identity-bound SQLite recovery before any read-only open."""
+
+        with self._connection(readonly=False) as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            connection.execute("PRAGMA schema_version").fetchone()
+            connection.execute("SELECT count(*) FROM sqlite_master").fetchone()
+            connection.commit()
 
     @contextmanager
     def _connection(self, *, readonly: bool) -> Iterator[sqlite3.Connection]:
@@ -675,21 +977,49 @@ class DailyFilledNotional:
             if binding is not None:
                 binding.close()
 
-    def _validate_ledger(self, connection: sqlite3.Connection) -> None:
+    def _schema_version(self, connection: sqlite3.Connection) -> int:
+        table = connection.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' "
+            "AND name = 'daily_filled_notional_schema'"
+        ).fetchone()
+        if table is None:
+            raise FilledNotionalIntegrityError("filled-notional schema table is missing")
+        try:
+            rows = connection.execute(
+                "SELECT schema_version FROM daily_filled_notional_schema"
+            ).fetchall()
+        except sqlite3.Error as exc:
+            raise FilledNotionalIntegrityError(
+                "filled-notional schema version is unreadable"
+            ) from exc
+        if len(rows) != 1 or type(rows[0][0]) is not int:
+            raise FilledNotionalIntegrityError("filled-notional schema version is invalid")
+        version = int(rows[0][0])
+        if version < _SCHEMA_VERSION:
+            raise FilledNotionalMigrationRequired(
+                f"filled-notional schema v{version} requires reviewed copy migration to v2"
+            )
+        if version > _SCHEMA_VERSION:
+            raise FilledNotionalIntegrityError(
+                f"unsupported future filled-notional schema v{version}"
+            )
+        return version
+
+    def _validate_ledger(self, connection: sqlite3.Connection) -> _LedgerState:
         integrity = connection.execute("PRAGMA integrity_check").fetchall()
         if len(integrity) != 1 or str(integrity[0][0]) != "ok":
             raise FilledNotionalIntegrityError("SQLite integrity_check failed")
-
+        self._schema_version(connection)
         expected_sql = {
             ("table", "daily_filled_notional_schema"): _SCHEMA_TABLE_SQL,
             ("table", "daily_filled_notional_records"): _RECORDS_TABLE_SQL,
+            ("table", "daily_filled_notional_conflicts"): _CONFLICTS_TABLE_SQL,
             ("index", "daily_filled_notional_execution_identity"): _UNIQUE_EXECUTION_SQL,
             ("index", "daily_filled_notional_scope_date"): _SCOPE_DATE_SQL,
             **{("trigger", name): sql for name, sql in _TRIGGER_SQL.items()},
         }
         rows = connection.execute("""
-            SELECT type, name, sql
-            FROM sqlite_master
+            SELECT type, name, sql FROM sqlite_master
             WHERE name LIKE 'daily_filled_notional_%'
             ORDER BY type, name
             """).fetchall()
@@ -701,46 +1031,56 @@ class DailyFilledNotional:
                 raise FilledNotionalIntegrityError(
                     f"filled-notional schema definition changed: {key[1]}"
                 )
-
         schema_rows = connection.execute(
-            "SELECT singleton, schema_version FROM daily_filled_notional_schema"
+            "SELECT singleton, schema_version, ledger_id FROM daily_filled_notional_schema"
         ).fetchall()
-        if [tuple(row) for row in schema_rows] != [(1, _SCHEMA_VERSION)]:
-            raise FilledNotionalIntegrityError("filled-notional schema version is invalid")
+        if len(schema_rows) != 1 or tuple(schema_rows[0][:2]) != (1, _SCHEMA_VERSION):
+            raise FilledNotionalIntegrityError("filled-notional schema singleton is invalid")
+        ledger_id = str(schema_rows[0][2])
+        if _LEDGER_ID_RE.fullmatch(ledger_id) is None:
+            raise FilledNotionalIntegrityError("filled-notional ledger identity is invalid")
 
+        fill_count, fill_head = self._validate_fills(connection, ledger_id)
+        conflict_count, conflict_head = self._validate_conflicts(connection, ledger_id)
+        metadata = os.lstat(self._path)
+        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+            raise FilledNotionalIntegrityError("ledger path identity is invalid")
+        return _LedgerState(
+            ledger_id=ledger_id,
+            database_device=metadata.st_dev,
+            database_inode=metadata.st_ino,
+            fill_count=fill_count,
+            fill_head=fill_head,
+            conflict_count=conflict_count,
+            conflict_head=conflict_head,
+        )
+
+    def _validate_fills(self, connection: sqlite3.Connection, ledger_id: str) -> tuple[int, str]:
         previous_hash = _ZERO_HASH
         expected_sequence = 1
-        records = connection.execute(
+        identities: set[tuple[str, str]] = set()
+        for row in connection.execute(
             "SELECT * FROM daily_filled_notional_records ORDER BY sequence"
-        ).fetchall()
-        identities: set[tuple[str, str, str]] = set()
-        for row in records:
+        ).fetchall():
             if int(row["sequence"]) != expected_sequence:
-                raise FilledNotionalIntegrityError(
-                    "filled-notional record sequence is not contiguous"
-                )
+                raise FilledNotionalIntegrityError("filled-notional sequence is not contiguous")
             account_id = _validate_stored_identifier(row["account_id"], "account_id")
             portfolio_id = _validate_stored_identifier(row["portfolio_id"], "portfolio_id")
             execution_id = _validate_stored_identifier(
                 row["broker_execution_id"], "broker_execution_id"
             )
-            identity = (account_id, portfolio_id, execution_id)
+            identity = (account_id, execution_id)
             if identity in identities:
-                raise FilledNotionalIntegrityError("duplicate broker execution identity in ledger")
+                raise FilledNotionalIntegrityError("duplicate account execution identity")
             identities.add(identity)
-            if str(row["side"]) not in {side.value for side in FillSide}:
+            side = str(row["side"])
+            if side not in {candidate.value for candidate in FillSide}:
                 raise FilledNotionalIntegrityError("stored fill side is invalid")
             quantity = _parse_canonical_positive_decimal(
-                row["quantity_text"],
-                "quantity",
-                max_digits=38,
-                max_abs_exponent=18,
+                row["quantity_text"], "quantity", max_digits=38, max_abs_exponent=18
             )
             price = _parse_canonical_positive_decimal(
-                row["price_text"],
-                "price",
-                max_digits=38,
-                max_abs_exponent=18,
+                row["price_text"], "price", max_digits=38, max_abs_exponent=18
             )
             notional = _parse_canonical_positive_decimal(row["notional_text"], "notional")
             currency = str(row["currency"])
@@ -751,12 +1091,12 @@ class DailyFilledNotional:
             if str(row["trading_date"]) != derived_day:
                 raise FilledNotionalIntegrityError("stored New York trading date is invalid")
             if _exact_multiply(quantity, price) != notional:
-                raise FilledNotionalIntegrityError("stored fill notional does not match quantity")
+                raise FilledNotionalIntegrityError("stored fill notional is inconsistent")
             if str(row["previous_hash"]) != previous_hash:
                 raise FilledNotionalIntegrityError("filled-notional hash chain is broken")
             canonical = _CanonicalFill(
                 broker_execution_id=execution_id,
-                side=str(row["side"]),
+                side=side,
                 quantity_text=str(row["quantity_text"]),
                 price_text=str(row["price_text"]),
                 currency=currency,
@@ -764,7 +1104,9 @@ class DailyFilledNotional:
                 trading_date=str(row["trading_date"]),
                 notional_text=str(row["notional_text"]),
             )
-            expected_hash = _record_hash(
+            expected_hash = _fill_hash(
+                self._key,
+                ledger_id,
                 expected_sequence,
                 account_id,
                 portfolio_id,
@@ -773,15 +1115,271 @@ class DailyFilledNotional:
             )
             stored_hash = str(row["record_hash"])
             if not hmac.compare_digest(stored_hash, expected_hash):
-                raise FilledNotionalIntegrityError("filled-notional record hash is invalid")
+                raise FilledNotionalIntegrityError("filled-notional record HMAC is invalid")
             previous_hash = stored_hash
             expected_sequence += 1
+        return expected_sequence - 1, previous_hash
+
+    def _validate_conflicts(
+        self, connection: sqlite3.Connection, ledger_id: str
+    ) -> tuple[int, str]:
+        previous_hash = _ZERO_HASH
+        expected_sequence = 1
+        for row in connection.execute(
+            "SELECT * FROM daily_filled_notional_conflicts ORDER BY sequence"
+        ).fetchall():
+            if int(row["sequence"]) != expected_sequence:
+                raise FilledNotionalIntegrityError("conflict sequence is not contiguous")
+            payload: dict[str, object] = {
+                "account_id": _validate_stored_identifier(row["account_id"], "account_id"),
+                "broker_execution_id": _validate_stored_identifier(
+                    row["broker_execution_id"], "broker_execution_id"
+                ),
+                "claimed_fill_json": str(row["claimed_fill_json"]),
+                "claimed_portfolio_id": _validate_stored_identifier(
+                    row["claimed_portfolio_id"], "claimed_portfolio_id"
+                ),
+                "existing_portfolio_id": _validate_stored_identifier(
+                    row["existing_portfolio_id"], "existing_portfolio_id"
+                ),
+                "existing_record_hash": str(row["existing_record_hash"]),
+                "observed_at_utc": str(row["observed_at_utc"]),
+                "previous_hash": str(row["previous_hash"]),
+                "sequence": expected_sequence,
+            }
+            if _HASH_RE.fullmatch(str(payload["existing_record_hash"])) is None:
+                raise FilledNotionalIntegrityError("conflict existing record hash is invalid")
+            try:
+                claimed = json.loads(str(payload["claimed_fill_json"]))
+            except (TypeError, json.JSONDecodeError) as exc:
+                raise FilledNotionalIntegrityError("conflict claimed fill is malformed") from exc
+            if _canonical_json(claimed) != payload["claimed_fill_json"]:
+                raise FilledNotionalIntegrityError("conflict claimed fill is not canonical")
+            _parse_canonical_utc(payload["observed_at_utc"])
+            if payload["previous_hash"] != previous_hash:
+                raise FilledNotionalIntegrityError("conflict hash chain is broken")
+            expected_hash = _conflict_hash(self._key, ledger_id, payload)
+            stored_hash = str(row["conflict_hash"])
+            if not hmac.compare_digest(stored_hash, expected_hash):
+                raise FilledNotionalIntegrityError("conflict record HMAC is invalid")
+            previous_hash = stored_hash
+            expected_sequence += 1
+        return expected_sequence - 1, previous_hash
+
+    @staticmethod
+    def _state_payload(state: _LedgerState) -> dict[str, object]:
+        return {
+            "conflict_count": state.conflict_count,
+            "conflict_head": state.conflict_head,
+            "database_device": state.database_device,
+            "database_inode": state.database_inode,
+            "fill_count": state.fill_count,
+            "fill_head": state.fill_head,
+            "ledger_id": state.ledger_id,
+        }
+
+    def _unsigned_anchor_payload(
+        self,
+        state: _LedgerState,
+        pending_state: Optional[_LedgerState],
+    ) -> dict[str, object]:
+        return {
+            "anchor_version": _ANCHOR_VERSION,
+            "pending_state": (
+                None if pending_state is None else self._state_payload(pending_state)
+            ),
+            "state": self._state_payload(state),
+        }
+
+    def _anchor_for_state(
+        self,
+        state: _LedgerState,
+        *,
+        pending_state: Optional[_LedgerState] = None,
+    ) -> _Anchor:
+        unsigned = self._unsigned_anchor_payload(state, pending_state)
+        return _Anchor(
+            state=state,
+            pending_state=pending_state,
+            mac=_keyed_hash(self._key, unsigned),
+        )
+
+    def _create_initial_anchor(self, state: _LedgerState) -> _Anchor:
+        try:
+            os.lstat(self._anchor_path)
+        except FileNotFoundError:
+            anchor = self._anchor_for_state(state)
+            return self._write_anchor_file(anchor, must_not_exist=True)
+        raise FilledNotionalIntegrityError("new ledger anchor path already exists")
+
+    def _load_anchor(self) -> _Anchor:
+        try:
+            metadata = os.lstat(self._anchor_path)
+            if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+                raise FilledNotionalIntegrityError("anchor must be a non-symlink regular file")
+            if metadata.st_mode & 0o077:
+                raise FilledNotionalIntegrityError("anchor permissions must be owner-only")
+            raw = self._anchor_path.read_bytes()
+            decoded = json.loads(raw.decode("ascii"))
+        except FilledNotionalError:
+            raise
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise FilledNotionalIntegrityError("anchor cannot be read safely") from exc
+        if type(decoded) is not dict or set(decoded) != {
+            "anchor_version",
+            "mac",
+            "pending_state",
+            "state",
+        }:
+            raise FilledNotionalIntegrityError("anchor shape is invalid")
+        unsigned = {key: decoded[key] for key in decoded if key != "mac"}
+        if unsigned["anchor_version"] != _ANCHOR_VERSION:
+            raise FilledNotionalIntegrityError("anchor version is unsupported")
+        mac = str(decoded["mac"])
+        expected_mac = _keyed_hash(self._key, unsigned)
+        if _HASH_RE.fullmatch(mac) is None or not hmac.compare_digest(mac, expected_mac):
+            raise FilledNotionalIntegrityError("anchor HMAC is invalid")
+        state = self._parse_anchor_state(unsigned["state"])
+        pending_value = unsigned["pending_state"]
+        pending_state = None if pending_value is None else self._parse_anchor_state(pending_value)
+        return _Anchor(state=state, pending_state=pending_state, mac=mac)
+
+    @staticmethod
+    def _parse_anchor_state(value: object) -> _LedgerState:
+        names = {
+            "conflict_count",
+            "conflict_head",
+            "database_device",
+            "database_inode",
+            "fill_count",
+            "fill_head",
+            "ledger_id",
+        }
+        if type(value) is not dict or set(value) != names:
+            raise FilledNotionalIntegrityError("anchor state shape is invalid")
+        if any(
+            type(value[name]) is not int or value[name] < 0
+            for name in ("conflict_count", "database_device", "database_inode", "fill_count")
+        ):
+            raise FilledNotionalIntegrityError("anchor counters or identity are invalid")
+        if _LEDGER_ID_RE.fullmatch(str(value["ledger_id"])) is None or any(
+            _HASH_RE.fullmatch(str(value[name])) is None for name in ("fill_head", "conflict_head")
+        ):
+            raise FilledNotionalIntegrityError("anchor identifiers are invalid")
+        return _LedgerState(
+            ledger_id=str(value["ledger_id"]),
+            database_device=int(value["database_device"]),
+            database_inode=int(value["database_inode"]),
+            fill_count=int(value["fill_count"]),
+            fill_head=str(value["fill_head"]),
+            conflict_count=int(value["conflict_count"]),
+            conflict_head=str(value["conflict_head"]),
+        )
+
+    def _reconcile_anchor(self, state: _LedgerState) -> _Anchor:
+        anchor = self._load_anchor()
+        anchored = anchor.state
+        if (
+            anchored.ledger_id != state.ledger_id
+            or anchored.database_device != state.database_device
+            or anchored.database_inode != state.database_inode
+        ):
+            raise FilledNotionalIntegrityError("anchor does not bind this ledger identity")
+        pending = anchor.pending_state
+        if pending is None and anchored == state:
+            return anchor
+        if pending is None:
+            raise FilledNotionalIntegrityError(
+                "ledger rollback, tail deletion, or stable-anchor rollback detected"
+            )
+        if (
+            pending.ledger_id != anchored.ledger_id
+            or pending.database_device != anchored.database_device
+            or pending.database_inode != anchored.database_inode
+        ):
+            raise FilledNotionalIntegrityError("pending anchor identity is invalid")
+        if state == anchored:
+            return self._replace_anchor(self._anchor_for_state(anchored), expected=anchor)
+        if state == pending:
+            return self._replace_anchor(self._anchor_for_state(pending), expected=anchor)
+        raise FilledNotionalIntegrityError("database does not match either atomic anchor state")
+
+    def _require_exact_anchor(self, state: _LedgerState) -> _Anchor:
+        anchor = self._load_anchor()
+        if anchor.pending_state is not None or anchor.state != state:
+            raise FilledNotionalIntegrityError("ledger and durable anchor differ")
+        return anchor
+
+    def _replace_anchor(self, desired: _Anchor, *, expected: _Anchor) -> _Anchor:
+        current = self._load_anchor()
+        if current == desired:
+            return current
+        if current != expected:
+            raise FilledNotionalIntegrityError("anchor changed concurrently")
+        return self._write_anchor_file(desired, must_not_exist=False)
+
+    def _write_anchor_file(self, anchor: _Anchor, *, must_not_exist: bool) -> _Anchor:
+        if must_not_exist:
+            try:
+                os.lstat(self._anchor_path)
+            except FileNotFoundError:
+                pass
+            else:
+                raise FilledNotionalIntegrityError("anchor already exists")
+        payload = self._unsigned_anchor_payload(anchor.state, anchor.pending_state)
+        payload["mac"] = anchor.mac
+        encoded = (_canonical_json(payload) + "\n").encode("ascii")
+        temporary = self._anchor_path.parent / (
+            f".{self._anchor_path.name}.tmp-{os.getpid()}-{secrets.token_hex(8)}"
+        )
+        descriptor: Optional[int] = None
+        directory_descriptor: Optional[int] = None
+        try:
+            descriptor = os.open(
+                temporary,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0),
+                0o600,
+            )
+            view = memoryview(encoded)
+            while view:
+                written = os.write(descriptor, view)
+                if written <= 0:
+                    raise OSError("anchor write made no progress")
+                view = view[written:]
+            os.fsync(descriptor)
+            os.close(descriptor)
+            descriptor = None
+            if must_not_exist:
+                try:
+                    os.link(temporary, self._anchor_path)
+                except FileExistsError as exc:
+                    raise FilledNotionalIntegrityError("anchor already exists") from exc
+                temporary.unlink()
+            else:
+                os.replace(temporary, self._anchor_path)
+            directory_descriptor = os.open(
+                self._anchor_path.parent,
+                os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_CLOEXEC", 0),
+            )
+            os.fsync(directory_descriptor)
+            loaded = self._load_anchor()
+            if loaded != anchor:
+                raise FilledNotionalIntegrityError("atomic anchor verification failed")
+            return loaded
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+            if directory_descriptor is not None:
+                os.close(directory_descriptor)
+            try:
+                temporary.unlink()
+            except FileNotFoundError:
+                pass
 
     def _total_for_date(self, connection: sqlite3.Connection, trading_day: date) -> Decimal:
         rows = connection.execute(
             """
-            SELECT notional_text
-            FROM daily_filled_notional_records
+            SELECT notional_text FROM daily_filled_notional_records
             WHERE account_id = ? AND portfolio_id = ?
               AND currency = ? AND trading_date = ?
             ORDER BY sequence
@@ -793,14 +1391,14 @@ class DailyFilledNotional:
                 trading_day.isoformat(),
             ),
         ).fetchall()
-        with localcontext() as context:
-            context.prec = MAX_PREC
-            context.traps[Inexact] = True
-            context.traps[Rounded] = True
-            return sum(
-                (_parse_canonical_positive_decimal(row[0], "notional") for row in rows),
-                Decimal("0"),
-            )
+        with _isolated_decimal_context() as context:
+            total = Decimal("0")
+            for row in rows:
+                total = context.add(
+                    total,
+                    _parse_canonical_positive_decimal(row[0], "notional"),
+                )
+            return total
 
 
 def _validate_stored_identifier(value: object, field_name: str) -> str:

--- a/robo_trader/risk/filled_notional/ledger.py
+++ b/robo_trader/risk/filled_notional/ledger.py
@@ -1671,7 +1671,7 @@ class DailyFilledNotional:
             WHERE name LIKE 'daily_filled_notional_%'
                OR (
                    type = 'trigger'
-                   AND tbl_name IN (?, ?, ?, ?)
+                   AND lower(tbl_name) IN (?, ?, ?, ?)
                )
             ORDER BY type, name
             """,

--- a/robo_trader/risk/filled_notional/ledger.py
+++ b/robo_trader/risk/filled_notional/ledger.py
@@ -2210,6 +2210,25 @@ class DailyFilledNotional:
             raise FilledNotionalIntegrityError(
                 "checkpoint authenticated rows do not match ledger state"
             )
+        authenticated_checkpoint_sequence, authenticated_checkpoint_head = (
+            self._validate_checkpoints(
+                connection,
+                ledger_id=ledger_id,
+                database_device=database_device,
+                database_inode=database_inode,
+                fill_count=fill_count,
+                fill_head=fill_head,
+                conflict_count=conflict_count,
+                conflict_head=conflict_head,
+            )
+        )
+        if (
+            authenticated_checkpoint_sequence != event_sequence
+            or authenticated_checkpoint_head != checkpoint_head
+        ):
+            raise FilledNotionalIntegrityError(
+                "authenticated checkpoint chain does not match ledger state"
+            )
         if fill_count == 0:
             fill_matches = fill_tail is None and fill_head == _ZERO_HASH
         else:

--- a/robo_trader/risk/filled_notional/ledger.py
+++ b/robo_trader/risk/filled_notional/ledger.py
@@ -14,10 +14,12 @@ and tail deletion. One authenticated database event ahead of the anchor is the
 only recoverable crash window (SQLite committed and the atomic anchor replace
 did not finish).
 
-No local-file design can prove a coordinated offline rollback of the database,
-anchor, *and* the external key/monotonic authority. Operators must protect and
-version the anchor independently (for example, immutable backup or a monotonic
-secret service). This module makes no claim beyond that explicit boundary.
+An HMAC does not prove freshness: an attacker who replays an older valid
+database and matching older valid anchor can pass all local checks while the
+HMAC key remains unchanged. Authoritative use therefore requires the caller's
+independent monotonic verifier to reject states older than the last accepted
+state. That verifier must keep its state outside the database/anchor failure
+domain (for example, in an independently operated monotonic service).
 
 The package is dormant: it grants no order, broker, runner, or startup authority.
 """
@@ -261,6 +263,10 @@ class FilledNotionalMigrationRequired(FilledNotionalUnavailable):
     """A preserved older schema requires an explicit reviewed migration."""
 
 
+class _PendingAnchorInProgress(RuntimeError):
+    """A valid pending transition may belong to another active writer."""
+
+
 class FillSide(str, Enum):
     """Economic direction of an actual executed fill."""
 
@@ -300,6 +306,17 @@ class ConflictEvidence:
     claimed_fill_json: str
     observed_at_utc: str
     conflict_hash: str
+
+
+@dataclass(frozen=True, slots=True)
+class MonotonicLedgerState:
+    """State that an independent monotonic authority must verify and advance."""
+
+    ledger_id: str
+    fill_count: int
+    fill_head: str
+    conflict_count: int
+    conflict_head: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -543,6 +560,7 @@ class DailyFilledNotional:
         *,
         anchor_path: Path | str,
         anchor_key: bytes,
+        monotonic_verifier: Callable[[MonotonicLedgerState], bool],
         account_id: str,
         portfolio_id: str,
         currency: str = "USD",
@@ -552,6 +570,11 @@ class DailyFilledNotional:
         self._path = lexical_path_preserving_leaf(database_path)
         self._anchor_path = lexical_path_preserving_leaf(anchor_path)
         self._key = self._validate_anchor_key(anchor_key)
+        if not callable(monotonic_verifier):
+            raise FilledNotionalUnavailable(
+                "independent monotonic verifier is required for authoritative accounting"
+            )
+        self._monotonic_verifier = monotonic_verifier
         self._validate_independent_anchor_path()
         self._account_id = _validate_identifier(account_id, "account_id")
         self._portfolio_id = _validate_identifier(portfolio_id, "portfolio_id")
@@ -566,6 +589,8 @@ class DailyFilledNotional:
 
         try:
             created = self._initialize_if_missing()
+            if not created:
+                self._preflight_existing_schema()
             self._recover_hot_journal()
             with self._connection(readonly=True) as connection:
                 state = self._validate_ledger(connection)
@@ -573,6 +598,7 @@ class DailyFilledNotional:
                     anchor = self._create_initial_anchor(state)
                 else:
                     anchor = self._reconcile_anchor(state)
+                self._verify_monotonic_state(state)
                 current_day = self._current_trading_date()
                 total = self._total_for_date(connection, current_day)
         except FilledNotionalError:
@@ -603,14 +629,70 @@ class DailyFilledNotional:
             raise FilledNotionalError("anchor path must differ from the SQLite ledger")
         if self._anchor_path.parent == self._path.parent:
             raise FilledNotionalError("anchor must be stored in a separate protected directory")
+        flags = (
+            os.O_RDONLY
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_CLOEXEC", 0)
+        )
+        descriptor: Optional[int] = None
         try:
-            metadata = os.lstat(self._anchor_path.parent)
+            descriptor = os.open(self._anchor_path.parent, flags)
+            metadata = os.fstat(descriptor)
+            path_metadata = os.lstat(self._anchor_path.parent)
         except OSError as exc:
             raise FilledNotionalError("anchor directory must already exist") from exc
-        if not stat.S_ISDIR(metadata.st_mode) or metadata.st_mode & 0o022:
-            raise FilledNotionalError(
-                "anchor directory must be a non-group/world-writable directory"
-            )
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+        if (
+            not stat.S_ISDIR(metadata.st_mode)
+            or metadata.st_mode & 0o022
+            or (metadata.st_dev, metadata.st_ino) != (path_metadata.st_dev, path_metadata.st_ino)
+        ):
+            raise FilledNotionalError("anchor directory is not safely bindable")
+        self._anchor_name = self._anchor_path.name
+        self._anchor_directory_device = metadata.st_dev
+        self._anchor_directory_inode = metadata.st_ino
+
+    @contextmanager
+    def _anchor_directory_descriptor(self) -> Iterator[int]:
+        flags = (
+            os.O_RDONLY
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_CLOEXEC", 0)
+        )
+        descriptor: Optional[int] = None
+        expected = (self._anchor_directory_device, self._anchor_directory_inode)
+        try:
+            descriptor = os.open(self._anchor_path.parent, flags)
+            metadata = os.fstat(descriptor)
+            path_metadata = os.lstat(self._anchor_path.parent)
+            if (metadata.st_dev, metadata.st_ino) != expected or (
+                path_metadata.st_dev,
+                path_metadata.st_ino,
+            ) != expected:
+                raise FilledNotionalIntegrityError("anchor directory identity changed")
+            yield descriptor
+            metadata = os.fstat(descriptor)
+            path_metadata = os.lstat(self._anchor_path.parent)
+            if (metadata.st_dev, metadata.st_ino) != expected or (
+                path_metadata.st_dev,
+                path_metadata.st_ino,
+            ) != expected:
+                raise FilledNotionalIntegrityError(
+                    "anchor directory identity changed during operation"
+                )
+        except FilledNotionalError:
+            raise
+        except OSError as exc:
+            raise FilledNotionalIntegrityError(
+                "anchor directory cannot be accessed safely"
+            ) from exc
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
 
     @property
     def database_path(self) -> Path:
@@ -647,6 +729,8 @@ class DailyFilledNotional:
                 connection.execute("BEGIN IMMEDIATE")
                 before = self._validate_ledger(connection)
                 anchor = self._reconcile_anchor(before)
+                self._assert_no_conflicts(before)
+                self._verify_monotonic_state(before)
                 existing = connection.execute(
                     """
                     SELECT portfolio_id, side, quantity_text, price_text, currency,
@@ -698,6 +782,7 @@ class DailyFilledNotional:
                         self._anchor_for_state(after),
                         expected=pending,
                     )
+                    self._verify_monotonic_state(after)
                 else:
                     self._commit_database(connection)
                     self._anchor = anchor
@@ -727,10 +812,30 @@ class DailyFilledNotional:
         self._require_available()
         try:
             trading_day = self._trading_date(as_of if as_of is not None else self._clock())
-            with self._connection(readonly=True) as connection:
-                state = self._validate_ledger(connection)
-                self._anchor = self._require_exact_anchor(state)
-                return self._total_for_date(connection, trading_day)
+            pending_attempts = 0
+            while True:
+                try:
+                    with self._connection(readonly=True) as connection:
+                        state = self._validate_ledger(connection)
+                        self._anchor = self._require_exact_anchor(state)
+                        self._assert_no_conflicts(state)
+                        self._verify_monotonic_state(state)
+                        return self._total_for_date(connection, trading_day)
+                except _PendingAnchorInProgress:
+                    pending_attempts += 1
+                    if pending_attempts > 3:
+                        raise FilledNotionalUnavailable(
+                            "pending anchor writer did not reach a stable state"
+                        )
+                    try:
+                        self._resolve_pending_anchor()
+                    except sqlite3.OperationalError as exc:
+                        if "locked" not in str(exc).lower():
+                            raise
+                        if pending_attempts == 3:
+                            raise FilledNotionalUnavailable(
+                                "pending anchor writer remained busy"
+                            ) from exc
         except FilledNotionalIntegrityError as exc:
             self._latch_failure(str(exc))
             raise
@@ -750,6 +855,7 @@ class DailyFilledNotional:
         *,
         anchor_path: Path | str,
         anchor_key: bytes,
+        monotonic_verifier: Callable[[MonotonicLedgerState], bool],
     ) -> tuple[ConflictEvidence, ...]:
         """Authenticate and return durable conflict markers without clearing them."""
 
@@ -757,6 +863,7 @@ class DailyFilledNotional:
             database_path,
             anchor_path=anchor_path,
             anchor_key=anchor_key,
+            monotonic_verifier=monotonic_verifier,
             account_id="__review__",
             portfolio_id="__review__",
             _review_only=True,
@@ -884,6 +991,30 @@ class DailyFilledNotional:
                 f"filled-notional accounting is latched unavailable: {self._failed_reason}"
             )
 
+    def _assert_no_conflicts(self, state: _LedgerState) -> None:
+        if state.conflict_count:
+            self._latch_failure("durable conflicting execution evidence requires review")
+            raise FilledNotionalConflict(self._failed_reason)
+
+    def _verify_monotonic_state(self, state: _LedgerState) -> None:
+        candidate = MonotonicLedgerState(
+            ledger_id=state.ledger_id,
+            fill_count=state.fill_count,
+            fill_head=state.fill_head,
+            conflict_count=state.conflict_count,
+            conflict_head=state.conflict_head,
+        )
+        try:
+            accepted = self._monotonic_verifier(candidate)
+        except Exception as exc:
+            raise FilledNotionalUnavailable(
+                "independent monotonic verification failed closed"
+            ) from exc
+        if accepted is not True:
+            raise FilledNotionalIntegrityError(
+                "independent monotonic authority rejected ledger state"
+            )
+
     def _latch_failure(self, reason: str) -> None:
         self._failed_reason = reason
 
@@ -948,15 +1079,46 @@ class DailyFilledNotional:
             connection.execute("SELECT count(*) FROM sqlite_master").fetchone()
             connection.commit()
 
+    def _preflight_existing_schema(self) -> None:
+        """Identify legacy state without permitting SQLite journal recovery."""
+
+        journal = Path(f"{self._path}-journal")
+        try:
+            journal_metadata = os.lstat(journal)
+        except FileNotFoundError:
+            journal_metadata = None
+        if journal_metadata is not None:
+            if stat.S_ISLNK(journal_metadata.st_mode) or not stat.S_ISREG(journal_metadata.st_mode):
+                raise FilledNotionalUnavailable(
+                    "SQLite journal prevents safe read-only schema detection"
+                )
+        try:
+            with self._connection(readonly=True, immutable=True) as connection:
+                self._schema_version(connection)
+        except FilledNotionalMigrationRequired:
+            raise
+        except FilledNotionalError:
+            raise
+        except (OSError, sqlite3.Error, SQLiteIdentityError) as exc:
+            raise FilledNotionalUnavailable(
+                "existing schema cannot be detected without SQLite recovery"
+            ) from exc
+
     @contextmanager
-    def _connection(self, *, readonly: bool) -> Iterator[sqlite3.Connection]:
+    def _connection(
+        self,
+        *,
+        readonly: bool,
+        immutable: bool = False,
+    ) -> Iterator[sqlite3.Connection]:
         binding: Optional[SQLitePathBinding] = None
         connection: Optional[sqlite3.Connection] = None
         try:
             binding = SQLitePathBinding.open_for_initialization(self._path, create=False)
             mode = "ro" if readonly else "rw"
+            immutable_query = "&immutable=1" if immutable else ""
             connection = sqlite3.connect(
-                self._path.as_uri() + f"?mode={mode}",
+                self._path.as_uri() + f"?mode={mode}{immutable_query}",
                 uri=True,
                 timeout=1.0,
                 isolation_level=None,
@@ -1205,26 +1367,71 @@ class DailyFilledNotional:
         )
 
     def _create_initial_anchor(self, state: _LedgerState) -> _Anchor:
-        try:
-            os.lstat(self._anchor_path)
-        except FileNotFoundError:
-            anchor = self._anchor_for_state(state)
-            return self._write_anchor_file(anchor, must_not_exist=True)
+        with self._anchor_directory_descriptor() as directory_descriptor:
+            try:
+                os.stat(
+                    self._anchor_name,
+                    dir_fd=directory_descriptor,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                anchor = self._anchor_for_state(state)
+                return self._write_anchor_file(anchor, must_not_exist=True)
         raise FilledNotionalIntegrityError("new ledger anchor path already exists")
 
     def _load_anchor(self) -> _Anchor:
+        descriptor: Optional[int] = None
         try:
-            metadata = os.lstat(self._anchor_path)
-            if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
-                raise FilledNotionalIntegrityError("anchor must be a non-symlink regular file")
-            if metadata.st_mode & 0o077:
-                raise FilledNotionalIntegrityError("anchor permissions must be owner-only")
-            raw = self._anchor_path.read_bytes()
+            with self._anchor_directory_descriptor() as directory_descriptor:
+                metadata = os.stat(
+                    self._anchor_name,
+                    dir_fd=directory_descriptor,
+                    follow_symlinks=False,
+                )
+                if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+                    raise FilledNotionalIntegrityError("anchor must be a non-symlink regular file")
+                if metadata.st_mode & 0o077:
+                    raise FilledNotionalIntegrityError("anchor permissions must be owner-only")
+                descriptor = os.open(
+                    self._anchor_name,
+                    os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0),
+                    dir_fd=directory_descriptor,
+                )
+                opened_metadata = os.fstat(descriptor)
+                if (metadata.st_dev, metadata.st_ino) != (
+                    opened_metadata.st_dev,
+                    opened_metadata.st_ino,
+                ):
+                    raise FilledNotionalIntegrityError("anchor identity changed while opening")
+                chunks: list[bytes] = []
+                size = 0
+                while True:
+                    chunk = os.read(descriptor, 8192)
+                    if not chunk:
+                        break
+                    size += len(chunk)
+                    if size > 65536:
+                        raise FilledNotionalIntegrityError("anchor file is too large")
+                    chunks.append(chunk)
+                final_metadata = os.stat(
+                    self._anchor_name,
+                    dir_fd=directory_descriptor,
+                    follow_symlinks=False,
+                )
+                if (metadata.st_dev, metadata.st_ino) != (
+                    final_metadata.st_dev,
+                    final_metadata.st_ino,
+                ):
+                    raise FilledNotionalIntegrityError("anchor identity changed while reading")
+                raw = b"".join(chunks)
             decoded = json.loads(raw.decode("ascii"))
         except FilledNotionalError:
             raise
         except (OSError, UnicodeError, json.JSONDecodeError) as exc:
             raise FilledNotionalIntegrityError("anchor cannot be read safely") from exc
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
         if type(decoded) is not dict or set(decoded) != {
             "anchor_version",
             "mac",
@@ -1306,9 +1513,30 @@ class DailyFilledNotional:
 
     def _require_exact_anchor(self, state: _LedgerState) -> _Anchor:
         anchor = self._load_anchor()
-        if anchor.pending_state is not None or anchor.state != state:
+        pending = anchor.pending_state
+        if pending is not None:
+            if (
+                pending.ledger_id != anchor.state.ledger_id
+                or pending.database_device != anchor.state.database_device
+                or pending.database_inode != anchor.state.database_inode
+                or state not in (anchor.state, pending)
+            ):
+                raise FilledNotionalIntegrityError(
+                    "pending anchor does not authenticate current ledger state"
+                )
+            raise _PendingAnchorInProgress
+        if anchor.state != state:
             raise FilledNotionalIntegrityError("ledger and durable anchor differ")
         return anchor
+
+    def _resolve_pending_anchor(self) -> None:
+        """Serialize behind a writer and reconcile only authenticated endpoints."""
+
+        with self._connection(readonly=False) as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            state = self._validate_ledger(connection)
+            self._anchor = self._reconcile_anchor(state)
+            connection.commit()
 
     def _replace_anchor(self, desired: _Anchor, *, expected: _Anchor) -> _Anchor:
         current = self._load_anchor()
@@ -1319,62 +1547,74 @@ class DailyFilledNotional:
         return self._write_anchor_file(desired, must_not_exist=False)
 
     def _write_anchor_file(self, anchor: _Anchor, *, must_not_exist: bool) -> _Anchor:
-        if must_not_exist:
-            try:
-                os.lstat(self._anchor_path)
-            except FileNotFoundError:
-                pass
-            else:
-                raise FilledNotionalIntegrityError("anchor already exists")
         payload = self._unsigned_anchor_payload(anchor.state, anchor.pending_state)
         payload["mac"] = anchor.mac
         encoded = (_canonical_json(payload) + "\n").encode("ascii")
-        temporary = self._anchor_path.parent / (
-            f".{self._anchor_path.name}.tmp-{os.getpid()}-{secrets.token_hex(8)}"
-        )
+        temporary_name = f".{self._anchor_name}.tmp-{os.getpid()}-{secrets.token_hex(8)}"
         descriptor: Optional[int] = None
-        directory_descriptor: Optional[int] = None
-        try:
-            descriptor = os.open(
-                temporary,
-                os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0),
-                0o600,
-            )
-            view = memoryview(encoded)
-            while view:
-                written = os.write(descriptor, view)
-                if written <= 0:
-                    raise OSError("anchor write made no progress")
-                view = view[written:]
-            os.fsync(descriptor)
-            os.close(descriptor)
-            descriptor = None
-            if must_not_exist:
-                try:
-                    os.link(temporary, self._anchor_path)
-                except FileExistsError as exc:
-                    raise FilledNotionalIntegrityError("anchor already exists") from exc
-                temporary.unlink()
-            else:
-                os.replace(temporary, self._anchor_path)
-            directory_descriptor = os.open(
-                self._anchor_path.parent,
-                os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_CLOEXEC", 0),
-            )
-            os.fsync(directory_descriptor)
-            loaded = self._load_anchor()
-            if loaded != anchor:
-                raise FilledNotionalIntegrityError("atomic anchor verification failed")
-            return loaded
-        finally:
-            if descriptor is not None:
-                os.close(descriptor)
-            if directory_descriptor is not None:
-                os.close(directory_descriptor)
+        with self._anchor_directory_descriptor() as directory_descriptor:
             try:
-                temporary.unlink()
-            except FileNotFoundError:
-                pass
+                if must_not_exist:
+                    try:
+                        os.stat(
+                            self._anchor_name,
+                            dir_fd=directory_descriptor,
+                            follow_symlinks=False,
+                        )
+                    except FileNotFoundError:
+                        pass
+                    else:
+                        raise FilledNotionalIntegrityError("anchor already exists")
+                descriptor = os.open(
+                    temporary_name,
+                    os.O_WRONLY
+                    | os.O_CREAT
+                    | os.O_EXCL
+                    | getattr(os, "O_NOFOLLOW", 0)
+                    | getattr(os, "O_CLOEXEC", 0),
+                    0o600,
+                    dir_fd=directory_descriptor,
+                )
+                view = memoryview(encoded)
+                while view:
+                    written = os.write(descriptor, view)
+                    if written <= 0:
+                        raise OSError("anchor write made no progress")
+                    view = view[written:]
+                os.fsync(descriptor)
+                os.close(descriptor)
+                descriptor = None
+                if must_not_exist:
+                    try:
+                        os.link(
+                            temporary_name,
+                            self._anchor_name,
+                            src_dir_fd=directory_descriptor,
+                            dst_dir_fd=directory_descriptor,
+                            follow_symlinks=False,
+                        )
+                    except FileExistsError as exc:
+                        raise FilledNotionalIntegrityError("anchor already exists") from exc
+                    os.unlink(temporary_name, dir_fd=directory_descriptor)
+                else:
+                    os.replace(
+                        temporary_name,
+                        self._anchor_name,
+                        src_dir_fd=directory_descriptor,
+                        dst_dir_fd=directory_descriptor,
+                    )
+                os.fsync(directory_descriptor)
+            finally:
+                if descriptor is not None:
+                    os.close(descriptor)
+                try:
+                    os.unlink(temporary_name, dir_fd=directory_descriptor)
+                except FileNotFoundError:
+                    pass
+        loaded = self._load_anchor()
+        if loaded != anchor:
+            raise FilledNotionalIntegrityError("atomic anchor verification failed")
+        return loaded
 
     def _total_for_date(self, connection: sqlite3.Connection, trading_day: date) -> Decimal:
         rows = connection.execute(

--- a/robo_trader/risk/filled_notional/ledger.py
+++ b/robo_trader/risk/filled_notional/ledger.py
@@ -303,6 +303,14 @@ _PROTECTED_TABLES = (
     "daily_filled_notional_checkpoints",
 )
 
+_CHECKPOINT_INTEGER_COLUMNS = (
+    "event_sequence",
+    "database_device",
+    "database_inode",
+    "fill_count",
+    "conflict_count",
+)
+
 
 class FilledNotionalError(RuntimeError):
     """Base error for the filled-notional safety boundary."""
@@ -698,13 +706,12 @@ class DailyFilledNotional:
                     connection.execute("BEGIN")
                     state = self._validate_ledger(connection)
                     anchor = self._require_exact_anchor(state)
-                    self._verify_monotonic_state(state)
                     self._ledger_id = state.ledger_id
                     current_day = self._current_trading_date()
                     total = self._total_for_date(connection, current_day)
                     anchor = self._require_exact_anchor(state)
-                    self._verify_monotonic_state(state)
                     connection.commit()
+                self._verify_monotonic_state(state)
             else:
                 database_was_missing = self._database_path_is_missing()
                 if database_was_missing:
@@ -729,15 +736,20 @@ class DailyFilledNotional:
                         state = self._validate_ledger(connection)
                         if created:
                             anchor = self._create_initial_anchor(state)
+                        elif not self._anchor_artifact_exists(self._anchor_name):
+                            if not self._is_authenticated_empty_initial_state(state):
+                                raise FilledNotionalIntegrityError(
+                                    "missing anchor cannot authenticate a non-empty ledger"
+                                )
+                            anchor = self._create_initial_anchor(state)
                         else:
                             anchor = self._reconcile_anchor(state)
-                        self._verify_monotonic_state(state)
                         self._ledger_id = state.ledger_id
                         current_day = self._current_trading_date()
                         total = self._total_for_date(connection, current_day)
                         anchor = self._require_exact_anchor(state)
-                        self._verify_monotonic_state(state)
                         connection.commit()
+                    self._verify_monotonic_state(state)
         except FilledNotionalError:
             raise
         except DecimalException as exc:
@@ -1097,20 +1109,41 @@ class DailyFilledNotional:
         try:
             trading_day = self._trading_date(as_of if as_of is not None else self._clock())
             pending_attempts = 0
+            snapshot_attempts = 0
             while True:
                 try:
-                    with self._connection(readonly=True) as connection:
-                        connection.execute("BEGIN")
-                        state = self._validate_checkpointed_state(connection)
-                        self._anchor = self._require_exact_anchor(state)
-                        self._assert_no_conflicts(state)
+                    # Serialize participating readers and writers at the
+                    # database/anchor transition boundary. The independently
+                    # operated monotonic authority runs only after the SQLite
+                    # read transaction closes, so a slow verifier cannot make
+                    # a writer time out after publishing a pending anchor.
+                    with self._anchor_transition_lock():
+                        with self._connection(readonly=True) as connection:
+                            connection.execute("BEGIN")
+                            state = self._validate_checkpointed_state(connection)
+                            self._anchor = self._require_exact_anchor(state)
+                            self._assert_no_conflicts(state)
+                            total = self._total_for_date(connection, trading_day)
+                            self._anchor = self._require_exact_anchor(state)
+                            connection.commit()
                         self._verify_monotonic_state(state)
-                        total = self._total_for_date(connection, trading_day)
-                        self._anchor = self._require_exact_anchor(state)
-                        self._verify_monotonic_state(state)
-                        connection.commit()
-                        self._state = state
-                        return total
+                        with self._connection(readonly=True) as connection:
+                            connection.execute("BEGIN")
+                            final_state = self._validate_checkpointed_state(connection)
+                            self._anchor = self._require_exact_anchor(final_state)
+                            self._assert_no_conflicts(final_state)
+                            final_total = self._total_for_date(connection, trading_day)
+                            self._anchor = self._require_exact_anchor(final_state)
+                            connection.commit()
+                    if final_state != state or final_total != total:
+                        snapshot_attempts += 1
+                        if snapshot_attempts > 3:
+                            raise FilledNotionalUnavailable(
+                                "filled-notional snapshot kept advancing during verification"
+                            )
+                        continue
+                    self._state = state
+                    return total
                 except _PendingAnchorInProgress:
                     pending_attempts += 1
                     if pending_attempts > 3:
@@ -1164,7 +1197,6 @@ class DailyFilledNotional:
                 connection.execute("BEGIN")
                 state = reviewer._validate_checkpointed_state(connection)
                 reviewer._require_exact_anchor(state)
-                reviewer._verify_monotonic_state(state)
                 rows = connection.execute(
                     "SELECT * FROM daily_filled_notional_conflicts ORDER BY sequence"
                 ).fetchall()
@@ -1182,9 +1214,9 @@ class DailyFilledNotional:
                     for row in rows
                 )
                 reviewer._require_exact_anchor(state)
-                reviewer._verify_monotonic_state(state)
                 connection.commit()
-                return evidence
+            reviewer._verify_monotonic_state(state)
+            return evidence
         except _PendingAnchorInProgress as exc:
             raise FilledNotionalUnavailable(
                 "quarantine review unavailable during pending anchor transition"
@@ -1778,8 +1810,14 @@ class DailyFilledNotional:
         fill_count, fill_head = self._validate_fills(connection, ledger_id)
         conflict_count, conflict_head = self._validate_conflicts(connection, ledger_id)
         metadata = os.lstat(self._path)
-        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
-            raise FilledNotionalIntegrityError("ledger path identity is invalid")
+        if (
+            stat.S_ISLNK(metadata.st_mode)
+            or not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+        ):
+            raise FilledNotionalIntegrityError(
+                "ledger path must be an exclusive non-symlink regular file"
+            )
         checkpoint_sequence, checkpoint_head = self._validate_checkpoints(
             connection,
             ledger_id=ledger_id,
@@ -1812,14 +1850,7 @@ class DailyFilledNotional:
         ).fetchone()
         if row is None:
             raise FilledNotionalIntegrityError("checkpoint state is missing")
-        integer_names = (
-            "event_sequence",
-            "database_device",
-            "database_inode",
-            "fill_count",
-            "conflict_count",
-        )
-        if any(type(row[name]) is not int or row[name] < 0 for name in integer_names):
+        if any(type(row[name]) is not int or row[name] < 0 for name in _CHECKPOINT_INTEGER_COLUMNS):
             raise FilledNotionalIntegrityError("checkpoint counters are invalid")
         checkpoint_ledger_id = str(row["ledger_id"])
         database_device = int(row["database_device"])
@@ -1858,6 +1889,7 @@ class DailyFilledNotional:
         if (
             stat.S_ISLNK(metadata.st_mode)
             or not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
             or (metadata.st_dev, metadata.st_ino) != (database_device, database_inode)
         ):
             raise FilledNotionalIntegrityError("checkpoint database identity changed")
@@ -2047,15 +2079,19 @@ class DailyFilledNotional:
         for row in connection.execute(
             "SELECT * FROM daily_filled_notional_checkpoints ORDER BY event_sequence"
         ):
-            if int(row["event_sequence"]) != expected_sequence:
+            if any(
+                type(row[name]) is not int or row[name] < 0 for name in _CHECKPOINT_INTEGER_COLUMNS
+            ):
+                raise FilledNotionalIntegrityError("checkpoint counters are invalid")
+            if row["event_sequence"] != expected_sequence:
                 raise FilledNotionalIntegrityError("checkpoint sequence is not contiguous")
             if str(row["ledger_id"]) != ledger_id:
                 raise FilledNotionalIntegrityError("checkpoint ledger identity changed")
-            checkpoint_database_device = int(row["database_device"])
-            checkpoint_database_inode = int(row["database_inode"])
-            checkpoint_fill_count = int(row["fill_count"])
+            checkpoint_database_device = row["database_device"]
+            checkpoint_database_inode = row["database_inode"]
+            checkpoint_fill_count = row["fill_count"]
             checkpoint_fill_head = str(row["fill_head"])
-            checkpoint_conflict_count = int(row["conflict_count"])
+            checkpoint_conflict_count = row["conflict_count"]
             checkpoint_conflict_head = str(row["conflict_head"])
             if str(row["previous_checkpoint_hash"]) != previous_hash:
                 raise FilledNotionalIntegrityError("checkpoint hash chain is broken")
@@ -2080,11 +2116,11 @@ class DailyFilledNotional:
         if final_row is None:
             raise FilledNotionalIntegrityError("initial checkpoint is missing")
         final_values = (
-            int(final_row["database_device"]),
-            int(final_row["database_inode"]),
-            int(final_row["fill_count"]),
+            final_row["database_device"],
+            final_row["database_inode"],
+            final_row["fill_count"],
             str(final_row["fill_head"]),
-            int(final_row["conflict_count"]),
+            final_row["conflict_count"],
             str(final_row["conflict_head"]),
         )
         if final_values != (
@@ -2116,6 +2152,18 @@ class DailyFilledNotional:
             "fill_head": state.fill_head,
             "ledger_id": state.ledger_id,
         }
+
+    @staticmethod
+    def _is_authenticated_empty_initial_state(state: _LedgerState) -> bool:
+        """Recognize only the fully audited zero-event initialization state."""
+
+        return (
+            state.fill_count == 0
+            and state.fill_head == _ZERO_HASH
+            and state.conflict_count == 0
+            and state.conflict_head == _ZERO_HASH
+            and state.checkpoint_sequence == 0
+        )
 
     def _unsigned_anchor_payload(
         self,

--- a/robo_trader/risk/filled_notional/ledger.py
+++ b/robo_trader/risk/filled_notional/ledger.py
@@ -437,6 +437,22 @@ class _Anchor:
     mac: str
 
 
+@dataclass(frozen=True, slots=True)
+class _RecoveryFileEvidence:
+    device: int
+    inode: int
+    size: int
+    modified_ns: int
+    changed_ns: int
+    digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class _HotJournalRecoveryEvidence:
+    database: _RecoveryFileEvidence
+    journal: _RecoveryFileEvidence
+
+
 def _normalized_sql(value: object) -> str:
     if not isinstance(value, str) or not value.strip():
         return ""
@@ -717,9 +733,9 @@ class DailyFilledNotional:
                 database_was_missing = self._database_path_is_missing()
                 if database_was_missing:
                     self._preflight_missing_database_artifacts()
-                    recovery_required = False
+                    recovery_required = None
                 else:
-                    recovery_required = self._preflight_existing_schema()
+                    recovery_required = None
                 with self._anchor_transition_lock(
                     pre_create_check=(
                         self._reject_missing_database_artifacts if database_was_missing else None
@@ -730,8 +746,10 @@ class DailyFilledNotional:
                         created = self._initialize_if_missing()
                         if not created:
                             recovery_required = self._preflight_existing_schema()
-                    if recovery_required:
-                        self._recover_hot_journal()
+                    else:
+                        recovery_required = self._preflight_existing_schema()
+                    if recovery_required is not None:
+                        self._recover_hot_journal(recovery_required)
                     with self._connection(readonly=True) as connection:
                         connection.execute("BEGIN")
                         state = self._validate_ledger(connection)
@@ -1576,10 +1594,14 @@ class DailyFilledNotional:
                 "preserve it for reviewed recovery"
             )
 
-    def _recover_hot_journal(self) -> None:
+    def _recover_hot_journal(self, expected: _HotJournalRecoveryEvidence) -> None:
         """Force identity-bound SQLite recovery before any read-only open."""
 
         self._require_exclusive_database_path()
+        if self._validate_hot_journal_recovery_on_copy() != expected:
+            raise FilledNotionalUnavailable(
+                "hot-journal recovery evidence changed after validation"
+            )
         with self._connection(readonly=False) as connection:
             connection.execute("BEGIN IMMEDIATE")
             connection.execute("PRAGMA schema_version").fetchone()
@@ -1659,7 +1681,7 @@ class DailyFilledNotional:
                 "SQLite ledger must use rollback-journal mode; WAL is unsupported"
             )
 
-    def _preflight_existing_schema(self) -> bool:
+    def _preflight_existing_schema(self) -> Optional[_HotJournalRecoveryEvidence]:
         """Identify legacy state without permitting SQLite journal recovery."""
 
         self._require_exclusive_database_path()
@@ -1695,8 +1717,7 @@ class DailyFilledNotional:
                 raise FilledNotionalUnavailable(
                     "hot journal recovery anchor does not bind this database"
                 )
-            self._validate_hot_journal_recovery_on_copy()
-            return True
+            return self._validate_hot_journal_recovery_on_copy()
         try:
             with self._connection(readonly=True, immutable=True) as connection:
                 self._schema_version(connection)
@@ -1708,10 +1729,10 @@ class DailyFilledNotional:
             raise FilledNotionalUnavailable(
                 "existing schema cannot be detected without SQLite recovery"
             ) from exc
-        return False
+        return None
 
     @staticmethod
-    def _copy_exclusive_regular_file(source: Path, target: Path) -> None:
+    def _copy_exclusive_regular_file(source: Path, target: Path) -> _RecoveryFileEvidence:
         """Copy a stable, single-link source without following a replacement path."""
 
         source_descriptor: Optional[int] = None
@@ -1739,10 +1760,12 @@ class DailyFilledNotional:
                 os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0),
                 0o600,
             )
+            digest = hashlib.sha256()
             while True:
                 chunk = os.read(source_descriptor, 1024 * 1024)
                 if not chunk:
                     break
+                digest.update(chunk)
                 view = memoryview(chunk)
                 while view:
                     written = os.write(target_descriptor, view)
@@ -1770,6 +1793,14 @@ class DailyFilledNotional:
                 raise FilledNotionalUnavailable(
                     "hot-journal recovery evidence changed while being copied"
                 )
+            return _RecoveryFileEvidence(
+                device=after.st_dev,
+                inode=after.st_ino,
+                size=after.st_size,
+                modified_ns=after.st_mtime_ns,
+                changed_ns=after.st_ctime_ns,
+                digest=digest.hexdigest(),
+            )
         except FilledNotionalError:
             raise
         except OSError as exc:
@@ -1782,7 +1813,7 @@ class DailyFilledNotional:
             if source_descriptor is not None:
                 os.close(source_descriptor)
 
-    def _validate_hot_journal_recovery_on_copy(self) -> None:
+    def _validate_hot_journal_recovery_on_copy(self) -> _HotJournalRecoveryEvidence:
         """Prove recovery yields the anchored current schema before touching evidence."""
 
         journal = Path(f"{self._path}-journal")
@@ -1790,14 +1821,19 @@ class DailyFilledNotional:
             with tempfile.TemporaryDirectory(prefix="filled-notional-recovery-") as directory:
                 copied_database = Path(directory) / "ledger.sqlite3"
                 copied_journal = Path(f"{copied_database}-journal")
-                self._copy_exclusive_regular_file(self._path, copied_database)
-                self._copy_exclusive_regular_file(journal, copied_journal)
+                database_evidence = self._copy_exclusive_regular_file(self._path, copied_database)
+                journal_evidence = self._copy_exclusive_regular_file(journal, copied_journal)
                 with sqlite3.connect(copied_database, isolation_level=None) as connection:
                     connection.row_factory = sqlite3.Row
                     connection.execute("BEGIN")
                     state = self._validate_ledger(connection)
                     self._require_anchor_authenticates_recovered_state(state)
+                    self._verify_monotonic_state(state)
                     connection.commit()
+                return _HotJournalRecoveryEvidence(
+                    database=database_evidence,
+                    journal=journal_evidence,
+                )
         except FilledNotionalError:
             raise
         except (OSError, sqlite3.Error) as exc:

--- a/robo_trader/risk/filled_notional/ledger.py
+++ b/robo_trader/risk/filled_notional/ledger.py
@@ -712,7 +712,11 @@ class DailyFilledNotional:
                     recovery_required = False
                 else:
                     recovery_required = self._preflight_existing_schema()
-                with self._anchor_transition_lock():
+                with self._anchor_transition_lock(
+                    pre_create_check=(
+                        self._reject_missing_database_artifacts if database_was_missing else None
+                    )
+                ):
                     created = False
                     if database_was_missing:
                         created = self._initialize_if_missing()
@@ -860,68 +864,73 @@ class DailyFilledNotional:
             if descriptor is not None:
                 os.close(descriptor)
 
+    def _validate_anchor_transition_lock(self, descriptor: int, directory_descriptor: int) -> None:
+        try:
+            metadata = os.fstat(descriptor)
+            path_metadata = os.stat(
+                self._anchor_lock_name,
+                dir_fd=directory_descriptor,
+                follow_symlinks=False,
+            )
+        except OSError as exc:
+            raise FilledNotionalIntegrityError(
+                "anchor transition lock identity cannot be verified"
+            ) from exc
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != os.geteuid()
+            or metadata.st_mode & 0o077
+            or metadata.st_nlink != 1
+            or (metadata.st_dev, metadata.st_ino) != (path_metadata.st_dev, path_metadata.st_ino)
+        ):
+            raise FilledNotionalIntegrityError("anchor transition lock is not safely bindable")
+
     @contextmanager
-    def _anchor_transition_lock(self, *, create: bool = True) -> Iterator[None]:
+    def _anchor_transition_lock(
+        self,
+        *,
+        create: bool = True,
+        pre_create_check: Optional[Callable[[], None]] = None,
+    ) -> Iterator[None]:
         """Serialize database commits through stable-anchor publication."""
 
         descriptor: Optional[int] = None
+        directory_locked = False
         with self._anchor_directory_descriptor() as directory_descriptor:
             try:
-                flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
-                if create:
-                    flags |= os.O_CREAT
-                descriptor = os.open(
-                    self._anchor_lock_name,
-                    flags,
-                    0o600,
-                    dir_fd=directory_descriptor,
-                )
-                metadata = os.fstat(descriptor)
-                path_metadata = os.stat(
-                    self._anchor_lock_name,
-                    dir_fd=directory_descriptor,
-                    follow_symlinks=False,
-                )
-                if (
-                    not stat.S_ISREG(metadata.st_mode)
-                    or metadata.st_mode & 0o077
-                    or metadata.st_nlink != 1
-                    or (metadata.st_dev, metadata.st_ino)
-                    != (path_metadata.st_dev, path_metadata.st_ino)
-                ):
-                    raise FilledNotionalIntegrityError(
-                        "anchor transition lock is not safely bindable"
+                try:
+                    fcntl.flock(directory_descriptor, fcntl.LOCK_EX)
+                    directory_locked = True
+                    if pre_create_check is not None:
+                        pre_create_check()
+                    flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+                    if create:
+                        flags |= os.O_CREAT
+                    descriptor = os.open(
+                        self._anchor_lock_name,
+                        flags,
+                        0o600,
+                        dir_fd=directory_descriptor,
                     )
-                fcntl.flock(descriptor, fcntl.LOCK_EX)
-            except FilledNotionalError:
-                if descriptor is not None:
-                    os.close(descriptor)
-                raise
-            except OSError as exc:
-                if descriptor is not None:
-                    os.close(descriptor)
-                raise FilledNotionalIntegrityError(
-                    "anchor transition lock cannot be used safely"
-                ) from exc
-            try:
+                    self._validate_anchor_transition_lock(descriptor, directory_descriptor)
+                    fcntl.flock(descriptor, fcntl.LOCK_EX)
+                    self._validate_anchor_transition_lock(descriptor, directory_descriptor)
+                except FilledNotionalError:
+                    raise
+                except OSError as exc:
+                    raise FilledNotionalIntegrityError(
+                        "anchor transition lock cannot be used safely"
+                    ) from exc
                 yield
-                final_metadata = os.fstat(descriptor)
-                final_path_metadata = os.stat(
-                    self._anchor_lock_name,
-                    dir_fd=directory_descriptor,
-                    follow_symlinks=False,
-                )
-                if final_metadata.st_nlink != 1 or (
-                    final_metadata.st_dev,
-                    final_metadata.st_ino,
-                ) != (final_path_metadata.st_dev, final_path_metadata.st_ino):
-                    raise FilledNotionalIntegrityError("anchor transition lock identity changed")
+                self._validate_anchor_transition_lock(descriptor, directory_descriptor)
             finally:
                 if descriptor is not None:
                     try:
                         fcntl.flock(descriptor, fcntl.LOCK_UN)
                     finally:
                         os.close(descriptor)
+                if directory_locked:
+                    fcntl.flock(directory_descriptor, fcntl.LOCK_UN)
 
     @property
     def database_path(self) -> Path:
@@ -1140,16 +1149,17 @@ class DailyFilledNotional:
     ) -> tuple[ConflictEvidence, ...]:
         """Authenticate and return durable conflict markers without clearing them."""
 
-        reviewer = cls(
-            database_path,
-            anchor_path=anchor_path,
-            anchor_key=anchor_key,
-            monotonic_verifier=monotonic_verifier,
-            account_id="__review__",
-            portfolio_id="__review__",
-            _review_only=True,
-        )
+        reviewer: Optional[DailyFilledNotional] = None
         try:
+            reviewer = cls(
+                database_path,
+                anchor_path=anchor_path,
+                anchor_key=anchor_key,
+                monotonic_verifier=monotonic_verifier,
+                account_id="__review__",
+                portfolio_id="__review__",
+                _review_only=True,
+            )
             with reviewer._connection(readonly=True, immutable=True) as connection:
                 connection.execute("BEGIN")
                 state = reviewer._validate_checkpointed_state(connection)
@@ -1175,8 +1185,13 @@ class DailyFilledNotional:
                 reviewer._verify_monotonic_state(state)
                 connection.commit()
                 return evidence
+        except _PendingAnchorInProgress as exc:
+            raise FilledNotionalUnavailable(
+                "quarantine review unavailable during pending anchor transition"
+            ) from exc
         finally:
-            reviewer._latch_failure("review-only instance cannot perform accounting")
+            if reviewer is not None:
+                reviewer._latch_failure("review-only instance cannot perform accounting")
 
     def _append_fill(
         self,
@@ -1410,6 +1425,12 @@ class DailyFilledNotional:
             with self._anchor_transition_lock(create=False):
                 self._raise_if_anchor_survives_missing_database()
             return
+        self._raise_if_anchor_survives_missing_database()
+
+    def _reject_missing_database_artifacts(self) -> None:
+        """Recheck missing-ledger evidence under noncreating directory serialization."""
+
+        self._reject_sidecars_without_database()
         self._raise_if_anchor_survives_missing_database()
 
     def _initialize_if_missing(self) -> bool:

--- a/robo_trader/risk/filled_notional/ledger.py
+++ b/robo_trader/risk/filled_notional/ledger.py
@@ -706,12 +706,18 @@ class DailyFilledNotional:
                     self._verify_monotonic_state(state)
                     connection.commit()
             else:
-                created = self._initialize_if_missing()
-                if not created:
-                    recovery_required = self._preflight_existing_schema()
-                else:
+                database_was_missing = self._database_path_is_missing()
+                if database_was_missing:
+                    self._preflight_missing_database_artifacts()
                     recovery_required = False
+                else:
+                    recovery_required = self._preflight_existing_schema()
                 with self._anchor_transition_lock():
+                    created = False
+                    if database_was_missing:
+                        created = self._initialize_if_missing()
+                        if not created:
+                            recovery_required = self._preflight_existing_schema()
                     if recovery_required:
                         self._recover_hot_journal()
                     with self._connection(readonly=True) as connection:
@@ -855,18 +861,18 @@ class DailyFilledNotional:
                 os.close(descriptor)
 
     @contextmanager
-    def _anchor_transition_lock(self) -> Iterator[None]:
+    def _anchor_transition_lock(self, *, create: bool = True) -> Iterator[None]:
         """Serialize database commits through stable-anchor publication."""
 
         descriptor: Optional[int] = None
         with self._anchor_directory_descriptor() as directory_descriptor:
             try:
+                flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+                if create:
+                    flags |= os.O_CREAT
                 descriptor = os.open(
                     self._anchor_lock_name,
-                    os.O_RDWR
-                    | os.O_CREAT
-                    | getattr(os, "O_NOFOLLOW", 0)
-                    | getattr(os, "O_CLOEXEC", 0),
+                    flags,
                     0o600,
                     dir_fd=directory_descriptor,
                 )
@@ -1365,6 +1371,47 @@ class DailyFilledNotional:
         _, trading_day = _canonical_utc(instant)
         return date.fromisoformat(trading_day)
 
+    def _database_path_is_missing(self) -> bool:
+        try:
+            os.lstat(self._path)
+        except FileNotFoundError:
+            return True
+        except OSError as exc:
+            raise FilledNotionalUnavailable(
+                "filled-notional database identity cannot be inspected safely"
+            ) from exc
+        return False
+
+    def _anchor_artifact_exists(self, name: str) -> bool:
+        with self._anchor_directory_descriptor() as directory_descriptor:
+            try:
+                os.stat(name, dir_fd=directory_descriptor, follow_symlinks=False)
+            except FileNotFoundError:
+                return False
+            except OSError as exc:
+                raise FilledNotionalIntegrityError(
+                    "anchor artifact identity cannot be inspected safely"
+                ) from exc
+        return True
+
+    def _raise_if_anchor_survives_missing_database(self) -> None:
+        if self._database_path_is_missing() and self._anchor_artifact_exists(self._anchor_name):
+            raise FilledNotionalIntegrityError(
+                "main database is absent while anchor survives; preserve it for review"
+            )
+
+    def _preflight_missing_database_artifacts(self) -> None:
+        """Reject preserved evidence before creating a database or transition lock."""
+
+        self._reject_sidecars_without_database()
+        if not self._anchor_artifact_exists(self._anchor_name):
+            return
+        if self._anchor_artifact_exists(self._anchor_lock_name):
+            with self._anchor_transition_lock(create=False):
+                self._raise_if_anchor_survives_missing_database()
+            return
+        self._raise_if_anchor_survives_missing_database()
+
     def _initialize_if_missing(self) -> bool:
         try:
             os.lstat(self._path)
@@ -1373,6 +1420,7 @@ class DailyFilledNotional:
             pass
 
         self._reject_sidecars_without_database()
+        self._raise_if_anchor_survives_missing_database()
 
         binding: Optional[SQLitePathBinding] = None
         connection: Optional[sqlite3.Connection] = None

--- a/robo_trader/risk/filled_notional/ledger.py
+++ b/robo_trader/risk/filled_notional/ledger.py
@@ -1595,18 +1595,26 @@ class DailyFilledNotional:
             )
 
     def _recover_hot_journal(self, expected: _HotJournalRecoveryEvidence) -> None:
-        """Force identity-bound SQLite recovery before any read-only open."""
+        """Preserve a hot journal because SQLite cannot bind it through recovery.
+
+        SQLite derives the rollback-journal name from the database pathname and
+        reopens that name internally.  Holding or validating a descriptor does
+        not prevent another process from replacing the pathname between the
+        final check and SQLite's first mutation.  Revalidate for diagnostic
+        consistency, but never open the authoritative database read-write while
+        a hot journal exists.  Reviewed recovery must operate on an isolated
+        copy and install a separately authenticated ledger generation.
+        """
 
         self._require_exclusive_database_path()
         if self._validate_hot_journal_recovery_on_copy() != expected:
             raise FilledNotionalUnavailable(
                 "hot-journal recovery evidence changed after validation"
             )
-        with self._connection(readonly=False) as connection:
-            connection.execute("BEGIN IMMEDIATE")
-            connection.execute("PRAGMA schema_version").fetchone()
-            connection.execute("SELECT count(*) FROM sqlite_master").fetchone()
-            connection.commit()
+        raise FilledNotionalUnavailable(
+            "automatic hot-journal recovery is unsafe; preserve the database, "
+            "journal, and anchor for reviewed recovery"
+        )
 
     def _reject_wal_sidecars(self) -> None:
         """Reject WAL state before SQLite can open or mutate WAL/SHM artifacts."""

--- a/robo_trader/risk/filled_notional/ledger.py
+++ b/robo_trader/risk/filled_notional/ledger.py
@@ -1193,30 +1193,15 @@ class DailyFilledNotional:
                 portfolio_id="__review__",
                 _review_only=True,
             )
-            with reviewer._connection(readonly=True, immutable=True) as connection:
-                connection.execute("BEGIN")
-                state = reviewer._validate_checkpointed_state(connection)
-                reviewer._require_exact_anchor(state)
-                rows = connection.execute(
-                    "SELECT * FROM daily_filled_notional_conflicts ORDER BY sequence"
-                ).fetchall()
-                evidence = tuple(
-                    ConflictEvidence(
-                        sequence=int(row["sequence"]),
-                        account_id=str(row["account_id"]),
-                        broker_execution_id=str(row["broker_execution_id"]),
-                        existing_portfolio_id=str(row["existing_portfolio_id"]),
-                        claimed_portfolio_id=str(row["claimed_portfolio_id"]),
-                        claimed_fill_json=str(row["claimed_fill_json"]),
-                        observed_at_utc=str(row["observed_at_utc"]),
-                        conflict_hash=str(row["conflict_hash"]),
-                    )
-                    for row in rows
-                )
-                reviewer._require_exact_anchor(state)
-                connection.commit()
-            reviewer._verify_monotonic_state(state)
-            return evidence
+            for _ in range(3):
+                state, anchor, evidence = reviewer._quarantine_snapshot()
+                reviewer._verify_monotonic_state(state)
+                final_state, final_anchor, final_evidence = reviewer._quarantine_snapshot()
+                if final_state == state and final_anchor == anchor and final_evidence == evidence:
+                    return evidence
+            raise FilledNotionalUnavailable(
+                "quarantine review snapshot kept advancing during verification"
+            )
         except _PendingAnchorInProgress as exc:
             raise FilledNotionalUnavailable(
                 "quarantine review unavailable during pending anchor transition"
@@ -1224,6 +1209,35 @@ class DailyFilledNotional:
         finally:
             if reviewer is not None:
                 reviewer._latch_failure("review-only instance cannot perform accounting")
+
+    def _quarantine_snapshot(
+        self,
+    ) -> tuple[_LedgerState, _Anchor, tuple[ConflictEvidence, ...]]:
+        """Read one immutable authenticated quarantine snapshot without mutating artifacts."""
+
+        with self._connection(readonly=True, immutable=True) as connection:
+            connection.execute("BEGIN")
+            state = self._validate_checkpointed_state(connection)
+            anchor = self._require_exact_anchor(state)
+            rows = connection.execute(
+                "SELECT * FROM daily_filled_notional_conflicts ORDER BY sequence"
+            ).fetchall()
+            evidence = tuple(
+                ConflictEvidence(
+                    sequence=int(row["sequence"]),
+                    account_id=str(row["account_id"]),
+                    broker_execution_id=str(row["broker_execution_id"]),
+                    existing_portfolio_id=str(row["existing_portfolio_id"]),
+                    claimed_portfolio_id=str(row["claimed_portfolio_id"]),
+                    claimed_fill_json=str(row["claimed_fill_json"]),
+                    observed_at_utc=str(row["observed_at_utc"]),
+                    conflict_hash=str(row["conflict_hash"]),
+                )
+                for row in rows
+            )
+            anchor = self._require_exact_anchor(state)
+            connection.commit()
+        return state, anchor, evidence
 
     def _append_fill(
         self,
@@ -1479,6 +1493,7 @@ class DailyFilledNotional:
         connection: Optional[sqlite3.Connection] = None
         try:
             binding = SQLitePathBinding.open_for_initialization(self._path, create=True)
+            self._require_exclusive_database_path(binding)
             connection = sqlite3.connect(
                 self._path.as_uri() + "?mode=rw",
                 uri=True,
@@ -1563,6 +1578,7 @@ class DailyFilledNotional:
     def _recover_hot_journal(self) -> None:
         """Force identity-bound SQLite recovery before any read-only open."""
 
+        self._require_exclusive_database_path()
         with self._connection(readonly=False) as connection:
             connection.execute("BEGIN IMMEDIATE")
             connection.execute("PRAGMA schema_version").fetchone()
@@ -1589,6 +1605,7 @@ class DailyFilledNotional:
     def _validate_existing_rollback_journal(self) -> None:
         """Ensure a rollback journal cannot redirect mutations through another inode name."""
 
+        self._require_exclusive_database_path()
         journal = Path(f"{self._path}-journal")
         try:
             metadata = os.lstat(journal)
@@ -1616,6 +1633,7 @@ class DailyFilledNotional:
         if (
             stat.S_ISLNK(database_metadata.st_mode)
             or not stat.S_ISREG(database_metadata.st_mode)
+            or database_metadata.st_nlink != 1
             or anchor.state.database_device != database_metadata.st_dev
             or anchor.state.database_inode != database_metadata.st_ino
         ):
@@ -1643,6 +1661,7 @@ class DailyFilledNotional:
     def _preflight_existing_schema(self) -> bool:
         """Identify legacy state without permitting SQLite journal recovery."""
 
+        self._require_exclusive_database_path()
         self._reject_wal_sidecars()
         journal = Path(f"{self._path}-journal")
         try:
@@ -1666,7 +1685,10 @@ class DailyFilledNotional:
                     "hot journal lacks an authenticated current-schema recovery anchor"
                 ) from exc
             if (
-                anchor.state.database_device != database_metadata.st_dev
+                stat.S_ISLNK(database_metadata.st_mode)
+                or not stat.S_ISREG(database_metadata.st_mode)
+                or database_metadata.st_nlink != 1
+                or anchor.state.database_device != database_metadata.st_dev
                 or anchor.state.database_inode != database_metadata.st_ino
             ):
                 raise FilledNotionalUnavailable(
@@ -1686,6 +1708,39 @@ class DailyFilledNotional:
             ) from exc
         return False
 
+    def _require_exclusive_database_path(
+        self, binding: Optional[SQLitePathBinding] = None
+    ) -> os.stat_result:
+        """Reject shared or redirected main files before SQLite can recover or write."""
+
+        try:
+            path_metadata = os.lstat(self._path)
+            descriptor_metadata = (
+                os.fstat(binding.guardian_file_descriptor) if binding is not None else None
+            )
+        except OSError as exc:
+            raise FilledNotionalUnavailable(
+                "main database identity cannot be inspected safely"
+            ) from exc
+        if (
+            stat.S_ISLNK(path_metadata.st_mode)
+            or not stat.S_ISREG(path_metadata.st_mode)
+            or path_metadata.st_nlink != 1
+        ):
+            raise FilledNotionalIntegrityError(
+                "main database must be an exclusive non-symlink regular file"
+            )
+        if descriptor_metadata is not None and (
+            not stat.S_ISREG(descriptor_metadata.st_mode)
+            or descriptor_metadata.st_nlink != 1
+            or (descriptor_metadata.st_dev, descriptor_metadata.st_ino)
+            != (path_metadata.st_dev, path_metadata.st_ino)
+        ):
+            raise FilledNotionalIntegrityError(
+                "main database guardian is not an exclusive bound regular file"
+            )
+        return path_metadata
+
     @contextmanager
     def _connection(
         self,
@@ -1696,12 +1751,15 @@ class DailyFilledNotional:
         binding: Optional[SQLitePathBinding] = None
         connection: Optional[sqlite3.Connection] = None
         try:
+            self._require_exclusive_database_path()
             binding = SQLitePathBinding.open_for_initialization(self._path, create=False)
+            self._require_exclusive_database_path(binding)
             self._require_rollback_journal_header(binding)
             self._reject_wal_sidecars()
             self._validate_existing_rollback_journal()
             mode = "ro" if readonly else "rw"
             immutable_query = "&immutable=1" if immutable else ""
+            self._require_exclusive_database_path(binding)
             connection = sqlite3.connect(
                 self._path.as_uri() + f"?mode={mode}{immutable_query}",
                 uri=True,

--- a/robo_trader/risk/filled_notional/ledger.py
+++ b/robo_trader/risk/filled_notional/ledger.py
@@ -1,0 +1,810 @@
+"""Append-only accounting for daily gross executed-fill notional.
+
+Only broker execution evidence belongs in this ledger.  An order being
+submitted, accepted, cancelled, or rejected is not an execution and cannot be
+represented by :class:`ExecutedFill`.
+
+The service is bound to one broker account and portfolio.  Each partial fill is
+recorded independently under its immutable broker execution identifier.  Exact
+replays are idempotent; a reuse of that identifier with different evidence is a
+fatal conflict.  Monetary arithmetic is performed entirely with ``Decimal``
+and persisted as canonical decimal text.
+
+This module grants no order or process-start authority and is not wired into
+the trading runner.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import re
+import sqlite3
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from decimal import MAX_PREC, Decimal, Inexact, Rounded, localcontext
+from enum import Enum
+from pathlib import Path
+from typing import Callable, Iterator, Optional
+from zoneinfo import ZoneInfo
+
+from robo_trader.safety.sqlite_identity import (
+    SQLiteIdentityError,
+    SQLitePathBinding,
+    lexical_path_preserving_leaf,
+    sqlite_connection_file_identity,
+)
+
+_NEW_YORK = ZoneInfo("America/New_York")
+_ZERO_HASH = "0" * 64
+_SCHEMA_VERSION = 1
+_IDENTIFIER_RE = re.compile(r"[\x21-\x7e]{1,128}\Z")
+_CURRENCY_RE = re.compile(r"[A-Z]{3}\Z")
+_DENIED_SQLITE_ACTIONS = frozenset(
+    action
+    for name in (
+        "SQLITE_ALTER_TABLE",
+        "SQLITE_ANALYZE",
+        "SQLITE_ATTACH",
+        "SQLITE_CREATE_INDEX",
+        "SQLITE_CREATE_TABLE",
+        "SQLITE_CREATE_TEMP_INDEX",
+        "SQLITE_CREATE_TEMP_TABLE",
+        "SQLITE_CREATE_TEMP_TRIGGER",
+        "SQLITE_CREATE_TEMP_VIEW",
+        "SQLITE_CREATE_TRIGGER",
+        "SQLITE_CREATE_VIEW",
+        "SQLITE_CREATE_VTABLE",
+        "SQLITE_DELETE",
+        "SQLITE_DETACH",
+        "SQLITE_DROP_INDEX",
+        "SQLITE_DROP_TABLE",
+        "SQLITE_DROP_TEMP_INDEX",
+        "SQLITE_DROP_TEMP_TABLE",
+        "SQLITE_DROP_TEMP_TRIGGER",
+        "SQLITE_DROP_TEMP_VIEW",
+        "SQLITE_DROP_TRIGGER",
+        "SQLITE_DROP_VIEW",
+        "SQLITE_DROP_VTABLE",
+        "SQLITE_REINDEX",
+        "SQLITE_UPDATE",
+    )
+    if (action := getattr(sqlite3, name, None)) is not None
+)
+
+_SCHEMA_TABLE_SQL = """
+CREATE TABLE daily_filled_notional_schema (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    schema_version INTEGER NOT NULL CHECK (schema_version = 1)
+)
+"""
+
+_RECORDS_TABLE_SQL = """
+CREATE TABLE daily_filled_notional_records (
+    sequence INTEGER PRIMARY KEY,
+    account_id TEXT NOT NULL,
+    portfolio_id TEXT NOT NULL,
+    broker_execution_id TEXT NOT NULL,
+    side TEXT NOT NULL CHECK (
+        side IN ('BUY', 'SELL', 'SELL_SHORT', 'BUY_TO_COVER')
+    ),
+    quantity_text TEXT NOT NULL,
+    price_text TEXT NOT NULL,
+    currency TEXT NOT NULL,
+    executed_at_utc TEXT NOT NULL,
+    trading_date TEXT NOT NULL,
+    notional_text TEXT NOT NULL,
+    previous_hash TEXT NOT NULL CHECK (length(previous_hash) = 64),
+    record_hash TEXT NOT NULL CHECK (length(record_hash) = 64)
+)
+"""
+
+_UNIQUE_EXECUTION_SQL = """
+CREATE UNIQUE INDEX daily_filled_notional_execution_identity
+ON daily_filled_notional_records(account_id, portfolio_id, broker_execution_id)
+"""
+
+_SCOPE_DATE_SQL = """
+CREATE INDEX daily_filled_notional_scope_date
+ON daily_filled_notional_records(account_id, portfolio_id, currency, trading_date)
+"""
+
+_TRIGGER_SQL = {
+    "daily_filled_notional_records_insert_guard": """
+        CREATE TRIGGER daily_filled_notional_records_insert_guard
+        BEFORE INSERT ON daily_filled_notional_records
+        WHEN NEW.sequence != COALESCE(
+                 (SELECT MAX(sequence) + 1 FROM daily_filled_notional_records), 1
+             )
+          OR NEW.previous_hash != COALESCE(
+                 (
+                     SELECT record_hash
+                     FROM daily_filled_notional_records
+                     ORDER BY sequence DESC LIMIT 1
+                 ), '0000000000000000000000000000000000000000000000000000000000000000'
+             )
+        BEGIN
+            SELECT RAISE(ABORT, 'filled-notional records must append to the chain');
+        END
+    """,
+    "daily_filled_notional_records_no_update": """
+        CREATE TRIGGER daily_filled_notional_records_no_update
+        BEFORE UPDATE ON daily_filled_notional_records
+        BEGIN
+            SELECT RAISE(ABORT, 'filled-notional records are append-only');
+        END
+    """,
+    "daily_filled_notional_records_no_delete": """
+        CREATE TRIGGER daily_filled_notional_records_no_delete
+        BEFORE DELETE ON daily_filled_notional_records
+        BEGIN
+            SELECT RAISE(ABORT, 'filled-notional records are append-only');
+        END
+    """,
+    "daily_filled_notional_schema_no_update": """
+        CREATE TRIGGER daily_filled_notional_schema_no_update
+        BEFORE UPDATE ON daily_filled_notional_schema
+        BEGIN
+            SELECT RAISE(ABORT, 'filled-notional schema is immutable');
+        END
+    """,
+    "daily_filled_notional_schema_no_delete": """
+        CREATE TRIGGER daily_filled_notional_schema_no_delete
+        BEFORE DELETE ON daily_filled_notional_schema
+        BEGIN
+            SELECT RAISE(ABORT, 'filled-notional schema is immutable');
+        END
+    """,
+    "daily_filled_notional_schema_insert_guard": """
+        CREATE TRIGGER daily_filled_notional_schema_insert_guard
+        BEFORE INSERT ON daily_filled_notional_schema
+        WHEN EXISTS (SELECT 1 FROM daily_filled_notional_schema)
+        BEGIN
+            SELECT RAISE(ABORT, 'filled-notional schema is immutable');
+        END
+    """,
+}
+
+
+class FilledNotionalError(RuntimeError):
+    """Base error for the filled-notional safety boundary."""
+
+
+class FilledNotionalUnavailable(FilledNotionalError):
+    """The durable total cannot be established safely."""
+
+
+class FilledNotionalIntegrityError(FilledNotionalUnavailable):
+    """The ledger schema or immutable record chain is invalid."""
+
+
+class FilledNotionalConflict(FilledNotionalUnavailable):
+    """One immutable execution identifier has conflicting evidence."""
+
+
+class FillSide(str, Enum):
+    """Economic direction of an executed fill.
+
+    Direction never changes gross-notional arithmetic: buys, sells, shorts,
+    and covers all add the absolute executed quantity multiplied by price.
+    """
+
+    BUY = "BUY"
+    SELL = "SELL"
+    SELL_SHORT = "SELL_SHORT"
+    BUY_TO_COVER = "BUY_TO_COVER"
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutedFill:
+    """Immutable evidence for one actual broker execution (including partials)."""
+
+    broker_execution_id: str
+    side: FillSide
+    quantity: Decimal
+    price: Decimal
+    currency: str
+    executed_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class FillAccountingResult:
+    """Result of appending or replaying one execution."""
+
+    recorded: bool
+    trading_date: date
+    fill_notional: Decimal
+    gross_filled_notional: Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class _CanonicalFill:
+    broker_execution_id: str
+    side: str
+    quantity_text: str
+    price_text: str
+    currency: str
+    executed_at_utc: str
+    trading_date: str
+    notional_text: str
+
+    @property
+    def notional(self) -> Decimal:
+        return Decimal(self.notional_text)
+
+
+def _normalized_sql(value: object) -> str:
+    if not isinstance(value, str) or not value.strip():
+        return ""
+    return re.sub(r"\s+", " ", value.strip().rstrip(";").lower())
+
+
+def _validate_identifier(value: object, field_name: str) -> str:
+    if type(value) is not str or _IDENTIFIER_RE.fullmatch(value) is None:
+        raise FilledNotionalError(
+            f"{field_name} must be 1-128 non-whitespace printable ASCII characters"
+        )
+    return value
+
+
+def _canonical_positive_decimal(
+    value: object,
+    field_name: str,
+    *,
+    max_digits: int = 38,
+    max_abs_exponent: int = 18,
+) -> str:
+    if type(value) is not Decimal or not value.is_finite() or value <= 0:
+        raise FilledNotionalError(f"{field_name} must be a finite positive Decimal")
+    decimal_tuple = value.as_tuple()
+    if (
+        len(decimal_tuple.digits) > max_digits
+        or not isinstance(decimal_tuple.exponent, int)
+        or abs(decimal_tuple.exponent) > max_abs_exponent
+    ):
+        raise FilledNotionalError(f"{field_name} exceeds the exact-decimal storage bound")
+    text = format(value, "f")
+    if len(text) > max_digits + max_abs_exponent + 2:
+        raise FilledNotionalError(f"{field_name} exceeds the exact-decimal storage bound")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return text
+
+
+def _canonical_nonzero_decimal_magnitude(value: object, field_name: str) -> str:
+    if type(value) is not Decimal or not value.is_finite() or value == 0:
+        raise FilledNotionalError(f"{field_name} must be a finite non-zero Decimal")
+    return _canonical_positive_decimal(value.copy_abs(), field_name)
+
+
+def _exact_multiply(left: Decimal, right: Decimal) -> Decimal:
+    with localcontext() as context:
+        context.prec = MAX_PREC
+        context.traps[Inexact] = True
+        context.traps[Rounded] = True
+        return left * right
+
+
+def _parse_canonical_positive_decimal(
+    value: object,
+    field_name: str,
+    *,
+    max_digits: int = 76,
+    max_abs_exponent: int = 36,
+) -> Decimal:
+    if type(value) is not str or not value:
+        raise FilledNotionalIntegrityError(f"stored {field_name} is not canonical decimal text")
+    try:
+        parsed = Decimal(value)
+    except Exception as exc:
+        raise FilledNotionalIntegrityError(f"stored {field_name} is malformed") from exc
+    try:
+        canonical = _canonical_positive_decimal(
+            parsed,
+            field_name,
+            max_digits=max_digits,
+            max_abs_exponent=max_abs_exponent,
+        )
+    except FilledNotionalError as exc:
+        raise FilledNotionalIntegrityError(f"stored {field_name} is invalid") from exc
+    if canonical != value:
+        raise FilledNotionalIntegrityError(f"stored {field_name} is not canonical decimal text")
+    return parsed
+
+
+def _canonical_utc(value: object) -> tuple[str, str]:
+    if type(value) is not datetime or value.tzinfo is None or value.utcoffset() is None:
+        raise FilledNotionalError("executed_at must be an aware datetime")
+    instant = value.astimezone(timezone.utc)
+    utc_text = instant.isoformat(timespec="microseconds").replace("+00:00", "Z")
+    trading_day = instant.astimezone(_NEW_YORK).date().isoformat()
+    return utc_text, trading_day
+
+
+def _parse_canonical_utc(value: object) -> datetime:
+    if type(value) is not str or not value.endswith("Z"):
+        raise FilledNotionalIntegrityError("stored execution timestamp is not canonical UTC")
+    try:
+        parsed = datetime.fromisoformat(value[:-1] + "+00:00")
+    except ValueError as exc:
+        raise FilledNotionalIntegrityError("stored execution timestamp is malformed") from exc
+    canonical, _ = _canonical_utc(parsed)
+    if canonical != value:
+        raise FilledNotionalIntegrityError("stored execution timestamp is not canonical UTC")
+    return parsed
+
+
+def _canonical_fill(fill: object) -> _CanonicalFill:
+    if type(fill) is not ExecutedFill:
+        raise FilledNotionalError("only exact ExecutedFill evidence can be recorded")
+    execution_id = _validate_identifier(fill.broker_execution_id, "broker_execution_id")
+    if type(fill.side) is not FillSide:
+        raise FilledNotionalError("side must be a FillSide")
+    quantity_text = _canonical_nonzero_decimal_magnitude(fill.quantity, "quantity")
+    price_text = _canonical_positive_decimal(fill.price, "price")
+    if type(fill.currency) is not str or _CURRENCY_RE.fullmatch(fill.currency) is None:
+        raise FilledNotionalError("currency must be a three-letter uppercase code")
+    executed_at_utc, trading_day = _canonical_utc(fill.executed_at)
+    notional = _exact_multiply(Decimal(quantity_text), Decimal(price_text))
+    notional_text = _canonical_positive_decimal(
+        notional,
+        "notional",
+        max_digits=76,
+        max_abs_exponent=36,
+    )
+    return _CanonicalFill(
+        broker_execution_id=execution_id,
+        side=fill.side.value,
+        quantity_text=quantity_text,
+        price_text=price_text,
+        currency=fill.currency,
+        executed_at_utc=executed_at_utc,
+        trading_date=trading_day,
+        notional_text=notional_text,
+    )
+
+
+def _record_hash(
+    sequence: int,
+    account_id: str,
+    portfolio_id: str,
+    fill: _CanonicalFill,
+    previous_hash: str,
+) -> str:
+    payload = {
+        "account_id": account_id,
+        "broker_execution_id": fill.broker_execution_id,
+        "currency": fill.currency,
+        "executed_at_utc": fill.executed_at_utc,
+        "notional_text": fill.notional_text,
+        "portfolio_id": portfolio_id,
+        "previous_hash": previous_hash,
+        "price_text": fill.price_text,
+        "quantity_text": fill.quantity_text,
+        "sequence": sequence,
+        "side": fill.side,
+        "trading_date": fill.trading_date,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("ascii")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _append_only_authorizer(
+    action: int,
+    argument_one: Optional[str],
+    argument_two: Optional[str],
+    database_name: Optional[str],
+    trigger_name: Optional[str],
+) -> int:
+    del argument_two, database_name, trigger_name
+    if action in _DENIED_SQLITE_ACTIONS:
+        return sqlite3.SQLITE_DENY
+    if action == sqlite3.SQLITE_PRAGMA and argument_one not in {"integrity_check"}:
+        return sqlite3.SQLITE_DENY
+    return sqlite3.SQLITE_OK
+
+
+class DailyFilledNotional:
+    """Scope-bound, durable accounting for gross executed-fill notional."""
+
+    def __init__(
+        self,
+        database_path: Path | str,
+        *,
+        account_id: str,
+        portfolio_id: str,
+        currency: str = "USD",
+        clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+    ) -> None:
+        self._path = lexical_path_preserving_leaf(database_path)
+        self._account_id = _validate_identifier(account_id, "account_id")
+        self._portfolio_id = _validate_identifier(portfolio_id, "portfolio_id")
+        if type(currency) is not str or _CURRENCY_RE.fullmatch(currency) is None:
+            raise FilledNotionalError("currency must be a three-letter uppercase code")
+        if not callable(clock):
+            raise FilledNotionalError("clock must be callable")
+        self._currency = currency
+        self._clock = clock
+        self._failed_reason: Optional[str] = None
+        self._restored_trading_date: date
+        self._restored_total: Decimal
+
+        try:
+            self._initialize_if_missing()
+            current_day = self._current_trading_date()
+            with self._connection(readonly=True) as connection:
+                self._validate_ledger(connection)
+                total = self._total_for_date(connection, current_day)
+        except FilledNotionalError:
+            raise
+        except (OSError, sqlite3.Error, SQLiteIdentityError) as exc:
+            raise FilledNotionalUnavailable("filled-notional ledger startup failed closed") from exc
+        self._restored_trading_date = current_day
+        self._restored_total = total
+
+    @property
+    def database_path(self) -> Path:
+        return self._path
+
+    @property
+    def restored_trading_date(self) -> date:
+        """Trading date restored during construction."""
+
+        return self._restored_trading_date
+
+    @property
+    def restored_gross_filled_notional(self) -> Decimal:
+        """Exact total restored from durable records during construction."""
+
+        return self._restored_total
+
+    def record_fill(self, fill: ExecutedFill) -> FillAccountingResult:
+        """Append one actual execution, or accept an exact replay idempotently."""
+
+        self._require_available()
+        canonical = _canonical_fill(fill)
+        if canonical.currency != self._currency:
+            raise FilledNotionalError("fill currency does not match the service scope")
+
+        try:
+            with self._connection(readonly=False) as connection:
+                connection.execute("BEGIN IMMEDIATE")
+                self._validate_ledger(connection)
+                existing = connection.execute(
+                    """
+                    SELECT side, quantity_text, price_text, currency,
+                           executed_at_utc, trading_date, notional_text
+                    FROM daily_filled_notional_records
+                    WHERE account_id = ? AND portfolio_id = ?
+                      AND broker_execution_id = ?
+                    """,
+                    (
+                        self._account_id,
+                        self._portfolio_id,
+                        canonical.broker_execution_id,
+                    ),
+                ).fetchone()
+                recorded = existing is None
+                if existing is not None:
+                    stored = tuple(str(value) for value in existing)
+                    expected = (
+                        canonical.side,
+                        canonical.quantity_text,
+                        canonical.price_text,
+                        canonical.currency,
+                        canonical.executed_at_utc,
+                        canonical.trading_date,
+                        canonical.notional_text,
+                    )
+                    if stored != expected:
+                        raise FilledNotionalConflict(
+                            "broker execution identity has conflicting immutable evidence"
+                        )
+                else:
+                    tail = connection.execute("""
+                        SELECT sequence, record_hash
+                        FROM daily_filled_notional_records
+                        ORDER BY sequence DESC LIMIT 1
+                        """).fetchone()
+                    sequence = 1 if tail is None else int(tail[0]) + 1
+                    previous_hash = _ZERO_HASH if tail is None else str(tail[1])
+                    digest = _record_hash(
+                        sequence,
+                        self._account_id,
+                        self._portfolio_id,
+                        canonical,
+                        previous_hash,
+                    )
+                    connection.execute(
+                        """
+                        INSERT INTO daily_filled_notional_records (
+                            sequence, account_id, portfolio_id, broker_execution_id,
+                            side, quantity_text, price_text, currency,
+                            executed_at_utc, trading_date, notional_text,
+                            previous_hash, record_hash
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            sequence,
+                            self._account_id,
+                            self._portfolio_id,
+                            canonical.broker_execution_id,
+                            canonical.side,
+                            canonical.quantity_text,
+                            canonical.price_text,
+                            canonical.currency,
+                            canonical.executed_at_utc,
+                            canonical.trading_date,
+                            canonical.notional_text,
+                            previous_hash,
+                            digest,
+                        ),
+                    )
+                trading_day = date.fromisoformat(canonical.trading_date)
+                total = self._total_for_date(connection, trading_day)
+                connection.commit()
+        except FilledNotionalConflict as exc:
+            self._latch_failure(str(exc))
+            raise
+        except FilledNotionalIntegrityError as exc:
+            self._latch_failure(str(exc))
+            raise
+        except (OSError, sqlite3.Error, SQLiteIdentityError) as exc:
+            self._latch_failure("filled-notional ledger write failed")
+            raise FilledNotionalUnavailable("filled-notional ledger write failed closed") from exc
+
+        return FillAccountingResult(
+            recorded=recorded,
+            trading_date=trading_day,
+            fill_notional=canonical.notional,
+            gross_filled_notional=total,
+        )
+
+    def current_gross_filled_notional(self, *, as_of: Optional[datetime] = None) -> Decimal:
+        """Read the exact total for the New York date containing ``as_of``.
+
+        This API performs no database mutation.  Omitting ``as_of`` uses the
+        injected clock, which also makes midnight and DST behavior testable.
+        """
+
+        self._require_available()
+        try:
+            trading_day = self._trading_date(as_of if as_of is not None else self._clock())
+            with self._connection(readonly=True) as connection:
+                self._validate_ledger(connection)
+                total = self._total_for_date(connection, trading_day)
+        except FilledNotionalIntegrityError as exc:
+            self._latch_failure(str(exc))
+            raise
+        except FilledNotionalError:
+            raise
+        except (OSError, sqlite3.Error, SQLiteIdentityError) as exc:
+            self._latch_failure("filled-notional ledger read failed")
+            raise FilledNotionalUnavailable("filled-notional ledger read failed closed") from exc
+        return total
+
+    def _require_available(self) -> None:
+        if self._failed_reason is not None:
+            raise FilledNotionalUnavailable(
+                f"filled-notional accounting is latched unavailable: {self._failed_reason}"
+            )
+
+    def _latch_failure(self, reason: str) -> None:
+        self._failed_reason = reason
+
+    def _current_trading_date(self) -> date:
+        return self._trading_date(self._clock())
+
+    @staticmethod
+    def _trading_date(instant: object) -> date:
+        _, trading_day = _canonical_utc(instant)
+        return date.fromisoformat(trading_day)
+
+    def _initialize_if_missing(self) -> None:
+        try:
+            os.lstat(self._path)
+            create = False
+        except FileNotFoundError:
+            create = True
+
+        binding: Optional[SQLitePathBinding] = None
+        connection: Optional[sqlite3.Connection] = None
+        try:
+            binding = SQLitePathBinding.open_for_initialization(self._path, create=create)
+            connection = sqlite3.connect(
+                self._path.as_uri() + "?mode=rw",
+                uri=True,
+                timeout=1.0,
+                isolation_level=None,
+            )
+            connection.row_factory = sqlite3.Row
+            bound = binding.bind_sqlite_connection(sqlite_connection_file_identity(connection))
+            if create:
+                connection.execute("PRAGMA journal_mode=DELETE")
+                connection.execute("PRAGMA synchronous=FULL")
+                connection.execute("BEGIN IMMEDIATE")
+                connection.execute(_SCHEMA_TABLE_SQL)
+                connection.execute(_RECORDS_TABLE_SQL)
+                connection.execute(_UNIQUE_EXECUTION_SQL)
+                connection.execute(_SCOPE_DATE_SQL)
+                for statement in _TRIGGER_SQL.values():
+                    connection.execute(statement)
+                connection.execute(
+                    "INSERT INTO daily_filled_notional_schema VALUES (1, ?)",
+                    (_SCHEMA_VERSION,),
+                )
+                connection.commit()
+            bound.assert_connection_identity(sqlite_connection_file_identity(connection))
+        finally:
+            if connection is not None:
+                if connection.in_transaction:
+                    connection.rollback()
+                connection.close()
+            if binding is not None:
+                binding.close()
+
+    @contextmanager
+    def _connection(self, *, readonly: bool) -> Iterator[sqlite3.Connection]:
+        binding: Optional[SQLitePathBinding] = None
+        connection: Optional[sqlite3.Connection] = None
+        try:
+            binding = SQLitePathBinding.open_for_initialization(self._path, create=False)
+            mode = "ro" if readonly else "rw"
+            connection = sqlite3.connect(
+                self._path.as_uri() + f"?mode={mode}",
+                uri=True,
+                timeout=1.0,
+                isolation_level=None,
+            )
+            connection.row_factory = sqlite3.Row
+            bound = binding.bind_sqlite_connection(sqlite_connection_file_identity(connection))
+            connection.execute("PRAGMA busy_timeout=1000")
+            connection.execute("PRAGMA foreign_keys=ON")
+            connection.set_authorizer(_append_only_authorizer)
+            bound.assert_connection_identity(sqlite_connection_file_identity(connection))
+            yield connection
+            bound.assert_connection_identity(sqlite_connection_file_identity(connection))
+        finally:
+            if connection is not None:
+                if connection.in_transaction:
+                    connection.rollback()
+                connection.close()
+            if binding is not None:
+                binding.close()
+
+    def _validate_ledger(self, connection: sqlite3.Connection) -> None:
+        integrity = connection.execute("PRAGMA integrity_check").fetchall()
+        if len(integrity) != 1 or str(integrity[0][0]) != "ok":
+            raise FilledNotionalIntegrityError("SQLite integrity_check failed")
+
+        expected_sql = {
+            ("table", "daily_filled_notional_schema"): _SCHEMA_TABLE_SQL,
+            ("table", "daily_filled_notional_records"): _RECORDS_TABLE_SQL,
+            ("index", "daily_filled_notional_execution_identity"): _UNIQUE_EXECUTION_SQL,
+            ("index", "daily_filled_notional_scope_date"): _SCOPE_DATE_SQL,
+            **{("trigger", name): sql for name, sql in _TRIGGER_SQL.items()},
+        }
+        rows = connection.execute("""
+            SELECT type, name, sql
+            FROM sqlite_master
+            WHERE name LIKE 'daily_filled_notional_%'
+            ORDER BY type, name
+            """).fetchall()
+        actual_sql = {(str(row[0]), str(row[1])): str(row[2]) for row in rows}
+        if set(actual_sql) != set(expected_sql):
+            raise FilledNotionalIntegrityError("filled-notional schema objects do not match")
+        for key, statement in expected_sql.items():
+            if _normalized_sql(actual_sql[key]) != _normalized_sql(statement):
+                raise FilledNotionalIntegrityError(
+                    f"filled-notional schema definition changed: {key[1]}"
+                )
+
+        schema_rows = connection.execute(
+            "SELECT singleton, schema_version FROM daily_filled_notional_schema"
+        ).fetchall()
+        if [tuple(row) for row in schema_rows] != [(1, _SCHEMA_VERSION)]:
+            raise FilledNotionalIntegrityError("filled-notional schema version is invalid")
+
+        previous_hash = _ZERO_HASH
+        expected_sequence = 1
+        records = connection.execute(
+            "SELECT * FROM daily_filled_notional_records ORDER BY sequence"
+        ).fetchall()
+        identities: set[tuple[str, str, str]] = set()
+        for row in records:
+            if int(row["sequence"]) != expected_sequence:
+                raise FilledNotionalIntegrityError(
+                    "filled-notional record sequence is not contiguous"
+                )
+            account_id = _validate_stored_identifier(row["account_id"], "account_id")
+            portfolio_id = _validate_stored_identifier(row["portfolio_id"], "portfolio_id")
+            execution_id = _validate_stored_identifier(
+                row["broker_execution_id"], "broker_execution_id"
+            )
+            identity = (account_id, portfolio_id, execution_id)
+            if identity in identities:
+                raise FilledNotionalIntegrityError("duplicate broker execution identity in ledger")
+            identities.add(identity)
+            if str(row["side"]) not in {side.value for side in FillSide}:
+                raise FilledNotionalIntegrityError("stored fill side is invalid")
+            quantity = _parse_canonical_positive_decimal(
+                row["quantity_text"],
+                "quantity",
+                max_digits=38,
+                max_abs_exponent=18,
+            )
+            price = _parse_canonical_positive_decimal(
+                row["price_text"],
+                "price",
+                max_digits=38,
+                max_abs_exponent=18,
+            )
+            notional = _parse_canonical_positive_decimal(row["notional_text"], "notional")
+            currency = str(row["currency"])
+            if _CURRENCY_RE.fullmatch(currency) is None:
+                raise FilledNotionalIntegrityError("stored currency is invalid")
+            executed_at = _parse_canonical_utc(row["executed_at_utc"])
+            _, derived_day = _canonical_utc(executed_at)
+            if str(row["trading_date"]) != derived_day:
+                raise FilledNotionalIntegrityError("stored New York trading date is invalid")
+            if _exact_multiply(quantity, price) != notional:
+                raise FilledNotionalIntegrityError("stored fill notional does not match quantity")
+            if str(row["previous_hash"]) != previous_hash:
+                raise FilledNotionalIntegrityError("filled-notional hash chain is broken")
+            canonical = _CanonicalFill(
+                broker_execution_id=execution_id,
+                side=str(row["side"]),
+                quantity_text=str(row["quantity_text"]),
+                price_text=str(row["price_text"]),
+                currency=currency,
+                executed_at_utc=str(row["executed_at_utc"]),
+                trading_date=str(row["trading_date"]),
+                notional_text=str(row["notional_text"]),
+            )
+            expected_hash = _record_hash(
+                expected_sequence,
+                account_id,
+                portfolio_id,
+                canonical,
+                previous_hash,
+            )
+            stored_hash = str(row["record_hash"])
+            if not hmac.compare_digest(stored_hash, expected_hash):
+                raise FilledNotionalIntegrityError("filled-notional record hash is invalid")
+            previous_hash = stored_hash
+            expected_sequence += 1
+
+    def _total_for_date(self, connection: sqlite3.Connection, trading_day: date) -> Decimal:
+        rows = connection.execute(
+            """
+            SELECT notional_text
+            FROM daily_filled_notional_records
+            WHERE account_id = ? AND portfolio_id = ?
+              AND currency = ? AND trading_date = ?
+            ORDER BY sequence
+            """,
+            (
+                self._account_id,
+                self._portfolio_id,
+                self._currency,
+                trading_day.isoformat(),
+            ),
+        ).fetchall()
+        with localcontext() as context:
+            context.prec = MAX_PREC
+            context.traps[Inexact] = True
+            context.traps[Rounded] = True
+            return sum(
+                (_parse_canonical_positive_decimal(row[0], "notional") for row in rows),
+                Decimal("0"),
+            )
+
+
+def _validate_stored_identifier(value: object, field_name: str) -> str:
+    try:
+        return _validate_identifier(value, field_name)
+    except FilledNotionalError as exc:
+        raise FilledNotionalIntegrityError(f"stored {field_name} is invalid") from exc

--- a/robo_trader/risk/filled_notional/ledger.py
+++ b/robo_trader/risk/filled_notional/ledger.py
@@ -68,6 +68,7 @@ _ZERO_HASH = "0" * 64
 _SCHEMA_VERSION = 3
 _ANCHOR_VERSION = 2
 _MAX_DAILY_FILL_ROWS = 100_000
+_SQLITE_SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")
 _IDENTIFIER_RE = re.compile(r"[\x21-\x7e]{1,128}\Z")
 _CURRENCY_RE = re.compile(r"[A-Z]{3}\Z")
 _LEDGER_ID_RE = re.compile(r"[0-9a-f]{32}\Z")
@@ -1316,6 +1317,8 @@ class DailyFilledNotional:
         except FileNotFoundError:
             pass
 
+        self._reject_sidecars_without_database()
+
         binding: Optional[SQLitePathBinding] = None
         connection: Optional[sqlite3.Connection] = None
         try:
@@ -1382,6 +1385,24 @@ class DailyFilledNotional:
                 connection.close()
             if binding is not None:
                 binding.close()
+
+    def _reject_sidecars_without_database(self) -> None:
+        """Preserve ambiguous SQLite recovery evidence when the main file is absent."""
+
+        for suffix in _SQLITE_SIDECAR_SUFFIXES:
+            sidecar = Path(f"{self._path}{suffix}")
+            try:
+                os.lstat(sidecar)
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                raise FilledNotionalUnavailable(
+                    "SQLite sidecar identity cannot be inspected safely"
+                ) from exc
+            raise FilledNotionalUnavailable(
+                "SQLite sidecar exists while the main database is absent; "
+                "preserve it for reviewed recovery"
+            )
 
     def _recover_hot_journal(self) -> None:
         """Force identity-bound SQLite recovery before any read-only open."""

--- a/robo_trader/risk/filled_notional/ledger.py
+++ b/robo_trader/risk/filled_notional/ledger.py
@@ -11,9 +11,10 @@ an independent secret authority; the key is never stored in the database or
 anchor. The anchor binds the ledger UUID, database device/inode, fill and
 quarantine heads/counts, and the latest append-only checkpoint. Each fill also
 contains an authenticated cumulative count and total for its accounting scope
-and New York trading date. Startup streams and audits the complete history;
-later operations validate bounded checkpoint, tail, and indexed scope state.
-This detects ledger rollback, replacement, tail deletion, and forged totals.
+and New York trading date. Startup and authoritative operations authenticate
+the complete history in addition to the durable checkpoint and indexed scope
+state. This detects ledger rollback, replacement, deletion, re-scoping, and
+forged totals.
 
 An HMAC does not prove freshness: an attacker who replays an older valid
 database and matching older valid anchor can pass all local checks while the
@@ -2107,7 +2108,7 @@ class DailyFilledNotional:
         )
 
     def _validate_checkpointed_state(self, connection: sqlite3.Connection) -> _LedgerState:
-        """Validate bounded authenticated state after the startup full audit."""
+        """Validate authenticated state, including every durable ledger row."""
 
         ledger_id = self._validate_schema(connection)
         row = connection.execute(
@@ -2193,6 +2194,21 @@ class DailyFilledNotional:
         ):
             raise FilledNotionalIntegrityError(
                 "checkpoint row counts or sequence spans do not match ledger state"
+            )
+        authenticated_fill_count, authenticated_fill_head = self._validate_fills(
+            connection, ledger_id
+        )
+        authenticated_conflict_count, authenticated_conflict_head = self._validate_conflicts(
+            connection, ledger_id
+        )
+        if (
+            authenticated_fill_count != fill_count
+            or authenticated_fill_head != fill_head
+            or authenticated_conflict_count != conflict_count
+            or authenticated_conflict_head != conflict_head
+        ):
+            raise FilledNotionalIntegrityError(
+                "checkpoint authenticated rows do not match ledger state"
             )
         if fill_count == 0:
             fill_matches = fill_tail is None and fill_head == _ZERO_HASH

--- a/robo_trader/risk/filled_notional/ledger.py
+++ b/robo_trader/risk/filled_notional/ledger.py
@@ -36,6 +36,7 @@ import re
 import secrets
 import sqlite3
 import stat
+import tempfile
 import uuid
 from contextlib import contextmanager
 from dataclasses import dataclass, replace
@@ -1694,6 +1695,7 @@ class DailyFilledNotional:
                 raise FilledNotionalUnavailable(
                     "hot journal recovery anchor does not bind this database"
                 )
+            self._validate_hot_journal_recovery_on_copy()
             return True
         try:
             with self._connection(readonly=True, immutable=True) as connection:
@@ -1707,6 +1709,101 @@ class DailyFilledNotional:
                 "existing schema cannot be detected without SQLite recovery"
             ) from exc
         return False
+
+    @staticmethod
+    def _copy_exclusive_regular_file(source: Path, target: Path) -> None:
+        """Copy a stable, single-link source without following a replacement path."""
+
+        source_descriptor: Optional[int] = None
+        target_descriptor: Optional[int] = None
+        try:
+            before = os.lstat(source)
+            source_descriptor = os.open(
+                source,
+                os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0),
+            )
+            opened = os.fstat(source_descriptor)
+            if (
+                stat.S_ISLNK(before.st_mode)
+                or not stat.S_ISREG(before.st_mode)
+                or before.st_nlink != 1
+                or not stat.S_ISREG(opened.st_mode)
+                or opened.st_nlink != 1
+                or (before.st_dev, before.st_ino) != (opened.st_dev, opened.st_ino)
+            ):
+                raise FilledNotionalUnavailable(
+                    "hot-journal recovery source is not an exclusive stable file"
+                )
+            target_descriptor = os.open(
+                target,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0),
+                0o600,
+            )
+            while True:
+                chunk = os.read(source_descriptor, 1024 * 1024)
+                if not chunk:
+                    break
+                view = memoryview(chunk)
+                while view:
+                    written = os.write(target_descriptor, view)
+                    if written <= 0:
+                        raise FilledNotionalUnavailable(
+                            "hot-journal recovery copy could not be completed"
+                        )
+                    view = view[written:]
+            os.fsync(target_descriptor)
+            after = os.fstat(source_descriptor)
+            current = os.lstat(source)
+            stable_fields = (
+                "st_dev",
+                "st_ino",
+                "st_nlink",
+                "st_size",
+                "st_mtime_ns",
+                "st_ctime_ns",
+            )
+            if any(
+                getattr(opened, field) != getattr(after, field)
+                or getattr(opened, field) != getattr(current, field)
+                for field in stable_fields
+            ):
+                raise FilledNotionalUnavailable(
+                    "hot-journal recovery evidence changed while being copied"
+                )
+        except FilledNotionalError:
+            raise
+        except OSError as exc:
+            raise FilledNotionalUnavailable(
+                "hot-journal recovery evidence cannot be copied safely"
+            ) from exc
+        finally:
+            if target_descriptor is not None:
+                os.close(target_descriptor)
+            if source_descriptor is not None:
+                os.close(source_descriptor)
+
+    def _validate_hot_journal_recovery_on_copy(self) -> None:
+        """Prove recovery yields the anchored current schema before touching evidence."""
+
+        journal = Path(f"{self._path}-journal")
+        try:
+            with tempfile.TemporaryDirectory(prefix="filled-notional-recovery-") as directory:
+                copied_database = Path(directory) / "ledger.sqlite3"
+                copied_journal = Path(f"{copied_database}-journal")
+                self._copy_exclusive_regular_file(self._path, copied_database)
+                self._copy_exclusive_regular_file(journal, copied_journal)
+                with sqlite3.connect(copied_database, isolation_level=None) as connection:
+                    connection.row_factory = sqlite3.Row
+                    connection.execute("BEGIN")
+                    state = self._validate_ledger(connection)
+                    self._require_anchor_authenticates_recovered_state(state)
+                    connection.commit()
+        except FilledNotionalError:
+            raise
+        except (OSError, sqlite3.Error) as exc:
+            raise FilledNotionalUnavailable(
+                "hot-journal recovery copy could not authenticate current-schema state"
+            ) from exc
 
     def _require_exclusive_database_path(
         self, binding: Optional[SQLitePathBinding] = None
@@ -2421,6 +2518,26 @@ class DailyFilledNotional:
             raise _PendingAnchorInProgress
         if anchor.state != state:
             raise FilledNotionalIntegrityError("ledger and durable anchor differ")
+        return anchor
+
+    def _require_anchor_authenticates_recovered_state(self, state: _LedgerState) -> _Anchor:
+        """Read-only validation for one endpoint of an atomic anchor transition."""
+
+        anchor = self._load_anchor()
+        pending = anchor.pending_state
+        if pending is None:
+            if anchor.state != state:
+                raise FilledNotionalIntegrityError("ledger and durable anchor differ")
+            return anchor
+        if (
+            pending.ledger_id != anchor.state.ledger_id
+            or pending.database_device != anchor.state.database_device
+            or pending.database_inode != anchor.state.database_inode
+            or state not in (anchor.state, pending)
+        ):
+            raise FilledNotionalIntegrityError(
+                "pending anchor does not authenticate recovered ledger state"
+            )
         return anchor
 
     def _resolve_pending_anchor(self) -> None:

--- a/robo_trader/risk/filled_notional/ledger.py
+++ b/robo_trader/risk/filled_notional/ledger.py
@@ -1634,7 +1634,15 @@ class DailyFilledNotional:
             )
 
     def _validate_existing_rollback_journal(self) -> None:
-        """Ensure a rollback journal cannot redirect mutations through another inode name."""
+        """Reject every authoritative open while rollback evidence exists.
+
+        Merely authenticating a hot journal is not enough: opening the database
+        through SQLite can recover it implicitly, rewrite the ledger, and remove
+        the only crash evidence.  Recovery is intentionally restricted to an
+        isolated reviewed copy, so both read and write connections must remain
+        unavailable until an operator installs a separately authenticated
+        generation.
+        """
 
         self._require_exclusive_database_path()
         journal = Path(f"{self._path}-journal")
@@ -1671,6 +1679,12 @@ class DailyFilledNotional:
             raise FilledNotionalUnavailable(
                 "hot journal recovery anchor does not bind this database"
             )
+        if self._review_only and anchor.pending_state is not None:
+            raise _PendingAnchorInProgress
+        raise FilledNotionalUnavailable(
+            "hot journal requires reviewed isolated-copy recovery; "
+            "authoritative database open is blocked"
+        )
 
     @staticmethod
     def _require_rollback_journal_header(binding: SQLitePathBinding) -> None:

--- a/robo_trader/risk/filled_notional/ledger.py
+++ b/robo_trader/risk/filled_notional/ledger.py
@@ -296,6 +296,13 @@ _TRIGGER_SQL = {
     """,
 }
 
+_PROTECTED_TABLES = (
+    "daily_filled_notional_schema",
+    "daily_filled_notional_records",
+    "daily_filled_notional_conflicts",
+    "daily_filled_notional_checkpoints",
+)
+
 
 class FilledNotionalError(RuntimeError):
     """Base error for the filled-notional safety boundary."""
@@ -671,6 +678,9 @@ class DailyFilledNotional:
                 "independent monotonic verifier is required for authoritative accounting"
             )
         self._monotonic_verifier = monotonic_verifier
+        self._review_only = _review_only
+        if self._review_only:
+            self._require_review_artifacts()
         self._validate_independent_anchor_path()
         self._account_id = _validate_identifier(account_id, "account_id")
         self._portfolio_id = _validate_identifier(portfolio_id, "portfolio_id")
@@ -681,24 +691,13 @@ class DailyFilledNotional:
         self._currency = currency
         self._clock = clock
         self._failed_reason: Optional[str] = None
-        self._review_only = _review_only
 
         try:
-            created = self._initialize_if_missing()
-            if not created:
-                recovery_required = self._preflight_existing_schema()
-            else:
-                recovery_required = False
-            with self._anchor_transition_lock():
-                if recovery_required:
-                    self._recover_hot_journal()
-                with self._connection(readonly=True) as connection:
+            if self._review_only:
+                with self._connection(readonly=True, immutable=True) as connection:
                     connection.execute("BEGIN")
                     state = self._validate_ledger(connection)
-                    if created:
-                        anchor = self._create_initial_anchor(state)
-                    else:
-                        anchor = self._reconcile_anchor(state)
+                    anchor = self._require_exact_anchor(state)
                     self._verify_monotonic_state(state)
                     self._ledger_id = state.ledger_id
                     current_day = self._current_trading_date()
@@ -706,6 +705,29 @@ class DailyFilledNotional:
                     anchor = self._require_exact_anchor(state)
                     self._verify_monotonic_state(state)
                     connection.commit()
+            else:
+                created = self._initialize_if_missing()
+                if not created:
+                    recovery_required = self._preflight_existing_schema()
+                else:
+                    recovery_required = False
+                with self._anchor_transition_lock():
+                    if recovery_required:
+                        self._recover_hot_journal()
+                    with self._connection(readonly=True) as connection:
+                        connection.execute("BEGIN")
+                        state = self._validate_ledger(connection)
+                        if created:
+                            anchor = self._create_initial_anchor(state)
+                        else:
+                            anchor = self._reconcile_anchor(state)
+                        self._verify_monotonic_state(state)
+                        self._ledger_id = state.ledger_id
+                        current_day = self._current_trading_date()
+                        total = self._total_for_date(connection, current_day)
+                        anchor = self._require_exact_anchor(state)
+                        self._verify_monotonic_state(state)
+                        connection.commit()
         except FilledNotionalError:
             raise
         except DecimalException as exc:
@@ -729,6 +751,32 @@ class DailyFilledNotional:
         if type(value) is not bytes or len(value) < 32:
             raise FilledNotionalError("anchor_key must be at least 32 exact bytes")
         return value
+
+    def _require_review_artifacts(self) -> None:
+        """Require existing exclusive regular artifacts without creating either one."""
+
+        for path, label in (
+            (self._path, "database"),
+            (self._anchor_path, "anchor"),
+        ):
+            try:
+                metadata = os.lstat(path)
+            except FileNotFoundError as exc:
+                raise FilledNotionalUnavailable(
+                    f"review requires existing filled-notional {label}"
+                ) from exc
+            except OSError as exc:
+                raise FilledNotionalUnavailable(
+                    f"review cannot inspect filled-notional {label} safely"
+                ) from exc
+            if (
+                stat.S_ISLNK(metadata.st_mode)
+                or not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_nlink != 1
+            ):
+                raise FilledNotionalUnavailable(
+                    f"review requires existing exclusive non-symlink regular {label}"
+                )
 
     def _validate_independent_anchor_path(self) -> None:
         if self._anchor_path == self._path:
@@ -982,6 +1030,13 @@ class DailyFilledNotional:
                         if mutated
                         else before
                     )
+                    if mutated:
+                        verified_after = self._validate_checkpointed_state(connection)
+                        if verified_after != after:
+                            raise FilledNotionalIntegrityError(
+                                "filled-notional append did not advance checkpoint state"
+                            )
+                        after = verified_after
                     trading_day = date.fromisoformat(canonical.trading_date)
                     total = self._total_for_date(connection, trading_day)
                     if mutated:
@@ -1089,7 +1144,7 @@ class DailyFilledNotional:
             _review_only=True,
         )
         try:
-            with reviewer._connection(readonly=True) as connection:
+            with reviewer._connection(readonly=True, immutable=True) as connection:
                 connection.execute("BEGIN")
                 state = reviewer._validate_checkpointed_state(connection)
                 reviewer._require_exact_anchor(state)
@@ -1610,11 +1665,18 @@ class DailyFilledNotional:
             ("index", "daily_filled_notional_scope_date"): _SCOPE_DATE_SQL,
             **{("trigger", name): sql for name, sql in _TRIGGER_SQL.items()},
         }
-        rows = connection.execute("""
+        rows = connection.execute(
+            """
             SELECT type, name, sql FROM sqlite_master
             WHERE name LIKE 'daily_filled_notional_%'
+               OR (
+                   type = 'trigger'
+                   AND tbl_name IN (?, ?, ?, ?)
+               )
             ORDER BY type, name
-            """).fetchall()
+            """,
+            _PROTECTED_TABLES,
+        ).fetchall()
         actual_sql = {(str(row[0]), str(row[1])): str(row[2]) for row in rows}
         if set(actual_sql) != set(expected_sql):
             raise FilledNotionalIntegrityError("filled-notional schema objects do not match")

--- a/robo_trader/risk/filled_notional/ledger.py
+++ b/robo_trader/risk/filled_notional/ledger.py
@@ -70,6 +70,11 @@ _SCHEMA_VERSION = 3
 _ANCHOR_VERSION = 2
 _MAX_DAILY_FILL_ROWS = 100_000
 _SQLITE_SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")
+# SQLite's POSIX VFS serializes writers on the RESERVED byte.  Holding the
+# same advisory lock through the journal-absence check and SQLite's first file
+# access closes the sidecar check-to-open race against every SQLite process.
+_SQLITE_PENDING_BYTE = 0x40000000
+_SQLITE_RESERVED_BYTE = _SQLITE_PENDING_BYTE + 1
 _IDENTIFIER_RE = re.compile(r"[\x21-\x7e]{1,128}\Z")
 _CURRENCY_RE = re.compile(r"[A-Z]{3}\Z")
 _LEDGER_ID_RE = re.compile(r"[0-9a-f]{32}\Z")
@@ -1905,10 +1910,43 @@ class DailyFilledNotional:
     ) -> Iterator[sqlite3.Connection]:
         binding: Optional[SQLitePathBinding] = None
         connection: Optional[sqlite3.Connection] = None
+        writer_guard: Optional[int] = None
         try:
             self._require_exclusive_database_path()
             binding = SQLitePathBinding.open_for_initialization(self._path, create=False)
             self._require_exclusive_database_path(binding)
+            if not readonly:
+                if not hasattr(os, "O_NOFOLLOW"):
+                    raise FilledNotionalUnavailable(
+                        "platform cannot serialize SQLite writer startup safely"
+                    )
+                writer_guard = os.open(
+                    self._path,
+                    os.O_RDWR | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0),
+                )
+                guard_metadata = os.fstat(writer_guard)
+                if (
+                    not stat.S_ISREG(guard_metadata.st_mode)
+                    or guard_metadata.st_nlink != 1
+                    or (guard_metadata.st_dev, guard_metadata.st_ino)
+                    != (binding.device, binding.inode)
+                ):
+                    raise FilledNotionalIntegrityError(
+                        "SQLite writer guard does not bind the authoritative database"
+                    )
+                try:
+                    fcntl.lockf(
+                        writer_guard,
+                        fcntl.LOCK_EX | fcntl.LOCK_NB,
+                        1,
+                        _SQLITE_RESERVED_BYTE,
+                        os.SEEK_SET,
+                    )
+                except OSError as exc:
+                    raise FilledNotionalUnavailable(
+                        "another SQLite writer owns the authoritative database"
+                    ) from exc
+                self._require_exclusive_database_path(binding)
             self._require_rollback_journal_header(binding)
             self._reject_wal_sidecars()
             self._validate_existing_rollback_journal()
@@ -1921,6 +1959,10 @@ class DailyFilledNotional:
                 timeout=1.0,
                 isolation_level=None,
             )
+            # sqlite3.connect is lazy on supported VFS implementations.  Recheck
+            # immediately before the first pragma while the RESERVED-byte guard
+            # excludes every other SQLite process from creating a journal.
+            self._validate_existing_rollback_journal()
             connection.row_factory = sqlite3.Row
             bound = binding.bind_sqlite_connection(sqlite_connection_file_identity(connection))
             journal_mode = connection.execute("PRAGMA journal_mode").fetchone()
@@ -1939,6 +1981,17 @@ class DailyFilledNotional:
                 connection.close()
             if binding is not None:
                 binding.close()
+            if writer_guard is not None:
+                try:
+                    fcntl.lockf(
+                        writer_guard,
+                        fcntl.LOCK_UN,
+                        1,
+                        _SQLITE_RESERVED_BYTE,
+                        os.SEEK_SET,
+                    )
+                finally:
+                    os.close(writer_guard)
 
     def _schema_version(self, connection: sqlite3.Connection) -> int:
         table = connection.execute(

--- a/robo_trader/risk/filled_notional/ledger.py
+++ b/robo_trader/risk/filled_notional/ledger.py
@@ -2167,6 +2167,33 @@ class DailyFilledNotional:
             "SELECT sequence, conflict_hash FROM daily_filled_notional_conflicts "
             "ORDER BY sequence DESC LIMIT 1"
         ).fetchone()
+        fill_span = connection.execute(
+            "SELECT COUNT(*) AS row_count, MIN(sequence) AS first_sequence, "
+            "MAX(sequence) AS last_sequence FROM daily_filled_notional_records"
+        ).fetchone()
+        conflict_span = connection.execute(
+            "SELECT COUNT(*) AS row_count, MIN(sequence) AS first_sequence, "
+            "MAX(sequence) AS last_sequence FROM daily_filled_notional_conflicts"
+        ).fetchone()
+
+        def span_matches(span: sqlite3.Row, expected_count: int) -> bool:
+            if type(span["row_count"]) is not int or int(span["row_count"]) != expected_count:
+                return False
+            if expected_count == 0:
+                return span["first_sequence"] is None and span["last_sequence"] is None
+            return (
+                type(span["first_sequence"]) is int
+                and type(span["last_sequence"]) is int
+                and int(span["first_sequence"]) == 1
+                and int(span["last_sequence"]) == expected_count
+            )
+
+        if not span_matches(fill_span, fill_count) or not span_matches(
+            conflict_span, conflict_count
+        ):
+            raise FilledNotionalIntegrityError(
+                "checkpoint row counts or sequence spans do not match ledger state"
+            )
         if fill_count == 0:
             fill_matches = fill_tail is None and fill_head == _ZERO_HASH
         else:

--- a/tests/risk/test_daily_filled_notional.py
+++ b/tests/risk/test_daily_filled_notional.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 import hashlib
+import os
+import shutil
+import signal
 import sqlite3
+import subprocess
+import sys
 from dataclasses import replace
 from datetime import datetime, timezone
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation, getcontext, setcontext
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
@@ -19,12 +24,14 @@ from robo_trader.risk.filled_notional import (
     FilledNotionalConflict,
     FilledNotionalError,
     FilledNotionalIntegrityError,
+    FilledNotionalMigrationRequired,
     FilledNotionalUnavailable,
     FillSide,
 )
 
 UTC = timezone.utc
 NEW_YORK = ZoneInfo("America/New_York")
+ANCHOR_KEY = b"test-only-independent-anchor-key-32-bytes-minimum"
 
 
 class MutableClock:
@@ -60,12 +67,20 @@ def _service(
     portfolio_id: str = "default",
     clock: MutableClock | None = None,
 ) -> DailyFilledNotional:
+    anchor_directory = path.parent / "protected-anchor"
+    anchor_directory.mkdir(mode=0o700, exist_ok=True)
     return DailyFilledNotional(
         path,
+        anchor_path=anchor_directory / f"{path.name}.anchor",
+        anchor_key=ANCHOR_KEY,
         account_id=account_id,
         portfolio_id=portfolio_id,
         clock=clock or MutableClock(datetime(2026, 7, 28, 20, 0, tzinfo=UTC)),
     )
+
+
+def _anchor_path(database_path: Path) -> Path:
+    return database_path.parent / "protected-anchor" / f"{database_path.name}.anchor"
 
 
 def test_counts_only_executed_fill_evidence_with_exact_decimal_math(tmp_path):
@@ -132,15 +147,29 @@ def test_conflicting_duplicate_fails_closed_and_latches_instance(tmp_path):
     original = _fill("broker.exec.1")
     ledger.record_fill(original)
 
-    with pytest.raises(FilledNotionalConflict, match="conflicting immutable evidence"):
+    with pytest.raises(FilledNotionalConflict, match="durable conflicting evidence"):
         ledger.record_fill(replace(original, price=Decimal("999")))
     with pytest.raises(FilledNotionalUnavailable, match="latched unavailable"):
         ledger.current_gross_filled_notional()
 
-    # The conflicting claim was never written.  A fresh process can restore the
-    # one durable execution and will fail again if the bad claim is replayed.
-    restarted = _service(ledger.database_path)
-    assert restarted.restored_gross_filled_notional == Decimal("20.5")
+    with sqlite3.connect(ledger.database_path) as connection:
+        assert connection.execute(
+            "SELECT count(*) FROM daily_filled_notional_conflicts"
+        ).fetchone() == (1,)
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            connection.execute("DELETE FROM daily_filled_notional_conflicts")
+    with pytest.raises(FilledNotionalConflict, match="requires review"):
+        _service(ledger.database_path)
+
+    review = DailyFilledNotional.review_quarantine(
+        ledger.database_path,
+        anchor_path=ledger.anchor_path,
+        anchor_key=ANCHOR_KEY,
+    )
+    assert len(review) == 1
+    assert review[0].broker_execution_id == "broker.exec.1"
+    assert review[0].existing_portfolio_id == "default"
+    assert review[0].claimed_portfolio_id == "default"
 
 
 def test_restart_restores_same_day_total_from_append_only_ledger(tmp_path):
@@ -163,12 +192,19 @@ def test_scope_isolated_by_account_and_portfolio(tmp_path):
     second_account = _service(path, account_id="DU99999")
 
     default.record_fill(_fill("same-exec", quantity="1", price="10"))
-    second_portfolio.record_fill(_fill("same-exec", quantity="2", price="10"))
     second_account.record_fill(_fill("same-exec", quantity="3", price="10"))
 
     assert default.current_gross_filled_notional() == Decimal("10")
-    assert second_portfolio.current_gross_filled_notional() == Decimal("20")
     assert second_account.current_gross_filled_notional() == Decimal("30")
+    with pytest.raises(FilledNotionalConflict, match="durable conflicting evidence"):
+        second_portfolio.record_fill(_fill("same-exec", quantity="2", price="10"))
+    review = DailyFilledNotional.review_quarantine(
+        path,
+        anchor_path=default.anchor_path,
+        anchor_key=ANCHOR_KEY,
+    )
+    assert review[0].existing_portfolio_id == "default"
+    assert review[0].claimed_portfolio_id == "income"
 
 
 def test_new_york_midnight_rollover_and_late_prior_day_fill(tmp_path):
@@ -286,7 +322,7 @@ def test_hash_tamper_fails_closed_even_with_required_schema_restored(tmp_path):
         )
         connection.execute(ledger_module._TRIGGER_SQL["daily_filled_notional_records_no_update"])
 
-    with pytest.raises(FilledNotionalIntegrityError, match="notional does not match"):
+    with pytest.raises(FilledNotionalIntegrityError, match="notional is inconsistent"):
         _service(path)
 
 
@@ -321,8 +357,290 @@ def test_current_query_is_read_only(tmp_path):
     ledger = _service(tmp_path / "notional.db")
     ledger.record_fill(_fill("exec-1"))
     before = ledger.database_path.read_bytes()
+    anchor_before = ledger.anchor_path.read_bytes()
 
     assert ledger.current_gross_filled_notional() == Decimal("20.5")
 
     assert ledger.database_path.read_bytes() == before
+    assert ledger.anchor_path.read_bytes() == anchor_before
     assert not Path(f"{ledger.database_path}-wal").exists()
+
+
+def test_anchor_write_crash_window_recovers_one_authenticated_fill(tmp_path, monkeypatch):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    original_replace = ledger._replace_anchor
+
+    def fail_final_anchor(desired, *, expected):
+        if expected.pending_state is not None and desired.pending_state is None:
+            raise OSError("injected crash before final atomic anchor replace")
+        return original_replace(desired, expected=expected)
+
+    monkeypatch.setattr(ledger, "_replace_anchor", fail_final_anchor)
+    with pytest.raises(FilledNotionalUnavailable, match="write failed closed"):
+        ledger.record_fill(_fill("committed-before-anchor"))
+
+    restarted = _service(path)
+    assert restarted.restored_gross_filled_notional == Decimal("20.5")
+    with sqlite3.connect(path) as connection:
+        assert connection.execute(
+            "SELECT count(*) FROM daily_filled_notional_records"
+        ).fetchone() == (1,)
+
+
+def test_crash_before_database_commit_resolves_pending_anchor_to_old_state(tmp_path, monkeypatch):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+
+    def fail_commit(connection):
+        raise sqlite3.OperationalError("injected crash before database commit")
+
+    monkeypatch.setattr(ledger, "_commit_database", fail_commit)
+    with pytest.raises(FilledNotionalUnavailable, match="write failed closed"):
+        ledger.record_fill(_fill("never-committed"))
+
+    restarted = _service(path)
+    assert restarted.restored_gross_filled_notional == Decimal("0")
+    with sqlite3.connect(path) as connection:
+        assert connection.execute(
+            "SELECT count(*) FROM daily_filled_notional_records"
+        ).fetchone() == (0,)
+
+
+def test_sigkill_hot_journal_is_recovered_rw_before_readonly_validation(tmp_path):
+    if not hasattr(signal, "SIGKILL"):
+        pytest.skip("SIGKILL unavailable on this host")
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    ledger.record_fill(_fill("durable"))
+    script = f"""
+import signal
+from datetime import datetime, timezone
+from decimal import Decimal
+from robo_trader.risk.filled_notional import DailyFilledNotional, ExecutedFill, FillSide
+
+service = DailyFilledNotional(
+    {str(path)!r},
+    anchor_path={str(ledger.anchor_path)!r},
+    anchor_key={ANCHOR_KEY!r},
+    account_id='DU12345',
+    portfolio_id='default',
+    clock=lambda: datetime(2026, 7, 28, 20, 0, tzinfo=timezone.utc),
+)
+def pause_before_commit(connection):
+    print('READY', flush=True)
+    signal.pause()
+service._commit_database = pause_before_commit
+service.record_fill(ExecutedFill(
+    broker_execution_id='uncommitted-crash',
+    side=FillSide.BUY,
+    quantity=Decimal('2'),
+    price=Decimal('10.25'),
+    currency='USD',
+    executed_at=datetime(2026, 7, 28, 15, 0, tzinfo=timezone.utc),
+))
+"""
+    child = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert child.stdout is not None
+        assert child.stdout.readline().strip() == "READY"
+        os.kill(child.pid, signal.SIGKILL)
+        child.wait(timeout=10)
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait(timeout=10)
+
+    journal = Path(f"{path}-journal")
+    assert journal.exists() and journal.stat().st_size > 0
+    restarted = _service(path)
+    assert restarted.restored_gross_filled_notional == Decimal("20.5")
+    with sqlite3.connect(path) as connection:
+        assert connection.execute(
+            "SELECT broker_execution_id FROM daily_filled_notional_records"
+        ).fetchall() == [("durable",)]
+
+
+def test_ledger_tail_deletion_is_detected_against_independent_anchor(tmp_path):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    ledger.record_fill(_fill("one"))
+    ledger.record_fill(_fill("two"))
+    with sqlite3.connect(path) as connection:
+        connection.execute("DROP TRIGGER daily_filled_notional_records_no_delete")
+        connection.execute("DELETE FROM daily_filled_notional_records WHERE sequence = 2")
+        connection.execute(ledger_module._TRIGGER_SQL["daily_filled_notional_records_no_delete"])
+
+    with pytest.raises(FilledNotionalIntegrityError, match="rollback, tail deletion"):
+        _service(path)
+
+
+def test_conflict_quarantine_tail_deletion_is_detected_by_anchor(tmp_path):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    original = _fill("conflicted")
+    ledger.record_fill(original)
+    with pytest.raises(FilledNotionalConflict):
+        ledger.record_fill(replace(original, price=Decimal("999")))
+    with sqlite3.connect(path) as connection:
+        connection.execute("DROP TRIGGER daily_filled_notional_conflicts_no_delete")
+        connection.execute("DELETE FROM daily_filled_notional_conflicts WHERE sequence = 1")
+        connection.execute(ledger_module._TRIGGER_SQL["daily_filled_notional_conflicts_no_delete"])
+
+    with pytest.raises(FilledNotionalIntegrityError, match="rollback, tail deletion"):
+        _service(path)
+
+
+def test_ledger_rollback_is_detected_against_newer_anchor(tmp_path):
+    path = tmp_path / "notional.db"
+    snapshot = tmp_path / "old-ledger-copy.db"
+    ledger = _service(path)
+    ledger.record_fill(_fill("one"))
+    shutil.copyfile(path, snapshot)
+    ledger.record_fill(_fill("two"))
+    shutil.copyfile(snapshot, path)
+
+    with pytest.raises(FilledNotionalIntegrityError, match="rollback, tail deletion"):
+        _service(path)
+
+
+def test_stable_anchor_rollback_is_not_mistaken_for_a_crash_window(tmp_path):
+    path = tmp_path / "notional.db"
+    old_anchor = tmp_path / "old.anchor"
+    ledger = _service(path)
+    ledger.record_fill(_fill("one"))
+    shutil.copyfile(ledger.anchor_path, old_anchor)
+    ledger.record_fill(_fill("two"))
+    shutil.copyfile(old_anchor, ledger.anchor_path)
+    os.chmod(ledger.anchor_path, 0o600)
+
+    with pytest.raises(FilledNotionalIntegrityError, match="stable-anchor rollback"):
+        _service(path)
+
+
+def test_ledger_replacement_is_detected_by_anchor_inode_binding(tmp_path):
+    path = tmp_path / "notional.db"
+    original = _service(path)
+    original.record_fill(_fill("original"))
+    other_path = tmp_path / "other" / "replacement.db"
+    other_path.parent.mkdir(mode=0o700)
+    replacement = _service(other_path)
+    replacement.record_fill(_fill("replacement"))
+
+    os.replace(other_path, path)
+
+    with pytest.raises(FilledNotionalIntegrityError, match="bind this ledger identity"):
+        _service(path)
+
+
+def test_anchor_replacement_with_other_valid_anchor_fails_closed(tmp_path):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    ledger.record_fill(_fill("original"))
+    other_path = tmp_path / "other" / "other.db"
+    other_path.parent.mkdir(mode=0o700)
+    other = _service(other_path)
+    other.record_fill(_fill("other"))
+
+    shutil.copyfile(other.anchor_path, ledger.anchor_path)
+    os.chmod(ledger.anchor_path, 0o600)
+
+    with pytest.raises(FilledNotionalIntegrityError, match="bind this ledger identity"):
+        _service(path)
+
+
+def test_anchor_content_or_external_key_mismatch_fails_closed(tmp_path):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    ledger.record_fill(_fill("anchored"))
+
+    with pytest.raises(FilledNotionalIntegrityError, match="HMAC is invalid"):
+        DailyFilledNotional(
+            path,
+            anchor_path=ledger.anchor_path,
+            anchor_key=b"different-independent-key-material-32-bytes",
+            account_id="DU12345",
+            portfolio_id="default",
+        )
+
+    payload = bytearray(ledger.anchor_path.read_bytes())
+    payload[payload.index(b"a")] = ord("b")
+    ledger.anchor_path.write_bytes(payload)
+    os.chmod(ledger.anchor_path, 0o600)
+    with pytest.raises(FilledNotionalIntegrityError):
+        _service(path)
+
+
+def test_hostile_global_decimal_context_cannot_round_or_overflow_accounting(tmp_path):
+    saved = getcontext().copy()
+    try:
+        hostile = getcontext()
+        hostile.prec = 1
+        hostile.Emax = 1
+        hostile.Emin = -1
+        hostile.clamp = 1
+        hostile.traps[InvalidOperation] = True
+        ledger = _service(tmp_path / "notional.db")
+        result = ledger.record_fill(
+            _fill(
+                "hostile-context",
+                quantity="12345678901234567890.123456789",
+                price="1.000000001",
+            )
+        )
+        assert result.gross_filled_notional == Decimal("12345678913580246791.358024679123456789")
+    finally:
+        setcontext(saved)
+
+
+def test_decimal_exception_is_typed_and_latches_unavailable(tmp_path, monkeypatch):
+    ledger = _service(tmp_path / "notional.db")
+
+    def fail_decimal(*args, **kwargs):
+        raise InvalidOperation("injected decimal fault")
+
+    monkeypatch.setattr(ledger_module, "_exact_multiply", fail_decimal)
+    with pytest.raises(FilledNotionalUnavailable, match="decimal failed closed"):
+        ledger.record_fill(_fill("decimal-fault"))
+    with pytest.raises(FilledNotionalUnavailable, match="latched unavailable"):
+        ledger.current_gross_filled_notional()
+
+
+def test_schema_v1_requires_explicit_copy_migration_without_anchor_creation(tmp_path):
+    path = tmp_path / "legacy-v1.db"
+    with sqlite3.connect(path) as connection:
+        connection.execute("""
+            CREATE TABLE daily_filled_notional_schema (
+                singleton INTEGER PRIMARY KEY,
+                schema_version INTEGER NOT NULL
+            )
+            """)
+        connection.execute("INSERT INTO daily_filled_notional_schema VALUES (1, 1)")
+    before = hashlib.sha256(path.read_bytes()).hexdigest()
+
+    with pytest.raises(FilledNotionalMigrationRequired, match="reviewed copy migration"):
+        _service(path)
+
+    assert hashlib.sha256(path.read_bytes()).hexdigest() == before
+    assert not _anchor_path(path).exists()
+
+
+def test_future_schema_version_fails_closed_without_downgrade(tmp_path):
+    path = tmp_path / "future.db"
+    with sqlite3.connect(path) as connection:
+        connection.execute("""
+            CREATE TABLE daily_filled_notional_schema (
+                singleton INTEGER PRIMARY KEY,
+                schema_version INTEGER NOT NULL
+            )
+            """)
+        connection.execute("INSERT INTO daily_filled_notional_schema VALUES (1, 99)")
+
+    with pytest.raises(FilledNotionalIntegrityError, match="unsupported future"):
+        _service(path)
+    assert not _anchor_path(path).exists()

--- a/tests/risk/test_daily_filled_notional.py
+++ b/tests/risk/test_daily_filled_notional.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import json
 import os
@@ -734,6 +735,50 @@ def test_missing_database_with_surviving_anchor_does_not_create_lock(tmp_path):
     assert all(not Path(f"{path}{suffix}").exists() for suffix in ("-wal", "-shm", "-journal"))
 
 
+@pytest.mark.parametrize("injected_artifact", ["anchor", "-wal", "-shm", "-journal"])
+def test_missing_database_race_rejects_without_creating_transition_lock(
+    tmp_path, monkeypatch, injected_artifact
+):
+    path = tmp_path / "notional.db"
+    anchor_directory = tmp_path / "protected-anchor"
+    anchor_directory.mkdir(mode=0o700)
+    anchor_path = anchor_directory / "notional.db.anchor"
+    lock_path = anchor_directory / ".notional.db.anchor.lock"
+    original_transition_lock = DailyFilledNotional._anchor_transition_lock
+    artifact_path = (
+        anchor_path if injected_artifact == "anchor" else Path(f"{path}{injected_artifact}")
+    )
+    artifact_before: list[tuple[bytes, int, int]] = []
+    paths_after_injection: list[tuple[str, ...]] = []
+
+    @contextmanager
+    def inject_before_lock(self, **kwargs):
+        artifact_path.write_bytes(b"preserved evidence injected before lock acquisition")
+        if artifact_path == anchor_path:
+            os.chmod(artifact_path, 0o600)
+        artifact_before.append(_file_snapshot(artifact_path))
+        paths_after_injection.append(_path_inventory(tmp_path))
+        with original_transition_lock(self, **kwargs):
+            yield
+
+    monkeypatch.setattr(DailyFilledNotional, "_anchor_transition_lock", inject_before_lock)
+
+    with pytest.raises(FilledNotionalUnavailable):
+        DailyFilledNotional(
+            path,
+            anchor_path=anchor_path,
+            anchor_key=ANCHOR_KEY,
+            monotonic_verifier=TestMonotonicVerifier(),
+            account_id="DU12345",
+            portfolio_id="default",
+        )
+
+    assert not path.exists()
+    assert not lock_path.exists()
+    assert _file_snapshot(artifact_path) == artifact_before[0]
+    assert _path_inventory(tmp_path) == paths_after_injection[0]
+
+
 def test_wal_shm_hardlinks_are_rejected_without_mutating_targets(tmp_path):
     path = tmp_path / "notional.db"
     ledger = _service(path)
@@ -1021,6 +1066,92 @@ def test_concurrent_writers_serialize_through_stable_anchor_publication(tmp_path
     assert _service(path).restored_gross_filled_notional == Decimal("41")
 
 
+def test_transition_lock_revalidates_path_identity_after_blocked_flock(tmp_path, monkeypatch):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    lock_path = ledger.anchor_path.parent / f".{ledger.anchor_path.name}.lock"
+    preserved_lock = ledger.anchor_path.parent / "preserved-transition.lock"
+    blocker = os.open(lock_path, os.O_RDWR)
+    fcntl.flock(blocker, fcntl.LOCK_EX)
+    worker_opened_lock = threading.Event()
+    worker_entered_section = threading.Event()
+    worker_result: list[BaseException] = []
+    worker_ident: list[int] = []
+    original_open = os.open
+
+    def observe_worker_open(target, flags, mode=0o777, *, dir_fd=None):
+        descriptor = original_open(target, flags, mode, dir_fd=dir_fd)
+        if (
+            worker_ident
+            and threading.get_ident() == worker_ident[0]
+            and target == ledger._anchor_lock_name
+        ):
+            worker_opened_lock.set()
+        return descriptor
+
+    monkeypatch.setattr(ledger_module.os, "open", observe_worker_open)
+
+    def acquire_transition_lock() -> None:
+        worker_ident.append(threading.get_ident())
+        try:
+            with ledger._anchor_transition_lock():
+                worker_entered_section.set()
+        except BaseException as exc:  # pragma: no cover - asserted below
+            worker_result.append(exc)
+
+    worker = threading.Thread(target=acquire_transition_lock)
+    worker.start()
+    assert worker_opened_lock.wait(timeout=5)
+    lock_path.rename(preserved_lock)
+    replacement = original_open(lock_path, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
+    os.close(replacement)
+    fcntl.flock(blocker, fcntl.LOCK_UN)
+    os.close(blocker)
+    worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    assert not worker_entered_section.is_set()
+    assert len(worker_result) == 1
+    assert isinstance(worker_result[0], FilledNotionalIntegrityError)
+    assert "transition lock" in str(worker_result[0])
+
+
+@pytest.mark.parametrize("mutation", ["mode", "link-count"])
+def test_transition_lock_revalidates_safety_metadata_after_flock(tmp_path, monkeypatch, mutation):
+    ledger = _service(tmp_path / "notional.db")
+    lock_path = ledger.anchor_path.parent / f".{ledger.anchor_path.name}.lock"
+    extra_link = ledger.anchor_path.parent / "extra-transition-lock-link"
+    lock_identity = (lock_path.stat().st_dev, lock_path.stat().st_ino)
+    original_flock = fcntl.flock
+    mutated = False
+    entered_section = False
+
+    def mutate_after_acquire(descriptor, operation):
+        nonlocal mutated
+        result = original_flock(descriptor, operation)
+        metadata = os.fstat(descriptor)
+        if (
+            not mutated
+            and operation & fcntl.LOCK_EX
+            and (metadata.st_dev, metadata.st_ino) == lock_identity
+        ):
+            mutated = True
+            if mutation == "mode":
+                os.chmod(lock_path, 0o644)
+            else:
+                os.link(lock_path, extra_link)
+        return result
+
+    monkeypatch.setattr(ledger_module.fcntl, "flock", mutate_after_acquire)
+
+    with pytest.raises(FilledNotionalIntegrityError, match="transition lock"):
+        with ledger._anchor_transition_lock():
+            entered_section = True
+
+    assert mutated
+    assert not entered_section
+
+
 def test_invalid_pending_anchor_identity_still_fails_closed(tmp_path):
     path = tmp_path / "notional.db"
     ledger = _service(path)
@@ -1245,6 +1376,129 @@ def test_review_quarantine_success_is_byte_inode_and_path_read_only(tmp_path):
     assert _file_snapshot(path) == database_before
     assert _file_snapshot(ledger.anchor_path) == anchor_before
     assert _path_inventory(tmp_path) == paths_before
+
+
+def test_review_quarantine_translates_concurrent_pending_writer_without_mutation(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    writer = _service(path)
+    pending_published = threading.Event()
+    release_writer = threading.Event()
+    writer_result: list[object] = []
+    original_commit = writer._commit_database
+
+    def hold_after_pending(connection):
+        pending_published.set()
+        if not release_writer.wait(timeout=5):
+            raise sqlite3.OperationalError("test timed out releasing pending writer")
+        original_commit(connection)
+
+    monkeypatch.setattr(writer, "_commit_database", hold_after_pending)
+
+    def write() -> None:
+        try:
+            writer_result.append(writer.record_fill(_fill("pending-during-review")))
+        except BaseException as exc:  # pragma: no cover - asserted below
+            writer_result.append(exc)
+
+    writer_thread = threading.Thread(target=write)
+    writer_thread.start()
+    assert pending_published.wait(timeout=5)
+    database_before = _file_snapshot(path)
+    anchor_before = _file_snapshot(ledger.anchor_path)
+    paths_before = _path_inventory(tmp_path)
+    try:
+        with pytest.raises(FilledNotionalUnavailable, match="pending anchor transition"):
+            DailyFilledNotional.review_quarantine(
+                path,
+                anchor_path=ledger.anchor_path,
+                anchor_key=ANCHOR_KEY,
+                monotonic_verifier=_MONOTONIC_VERIFIERS[str(path)],
+            )
+
+        assert _file_snapshot(path) == database_before
+        assert _file_snapshot(ledger.anchor_path) == anchor_before
+        assert _path_inventory(tmp_path) == paths_before
+    finally:
+        release_writer.set()
+        writer_thread.join(timeout=5)
+
+    assert not writer_thread.is_alive()
+    assert len(writer_result) == 1
+    assert not isinstance(writer_result[0], BaseException)
+
+
+def test_review_quarantine_translates_pending_writer_after_constructor(tmp_path, monkeypatch):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    writer = _service(path)
+    pending_published = threading.Event()
+    release_writer = threading.Event()
+    writer_result: list[object] = []
+    writer_thread: list[threading.Thread] = []
+    original_commit = writer._commit_database
+    original_require = DailyFilledNotional._require_exact_anchor
+    review_require_calls = 0
+    database_at_pending: list[tuple[bytes, int, int]] = []
+    anchor_at_pending: list[tuple[bytes, int, int]] = []
+    paths_at_pending: list[tuple[str, ...]] = []
+
+    def hold_after_pending(connection):
+        pending_published.set()
+        if not release_writer.wait(timeout=5):
+            raise sqlite3.OperationalError("test timed out releasing pending writer")
+        original_commit(connection)
+
+    monkeypatch.setattr(writer, "_commit_database", hold_after_pending)
+
+    def write() -> None:
+        try:
+            writer_result.append(writer.record_fill(_fill("pending-after-review-construction")))
+        except BaseException as exc:  # pragma: no cover - asserted below
+            writer_result.append(exc)
+
+    def start_writer_before_review_read(self, state):
+        nonlocal review_require_calls
+        if self._review_only:
+            review_require_calls += 1
+            if review_require_calls == 3:
+                thread = threading.Thread(target=write)
+                writer_thread.append(thread)
+                thread.start()
+                if not pending_published.wait(timeout=5):
+                    raise RuntimeError("test timed out waiting for pending writer")
+                database_at_pending.append(_file_snapshot(path))
+                anchor_at_pending.append(_file_snapshot(ledger.anchor_path))
+                paths_at_pending.append(_path_inventory(tmp_path))
+        return original_require(self, state)
+
+    monkeypatch.setattr(
+        DailyFilledNotional, "_require_exact_anchor", start_writer_before_review_read
+    )
+
+    try:
+        with pytest.raises(FilledNotionalUnavailable, match="pending anchor transition"):
+            DailyFilledNotional.review_quarantine(
+                path,
+                anchor_path=ledger.anchor_path,
+                anchor_key=ANCHOR_KEY,
+                monotonic_verifier=_MONOTONIC_VERIFIERS[str(path)],
+            )
+
+        assert _file_snapshot(path) == database_at_pending[0]
+        assert _file_snapshot(ledger.anchor_path) == anchor_at_pending[0]
+        assert _path_inventory(tmp_path) == paths_at_pending[0]
+    finally:
+        release_writer.set()
+        if writer_thread:
+            writer_thread[0].join(timeout=5)
+
+    assert review_require_calls == 3
+    assert writer_thread and not writer_thread[0].is_alive()
+    assert len(writer_result) == 1
+    assert not isinstance(writer_result[0], BaseException)
 
 
 @pytest.mark.parametrize("missing_artifact", ["database", "anchor"])

--- a/tests/risk/test_daily_filled_notional.py
+++ b/tests/risk/test_daily_filled_notional.py
@@ -1328,7 +1328,9 @@ def test_pending_writer_timeout_is_bounded_and_does_not_latch_reader(tmp_path, m
     assert ledger.current_gross_filled_notional() == Decimal("0")
 
 
-def test_sigkill_hot_journal_is_recovered_rw_before_readonly_validation(tmp_path):
+def test_sigkill_hot_journal_is_preserved_for_review_without_authoritative_mutation(
+    tmp_path, monkeypatch
+):
     if not hasattr(signal, "SIGKILL"):
         pytest.skip("SIGKILL unavailable on this host")
     path = tmp_path / "notional.db"
@@ -1380,12 +1382,23 @@ service.record_fill(ExecutedFill(
 
     journal = Path(f"{path}-journal")
     assert journal.exists() and journal.stat().st_size > 0
-    restarted = _service(path)
-    assert restarted.restored_gross_filled_notional == Decimal("20.5")
-    with sqlite3.connect(path) as connection:
-        assert connection.execute(
-            "SELECT broker_execution_id FROM daily_filled_notional_records"
-        ).fetchall() == [("durable",)]
+    database_before = _file_snapshot(path)
+    journal_before = _file_snapshot(journal)
+    anchor_before = _file_snapshot(ledger.anchor_path)
+    paths_before = _path_inventory(tmp_path)
+
+    def reject_authoritative_sqlite_open(*args, **kwargs):
+        pytest.fail("hot-journal handling must not reopen the authoritative database")
+
+    monkeypatch.setattr(DailyFilledNotional, "_connection", reject_authoritative_sqlite_open)
+
+    with pytest.raises(FilledNotionalUnavailable, match="automatic hot-journal recovery"):
+        _service(path)
+
+    assert _file_snapshot(path) == database_before
+    assert _file_snapshot(journal) == journal_before
+    assert _file_snapshot(ledger.anchor_path) == anchor_before
+    assert _path_inventory(tmp_path) == paths_before
 
 
 def test_hot_journal_monotonic_rejection_preserves_all_original_evidence(tmp_path):
@@ -1452,7 +1465,9 @@ signal.pause()
     assert _path_inventory(tmp_path) == paths_before
 
 
-def test_hot_journal_is_revalidated_under_lock_immediately_before_recovery(tmp_path, monkeypatch):
+def test_hot_journal_swap_after_final_validation_cannot_mutate_authoritative_files(
+    tmp_path, monkeypatch
+):
     if not hasattr(signal, "SIGKILL"):
         pytest.skip("SIGKILL unavailable on this host")
     path = tmp_path / "replaced-hot-journal.db"
@@ -1497,31 +1512,35 @@ signal.pause()
     replacement_bytes = bytearray(journal.read_bytes())
     replacement_bytes[0] ^= 0xFF
     replacement.write_bytes(replacement_bytes)
+    preserved_original = tmp_path / "preserved-original.journal"
     original_validator = DailyFilledNotional._validate_hot_journal_recovery_on_copy
     validation_calls = 0
 
-    def replace_after_first_validation(self):
+    def replace_after_final_validation(self):
         nonlocal validation_calls
         validation_calls += 1
         evidence = original_validator(self)
-        if validation_calls == 1:
+        if validation_calls == 2:
+            os.replace(journal, preserved_original)
             os.replace(replacement, journal)
         return evidence
 
     monkeypatch.setattr(
         DailyFilledNotional,
         "_validate_hot_journal_recovery_on_copy",
-        replace_after_first_validation,
+        replace_after_final_validation,
     )
     database_before = _file_snapshot(path)
     anchor_before = _file_snapshot(ledger.anchor_path)
+    original_journal_before = _file_snapshot(journal)
 
-    with pytest.raises(FilledNotionalError):
+    with pytest.raises(FilledNotionalUnavailable, match="automatic hot-journal recovery"):
         _service(path)
 
     assert validation_calls == 2
     assert _file_snapshot(path) == database_before
     assert journal.read_bytes() == bytes(replacement_bytes)
+    assert _file_snapshot(preserved_original) == original_journal_before
     assert _file_snapshot(ledger.anchor_path) == anchor_before
 
 

--- a/tests/risk/test_daily_filled_notional.py
+++ b/tests/risk/test_daily_filled_notional.py
@@ -892,7 +892,7 @@ def test_hardlinked_main_ledger_is_rejected_before_fill_mutation(tmp_path):
     anchor_before = _file_snapshot(ledger.anchor_path)
     paths_before = _path_inventory(tmp_path)
 
-    with pytest.raises(FilledNotionalIntegrityError, match="checkpoint database identity"):
+    with pytest.raises(FilledNotionalIntegrityError, match="exclusive non-symlink regular"):
         ledger.record_fill(_fill("must-not-mutate-hardlinked-ledger"))
 
     assert _file_snapshot(path) == database_before
@@ -1388,6 +1388,69 @@ service.record_fill(ExecutedFill(
         ).fetchall() == [("durable",)]
 
 
+def test_sigkill_spilled_hot_journal_rejects_hardlinked_main_without_mutation(tmp_path):
+    if not hasattr(signal, "SIGKILL"):
+        pytest.skip("SIGKILL unavailable on this host")
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    ledger.record_fill(_fill("durable-before-spill"))
+    stable_database = path.read_bytes()
+    script = f"""
+import signal
+import sqlite3
+
+connection = sqlite3.connect({str(path)!r}, isolation_level=None)
+connection.execute('PRAGMA journal_mode=DELETE')
+connection.execute('PRAGMA synchronous=FULL')
+connection.execute('PRAGMA cache_size=1')
+connection.execute('PRAGMA cache_spill=ON')
+connection.execute('BEGIN IMMEDIATE')
+connection.execute('CREATE TABLE spill_payload (id INTEGER PRIMARY KEY, value BLOB)')
+connection.executemany(
+    'INSERT INTO spill_payload VALUES (?, randomblob(4096))',
+    ((index,) for index in range(1, 513)),
+)
+print('READY', flush=True)
+signal.pause()
+"""
+    child = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert child.stdout is not None
+        assert child.stdout.readline().strip() == "READY"
+        os.kill(child.pid, signal.SIGKILL)
+        child.wait(timeout=10)
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait(timeout=10)
+
+    journal = Path(f"{path}-journal")
+    assert journal.exists() and journal.stat().st_size > 0
+    assert path.read_bytes() != stable_database
+    preserved_alias = tmp_path / "preserved-hot-ledger.db"
+    os.link(path, preserved_alias)
+    database_before = _file_snapshot(path)
+    alias_before = _file_snapshot(preserved_alias)
+    journal_before = _file_snapshot(journal)
+    anchor_before = _file_snapshot(ledger.anchor_path)
+    paths_before = _path_inventory(tmp_path)
+
+    with pytest.raises(FilledNotionalUnavailable, match="exclusive non-symlink regular"):
+        _service(path)
+
+    assert _file_snapshot(path) == database_before
+    assert _file_snapshot(preserved_alias) == alias_before
+    assert _file_snapshot(journal) == journal_before
+    assert _file_snapshot(ledger.anchor_path) == anchor_before
+    assert path.samefile(preserved_alias)
+    assert _path_inventory(tmp_path) == paths_before
+
+
 def test_ledger_tail_deletion_is_detected_against_independent_anchor(tmp_path):
     path = tmp_path / "notional.db"
     ledger = _service(path)
@@ -1515,6 +1578,46 @@ def test_review_quarantine_success_is_byte_inode_and_path_read_only(tmp_path):
     assert _file_snapshot(path) == database_before
     assert _file_snapshot(ledger.anchor_path) == anchor_before
     assert _path_inventory(tmp_path) == paths_before
+
+
+def test_review_quarantine_retries_when_conflict_commits_during_verification(tmp_path):
+    path = tmp_path / "notional.db"
+    verifier = TestMonotonicVerifier()
+    ledger = _service(path, monotonic_verifier=verifier)
+    original = _fill("conflict-during-review-verification")
+    ledger.record_fill(original)
+    writer = _service(path, monotonic_verifier=verifier)
+
+    class CommitConflictDuringSecondVerification:
+        def __init__(self) -> None:
+            self.calls = 0
+            self.conflict_committed = False
+
+        def __call__(self, state) -> bool:
+            self.calls += 1
+            accepted = verifier(state)
+            if self.calls == 2:
+                try:
+                    writer.record_fill(replace(original, price=Decimal("999")))
+                except FilledNotionalConflict:
+                    self.conflict_committed = True
+                else:  # pragma: no cover - durable conflict must reject the writer
+                    raise AssertionError("conflicting execution unexpectedly succeeded")
+            return accepted
+
+    race_verifier = CommitConflictDuringSecondVerification()
+
+    evidence = DailyFilledNotional.review_quarantine(
+        path,
+        anchor_path=ledger.anchor_path,
+        anchor_key=ANCHOR_KEY,
+        monotonic_verifier=race_verifier,
+    )
+
+    assert race_verifier.conflict_committed
+    assert race_verifier.calls >= 3
+    assert len(evidence) == 1
+    assert evidence[0].broker_execution_id == original.broker_execution_id
 
 
 def test_review_quarantine_translates_concurrent_pending_writer_without_mutation(

--- a/tests/risk/test_daily_filled_notional.py
+++ b/tests/risk/test_daily_filled_notional.py
@@ -1,0 +1,328 @@
+"""Adversarial tests for durable daily gross-filled-notional accounting."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from dataclasses import replace
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+import robo_trader.risk.filled_notional.ledger as ledger_module
+from robo_trader.risk.filled_notional import (
+    DailyFilledNotional,
+    ExecutedFill,
+    FilledNotionalConflict,
+    FilledNotionalError,
+    FilledNotionalIntegrityError,
+    FilledNotionalUnavailable,
+    FillSide,
+)
+
+UTC = timezone.utc
+NEW_YORK = ZoneInfo("America/New_York")
+
+
+class MutableClock:
+    def __init__(self, value: datetime) -> None:
+        self.value = value
+
+    def __call__(self) -> datetime:
+        return self.value
+
+
+def _fill(
+    execution_id: str,
+    *,
+    side: FillSide = FillSide.BUY,
+    quantity: str = "2",
+    price: str = "10.25",
+    executed_at: datetime = datetime(2026, 7, 28, 15, 0, tzinfo=UTC),
+) -> ExecutedFill:
+    return ExecutedFill(
+        broker_execution_id=execution_id,
+        side=side,
+        quantity=Decimal(quantity),
+        price=Decimal(price),
+        currency="USD",
+        executed_at=executed_at,
+    )
+
+
+def _service(
+    path: Path,
+    *,
+    account_id: str = "DU12345",
+    portfolio_id: str = "default",
+    clock: MutableClock | None = None,
+) -> DailyFilledNotional:
+    return DailyFilledNotional(
+        path,
+        account_id=account_id,
+        portfolio_id=portfolio_id,
+        clock=clock or MutableClock(datetime(2026, 7, 28, 20, 0, tzinfo=UTC)),
+    )
+
+
+def test_counts_only_executed_fill_evidence_with_exact_decimal_math(tmp_path):
+    ledger = _service(tmp_path / "notional.db")
+
+    results = [
+        ledger.record_fill(_fill("buy", side=FillSide.BUY, quantity="0.1", price="0.2")),
+        ledger.record_fill(_fill("sell", side=FillSide.SELL, quantity="-3", price="4.01")),
+        ledger.record_fill(_fill("short", side=FillSide.SELL_SHORT, quantity="1.25", price="8")),
+        ledger.record_fill(
+            _fill("cover", side=FillSide.BUY_TO_COVER, quantity="-0.5", price="9.5")
+        ),
+    ]
+
+    assert [result.recorded for result in results] == [True, True, True, True]
+    assert ledger.current_gross_filled_notional() == Decimal("26.80")
+    assert isinstance(ledger.current_gross_filled_notional(), Decimal)
+
+
+def test_partial_fills_count_by_unique_broker_execution_not_parent_order(tmp_path):
+    ledger = _service(tmp_path / "notional.db")
+
+    first = ledger.record_fill(_fill("order-7.partial-1", quantity="2", price="100.10"))
+    second = ledger.record_fill(_fill("order-7.partial-2", quantity="3", price="100.20"))
+
+    assert first.gross_filled_notional == Decimal("200.2")
+    assert second.gross_filled_notional == Decimal("500.8")
+
+
+def test_decimal_product_beyond_default_context_precision_is_not_rounded(tmp_path):
+    ledger = _service(tmp_path / "notional.db")
+
+    result = ledger.record_fill(
+        _fill(
+            "high-precision",
+            quantity="12345678901234567890.123456789",
+            price="1.000000001",
+        )
+    )
+
+    assert result.fill_notional == Decimal("12345678913580246791.358024679123456789")
+    assert result.gross_filled_notional == Decimal("12345678913580246791.358024679123456789")
+
+
+def test_exact_execution_replay_is_idempotent(tmp_path):
+    ledger = _service(tmp_path / "notional.db")
+    fill = _fill("broker.exec.1", quantity="7", price="12.345")
+
+    original = ledger.record_fill(fill)
+    replay = ledger.record_fill(fill)
+
+    assert original.recorded is True
+    assert replay.recorded is False
+    assert replay.fill_notional == Decimal("86.415")
+    assert replay.gross_filled_notional == Decimal("86.415")
+    with sqlite3.connect(ledger.database_path) as connection:
+        assert connection.execute(
+            "SELECT count(*) FROM daily_filled_notional_records"
+        ).fetchone() == (1,)
+
+
+def test_conflicting_duplicate_fails_closed_and_latches_instance(tmp_path):
+    ledger = _service(tmp_path / "notional.db")
+    original = _fill("broker.exec.1")
+    ledger.record_fill(original)
+
+    with pytest.raises(FilledNotionalConflict, match="conflicting immutable evidence"):
+        ledger.record_fill(replace(original, price=Decimal("999")))
+    with pytest.raises(FilledNotionalUnavailable, match="latched unavailable"):
+        ledger.current_gross_filled_notional()
+
+    # The conflicting claim was never written.  A fresh process can restore the
+    # one durable execution and will fail again if the bad claim is replayed.
+    restarted = _service(ledger.database_path)
+    assert restarted.restored_gross_filled_notional == Decimal("20.5")
+
+
+def test_restart_restores_same_day_total_from_append_only_ledger(tmp_path):
+    path = tmp_path / "notional.db"
+    first_process = _service(path)
+    first_process.record_fill(_fill("exec-1", quantity="2", price="10"))
+    first_process.record_fill(_fill("exec-2", quantity="4", price="2.5"))
+
+    restarted = _service(path)
+
+    assert restarted.restored_trading_date.isoformat() == "2026-07-28"
+    assert restarted.restored_gross_filled_notional == Decimal("30")
+    assert restarted.current_gross_filled_notional() == Decimal("30")
+
+
+def test_scope_isolated_by_account_and_portfolio(tmp_path):
+    path = tmp_path / "notional.db"
+    default = _service(path)
+    second_portfolio = _service(path, portfolio_id="income")
+    second_account = _service(path, account_id="DU99999")
+
+    default.record_fill(_fill("same-exec", quantity="1", price="10"))
+    second_portfolio.record_fill(_fill("same-exec", quantity="2", price="10"))
+    second_account.record_fill(_fill("same-exec", quantity="3", price="10"))
+
+    assert default.current_gross_filled_notional() == Decimal("10")
+    assert second_portfolio.current_gross_filled_notional() == Decimal("20")
+    assert second_account.current_gross_filled_notional() == Decimal("30")
+
+
+def test_new_york_midnight_rollover_and_late_prior_day_fill(tmp_path):
+    clock = MutableClock(datetime(2026, 7, 29, 3, 59, 59, tzinfo=UTC))
+    ledger = _service(tmp_path / "notional.db", clock=clock)
+    ledger.record_fill(
+        _fill("before-midnight", executed_at=datetime(2026, 7, 29, 3, 59, tzinfo=UTC))
+    )
+    assert ledger.current_gross_filled_notional() == Decimal("20.5")
+
+    clock.value = datetime(2026, 7, 29, 4, 0, tzinfo=UTC)
+    assert ledger.current_gross_filled_notional() == Decimal("0")
+    ledger.record_fill(_fill("after-midnight", executed_at=datetime(2026, 7, 29, 4, 0, tzinfo=UTC)))
+    assert ledger.current_gross_filled_notional() == Decimal("20.5")
+
+    ledger.record_fill(
+        _fill("late-prior-day", executed_at=datetime(2026, 7, 29, 3, 30, tzinfo=UTC))
+    )
+    assert ledger.current_gross_filled_notional() == Decimal("20.5")
+    assert ledger.current_gross_filled_notional(
+        as_of=datetime(2026, 7, 29, 3, 59, tzinfo=UTC)
+    ) == Decimal("41")
+
+
+def test_dst_fold_maps_both_real_instants_to_same_new_york_date(tmp_path):
+    clock = MutableClock(datetime(2026, 11, 1, 8, 0, tzinfo=UTC))
+    ledger = _service(tmp_path / "notional.db", clock=clock)
+    first_one_thirty = datetime(2026, 11, 1, 1, 30, tzinfo=NEW_YORK, fold=0)
+    second_one_thirty = datetime(2026, 11, 1, 1, 30, tzinfo=NEW_YORK, fold=1)
+
+    ledger.record_fill(_fill("dst-edt", executed_at=first_one_thirty))
+    ledger.record_fill(_fill("dst-est", executed_at=second_one_thirty))
+
+    assert first_one_thirty.astimezone(UTC) != second_one_thirty.astimezone(UTC)
+    assert ledger.current_gross_filled_notional() == Decimal("41")
+
+
+def test_spring_dst_and_utc_date_boundary_are_deterministic(tmp_path):
+    clock = MutableClock(datetime(2026, 3, 9, 1, 0, tzinfo=UTC))  # Mar 8, 21:00 EDT
+    ledger = _service(tmp_path / "notional.db", clock=clock)
+    ledger.record_fill(_fill("spring-before", executed_at=datetime(2026, 3, 8, 6, 59, tzinfo=UTC)))
+    ledger.record_fill(_fill("spring-after", executed_at=datetime(2026, 3, 8, 7, 1, tzinfo=UTC)))
+
+    assert ledger.current_gross_filled_notional() == Decimal("41")
+
+
+def test_non_execution_and_inexact_or_malformed_evidence_is_rejected(tmp_path):
+    ledger = _service(tmp_path / "notional.db")
+
+    with pytest.raises(FilledNotionalError, match="only exact ExecutedFill"):
+        ledger.record_fill(object())  # type: ignore[arg-type]
+    with pytest.raises(FilledNotionalError, match="side must be a FillSide"):
+        ledger.record_fill(replace(_fill("submitted"), side="SUBMITTED"))  # type: ignore[arg-type]
+    with pytest.raises(FilledNotionalError, match="finite non-zero Decimal"):
+        ledger.record_fill(replace(_fill("float"), quantity=1.0))  # type: ignore[arg-type]
+    with pytest.raises(FilledNotionalError, match="aware datetime"):
+        ledger.record_fill(replace(_fill("naive"), executed_at=datetime(2026, 7, 28)))
+    assert ledger.current_gross_filled_notional() == Decimal("0")
+
+
+def test_database_triggers_deny_update_and_delete(tmp_path):
+    ledger = _service(tmp_path / "notional.db")
+    ledger.record_fill(_fill("immutable"))
+
+    with sqlite3.connect(ledger.database_path) as connection:
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            connection.execute("UPDATE daily_filled_notional_records SET price_text = '1'")
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            connection.execute("DELETE FROM daily_filled_notional_records")
+        with pytest.raises(sqlite3.IntegrityError, match="append to the chain"):
+            connection.execute("""
+                INSERT OR REPLACE INTO daily_filled_notional_records
+                SELECT sequence, account_id, portfolio_id, broker_execution_id,
+                       side, quantity_text, '1', currency, executed_at_utc,
+                       trading_date, notional_text, previous_hash, record_hash
+                FROM daily_filled_notional_records WHERE sequence = 1
+                """)
+
+
+def test_trigger_removal_and_row_tamper_fail_closed_on_restart(tmp_path):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    ledger.record_fill(_fill("tamper-target"))
+    with sqlite3.connect(path) as connection:
+        connection.execute("DROP TRIGGER daily_filled_notional_records_no_update")
+        connection.execute(
+            "UPDATE daily_filled_notional_records SET notional_text = '1' WHERE sequence = 1"
+        )
+
+    with pytest.raises(FilledNotionalIntegrityError, match="schema objects do not match"):
+        _service(path)
+
+
+def test_service_connection_has_no_update_delete_or_schema_authority(tmp_path):
+    ledger = _service(tmp_path / "notional.db")
+    ledger.record_fill(_fill("immutable"))
+
+    with ledger._connection(readonly=False) as connection:
+        with pytest.raises(sqlite3.DatabaseError, match="not authorized"):
+            connection.execute("UPDATE daily_filled_notional_records SET price_text = '1'")
+        with pytest.raises(sqlite3.DatabaseError, match="not authorized"):
+            connection.execute("DELETE FROM daily_filled_notional_records")
+        with pytest.raises(sqlite3.DatabaseError, match="not authorized"):
+            connection.execute("DROP TABLE daily_filled_notional_records")
+
+
+def test_hash_tamper_fails_closed_even_with_required_schema_restored(tmp_path):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    ledger.record_fill(_fill("tamper-target"))
+    with sqlite3.connect(path) as connection:
+        connection.execute("DROP TRIGGER daily_filled_notional_records_no_update")
+        connection.execute(
+            "UPDATE daily_filled_notional_records SET price_text = '11' WHERE sequence = 1"
+        )
+        connection.execute(ledger_module._TRIGGER_SQL["daily_filled_notional_records_no_update"])
+
+    with pytest.raises(FilledNotionalIntegrityError, match="notional does not match"):
+        _service(path)
+
+
+def test_database_read_failure_latches_service_unavailable(tmp_path, monkeypatch):
+    ledger = _service(tmp_path / "notional.db")
+    ledger.record_fill(_fill("exec-1"))
+    original_connect = ledger_module.sqlite3.connect
+
+    def fail_connect(*args, **kwargs):
+        raise sqlite3.OperationalError("injected database outage")
+
+    monkeypatch.setattr(ledger_module.sqlite3, "connect", fail_connect)
+    with pytest.raises(FilledNotionalUnavailable, match="read failed closed"):
+        ledger.current_gross_filled_notional()
+    monkeypatch.setattr(ledger_module.sqlite3, "connect", original_connect)
+    with pytest.raises(FilledNotionalUnavailable, match="latched unavailable"):
+        ledger.current_gross_filled_notional()
+
+
+def test_corrupt_database_fails_closed_without_replacing_it(tmp_path):
+    path = tmp_path / "notional.db"
+    contents = b"not a sqlite database; preserve this evidence"
+    path.write_bytes(contents)
+    before = hashlib.sha256(contents).hexdigest()
+
+    with pytest.raises(FilledNotionalUnavailable, match="startup failed closed"):
+        _service(path)
+    assert hashlib.sha256(path.read_bytes()).hexdigest() == before
+
+
+def test_current_query_is_read_only(tmp_path):
+    ledger = _service(tmp_path / "notional.db")
+    ledger.record_fill(_fill("exec-1"))
+    before = ledger.database_path.read_bytes()
+
+    assert ledger.current_gross_filled_notional() == Decimal("20.5")
+
+    assert ledger.database_path.read_bytes() == before
+    assert not Path(f"{ledger.database_path}-wal").exists()

--- a/tests/risk/test_daily_filled_notional.py
+++ b/tests/risk/test_daily_filled_notional.py
@@ -2445,6 +2445,59 @@ signal.pause()
     assert _file_snapshot(ledger.anchor_path) == anchor_before
 
 
+def test_writer_guard_closes_journal_check_to_open_race(tmp_path, monkeypatch):
+    path = tmp_path / "writer-guard-race.db"
+    ledger = _service(path)
+    original_validate = ledger._validate_existing_rollback_journal
+    probe_results: list[subprocess.CompletedProcess[str]] = []
+    validation_calls = 0
+
+    def validate_then_probe_competing_sqlite_writer() -> None:
+        nonlocal validation_calls
+        original_validate()
+        validation_calls += 1
+        if validation_calls != 1:
+            return
+        script = f"""
+import sqlite3
+
+connection = sqlite3.connect({str(path)!r}, isolation_level=None, timeout=0)
+try:
+    connection.execute('BEGIN IMMEDIATE')
+except sqlite3.OperationalError as exc:
+    print(str(exc), flush=True)
+else:
+    print('UNEXPECTED-WRITER-LOCK', flush=True)
+finally:
+    connection.close()
+"""
+        probe_results.append(
+            subprocess.run(
+                [sys.executable, "-c", script],
+                capture_output=True,
+                check=False,
+                text=True,
+                timeout=10,
+            )
+        )
+
+    monkeypatch.setattr(
+        ledger,
+        "_validate_existing_rollback_journal",
+        validate_then_probe_competing_sqlite_writer,
+    )
+
+    result = ledger.record_fill(_fill("writer-guard-race"))
+
+    assert result.recorded
+    assert validation_calls >= 2
+    assert len(probe_results) == 1
+    assert probe_results[0].returncode == 0
+    assert "locked" in probe_results[0].stdout.lower()
+    assert "UNEXPECTED-WRITER-LOCK" not in probe_results[0].stdout
+    assert not Path(f"{path}-journal").exists()
+
+
 def test_future_schema_version_fails_closed_without_downgrade(tmp_path):
     path = tmp_path / "future.db"
     with sqlite3.connect(path) as connection:

--- a/tests/risk/test_daily_filled_notional.py
+++ b/tests/risk/test_daily_filled_notional.py
@@ -495,6 +495,74 @@ def test_current_query_is_read_only(tmp_path):
     assert not Path(f"{ledger.database_path}-wal").exists()
 
 
+@pytest.mark.parametrize("suffix", ["-wal", "-shm", "-journal"])
+@pytest.mark.parametrize("sidecar_kind", ["plain", "hardlink", "symlink", "directory"])
+def test_missing_database_preserves_and_rejects_every_sqlite_sidecar(
+    tmp_path, suffix, sidecar_kind
+):
+    path = tmp_path / "notional.db"
+    sidecar = Path(f"{path}{suffix}")
+    preserved_target = tmp_path / f"preserved-{sidecar_kind}{suffix}"
+    marker = None
+
+    if sidecar_kind == "plain":
+        sidecar.write_bytes(b"preserve plain sidecar evidence")
+    elif sidecar_kind == "hardlink":
+        preserved_target.write_bytes(b"preserve hardlinked sidecar evidence")
+        os.link(preserved_target, sidecar)
+    elif sidecar_kind == "symlink":
+        preserved_target.write_bytes(b"preserve symlink target evidence")
+        sidecar.symlink_to(preserved_target)
+    else:
+        sidecar.mkdir()
+        marker = sidecar / "preserve.marker"
+        marker.write_bytes(b"preserve non-regular sidecar evidence")
+
+    def stable_metadata(candidate: Path):
+        metadata = candidate.lstat()
+        return (
+            metadata.st_dev,
+            metadata.st_ino,
+            metadata.st_mode,
+            metadata.st_nlink,
+            metadata.st_size,
+            metadata.st_mtime_ns,
+            metadata.st_ctime_ns,
+        )
+
+    sidecar_metadata = stable_metadata(sidecar)
+    sidecar_link = os.readlink(sidecar) if sidecar_kind == "symlink" else None
+    target_metadata = (
+        stable_metadata(preserved_target) if sidecar_kind in {"hardlink", "symlink"} else None
+    )
+    target_bytes = (
+        preserved_target.read_bytes() if sidecar_kind in {"hardlink", "symlink"} else None
+    )
+    sidecar_bytes = sidecar.read_bytes() if sidecar_kind == "plain" else None
+    marker_metadata = stable_metadata(marker) if marker is not None else None
+    marker_bytes = marker.read_bytes() if marker is not None else None
+
+    with pytest.raises(FilledNotionalUnavailable, match="main database is absent"):
+        _service(path)
+
+    assert not path.exists()
+    assert not _anchor_path(path).exists()
+    assert stable_metadata(sidecar) == sidecar_metadata
+    if sidecar_kind == "plain":
+        assert sidecar.read_bytes() == sidecar_bytes
+    elif sidecar_kind in {"hardlink", "symlink"}:
+        assert stable_metadata(preserved_target) == target_metadata
+        assert preserved_target.read_bytes() == target_bytes
+        if sidecar_kind == "hardlink":
+            assert sidecar.samefile(preserved_target)
+        else:
+            assert os.readlink(sidecar) == sidecar_link
+    else:
+        assert marker is not None
+        assert stable_metadata(marker) == marker_metadata
+        assert marker.read_bytes() == marker_bytes
+
+
 def test_wal_shm_hardlinks_are_rejected_without_mutating_targets(tmp_path):
     path = tmp_path / "notional.db"
     ledger = _service(path)

--- a/tests/risk/test_daily_filled_notional.py
+++ b/tests/risk/test_daily_filled_notional.py
@@ -120,6 +120,15 @@ def _anchor_path(database_path: Path) -> Path:
     return database_path.parent / "protected-anchor" / f"{database_path.name}.anchor"
 
 
+def _file_snapshot(path: Path) -> tuple[bytes, int, int]:
+    metadata = os.lstat(path)
+    return path.read_bytes(), metadata.st_dev, metadata.st_ino
+
+
+def _path_inventory(root: Path) -> tuple[str, ...]:
+    return tuple(sorted(str(path.relative_to(root)) for path in root.rglob("*")))
+
+
 def test_counts_only_executed_fill_evidence_with_exact_decimal_math(tmp_path):
     ledger = _service(tmp_path / "notional.db")
 
@@ -425,6 +434,84 @@ def test_trigger_removal_and_row_tamper_fail_closed_on_restart(tmp_path):
 
     with pytest.raises(FilledNotionalIntegrityError, match="schema objects do not match"):
         _service(path)
+
+
+def test_foreign_raise_ignore_trigger_on_protected_table_fails_closed_without_mutation(tmp_path):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    with sqlite3.connect(path) as connection:
+        connection.execute("""
+            CREATE TRIGGER foreign_suppress_filled_notional_insert
+            BEFORE INSERT ON daily_filled_notional_records
+            BEGIN
+                SELECT RAISE(IGNORE);
+            END
+            """)
+
+    database_before = path.read_bytes()
+    database_identity = (os.lstat(path).st_dev, os.lstat(path).st_ino)
+    anchor_before = ledger.anchor_path.read_bytes()
+    anchor_identity = (
+        os.lstat(ledger.anchor_path).st_dev,
+        os.lstat(ledger.anchor_path).st_ino,
+    )
+
+    with pytest.raises(FilledNotionalIntegrityError, match="schema objects do not match"):
+        ledger.record_fill(_fill("must-not-be-ignored"))
+
+    assert path.read_bytes() == database_before
+    assert (os.lstat(path).st_dev, os.lstat(path).st_ino) == database_identity
+    assert ledger.anchor_path.read_bytes() == anchor_before
+    assert (
+        os.lstat(ledger.anchor_path).st_dev,
+        os.lstat(ledger.anchor_path).st_ino,
+    ) == anchor_identity
+
+
+@pytest.mark.parametrize("suppressed_append", ["fill", "checkpoint"])
+def test_record_fill_verifies_uncommitted_append_advanced_before_anchor_publication(
+    tmp_path, monkeypatch, suppressed_append
+):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    database_before = path.read_bytes()
+    database_identity = (os.lstat(path).st_dev, os.lstat(path).st_ino)
+    anchor_before = ledger.anchor_path.read_bytes()
+    anchor_identity = (
+        os.lstat(ledger.anchor_path).st_dev,
+        os.lstat(ledger.anchor_path).st_ino,
+    )
+
+    if suppressed_append == "fill":
+        monkeypatch.setattr(ledger, "_append_fill", lambda *args, **kwargs: "f" * 64)
+    else:
+        monkeypatch.setattr(
+            ledger,
+            "_append_checkpoint",
+            lambda connection, before, after: replace(
+                after,
+                checkpoint_sequence=before.checkpoint_sequence + 1,
+                checkpoint_head="f" * 64,
+            ),
+        )
+
+    with pytest.raises(FilledNotionalIntegrityError, match="checkpoint|append"):
+        ledger.record_fill(_fill(f"suppressed-{suppressed_append}"))
+
+    assert path.read_bytes() == database_before
+    assert (os.lstat(path).st_dev, os.lstat(path).st_ino) == database_identity
+    assert ledger.anchor_path.read_bytes() == anchor_before
+    assert (
+        os.lstat(ledger.anchor_path).st_dev,
+        os.lstat(ledger.anchor_path).st_ino,
+    ) == anchor_identity
+    with sqlite3.connect(path) as connection:
+        assert connection.execute(
+            "SELECT count(*) FROM daily_filled_notional_records"
+        ).fetchone() == (0,)
+        assert connection.execute(
+            "SELECT count(*) FROM daily_filled_notional_checkpoints"
+        ).fetchone() == (1,)
 
 
 def test_service_connection_has_no_update_delete_or_schema_authority(tmp_path):
@@ -1035,7 +1122,7 @@ def test_review_reverifies_monotonic_state_after_constructor_before_return(tmp_p
     @contextmanager
     def restore_before_review(self, *, readonly, immutable=False):
         nonlocal authoritative_read_count
-        if readonly and not immutable:
+        if readonly:
             authoritative_read_count += 1
             if authoritative_read_count == 2:
                 path.write_bytes(old_database)
@@ -1053,6 +1140,116 @@ def test_review_reverifies_monotonic_state_after_constructor_before_return(tmp_p
             anchor_key=ANCHOR_KEY,
             monotonic_verifier=verifier,
         )
+
+
+def test_review_quarantine_success_is_byte_inode_and_path_read_only(tmp_path):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    ledger.record_fill(_fill("review-read-only"))
+    database_before = _file_snapshot(path)
+    anchor_before = _file_snapshot(ledger.anchor_path)
+    paths_before = _path_inventory(tmp_path)
+
+    evidence = DailyFilledNotional.review_quarantine(
+        path,
+        anchor_path=ledger.anchor_path,
+        anchor_key=ANCHOR_KEY,
+        monotonic_verifier=_MONOTONIC_VERIFIERS[str(path)],
+    )
+
+    assert evidence == ()
+    assert _file_snapshot(path) == database_before
+    assert _file_snapshot(ledger.anchor_path) == anchor_before
+    assert _path_inventory(tmp_path) == paths_before
+
+
+@pytest.mark.parametrize("missing_artifact", ["database", "anchor"])
+def test_review_requires_existing_artifacts_without_creating_or_mutating(
+    tmp_path, missing_artifact
+):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    target = path if missing_artifact == "database" else ledger.anchor_path
+    survivor = ledger.anchor_path if missing_artifact == "database" else path
+    target.unlink()
+    survivor_before = _file_snapshot(survivor)
+    paths_before = _path_inventory(tmp_path)
+
+    with pytest.raises(FilledNotionalUnavailable, match="review requires existing"):
+        DailyFilledNotional.review_quarantine(
+            path,
+            anchor_path=ledger.anchor_path,
+            anchor_key=ANCHOR_KEY,
+            monotonic_verifier=_MONOTONIC_VERIFIERS[str(path)],
+        )
+
+    assert not target.exists()
+    assert _file_snapshot(survivor) == survivor_before
+    assert _path_inventory(tmp_path) == paths_before
+
+
+@pytest.mark.parametrize("mistyped_artifact", ["database", "anchor"])
+def test_review_rejects_mistyped_artifacts_without_mutating_paths(tmp_path, mistyped_artifact):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    target = path if mistyped_artifact == "database" else ledger.anchor_path
+    survivor = ledger.anchor_path if mistyped_artifact == "database" else path
+    preserved = tmp_path / f"preserved-{mistyped_artifact}"
+    target.rename(preserved)
+    target.mkdir(mode=0o700)
+    target_identity = (os.lstat(target).st_dev, os.lstat(target).st_ino)
+    preserved_before = _file_snapshot(preserved)
+    survivor_before = _file_snapshot(survivor)
+    paths_before = _path_inventory(tmp_path)
+
+    with pytest.raises(FilledNotionalUnavailable, match="non-symlink regular"):
+        DailyFilledNotional.review_quarantine(
+            path,
+            anchor_path=ledger.anchor_path,
+            anchor_key=ANCHOR_KEY,
+            monotonic_verifier=_MONOTONIC_VERIFIERS[str(path)],
+        )
+
+    assert target.is_dir()
+    assert (os.lstat(target).st_dev, os.lstat(target).st_ino) == target_identity
+    assert _file_snapshot(preserved) == preserved_before
+    assert _file_snapshot(survivor) == survivor_before
+    assert _path_inventory(tmp_path) == paths_before
+
+
+@pytest.mark.parametrize("deleted_artifact", ["database", "anchor"])
+def test_review_does_not_recreate_artifact_deleted_after_preflight(
+    tmp_path, monkeypatch, deleted_artifact
+):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    target = path if deleted_artifact == "database" else ledger.anchor_path
+    survivor = ledger.anchor_path if deleted_artifact == "database" else path
+    preserved = tmp_path / f"deleted-during-review-{deleted_artifact}"
+    target_before = _file_snapshot(target)
+    survivor_before = _file_snapshot(survivor)
+    paths_after_deletion: list[tuple[str, ...]] = []
+    original_require = DailyFilledNotional._require_review_artifacts
+
+    def delete_after_preflight(self):
+        original_require(self)
+        target.rename(preserved)
+        paths_after_deletion.append(_path_inventory(tmp_path))
+
+    monkeypatch.setattr(DailyFilledNotional, "_require_review_artifacts", delete_after_preflight)
+
+    with pytest.raises(FilledNotionalUnavailable):
+        DailyFilledNotional.review_quarantine(
+            path,
+            anchor_path=ledger.anchor_path,
+            anchor_key=ANCHOR_KEY,
+            monotonic_verifier=_MONOTONIC_VERIFIERS[str(path)],
+        )
+
+    assert not target.exists()
+    assert _file_snapshot(preserved) == target_before
+    assert _file_snapshot(survivor) == survivor_before
+    assert _path_inventory(tmp_path) == paths_after_deletion[0]
 
 
 def test_authoritative_service_requires_independent_monotonic_verifier(tmp_path):

--- a/tests/risk/test_daily_filled_notional.py
+++ b/tests/risk/test_daily_filled_notional.py
@@ -11,6 +11,7 @@ import sqlite3
 import subprocess
 import sys
 import threading
+from contextlib import contextmanager
 from dataclasses import replace
 from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation, getcontext, setcontext
@@ -35,7 +36,7 @@ from robo_trader.risk.filled_notional import (
 UTC = timezone.utc
 NEW_YORK = ZoneInfo("America/New_York")
 ANCHOR_KEY = b"test-only-independent-anchor-key-32-bytes-minimum"
-_MONOTONIC_VERIFIERS = {}
+_MONOTONIC_VERIFIERS: dict[str, "TestMonotonicVerifier"] = {}
 
 
 class TestMonotonicVerifier:
@@ -243,6 +244,48 @@ def test_restart_restores_same_day_total_from_append_only_ledger(tmp_path):
     assert restarted.current_gross_filled_notional() == Decimal("30")
 
 
+def test_hot_path_uses_authenticated_checkpoints_without_history_rescans(tmp_path, monkeypatch):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+
+    def forbid_history_scan(*args, **kwargs):
+        pytest.fail("hot accounting path performed an unbounded history scan")
+
+    monkeypatch.setattr(ledger, "_validate_fills", forbid_history_scan)
+    monkeypatch.setattr(ledger, "_validate_conflicts", forbid_history_scan)
+    for index in range(400):
+        ledger.record_fill(_fill(f"bounded-{index}"))
+
+    assert ledger.current_gross_filled_notional() == Decimal("8200")
+    with sqlite3.connect(path) as connection:
+        assert connection.execute(
+            "SELECT count(*) FROM daily_filled_notional_checkpoints"
+        ).fetchone() == (401,)
+
+    monkeypatch.undo()
+    assert _service(path).restored_gross_filled_notional == Decimal("8200")
+
+
+def test_daily_scope_limit_rejects_append_before_any_durable_mutation(tmp_path, monkeypatch):
+    path = tmp_path / "notional.db"
+    monkeypatch.setattr(ledger_module, "_MAX_DAILY_FILL_ROWS", 2)
+    ledger = _service(path)
+    ledger.record_fill(_fill("bounded-one"))
+    ledger.record_fill(_fill("bounded-two"))
+
+    with pytest.raises(FilledNotionalUnavailable, match="bounded accounting limit"):
+        ledger.record_fill(_fill("must-not-persist"))
+
+    with sqlite3.connect(path) as connection:
+        assert connection.execute(
+            "SELECT count(*) FROM daily_filled_notional_records"
+        ).fetchone() == (2,)
+        assert connection.execute(
+            "SELECT count(*) FROM daily_filled_notional_checkpoints"
+        ).fetchone() == (3,)
+    assert ledger.current_gross_filled_notional() == Decimal("41")
+
+
 def test_scope_isolated_by_account_and_portfolio(tmp_path):
     path = tmp_path / "notional.db"
     default = _service(path)
@@ -338,7 +381,8 @@ def test_database_triggers_deny_update_and_delete(tmp_path):
                 INSERT OR REPLACE INTO daily_filled_notional_records
                 SELECT sequence, account_id, portfolio_id, broker_execution_id,
                        side, quantity_text, '1', currency, executed_at_utc,
-                       trading_date, notional_text, previous_hash, record_hash
+                       trading_date, notional_text, scope_fill_count, scope_total_text,
+                       previous_hash, record_hash
                 FROM daily_filled_notional_records WHERE sequence = 1
                 """)
 
@@ -528,6 +572,63 @@ def test_reader_waits_for_concurrent_pending_writer_without_latching(tmp_path, m
     assert reader.current_gross_filled_notional() == Decimal("20.5")
 
 
+def test_reader_snapshot_rechecks_anchor_before_returning_during_writer_race(tmp_path, monkeypatch):
+    path = tmp_path / "notional.db"
+    writer = _service(path)
+    reader = _service(path)
+    snapshot_total_ready = threading.Event()
+    writer_pending = threading.Event()
+    original_total = reader._total_for_date
+    original_commit = writer._commit_database
+    total_calls = 0
+    results: dict[str, object] = {}
+
+    def gated_total(connection, trading_day):
+        nonlocal total_calls
+        total = original_total(connection, trading_day)
+        total_calls += 1
+        if total_calls == 1:
+            snapshot_total_ready.set()
+            if not writer_pending.wait(timeout=5):
+                raise sqlite3.OperationalError("test writer did not reach pending state")
+        return total
+
+    def observed_commit(connection):
+        writer_pending.set()
+        original_commit(connection)
+
+    monkeypatch.setattr(reader, "_total_for_date", gated_total)
+    monkeypatch.setattr(writer, "_commit_database", observed_commit)
+
+    def read() -> None:
+        try:
+            results["read"] = reader.current_gross_filled_notional()
+        except BaseException as exc:  # pragma: no cover - asserted below
+            results["read"] = exc
+
+    def write() -> None:
+        try:
+            results["write"] = writer.record_fill(_fill("snapshot-race"))
+        except BaseException as exc:  # pragma: no cover - asserted below
+            results["write"] = exc
+
+    reader_thread = threading.Thread(target=read)
+    writer_thread = threading.Thread(target=write)
+    reader_thread.start()
+    assert snapshot_total_ready.wait(timeout=5)
+    writer_thread.start()
+    reader_thread.join(timeout=5)
+    writer_thread.join(timeout=5)
+
+    assert not reader_thread.is_alive()
+    assert not writer_thread.is_alive()
+    assert not isinstance(results.get("read"), BaseException)
+    assert not isinstance(results.get("write"), BaseException)
+    assert results["read"] == Decimal("20.5")
+    assert total_calls >= 2
+    assert reader._failed_reason is None
+
+
 def test_invalid_pending_anchor_identity_still_fails_closed(tmp_path):
     path = tmp_path / "notional.db"
     ledger = _service(path)
@@ -699,6 +800,40 @@ def test_coordinated_old_database_and_anchor_replay_requires_monotonic_rejection
         _service(path, monotonic_verifier=verifier)
 
 
+def test_review_reverifies_monotonic_state_after_constructor_before_return(tmp_path, monkeypatch):
+    path = tmp_path / "notional.db"
+    verifier = TestMonotonicVerifier()
+    ledger = _service(path, monotonic_verifier=verifier)
+    ledger.record_fill(_fill("older"))
+    old_database = path.read_bytes()
+    old_anchor = ledger.anchor_path.read_bytes()
+    ledger.record_fill(_fill("newer"))
+    original_connection = DailyFilledNotional._connection
+    authoritative_read_count = 0
+
+    @contextmanager
+    def restore_before_review(self, *, readonly, immutable=False):
+        nonlocal authoritative_read_count
+        if readonly and not immutable:
+            authoritative_read_count += 1
+            if authoritative_read_count == 2:
+                path.write_bytes(old_database)
+                ledger.anchor_path.write_bytes(old_anchor)
+                os.chmod(ledger.anchor_path, 0o600)
+        with original_connection(self, readonly=readonly, immutable=immutable) as connection:
+            yield connection
+
+    monkeypatch.setattr(DailyFilledNotional, "_connection", restore_before_review)
+
+    with pytest.raises(FilledNotionalIntegrityError, match="monotonic authority rejected"):
+        DailyFilledNotional.review_quarantine(
+            path,
+            anchor_path=ledger.anchor_path,
+            anchor_key=ANCHOR_KEY,
+            monotonic_verifier=verifier,
+        )
+
+
 def test_authoritative_service_requires_independent_monotonic_verifier(tmp_path):
     path = tmp_path / "notional.db"
     anchor_directory = tmp_path / "protected-anchor"
@@ -862,8 +997,11 @@ def test_decimal_exception_is_typed_and_latches_unavailable(tmp_path, monkeypatc
         ledger.current_gross_filled_notional()
 
 
-def test_schema_v1_requires_explicit_copy_migration_without_anchor_creation(tmp_path):
-    path = tmp_path / "legacy-v1.db"
+@pytest.mark.parametrize("schema_version", [1, 2])
+def test_legacy_schema_requires_explicit_copy_migration_without_anchor_creation(
+    tmp_path, schema_version
+):
+    path = tmp_path / f"legacy-v{schema_version}.db"
     with sqlite3.connect(path) as connection:
         connection.execute("""
             CREATE TABLE daily_filled_notional_schema (
@@ -871,10 +1009,12 @@ def test_schema_v1_requires_explicit_copy_migration_without_anchor_creation(tmp_
                 schema_version INTEGER NOT NULL
             )
             """)
-        connection.execute("INSERT INTO daily_filled_notional_schema VALUES (1, 1)")
+        connection.execute(
+            "INSERT INTO daily_filled_notional_schema VALUES (1, ?)", (schema_version,)
+        )
     before = hashlib.sha256(path.read_bytes()).hexdigest()
 
-    with pytest.raises(FilledNotionalMigrationRequired, match="reviewed copy migration"):
+    with pytest.raises(FilledNotionalMigrationRequired, match="reviewed copy migration to v3"):
         _service(path)
 
     assert hashlib.sha256(path.read_bytes()).hexdigest() == before
@@ -932,7 +1072,88 @@ signal.pause()
     database_stat_before = path.stat()
     journal_stat_before = journal.stat()
 
-    with pytest.raises(FilledNotionalMigrationRequired, match="reviewed copy migration"):
+    with pytest.raises(
+        FilledNotionalUnavailable, match="authenticated current-schema recovery anchor"
+    ):
+        _service(path)
+
+    assert path.read_bytes() == database_before
+    assert journal.read_bytes() == journal_before
+    assert (path.stat().st_ino, path.stat().st_mtime_ns) == (
+        database_stat_before.st_ino,
+        database_stat_before.st_mtime_ns,
+    )
+    assert (journal.stat().st_ino, journal.stat().st_mtime_ns) == (
+        journal_stat_before.st_ino,
+        journal_stat_before.st_mtime_ns,
+    )
+    assert not _anchor_path(path).exists()
+
+
+def test_spilled_uncommitted_current_version_cannot_authorize_legacy_recovery(tmp_path):
+    if not hasattr(signal, "SIGKILL"):
+        pytest.skip("SIGKILL unavailable on this host")
+    path = tmp_path / "legacy-spilled-current-version.db"
+    with sqlite3.connect(path) as connection:
+        connection.execute("PRAGMA journal_mode=DELETE")
+        connection.execute("PRAGMA synchronous=FULL")
+        connection.execute("""
+            CREATE TABLE daily_filled_notional_schema (
+                singleton INTEGER PRIMARY KEY,
+                schema_version INTEGER NOT NULL
+            )
+            """)
+        connection.execute("INSERT INTO daily_filled_notional_schema VALUES (1, 1)")
+        connection.execute("CREATE TABLE legacy_payload (id INTEGER PRIMARY KEY, value BLOB)")
+        connection.executemany(
+            "INSERT INTO legacy_payload VALUES (?, ?)",
+            ((index, b"a" * 4096) for index in range(1, 257)),
+        )
+    script = f"""
+import signal
+import sqlite3
+
+connection = sqlite3.connect({str(path)!r}, isolation_level=None)
+connection.execute('PRAGMA journal_mode=DELETE')
+connection.execute('PRAGMA synchronous=FULL')
+connection.execute('PRAGMA cache_size=1')
+connection.execute('PRAGMA cache_spill=ON')
+connection.execute('BEGIN IMMEDIATE')
+connection.execute('UPDATE daily_filled_notional_schema SET schema_version = 3')
+connection.execute("UPDATE legacy_payload SET value = randomblob(4096)")
+print('READY', flush=True)
+signal.pause()
+"""
+    child = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert child.stdout is not None
+        assert child.stdout.readline().strip() == "READY"
+        os.kill(child.pid, signal.SIGKILL)
+        child.wait(timeout=10)
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait(timeout=10)
+
+    journal = Path(f"{path}-journal")
+    assert journal.exists() and journal.stat().st_size > 0
+    with sqlite3.connect(f"file:{path}?mode=ro&immutable=1", uri=True) as connection:
+        assert connection.execute(
+            "SELECT schema_version FROM daily_filled_notional_schema"
+        ).fetchone() == (3,)
+    database_before = path.read_bytes()
+    journal_before = journal.read_bytes()
+    database_stat_before = path.stat()
+    journal_stat_before = journal.stat()
+
+    with pytest.raises(
+        FilledNotionalUnavailable, match="authenticated current-schema recovery anchor"
+    ):
         _service(path)
 
     assert path.read_bytes() == database_before

--- a/tests/risk/test_daily_filled_notional.py
+++ b/tests/risk/test_daily_filled_notional.py
@@ -280,26 +280,36 @@ def test_restart_restores_same_day_total_from_append_only_ledger(tmp_path):
     assert restarted.current_gross_filled_notional() == Decimal("30")
 
 
-def test_hot_path_uses_authenticated_checkpoints_without_history_rescans(tmp_path, monkeypatch):
+def test_authoritative_operations_reauthenticate_history(tmp_path, monkeypatch):
     path = tmp_path / "notional.db"
     ledger = _service(path)
+    original_validate_fills = ledger._validate_fills
+    original_validate_conflicts = ledger._validate_conflicts
+    validation_calls = {"fills": 0, "conflicts": 0}
 
-    def forbid_history_scan(*args, **kwargs):
-        pytest.fail("hot accounting path performed an unbounded history scan")
+    def observe_fill_validation(*args, **kwargs):
+        validation_calls["fills"] += 1
+        return original_validate_fills(*args, **kwargs)
 
-    monkeypatch.setattr(ledger, "_validate_fills", forbid_history_scan)
-    monkeypatch.setattr(ledger, "_validate_conflicts", forbid_history_scan)
-    for index in range(400):
+    def observe_conflict_validation(*args, **kwargs):
+        validation_calls["conflicts"] += 1
+        return original_validate_conflicts(*args, **kwargs)
+
+    monkeypatch.setattr(ledger, "_validate_fills", observe_fill_validation)
+    monkeypatch.setattr(ledger, "_validate_conflicts", observe_conflict_validation)
+    for index in range(40):
         ledger.record_fill(_fill(f"bounded-{index}"))
 
-    assert ledger.current_gross_filled_notional() == Decimal("8200")
+    assert ledger.current_gross_filled_notional() == Decimal("820")
+    assert validation_calls["fills"] >= 41
+    assert validation_calls["conflicts"] >= 41
     with sqlite3.connect(path) as connection:
         assert connection.execute(
             "SELECT count(*) FROM daily_filled_notional_checkpoints"
-        ).fetchone() == (401,)
+        ).fetchone() == (41,)
 
     monkeypatch.undo()
-    assert _service(path).restored_gross_filled_notional == Decimal("8200")
+    assert _service(path).restored_gross_filled_notional == Decimal("820")
 
 
 def test_daily_scope_limit_rejects_append_before_any_durable_mutation(tmp_path, monkeypatch):
@@ -1635,6 +1645,26 @@ def test_long_lived_service_rejects_middle_fill_deletion_before_total_read(tmp_p
         connection.execute(ledger_module._TRIGGER_SQL["daily_filled_notional_records_no_delete"])
 
     with pytest.raises(FilledNotionalIntegrityError, match="row counts or sequence spans"):
+        ledger.current_gross_filled_notional()
+
+
+def test_long_lived_service_rejects_middle_fill_rescope_before_total_read(tmp_path):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    ledger.record_fill(_fill("scope-one"))
+    ledger.record_fill(_fill("scope-two"))
+    other_portfolio = _service(path, portfolio_id="other")
+    other_portfolio.record_fill(_fill("other-scope-tail"))
+
+    with sqlite3.connect(path) as connection:
+        connection.execute("DROP TRIGGER daily_filled_notional_records_no_update")
+        connection.execute(
+            "UPDATE daily_filled_notional_records SET portfolio_id = ? WHERE sequence = 2",
+            ("other",),
+        )
+        connection.execute(ledger_module._TRIGGER_SQL["daily_filled_notional_records_no_update"])
+
+    with pytest.raises(FilledNotionalIntegrityError):
         ledger.current_gross_filled_notional()
 
 

--- a/tests/risk/test_daily_filled_notional.py
+++ b/tests/risk/test_daily_filled_notional.py
@@ -1668,6 +1668,36 @@ def test_long_lived_service_rejects_middle_fill_rescope_before_total_read(tmp_pa
         ledger.current_gross_filled_notional()
 
 
+@pytest.mark.parametrize("operation", ["total", "record"])
+def test_long_lived_service_rejects_middle_checkpoint_deletion_before_use(tmp_path, operation):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    ledger.record_fill(_fill("checkpoint-one"))
+    ledger.record_fill(_fill("checkpoint-two"))
+    ledger.record_fill(_fill("checkpoint-three"))
+
+    with sqlite3.connect(path) as connection:
+        connection.execute("DROP TRIGGER daily_filled_notional_checkpoints_no_delete")
+        connection.execute("DELETE FROM daily_filled_notional_checkpoints WHERE event_sequence = 1")
+        connection.execute(
+            ledger_module._TRIGGER_SQL["daily_filled_notional_checkpoints_no_delete"]
+        )
+
+    with pytest.raises(FilledNotionalIntegrityError, match="checkpoint sequence is not contiguous"):
+        if operation == "total":
+            ledger.current_gross_filled_notional()
+        else:
+            ledger.record_fill(_fill("must-not-append"))
+
+    with sqlite3.connect(path) as connection:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM daily_filled_notional_records"
+        ).fetchone() == (3,)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM daily_filled_notional_checkpoints"
+        ).fetchone() == (3,)
+
+
 def test_conflict_quarantine_tail_deletion_is_detected_by_anchor(tmp_path):
     path = tmp_path / "notional.db"
     ledger = _service(path)

--- a/tests/risk/test_daily_filled_notional.py
+++ b/tests/risk/test_daily_filled_notional.py
@@ -2396,6 +2396,55 @@ signal.pause()
     assert _file_snapshot(ledger.anchor_path) == anchor_before
 
 
+def test_existing_service_rejects_new_hot_journal_without_sqlite_recovery(tmp_path):
+    if not hasattr(signal, "SIGKILL"):
+        pytest.skip("SIGKILL unavailable on this host")
+    path = tmp_path / "existing-service-hot-journal.db"
+    ledger = _service(path)
+    ledger.record_fill(_fill("existing-service-initial"))
+
+    script = f"""
+import signal
+import sqlite3
+
+connection = sqlite3.connect({str(path)!r}, isolation_level=None)
+connection.execute('PRAGMA journal_mode=DELETE')
+connection.execute('PRAGMA synchronous=FULL')
+connection.execute('BEGIN IMMEDIATE')
+connection.execute('CREATE TABLE crash_probe (value TEXT)')
+print('READY', flush=True)
+signal.pause()
+"""
+    child = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert child.stdout is not None
+        assert child.stdout.readline().strip() == "READY"
+        os.kill(child.pid, signal.SIGKILL)
+        child.wait(timeout=10)
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait(timeout=10)
+
+    journal = Path(f"{path}-journal")
+    assert journal.exists() and journal.stat().st_size > 0
+    database_before = _file_snapshot(path)
+    journal_before = _file_snapshot(journal)
+    anchor_before = _file_snapshot(ledger.anchor_path)
+
+    with pytest.raises(FilledNotionalUnavailable, match="reviewed isolated-copy recovery"):
+        ledger.record_fill(_fill("existing-service-must-block"))
+
+    assert _file_snapshot(path) == database_before
+    assert _file_snapshot(journal) == journal_before
+    assert _file_snapshot(ledger.anchor_path) == anchor_before
+
+
 def test_future_schema_version_fails_closed_without_downgrade(tmp_path):
     path = tmp_path / "future.db"
     with sqlite3.connect(path) as connection:

--- a/tests/risk/test_daily_filled_notional.py
+++ b/tests/risk/test_daily_filled_notional.py
@@ -679,6 +679,61 @@ def test_missing_database_preserves_and_rejects_every_sqlite_sidecar(
         assert marker.read_bytes() == marker_bytes
 
 
+def test_missing_database_with_surviving_anchor_and_lock_creates_nothing(tmp_path):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    preserved_database = tmp_path / "preserved-notional.db"
+    path.rename(preserved_database)
+    lock_path = ledger.anchor_path.parent / f".{ledger.anchor_path.name}.lock"
+    assert lock_path.exists()
+    preserved_database_before = _file_snapshot(preserved_database)
+    anchor_before = _file_snapshot(ledger.anchor_path)
+    lock_before = _file_snapshot(lock_path)
+    paths_before = _path_inventory(tmp_path)
+
+    with pytest.raises(
+        FilledNotionalIntegrityError, match="main database is absent while anchor survives"
+    ):
+        _service(path)
+
+    assert not path.exists()
+    assert _file_snapshot(preserved_database) == preserved_database_before
+    assert _file_snapshot(ledger.anchor_path) == anchor_before
+    assert _file_snapshot(lock_path) == lock_before
+    assert _path_inventory(tmp_path) == paths_before
+    assert all(not Path(f"{path}{suffix}").exists() for suffix in ("-wal", "-shm", "-journal"))
+
+
+def test_missing_database_with_surviving_anchor_does_not_create_lock(tmp_path):
+    path = tmp_path / "notional.db"
+    anchor_directory = tmp_path / "protected-anchor"
+    anchor_directory.mkdir(mode=0o700)
+    anchor_path = anchor_directory / "notional.db.anchor"
+    anchor_path.write_bytes(b"preserved-anchor-evidence")
+    os.chmod(anchor_path, 0o600)
+    lock_path = anchor_directory / ".notional.db.anchor.lock"
+    anchor_before = _file_snapshot(anchor_path)
+    paths_before = _path_inventory(tmp_path)
+
+    with pytest.raises(
+        FilledNotionalIntegrityError, match="main database is absent while anchor survives"
+    ):
+        DailyFilledNotional(
+            path,
+            anchor_path=anchor_path,
+            anchor_key=ANCHOR_KEY,
+            monotonic_verifier=TestMonotonicVerifier(),
+            account_id="DU12345",
+            portfolio_id="default",
+        )
+
+    assert not path.exists()
+    assert not lock_path.exists()
+    assert _file_snapshot(anchor_path) == anchor_before
+    assert _path_inventory(tmp_path) == paths_before
+    assert all(not Path(f"{path}{suffix}").exists() for suffix in ("-wal", "-shm", "-journal"))
+
+
 def test_wal_shm_hardlinks_are_rejected_without_mutating_targets(tmp_path):
     path = tmp_path / "notional.db"
     ledger = _service(path)

--- a/tests/risk/test_daily_filled_notional.py
+++ b/tests/risk/test_daily_filled_notional.py
@@ -436,36 +436,65 @@ def test_trigger_removal_and_row_tamper_fail_closed_on_restart(tmp_path):
         _service(path)
 
 
-def test_foreign_raise_ignore_trigger_on_protected_table_fails_closed_without_mutation(tmp_path):
+@pytest.mark.parametrize(
+    "protected_table",
+    [
+        "daily_filled_notional_schema",
+        "daily_filled_notional_records",
+        "daily_filled_notional_conflicts",
+        "daily_filled_notional_checkpoints",
+    ],
+)
+@pytest.mark.parametrize("target_case", ["mixed", "uppercase"])
+def test_case_variant_foreign_trigger_on_every_protected_table_fails_closed_without_mutation(
+    tmp_path, protected_table, target_case
+):
     path = tmp_path / "notional.db"
     ledger = _service(path)
+    target_identifier = (
+        protected_table.upper()
+        if target_case == "uppercase"
+        else "".join(
+            character.upper() if index % 2 == 0 else character.lower()
+            for index, character in enumerate(protected_table)
+        )
+    )
+    trigger_name = f"foreign_suppress_{target_case}_{protected_table}"
     with sqlite3.connect(path) as connection:
-        connection.execute("""
-            CREATE TRIGGER foreign_suppress_filled_notional_insert
-            BEFORE INSERT ON daily_filled_notional_records
+        connection.execute(f"""
+            CREATE TRIGGER "{trigger_name}"
+            BEFORE INSERT ON "{target_identifier}"
             BEGIN
                 SELECT RAISE(IGNORE);
             END
             """)
+        assert connection.execute(
+            "SELECT tbl_name FROM sqlite_master WHERE type = 'trigger' AND name = ?",
+            (trigger_name,),
+        ).fetchone() == (target_identifier,)
 
-    database_before = path.read_bytes()
-    database_identity = (os.lstat(path).st_dev, os.lstat(path).st_ino)
-    anchor_before = ledger.anchor_path.read_bytes()
-    anchor_identity = (
-        os.lstat(ledger.anchor_path).st_dev,
-        os.lstat(ledger.anchor_path).st_ino,
-    )
+    database_before = _file_snapshot(path)
+    anchor_before = _file_snapshot(ledger.anchor_path)
+    paths_before = _path_inventory(tmp_path)
 
     with pytest.raises(FilledNotionalIntegrityError, match="schema objects do not match"):
-        ledger.record_fill(_fill("must-not-be-ignored"))
+        ledger.record_fill(_fill(f"must-not-be-ignored-{target_case}-{protected_table}"))
 
-    assert path.read_bytes() == database_before
-    assert (os.lstat(path).st_dev, os.lstat(path).st_ino) == database_identity
-    assert ledger.anchor_path.read_bytes() == anchor_before
-    assert (
-        os.lstat(ledger.anchor_path).st_dev,
-        os.lstat(ledger.anchor_path).st_ino,
-    ) == anchor_identity
+    assert _file_snapshot(path) == database_before
+    assert _file_snapshot(ledger.anchor_path) == anchor_before
+    assert _path_inventory(tmp_path) == paths_before
+
+    with pytest.raises(FilledNotionalIntegrityError, match="schema objects do not match"):
+        DailyFilledNotional.review_quarantine(
+            path,
+            anchor_path=ledger.anchor_path,
+            anchor_key=ANCHOR_KEY,
+            monotonic_verifier=_MONOTONIC_VERIFIERS[str(path)],
+        )
+
+    assert _file_snapshot(path) == database_before
+    assert _file_snapshot(ledger.anchor_path) == anchor_before
+    assert _path_inventory(tmp_path) == paths_before
 
 
 @pytest.mark.parametrize("suppressed_append", ["fill", "checkpoint"])

--- a/tests/risk/test_daily_filled_notional.py
+++ b/tests/risk/test_daily_filled_notional.py
@@ -544,6 +544,39 @@ def test_record_fill_verifies_uncommitted_append_advanced_before_anchor_publicat
         ).fetchone() == (1,)
 
 
+def test_checkpoint_text_in_integer_column_fails_closed_with_typed_error(tmp_path):
+    ledger = _service(tmp_path / "notional.db")
+    malformed_row = {
+        "event_sequence": 0,
+        "ledger_id": ledger._ledger_id,
+        "database_device": "oops",
+        "database_inode": 1,
+        "fill_count": 0,
+        "fill_head": "0" * 64,
+        "conflict_count": 0,
+        "conflict_head": "0" * 64,
+        "previous_checkpoint_hash": "0" * 64,
+        "checkpoint_hash": "0" * 64,
+    }
+
+    class MalformedCheckpointConnection:
+        @staticmethod
+        def execute(_statement):
+            return (malformed_row,)
+
+    with pytest.raises(FilledNotionalIntegrityError, match="checkpoint counters"):
+        ledger._validate_checkpoints(
+            MalformedCheckpointConnection(),  # type: ignore[arg-type]
+            ledger_id=ledger._ledger_id,
+            database_device=1,
+            database_inode=1,
+            fill_count=0,
+            fill_head="0" * 64,
+            conflict_count=0,
+            conflict_head="0" * 64,
+        )
+
+
 def test_service_connection_has_no_update_delete_or_schema_authority(tmp_path):
     ledger = _service(tmp_path / "notional.db")
     ledger.record_fill(_fill("immutable"))
@@ -849,6 +882,25 @@ def test_hardlinked_rollback_journal_is_rejected_without_mutation(tmp_path):
     )
 
 
+def test_hardlinked_main_ledger_is_rejected_before_fill_mutation(tmp_path):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    preserved_alias = tmp_path / "preserved-ledger.db"
+    os.link(path, preserved_alias)
+    database_before = _file_snapshot(path)
+    alias_before = _file_snapshot(preserved_alias)
+    anchor_before = _file_snapshot(ledger.anchor_path)
+    paths_before = _path_inventory(tmp_path)
+
+    with pytest.raises(FilledNotionalIntegrityError, match="checkpoint database identity"):
+        ledger.record_fill(_fill("must-not-mutate-hardlinked-ledger"))
+
+    assert _file_snapshot(path) == database_before
+    assert _file_snapshot(preserved_alias) == alias_before
+    assert _file_snapshot(ledger.anchor_path) == anchor_before
+    assert _path_inventory(tmp_path) == paths_before
+
+
 def test_anchor_write_crash_window_recovers_one_authenticated_fill(tmp_path, monkeypatch):
     path = tmp_path / "notional.db"
     ledger = _service(path)
@@ -890,17 +942,115 @@ def test_crash_before_database_commit_resolves_pending_anchor_to_old_state(tmp_p
         ).fetchone() == (0,)
 
 
+def test_empty_initialized_database_recovers_when_initial_anchor_creation_failed(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "notional.db"
+    original_create = DailyFilledNotional._create_initial_anchor
+
+    def fail_initial_anchor(self, state):
+        del self, state
+        raise OSError("injected failure after initial database commit")
+
+    monkeypatch.setattr(DailyFilledNotional, "_create_initial_anchor", fail_initial_anchor)
+    with pytest.raises(FilledNotionalUnavailable, match="startup failed closed"):
+        _service(path)
+
+    assert path.is_file()
+    assert not _anchor_path(path).exists()
+    with sqlite3.connect(path) as connection:
+        assert connection.execute(
+            "SELECT count(*) FROM daily_filled_notional_records"
+        ).fetchone() == (0,)
+        assert connection.execute(
+            "SELECT count(*) FROM daily_filled_notional_conflicts"
+        ).fetchone() == (0,)
+
+    monkeypatch.setattr(DailyFilledNotional, "_create_initial_anchor", original_create)
+    restarted = _service(path)
+
+    assert restarted.restored_gross_filled_notional == Decimal("0")
+    assert restarted.anchor_path.is_file()
+
+
+def test_missing_anchor_never_reinitializes_nonempty_ledger(tmp_path):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    ledger.record_fill(_fill("durable-before-anchor-loss"))
+    database_before = _file_snapshot(path)
+    ledger.anchor_path.unlink()
+    paths_before = _path_inventory(tmp_path)
+
+    with pytest.raises(
+        FilledNotionalIntegrityError, match="cannot authenticate a non-empty ledger"
+    ):
+        _service(path)
+
+    assert _file_snapshot(path) == database_before
+    assert not ledger.anchor_path.exists()
+    assert _path_inventory(tmp_path) == paths_before
+
+
+def test_slow_monotonic_read_verifier_serializes_writer_without_sqlite_timeout(tmp_path):
+    path = tmp_path / "notional.db"
+    writer = _service(path)
+    reader = _service(path)
+    verifier_started = threading.Event()
+    release_verifier = threading.Event()
+    verification_state = TestMonotonicVerifier()
+    read_results: list[object] = []
+    write_results: list[object] = []
+
+    def slow_verifier(state):
+        verifier_started.set()
+        if not release_verifier.wait(timeout=5):
+            raise RuntimeError("test timed out releasing monotonic verifier")
+        return verification_state(state)
+
+    reader._monotonic_verifier = slow_verifier
+
+    def read() -> None:
+        try:
+            read_results.append(reader.current_gross_filled_notional())
+        except BaseException as exc:  # pragma: no cover - asserted below
+            read_results.append(exc)
+
+    def write() -> None:
+        try:
+            write_results.append(writer.record_fill(_fill("during-slow-verification")))
+        except BaseException as exc:  # pragma: no cover - asserted below
+            write_results.append(exc)
+
+    reader_thread = threading.Thread(target=read)
+    writer_thread = threading.Thread(target=write)
+    reader_thread.start()
+    assert verifier_started.wait(timeout=5)
+    writer_thread.start()
+    writer_thread.join(timeout=0.2)
+
+    try:
+        assert writer_thread.is_alive(), "writer bypassed the transition-boundary lock"
+        assert write_results == []
+    finally:
+        release_verifier.set()
+        reader_thread.join(timeout=5)
+        writer_thread.join(timeout=5)
+
+    assert not reader_thread.is_alive()
+    assert not writer_thread.is_alive()
+    assert read_results == [Decimal("0")]
+    assert len(write_results) == 1
+    assert not isinstance(write_results[0], BaseException)
+    assert reader.current_gross_filled_notional() == Decimal("20.5")
+
+
 def test_reader_waits_for_concurrent_pending_writer_without_latching(tmp_path, monkeypatch):
     path = tmp_path / "notional.db"
     writer = _service(path)
     reader = _service(path)
     pending_ready = threading.Event()
-    reader_reconciling = threading.Event()
-    reader_retrying = threading.Event()
     release_writer = threading.Event()
     original_commit = writer._commit_database
-    original_resolve = reader._resolve_pending_anchor
-    resolve_attempts = 0
     results: list[object] = []
 
     def gated_commit(connection):
@@ -909,17 +1059,7 @@ def test_reader_waits_for_concurrent_pending_writer_without_latching(tmp_path, m
             raise sqlite3.OperationalError("test timed out waiting to release writer")
         original_commit(connection)
 
-    def observed_resolve():
-        nonlocal resolve_attempts
-        resolve_attempts += 1
-        reader_reconciling.set()
-        if resolve_attempts == 1:
-            raise sqlite3.OperationalError("database is locked")
-        reader_retrying.set()
-        original_resolve()
-
     monkeypatch.setattr(writer, "_commit_database", gated_commit)
-    monkeypatch.setattr(reader, "_resolve_pending_anchor", observed_resolve)
 
     def write() -> None:
         try:
@@ -938,8 +1078,9 @@ def test_reader_waits_for_concurrent_pending_writer_without_latching(tmp_path, m
     writer_thread.start()
     assert pending_ready.wait(timeout=5)
     reader_thread.start()
-    assert reader_reconciling.wait(timeout=5)
-    assert reader_retrying.wait(timeout=5)
+    reader_thread.join(timeout=0.2)
+    assert reader_thread.is_alive(), "reader bypassed the writer transition lock"
+    assert len(results) == 0
     release_writer.set()
     writer_thread.join(timeout=5)
     reader_thread.join(timeout=5)
@@ -947,7 +1088,6 @@ def test_reader_waits_for_concurrent_pending_writer_without_latching(tmp_path, m
     assert not writer_thread.is_alive()
     assert not reader_thread.is_alive()
     assert not any(isinstance(result, BaseException) for result in results)
-    assert resolve_attempts >= 2
     assert Decimal("20.5") in results
     assert reader.current_gross_filled_notional() == Decimal("20.5")
 
@@ -957,9 +1097,8 @@ def test_reader_snapshot_rechecks_anchor_before_returning_during_writer_race(tmp
     writer = _service(path)
     reader = _service(path)
     snapshot_total_ready = threading.Event()
-    writer_pending = threading.Event()
+    release_reader = threading.Event()
     original_total = reader._total_for_date
-    original_commit = writer._commit_database
     total_calls = 0
     results: dict[str, object] = {}
 
@@ -969,16 +1108,11 @@ def test_reader_snapshot_rechecks_anchor_before_returning_during_writer_race(tmp
         total_calls += 1
         if total_calls == 1:
             snapshot_total_ready.set()
-            if not writer_pending.wait(timeout=5):
-                raise sqlite3.OperationalError("test writer did not reach pending state")
+            if not release_reader.wait(timeout=5):
+                raise sqlite3.OperationalError("test timed out releasing reader snapshot")
         return total
 
-    def observed_commit(connection):
-        writer_pending.set()
-        original_commit(connection)
-
     monkeypatch.setattr(reader, "_total_for_date", gated_total)
-    monkeypatch.setattr(writer, "_commit_database", observed_commit)
 
     def read() -> None:
         try:
@@ -997,6 +1131,10 @@ def test_reader_snapshot_rechecks_anchor_before_returning_during_writer_race(tmp
     reader_thread.start()
     assert snapshot_total_ready.wait(timeout=5)
     writer_thread.start()
+    writer_thread.join(timeout=0.2)
+    assert writer_thread.is_alive(), "writer bypassed the reader transition lock"
+    assert "write" not in results
+    release_reader.set()
     reader_thread.join(timeout=5)
     writer_thread.join(timeout=5)
 
@@ -1004,9 +1142,10 @@ def test_reader_snapshot_rechecks_anchor_before_returning_during_writer_race(tmp
     assert not writer_thread.is_alive()
     assert not isinstance(results.get("read"), BaseException)
     assert not isinstance(results.get("write"), BaseException)
-    assert results["read"] == Decimal("20.5")
+    assert results["read"] == Decimal("0")
     assert total_calls >= 2
     assert reader._failed_reason is None
+    assert reader.current_gross_filled_notional() == Decimal("20.5")
 
 
 def test_concurrent_writers_serialize_through_stable_anchor_publication(tmp_path, monkeypatch):

--- a/tests/risk/test_daily_filled_notional.py
+++ b/tests/risk/test_daily_filled_notional.py
@@ -179,6 +179,32 @@ def test_exact_execution_replay_is_idempotent(tmp_path):
         ).fetchone() == (1,)
 
 
+def test_exact_replay_rechecks_monotonic_authority_at_return_boundary(tmp_path):
+    ledger = _service(tmp_path / "notional.db")
+    fill = _fill("broker.exec.return-boundary")
+    ledger.record_fill(fill)
+
+    class RejectSecondVerification:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def __call__(self, state) -> bool:
+            del state
+            self.calls += 1
+            return self.calls == 1
+
+    verifier = RejectSecondVerification()
+    ledger._monotonic_verifier = verifier
+
+    with pytest.raises(FilledNotionalIntegrityError, match="monotonic authority rejected"):
+        ledger.record_fill(fill)
+    assert verifier.calls == 2
+    with sqlite3.connect(ledger.database_path) as connection:
+        assert connection.execute(
+            "SELECT count(*) FROM daily_filled_notional_records"
+        ).fetchone() == (1,)
+
+
 def test_conflicting_duplicate_fails_closed_and_latches_instance(tmp_path):
     ledger = _service(tmp_path / "notional.db")
     original = _fill("broker.exec.1")
@@ -469,6 +495,76 @@ def test_current_query_is_read_only(tmp_path):
     assert not Path(f"{ledger.database_path}-wal").exists()
 
 
+def test_wal_shm_hardlinks_are_rejected_without_mutating_targets(tmp_path):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    with sqlite3.connect(path, isolation_level=None) as connection:
+        assert connection.execute("PRAGMA journal_mode=WAL").fetchone() == ("wal",)
+
+    wal_target = tmp_path / "preserved.wal"
+    shm_target = tmp_path / "preserved.shm"
+    wal_target.write_bytes(b"preserve WAL evidence")
+    shm_target.write_bytes(b"preserve SHM evidence")
+    wal_path = Path(f"{path}-wal")
+    shm_path = Path(f"{path}-shm")
+    os.link(wal_target, wal_path)
+    os.link(shm_target, shm_path)
+    wal_before = wal_target.read_bytes()
+    shm_before = shm_target.read_bytes()
+    wal_stat = wal_target.stat()
+    shm_stat = shm_target.stat()
+
+    with pytest.raises(FilledNotionalUnavailable, match="WAL/SHM sidecars are unsupported"):
+        _service(path)
+
+    assert wal_target.read_bytes() == wal_before
+    assert shm_target.read_bytes() == shm_before
+    assert (wal_target.stat().st_ino, wal_target.stat().st_size) == (
+        wal_stat.st_ino,
+        wal_stat.st_size,
+    )
+    assert (shm_target.stat().st_ino, shm_target.stat().st_size) == (
+        shm_stat.st_ino,
+        shm_stat.st_size,
+    )
+
+
+def test_clean_wal_mode_is_rejected_before_sqlite_creates_sidecars(tmp_path):
+    path = tmp_path / "notional.db"
+    _service(path)
+    with sqlite3.connect(path, isolation_level=None) as connection:
+        assert connection.execute("PRAGMA journal_mode=WAL").fetchone() == ("wal",)
+    assert not Path(f"{path}-wal").exists()
+    assert not Path(f"{path}-shm").exists()
+
+    with pytest.raises(FilledNotionalUnavailable, match="rollback-journal mode"):
+        _service(path)
+
+    assert not Path(f"{path}-wal").exists()
+    assert not Path(f"{path}-shm").exists()
+
+
+def test_hardlinked_rollback_journal_is_rejected_without_mutation(tmp_path):
+    path = tmp_path / "notional.db"
+    _service(path)
+    target = tmp_path / "preserved.journal"
+    target.write_bytes(b"preserve rollback evidence")
+    journal_path = Path(f"{path}-journal")
+    os.link(target, journal_path)
+    before = target.read_bytes()
+    target_stat = target.stat()
+
+    with pytest.raises(FilledNotionalUnavailable, match="journal prevents safe"):
+        _service(path)
+
+    assert target.read_bytes() == before
+    assert (target.stat().st_ino, target.stat().st_size, target.stat().st_nlink) == (
+        target_stat.st_ino,
+        target_stat.st_size,
+        target_stat.st_nlink,
+    )
+
+
 def test_anchor_write_crash_window_recovers_one_authenticated_fill(tmp_path, monkeypatch):
     path = tmp_path / "notional.db"
     ledger = _service(path)
@@ -627,6 +723,63 @@ def test_reader_snapshot_rechecks_anchor_before_returning_during_writer_race(tmp
     assert results["read"] == Decimal("20.5")
     assert total_calls >= 2
     assert reader._failed_reason is None
+
+
+def test_concurrent_writers_serialize_through_stable_anchor_publication(tmp_path, monkeypatch):
+    path = tmp_path / "notional.db"
+    first = _service(path)
+    second = _service(path)
+    first_reached_post_commit = threading.Event()
+    release_first = threading.Event()
+    second_started = threading.Event()
+    second_done = threading.Event()
+    results: dict[str, object] = {}
+    original_replace = first._replace_anchor
+
+    def gate_final_anchor(desired, *, expected):
+        if expected.pending_state is not None and desired.pending_state is None:
+            first_reached_post_commit.set()
+            if not release_first.wait(timeout=5):
+                raise sqlite3.OperationalError("test timed out releasing first writer")
+        return original_replace(desired, expected=expected)
+
+    monkeypatch.setattr(first, "_replace_anchor", gate_final_anchor)
+
+    def write_first() -> None:
+        try:
+            results["first"] = first.record_fill(_fill("writer-one"))
+        except BaseException as exc:  # pragma: no cover - asserted below
+            results["first"] = exc
+
+    def write_second() -> None:
+        second_started.set()
+        try:
+            results["second"] = second.record_fill(_fill("writer-two"))
+        except BaseException as exc:  # pragma: no cover - asserted below
+            results["second"] = exc
+        finally:
+            second_done.set()
+
+    first_thread = threading.Thread(target=write_first)
+    second_thread = threading.Thread(target=write_second)
+    first_thread.start()
+    assert first_reached_post_commit.wait(timeout=5)
+    second_thread.start()
+    assert second_started.wait(timeout=5)
+    assert not second_done.wait(timeout=0.1)
+    release_first.set()
+    first_thread.join(timeout=5)
+    second_thread.join(timeout=5)
+
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert not isinstance(results.get("first"), BaseException)
+    assert not isinstance(results.get("second"), BaseException)
+    with sqlite3.connect(path) as connection:
+        assert connection.execute(
+            "SELECT broker_execution_id FROM daily_filled_notional_records ORDER BY sequence"
+        ).fetchall() == [("writer-one",), ("writer-two",)]
+    assert _service(path).restored_gross_filled_notional == Decimal("41")
 
 
 def test_invalid_pending_anchor_identity_still_fails_closed(tmp_path):

--- a/tests/risk/test_daily_filled_notional.py
+++ b/tests/risk/test_daily_filled_notional.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import shutil
 import signal
 import sqlite3
 import subprocess
 import sys
+import threading
 from dataclasses import replace
 from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation, getcontext, setcontext
@@ -27,11 +29,40 @@ from robo_trader.risk.filled_notional import (
     FilledNotionalMigrationRequired,
     FilledNotionalUnavailable,
     FillSide,
+    MonotonicLedgerState,
 )
 
 UTC = timezone.utc
 NEW_YORK = ZoneInfo("America/New_York")
 ANCHOR_KEY = b"test-only-independent-anchor-key-32-bytes-minimum"
+_MONOTONIC_VERIFIERS = {}
+
+
+class TestMonotonicVerifier:
+    __test__ = False
+
+    def __init__(self) -> None:
+        self.state: MonotonicLedgerState | None = None
+
+    def __call__(self, candidate: MonotonicLedgerState) -> bool:
+        prior = self.state
+        if prior is None:
+            self.state = candidate
+            return True
+        if candidate == prior:
+            return True
+        if candidate.ledger_id != prior.ledger_id:
+            return False
+        fill_delta = candidate.fill_count - prior.fill_count
+        conflict_delta = candidate.conflict_count - prior.conflict_count
+        if fill_delta < 0 or conflict_delta < 0 or fill_delta + conflict_delta != 1:
+            return False
+        if fill_delta == 0 and candidate.fill_head != prior.fill_head:
+            return False
+        if conflict_delta == 0 and candidate.conflict_head != prior.conflict_head:
+            return False
+        self.state = candidate
+        return True
 
 
 class MutableClock:
@@ -66,13 +97,18 @@ def _service(
     account_id: str = "DU12345",
     portfolio_id: str = "default",
     clock: MutableClock | None = None,
+    monotonic_verifier=None,
 ) -> DailyFilledNotional:
     anchor_directory = path.parent / "protected-anchor"
     anchor_directory.mkdir(mode=0o700, exist_ok=True)
+    verifier = monotonic_verifier or _MONOTONIC_VERIFIERS.setdefault(
+        str(path), TestMonotonicVerifier()
+    )
     return DailyFilledNotional(
         path,
         anchor_path=anchor_directory / f"{path.name}.anchor",
         anchor_key=ANCHOR_KEY,
+        monotonic_verifier=verifier,
         account_id=account_id,
         portfolio_id=portfolio_id,
         clock=clock or MutableClock(datetime(2026, 7, 28, 20, 0, tzinfo=UTC)),
@@ -165,11 +201,33 @@ def test_conflicting_duplicate_fails_closed_and_latches_instance(tmp_path):
         ledger.database_path,
         anchor_path=ledger.anchor_path,
         anchor_key=ANCHOR_KEY,
+        monotonic_verifier=_MONOTONIC_VERIFIERS[str(ledger.database_path)],
     )
     assert len(review) == 1
     assert review[0].broker_execution_id == "broker.exec.1"
     assert review[0].existing_portfolio_id == "default"
     assert review[0].claimed_portfolio_id == "default"
+
+
+def test_preexisting_instances_observe_durable_conflict_on_every_operation(tmp_path):
+    path = tmp_path / "notional.db"
+    writer = _service(path)
+    reader = _service(path)
+    appender = _service(path)
+    original = _fill("shared-conflict")
+    writer.record_fill(original)
+
+    with pytest.raises(FilledNotionalConflict):
+        writer.record_fill(replace(original, price=Decimal("999")))
+    with pytest.raises(FilledNotionalConflict, match="requires review"):
+        reader.current_gross_filled_notional()
+    with pytest.raises(FilledNotionalConflict, match="requires review"):
+        appender.record_fill(_fill("must-not-append"))
+
+    with sqlite3.connect(path) as connection:
+        assert connection.execute(
+            "SELECT count(*) FROM daily_filled_notional_records"
+        ).fetchone() == (1,)
 
 
 def test_restart_restores_same_day_total_from_append_only_ledger(tmp_path):
@@ -202,6 +260,7 @@ def test_scope_isolated_by_account_and_portfolio(tmp_path):
         path,
         anchor_path=default.anchor_path,
         anchor_key=ANCHOR_KEY,
+        monotonic_verifier=_MONOTONIC_VERIFIERS[str(path)],
     )
     assert review[0].existing_portfolio_id == "default"
     assert review[0].claimed_portfolio_id == "income"
@@ -348,7 +407,7 @@ def test_corrupt_database_fails_closed_without_replacing_it(tmp_path):
     path.write_bytes(contents)
     before = hashlib.sha256(contents).hexdigest()
 
-    with pytest.raises(FilledNotionalUnavailable, match="startup failed closed"):
+    with pytest.raises(FilledNotionalUnavailable, match="cannot be detected"):
         _service(path)
     assert hashlib.sha256(path.read_bytes()).hexdigest() == before
 
@@ -407,6 +466,105 @@ def test_crash_before_database_commit_resolves_pending_anchor_to_old_state(tmp_p
         ).fetchone() == (0,)
 
 
+def test_reader_waits_for_concurrent_pending_writer_without_latching(tmp_path, monkeypatch):
+    path = tmp_path / "notional.db"
+    writer = _service(path)
+    reader = _service(path)
+    pending_ready = threading.Event()
+    reader_reconciling = threading.Event()
+    reader_retrying = threading.Event()
+    release_writer = threading.Event()
+    original_commit = writer._commit_database
+    original_resolve = reader._resolve_pending_anchor
+    resolve_attempts = 0
+    results: list[object] = []
+
+    def gated_commit(connection):
+        pending_ready.set()
+        if not release_writer.wait(timeout=5):
+            raise sqlite3.OperationalError("test timed out waiting to release writer")
+        original_commit(connection)
+
+    def observed_resolve():
+        nonlocal resolve_attempts
+        resolve_attempts += 1
+        reader_reconciling.set()
+        if resolve_attempts == 1:
+            raise sqlite3.OperationalError("database is locked")
+        reader_retrying.set()
+        original_resolve()
+
+    monkeypatch.setattr(writer, "_commit_database", gated_commit)
+    monkeypatch.setattr(reader, "_resolve_pending_anchor", observed_resolve)
+
+    def write() -> None:
+        try:
+            results.append(writer.record_fill(_fill("concurrent-fill")))
+        except BaseException as exc:  # pragma: no cover - asserted below
+            results.append(exc)
+
+    def read() -> None:
+        try:
+            results.append(reader.current_gross_filled_notional())
+        except BaseException as exc:  # pragma: no cover - asserted below
+            results.append(exc)
+
+    writer_thread = threading.Thread(target=write)
+    reader_thread = threading.Thread(target=read)
+    writer_thread.start()
+    assert pending_ready.wait(timeout=5)
+    reader_thread.start()
+    assert reader_reconciling.wait(timeout=5)
+    assert reader_retrying.wait(timeout=5)
+    release_writer.set()
+    writer_thread.join(timeout=5)
+    reader_thread.join(timeout=5)
+
+    assert not writer_thread.is_alive()
+    assert not reader_thread.is_alive()
+    assert not any(isinstance(result, BaseException) for result in results)
+    assert resolve_attempts >= 2
+    assert Decimal("20.5") in results
+    assert reader.current_gross_filled_notional() == Decimal("20.5")
+
+
+def test_invalid_pending_anchor_identity_still_fails_closed(tmp_path):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    payload = json.loads(ledger.anchor_path.read_text(encoding="ascii"))
+    payload["pending_state"] = dict(payload["state"])
+    payload["pending_state"]["database_inode"] += 1
+    unsigned = {key: payload[key] for key in payload if key != "mac"}
+    payload["mac"] = ledger_module._keyed_hash(ANCHOR_KEY, unsigned)
+    ledger.anchor_path.write_text(ledger_module._canonical_json(payload) + "\n", encoding="ascii")
+    os.chmod(ledger.anchor_path, 0o600)
+
+    with pytest.raises(FilledNotionalIntegrityError, match="pending anchor"):
+        ledger.current_gross_filled_notional()
+
+
+def test_pending_writer_timeout_is_bounded_and_does_not_latch_reader(tmp_path, monkeypatch):
+    ledger = _service(tmp_path / "notional.db")
+    with ledger._connection(readonly=True) as connection:
+        state = ledger._validate_ledger(connection)
+    ledger._anchor = ledger._replace_anchor(
+        ledger._anchor_for_state(state, pending_state=state),
+        expected=ledger._anchor,
+    )
+    original_resolve = ledger._resolve_pending_anchor
+
+    def always_busy():
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(ledger, "_resolve_pending_anchor", always_busy)
+    with pytest.raises(FilledNotionalUnavailable, match="remained busy"):
+        ledger.current_gross_filled_notional()
+    assert ledger._failed_reason is None
+
+    monkeypatch.setattr(ledger, "_resolve_pending_anchor", original_resolve)
+    assert ledger.current_gross_filled_notional() == Decimal("0")
+
+
 def test_sigkill_hot_journal_is_recovered_rw_before_readonly_validation(tmp_path):
     if not hasattr(signal, "SIGKILL"):
         pytest.skip("SIGKILL unavailable on this host")
@@ -423,6 +581,7 @@ service = DailyFilledNotional(
     {str(path)!r},
     anchor_path={str(ledger.anchor_path)!r},
     anchor_key={ANCHOR_KEY!r},
+    monotonic_verifier=lambda state: True,
     account_id='DU12345',
     portfolio_id='default',
     clock=lambda: datetime(2026, 7, 28, 20, 0, tzinfo=timezone.utc),
@@ -523,6 +682,42 @@ def test_stable_anchor_rollback_is_not_mistaken_for_a_crash_window(tmp_path):
         _service(path)
 
 
+def test_coordinated_old_database_and_anchor_replay_requires_monotonic_rejection(tmp_path):
+    path = tmp_path / "notional.db"
+    verifier = TestMonotonicVerifier()
+    ledger = _service(path, monotonic_verifier=verifier)
+    ledger.record_fill(_fill("one"))
+    old_database = path.read_bytes()
+    old_anchor = ledger.anchor_path.read_bytes()
+    ledger.record_fill(_fill("two"))
+
+    path.write_bytes(old_database)
+    ledger.anchor_path.write_bytes(old_anchor)
+    os.chmod(ledger.anchor_path, 0o600)
+
+    with pytest.raises(FilledNotionalIntegrityError, match="monotonic authority rejected"):
+        _service(path, monotonic_verifier=verifier)
+
+
+def test_authoritative_service_requires_independent_monotonic_verifier(tmp_path):
+    path = tmp_path / "notional.db"
+    anchor_directory = tmp_path / "protected-anchor"
+    anchor_directory.mkdir(mode=0o700)
+
+    with pytest.raises(FilledNotionalUnavailable, match="monotonic verifier is required"):
+        DailyFilledNotional(
+            path,
+            anchor_path=anchor_directory / "notional.db.anchor",
+            anchor_key=ANCHOR_KEY,
+            monotonic_verifier=None,  # type: ignore[arg-type]
+            account_id="DU12345",
+            portfolio_id="default",
+        )
+
+    assert not path.exists()
+    assert not (anchor_directory / "notional.db.anchor").exists()
+
+
 def test_ledger_replacement_is_detected_by_anchor_inode_binding(tmp_path):
     path = tmp_path / "notional.db"
     original = _service(path)
@@ -554,6 +749,61 @@ def test_anchor_replacement_with_other_valid_anchor_fails_closed(tmp_path):
         _service(path)
 
 
+def test_anchor_directory_replacement_cannot_transfer_authority(tmp_path):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    ledger.record_fill(_fill("original"))
+    anchor_directory = ledger.anchor_path.parent
+    moved_directory = tmp_path / "original-anchor-directory"
+    original_anchor = ledger.anchor_path.read_bytes()
+
+    os.rename(anchor_directory, moved_directory)
+    anchor_directory.mkdir(mode=0o700)
+    replacement_anchor = anchor_directory / ledger.anchor_path.name
+    replacement_anchor.write_bytes(original_anchor)
+    os.chmod(replacement_anchor, 0o600)
+
+    with pytest.raises(FilledNotionalIntegrityError, match="directory identity changed"):
+        ledger.current_gross_filled_notional()
+    assert replacement_anchor.read_bytes() == original_anchor
+
+
+def test_anchor_directory_swap_during_replace_is_rejected_without_authority_transfer(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    anchor_directory = ledger.anchor_path.parent
+    moved_directory = tmp_path / "moved-bound-anchor"
+    original_anchor = ledger.anchor_path.read_bytes()
+    real_replace = ledger_module.os.replace
+    swapped = False
+
+    def race_replace(source, destination, *args, **kwargs):
+        nonlocal swapped
+        if not swapped and destination == ledger.anchor_path.name:
+            swapped = True
+            os.rename(anchor_directory, moved_directory)
+            anchor_directory.mkdir(mode=0o700)
+            replacement_anchor = anchor_directory / ledger.anchor_path.name
+            replacement_anchor.write_bytes(original_anchor)
+            os.chmod(replacement_anchor, 0o600)
+        return real_replace(source, destination, *args, **kwargs)
+
+    monkeypatch.setattr(ledger_module.os, "replace", race_replace)
+
+    with pytest.raises(FilledNotionalIntegrityError, match="identity changed during"):
+        ledger.record_fill(_fill("racing-fill"))
+
+    replacement_anchor = anchor_directory / ledger.anchor_path.name
+    assert swapped is True
+    assert replacement_anchor.read_bytes() == original_anchor
+    with sqlite3.connect(path) as connection:
+        assert connection.execute(
+            "SELECT count(*) FROM daily_filled_notional_records"
+        ).fetchone() == (0,)
+
+
 def test_anchor_content_or_external_key_mismatch_fails_closed(tmp_path):
     path = tmp_path / "notional.db"
     ledger = _service(path)
@@ -564,6 +814,7 @@ def test_anchor_content_or_external_key_mismatch_fails_closed(tmp_path):
             path,
             anchor_path=ledger.anchor_path,
             anchor_key=b"different-independent-key-material-32-bytes",
+            monotonic_verifier=_MONOTONIC_VERIFIERS[str(path)],
             account_id="DU12345",
             portfolio_id="default",
         )
@@ -627,6 +878,73 @@ def test_schema_v1_requires_explicit_copy_migration_without_anchor_creation(tmp_
         _service(path)
 
     assert hashlib.sha256(path.read_bytes()).hexdigest() == before
+    assert not _anchor_path(path).exists()
+
+
+def test_sigkill_v1_hot_journal_is_preserved_byte_for_byte(tmp_path):
+    if not hasattr(signal, "SIGKILL"):
+        pytest.skip("SIGKILL unavailable on this host")
+    path = tmp_path / "legacy-hot-v1.db"
+    with sqlite3.connect(path) as connection:
+        connection.execute("PRAGMA journal_mode=DELETE")
+        connection.execute("PRAGMA synchronous=FULL")
+        connection.execute("""
+            CREATE TABLE daily_filled_notional_schema (
+                singleton INTEGER PRIMARY KEY,
+                schema_version INTEGER NOT NULL
+            )
+            """)
+        connection.execute("INSERT INTO daily_filled_notional_schema VALUES (1, 1)")
+        connection.execute("CREATE TABLE legacy_payload (id INTEGER PRIMARY KEY, value TEXT)")
+        connection.execute("INSERT INTO legacy_payload VALUES (1, 'original')")
+    script = f"""
+import signal
+import sqlite3
+
+connection = sqlite3.connect({str(path)!r}, isolation_level=None)
+connection.execute('PRAGMA journal_mode=DELETE')
+connection.execute('PRAGMA synchronous=FULL')
+connection.execute('BEGIN IMMEDIATE')
+connection.execute("UPDATE legacy_payload SET value = 'uncommitted' WHERE id = 1")
+print('READY', flush=True)
+signal.pause()
+"""
+    child = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert child.stdout is not None
+        assert child.stdout.readline().strip() == "READY"
+        os.kill(child.pid, signal.SIGKILL)
+        child.wait(timeout=10)
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait(timeout=10)
+
+    journal = Path(f"{path}-journal")
+    assert journal.exists() and journal.stat().st_size > 0
+    database_before = path.read_bytes()
+    journal_before = journal.read_bytes()
+    database_stat_before = path.stat()
+    journal_stat_before = journal.stat()
+
+    with pytest.raises(FilledNotionalMigrationRequired, match="reviewed copy migration"):
+        _service(path)
+
+    assert path.read_bytes() == database_before
+    assert journal.read_bytes() == journal_before
+    assert (path.stat().st_ino, path.stat().st_mtime_ns) == (
+        database_stat_before.st_ino,
+        database_stat_before.st_mtime_ns,
+    )
+    assert (journal.stat().st_ino, journal.stat().st_mtime_ns) == (
+        journal_stat_before.st_ino,
+        journal_stat_before.st_mtime_ns,
+    )
     assert not _anchor_path(path).exists()
 
 

--- a/tests/risk/test_daily_filled_notional.py
+++ b/tests/risk/test_daily_filled_notional.py
@@ -1388,6 +1388,143 @@ service.record_fill(ExecutedFill(
         ).fetchall() == [("durable",)]
 
 
+def test_hot_journal_monotonic_rejection_preserves_all_original_evidence(tmp_path):
+    if not hasattr(signal, "SIGKILL"):
+        pytest.skip("SIGKILL unavailable on this host")
+    path = tmp_path / "monotonic-replay-hot.db"
+    verifier = TestMonotonicVerifier()
+    ledger = _service(path, monotonic_verifier=verifier)
+    ledger.record_fill(_fill("older"))
+    old_database = path.read_bytes()
+    old_anchor = ledger.anchor_path.read_bytes()
+    ledger.record_fill(_fill("newer"))
+
+    path.write_bytes(old_database)
+    ledger.anchor_path.write_bytes(old_anchor)
+    os.chmod(ledger.anchor_path, 0o600)
+    script = f"""
+import signal
+import sqlite3
+
+connection = sqlite3.connect({str(path)!r}, isolation_level=None)
+connection.execute('PRAGMA journal_mode=DELETE')
+connection.execute('PRAGMA synchronous=FULL')
+connection.execute('PRAGMA cache_size=1')
+connection.execute('PRAGMA cache_spill=ON')
+connection.execute('BEGIN IMMEDIATE')
+connection.execute('CREATE TABLE spill_payload (id INTEGER PRIMARY KEY, value BLOB)')
+connection.executemany(
+    'INSERT INTO spill_payload VALUES (?, randomblob(4096))',
+    ((index,) for index in range(1, 513)),
+)
+print('READY', flush=True)
+signal.pause()
+"""
+    child = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert child.stdout is not None
+        assert child.stdout.readline().strip() == "READY"
+        os.kill(child.pid, signal.SIGKILL)
+        child.wait(timeout=10)
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait(timeout=10)
+
+    journal = Path(f"{path}-journal")
+    assert journal.exists() and journal.stat().st_size > 0
+    database_before = _file_snapshot(path)
+    journal_before = _file_snapshot(journal)
+    anchor_before = _file_snapshot(ledger.anchor_path)
+    paths_before = _path_inventory(tmp_path)
+
+    with pytest.raises(FilledNotionalIntegrityError, match="monotonic authority rejected"):
+        _service(path, monotonic_verifier=verifier)
+
+    assert _file_snapshot(path) == database_before
+    assert _file_snapshot(journal) == journal_before
+    assert _file_snapshot(ledger.anchor_path) == anchor_before
+    assert _path_inventory(tmp_path) == paths_before
+
+
+def test_hot_journal_is_revalidated_under_lock_immediately_before_recovery(tmp_path, monkeypatch):
+    if not hasattr(signal, "SIGKILL"):
+        pytest.skip("SIGKILL unavailable on this host")
+    path = tmp_path / "replaced-hot-journal.db"
+    ledger = _service(path)
+    ledger.record_fill(_fill("durable-before-replacement"))
+    script = f"""
+import signal
+import sqlite3
+
+connection = sqlite3.connect({str(path)!r}, isolation_level=None)
+connection.execute('PRAGMA journal_mode=DELETE')
+connection.execute('PRAGMA synchronous=FULL')
+connection.execute('PRAGMA cache_size=1')
+connection.execute('PRAGMA cache_spill=ON')
+connection.execute('BEGIN IMMEDIATE')
+connection.execute('CREATE TABLE spill_payload (id INTEGER PRIMARY KEY, value BLOB)')
+connection.executemany(
+    'INSERT INTO spill_payload VALUES (?, randomblob(4096))',
+    ((index,) for index in range(1, 513)),
+)
+print('READY', flush=True)
+signal.pause()
+"""
+    child = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert child.stdout is not None
+        assert child.stdout.readline().strip() == "READY"
+        os.kill(child.pid, signal.SIGKILL)
+        child.wait(timeout=10)
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait(timeout=10)
+
+    journal = Path(f"{path}-journal")
+    replacement = tmp_path / "replacement.journal"
+    replacement_bytes = bytearray(journal.read_bytes())
+    replacement_bytes[0] ^= 0xFF
+    replacement.write_bytes(replacement_bytes)
+    original_validator = DailyFilledNotional._validate_hot_journal_recovery_on_copy
+    validation_calls = 0
+
+    def replace_after_first_validation(self):
+        nonlocal validation_calls
+        validation_calls += 1
+        evidence = original_validator(self)
+        if validation_calls == 1:
+            os.replace(replacement, journal)
+        return evidence
+
+    monkeypatch.setattr(
+        DailyFilledNotional,
+        "_validate_hot_journal_recovery_on_copy",
+        replace_after_first_validation,
+    )
+    database_before = _file_snapshot(path)
+    anchor_before = _file_snapshot(ledger.anchor_path)
+
+    with pytest.raises(FilledNotionalError):
+        _service(path)
+
+    assert validation_calls == 2
+    assert _file_snapshot(path) == database_before
+    assert journal.read_bytes() == bytes(replacement_bytes)
+    assert _file_snapshot(ledger.anchor_path) == anchor_before
+
+
 def test_sigkill_spilled_hot_journal_rejects_hardlinked_main_without_mutation(tmp_path):
     if not hasattr(signal, "SIGKILL"):
         pytest.skip("SIGKILL unavailable on this host")

--- a/tests/risk/test_daily_filled_notional.py
+++ b/tests/risk/test_daily_filled_notional.py
@@ -2167,6 +2167,79 @@ signal.pause()
     assert not _anchor_path(path).exists()
 
 
+def test_authenticated_anchor_does_not_destroy_spilled_legacy_journal(tmp_path):
+    if not hasattr(signal, "SIGKILL"):
+        pytest.skip("SIGKILL unavailable on this host")
+    path = tmp_path / "anchored-legacy-spill.db"
+    ledger = _service(path)
+
+    with sqlite3.connect(path) as connection:
+        for trigger in ledger_module._TRIGGER_SQL:
+            connection.execute(f'DROP TRIGGER "{trigger}"')
+        connection.execute("ALTER TABLE daily_filled_notional_schema RENAME TO discarded_v3_schema")
+        connection.execute("""
+            CREATE TABLE daily_filled_notional_schema (
+                singleton INTEGER PRIMARY KEY,
+                schema_version INTEGER NOT NULL
+            )
+            """)
+        connection.execute("INSERT INTO daily_filled_notional_schema VALUES (1, 1)")
+        connection.execute("DROP TABLE discarded_v3_schema")
+        connection.execute("CREATE TABLE spill_payload (id INTEGER PRIMARY KEY, value BLOB)")
+        connection.executemany(
+            "INSERT INTO spill_payload VALUES (?, ?)",
+            ((index, b"a" * 4096) for index in range(1, 257)),
+        )
+
+    script = f"""
+import signal
+import sqlite3
+
+connection = sqlite3.connect({str(path)!r}, isolation_level=None)
+connection.execute('PRAGMA journal_mode=DELETE')
+connection.execute('PRAGMA synchronous=FULL')
+connection.execute('PRAGMA cache_size=1')
+connection.execute('PRAGMA cache_spill=ON')
+connection.execute('BEGIN IMMEDIATE')
+connection.execute('UPDATE daily_filled_notional_schema SET schema_version = 2')
+connection.execute('UPDATE spill_payload SET value = randomblob(4096)')
+print('READY', flush=True)
+signal.pause()
+"""
+    child = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert child.stdout is not None
+        assert child.stdout.readline().strip() == "READY"
+        os.kill(child.pid, signal.SIGKILL)
+        child.wait(timeout=10)
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait(timeout=10)
+
+    journal = Path(f"{path}-journal")
+    assert journal.exists() and journal.stat().st_size > 0
+    with sqlite3.connect(f"file:{path}?mode=ro&immutable=1", uri=True) as connection:
+        assert connection.execute(
+            "SELECT schema_version FROM daily_filled_notional_schema"
+        ).fetchone() == (2,)
+    database_before = _file_snapshot(path)
+    journal_before = _file_snapshot(journal)
+    anchor_before = _file_snapshot(ledger.anchor_path)
+
+    with pytest.raises(FilledNotionalMigrationRequired, match="reviewed copy migration"):
+        _service(path)
+
+    assert _file_snapshot(path) == database_before
+    assert _file_snapshot(journal) == journal_before
+    assert _file_snapshot(ledger.anchor_path) == anchor_before
+
+
 def test_future_schema_version_fails_closed_without_downgrade(tmp_path):
     path = tmp_path / "future.db"
     with sqlite3.connect(path) as connection:

--- a/tests/risk/test_daily_filled_notional.py
+++ b/tests/risk/test_daily_filled_notional.py
@@ -1621,6 +1621,23 @@ def test_ledger_tail_deletion_is_detected_against_independent_anchor(tmp_path):
         _service(path)
 
 
+def test_long_lived_service_rejects_middle_fill_deletion_before_total_read(tmp_path):
+    path = tmp_path / "notional.db"
+    ledger = _service(path)
+    ledger.record_fill(_fill("scope-one"))
+    ledger.record_fill(_fill("scope-two"))
+    other_portfolio = _service(path, portfolio_id="other")
+    other_portfolio.record_fill(_fill("other-scope-tail"))
+
+    with sqlite3.connect(path) as connection:
+        connection.execute("DROP TRIGGER daily_filled_notional_records_no_delete")
+        connection.execute("DELETE FROM daily_filled_notional_records WHERE sequence = 2")
+        connection.execute(ledger_module._TRIGGER_SQL["daily_filled_notional_records_no_delete"])
+
+    with pytest.raises(FilledNotionalIntegrityError, match="row counts or sequence spans"):
+        ledger.current_gross_filled_notional()
+
+
 def test_conflict_quarantine_tail_deletion_is_detected_by_anchor(tmp_path):
     path = tmp_path / "notional.db"
     ledger = _service(path)


### PR DESCRIPTION
## Outcome

Adds a dormant Gate-A ledger for exact daily gross filled-notional restoration. This slice grants no startup or order authority.

## Safety contract

- counts immutable broker execution/fill evidence only, never submitted or cancelled orders
- absolute notional for buys, sells, shorts, covers, and distinct partial fills
- exact replay idempotency; conflicting duplicate latches unavailable
- exact Decimal arithmetic isolated from ambient context
- account, portfolio, currency, and America/New_York trading-date scoping
- append-only SQLite ledger with hash-chain, schema, integrity, and DB identity validation
- restart restoration and read-only current-total query
- tamper, replacement, malformed evidence, and DB failure fail closed

## Verification

- 18 focused adversarial tests passed
- 2,670 full tests passed, 5 skipped
- targeted Black, isort, Flake8, Bandit, compileall, MyPy, pip-check, and diff checks passed
- independent adversarial review is in progress on this exact head

## Remediation scope

PR 7 / Gate A in `docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md`. Production fill ingestion and entry-risk wiring remain separate, blocked follow-ups.

Gate A remains closed. The trader remains stopped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large new risk/accounting boundary (~2.9k lines) with complex durability, anchor, and monotonic contracts; dormant today but intended for production fill limits once wired.
> 
> **Overview**
> Adds **`robo_trader/risk/filled_notional`**, a **dormant** Gate-A slice that exposes durable accounting primitives but does **not** hook into the runner, order submission, or startup.
> 
> **`DailyFilledNotional`** records only immutable broker **executions** (exact `Decimal`, NY trading-date scope per account/portfolio/currency), with idempotent replay by `broker_execution_id` and durable **conflict** markers when the same ID disagrees. Appends use an HMAC-protected **checkpoint chain** in SQLite plus a separate-directory **anchor** (pending-then-stable transitions, transition lock, inode-bound paths) and a caller-supplied **monotonic verifier** so replayed older DB+anchor pairs cannot pass as fresh.
> 
> Startup streams full chain validation; the hot path bounds work via latest checkpoint and scope totals (including a per-scope daily fill cap). Opens **fail closed** on legacy schema (migration required), WAL/hot journals, tamper, and integrity issues. **`review_quarantine`** reads conflict evidence immutably without mutating artifacts.
> 
> **`MIGRATION.md`** documents the reviewed path from v1/v2 to schema v3 without in-place rewrites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca9d0378659b399b294449990a275d3d650984f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->