### PR TITLE
feat(safety): enforce Gate-A strategy containment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,7 +75,7 @@ DATA_BAR_SIZE=5 mins            # Bar size for historical data
 # ====================
 # Strategy Configuration
 # ====================
-STRATEGY_ENABLED=momentum,mean_reversion  # Comma-separated list
+STRATEGY_ENABLED=baseline_sma  # Gate-A permits exactly this strategy
 STRATEGY_COMBINATION=weighted    # Signal combination: vote, weighted, priority
 STRATEGY_MIN_CONFIDENCE=0.6      # Minimum signal confidence
 STRATEGY_REBALANCE=daily         # Rebalance frequency

--- a/.env.template
+++ b/.env.template
@@ -15,7 +15,7 @@ TRADING_SYMBOLS=AAPL,NVDA,TSLA,GOOGL,MSFT,AMZN,META,NFLX
 
 # Enabled strategies (comma-separated)
 # Available: momentum, mean_reversion, ml_enhanced, microstructure, pairs_trading, stat_arbitrage
-STRATEGY_ENABLED_STRATEGIES=momentum,mean_reversion,ml_enhanced,microstructure,pairs_trading
+STRATEGY_ENABLED_STRATEGIES=baseline_sma
 
 # ============================================
 # INTERACTIVE BROKERS CONFIGURATION
@@ -115,10 +115,14 @@ ML_FEATURE_INTERVAL=5
 ML_CONFIDENCE_THRESHOLD=0.6
 
 # Enable ML-enhanced strategy
-ML_ENHANCED_ENABLED=true
+ML_ENHANCED_ENABLED=false
 
 # Enable smart execution algorithms
-SMART_EXECUTION_ENABLED=true
+SMART_EXECUTION_ENABLED=false
+AI_TRADING_ENABLED=false
+EXECUTION_SHORT_SELLING=false
+ML_SELECTOR_ENABLED=false
+RISK_TAKE_PROFIT_ENABLED=false
 
 # Enable advanced risk management with Kelly sizing and kill switches
 ADVANCED_RISK_ENABLED=true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -174,7 +174,7 @@ jobs:
           MODEL_ARTIFACT_SET: ci-fixtures
           BUILD_ID: github-actions
           TRADING_SYMBOLS: AAPL
-          STRATEGY_ENABLED_STRATEGIES: momentum
+          STRATEGY_ENABLED_STRATEGIES: baseline_sma
           RISK_MAX_POSITION_SIZE: "1000"
           RISK_STOP_LOSS_PERCENT: "0.02"
           RISK_MAX_DAILY_LOSS: "100"
@@ -261,7 +261,7 @@ jobs:
           MODEL_ARTIFACT_SET: ci-fixtures
           BUILD_ID: github-actions
           TRADING_SYMBOLS: AAPL
-          STRATEGY_ENABLED_STRATEGIES: momentum
+          STRATEGY_ENABLED_STRATEGIES: baseline_sma
           RISK_MAX_POSITION_SIZE: "1000"
           RISK_STOP_LOSS_PERCENT: "0.02"
           RISK_MAX_DAILY_LOSS: "100"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,7 +107,7 @@ services:
       - SAFETY_JOURNAL_PATH=${SAFETY_JOURNAL_PATH:?Set the dedicated paper safety journal path}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
       - WEBSOCKET_URL=ws://websocket:8765
-      - STRATEGY_ENABLED_STRATEGIES=${STRATEGY_ENABLED_STRATEGIES:-momentum,mean_reversion}
+      - STRATEGY_ENABLED_STRATEGIES=${STRATEGY_ENABLED_STRATEGIES:-baseline_sma}
       - RISK_MAX_POSITION_SIZE=${RISK_MAX_POSITION_SIZE:-10000}
       - RISK_STOP_LOSS_PERCENT=${RISK_STOP_LOSS_PERCENT:-0.02}
     volumes:

--- a/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
+++ b/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
@@ -1567,7 +1567,13 @@ Update after each merge.
 - PR 7: Staged. Dormant entry-risk PR #114, dormant filled-notional PR #116,
   and paper-path containment PR #117 are under review. All must remain within
   the sole Gate-A staging exception above; integration and post-PR6 strategy
-  readiness work remain open.
+  readiness work remain open. PR #117 is explicitly non-authorizing for new
+  exposure: Python code in one interpreter is one trust domain, so private
+  attributes and closure cells are not accepted as security isolation. The
+  staging slice publishes no baseline entry handle or intent, exports no BUY
+  capability issuer, and terminal baseline submission fails closed. Only
+  semantic paper reductions retain capability-backed execution until the
+  integrated risk-admission boundary is independently enforceable.
 - PR 8: Not started
 - PR 9: Not started
 - PR 10: Not started

--- a/robo_trader/config.py
+++ b/robo_trader/config.py
@@ -25,7 +25,6 @@ from .gatea_containment import (
     assert_gate_a_config,
     validate_gate_a_environment,
 )
-
 from .logger import get_logger
 from .runtime_contract_constants import PAPER_SAFETY_EXECUTION_DOMAIN_SCOPE
 from .utils.config_validator import ConfigValidator, EnhancedTradingConfig
@@ -1081,23 +1080,16 @@ def load_config_from_env() -> Config:
     config = Config(**config_dict)
 
     # Load multi-portfolio configurations
-    try:
-        from .multiuser.portfolio_config import load_portfolio_configs
+    from .multiuser.portfolio_config import load_portfolio_configs
 
+    try:
         portfolio_configs = load_portfolio_configs()
         config.portfolio_configs = [pc.to_dict() for pc in portfolio_configs]
-    except Exception as e:
-        logger.warning(f"Could not load portfolio configs: {e}")
-        # Fall back to single default portfolio
-        config.portfolio_configs = [
-            {
-                "id": "default",
-                "name": "Default Portfolio",
-                "starting_cash": config.default_cash,
-                "symbols": ",".join(config.symbols),
-                "active": True,
-            }
-        ]
+        assert_gate_a_config(config)
+    except (GateAContainmentError, TypeError, ValueError) as exc:
+        raise ConfigValidationError(
+            f"Explicit portfolio configuration violates Gate-A containment: {exc}"
+        ) from exc
 
     return config
 

--- a/robo_trader/config.py
+++ b/robo_trader/config.py
@@ -906,7 +906,7 @@ def load_config_from_env() -> Config:
     - RISK_MAX_POSITION_PCT=0.02
     - DATA_PROVIDER=IBKR
     - IBKR_HOST=127.0.0.1
-    - STRATEGY_ENABLED_STRATEGIES=momentum,mean_reversion
+    - STRATEGY_ENABLED_STRATEGIES=baseline_sma
     - MONITORING_LOG_LEVEL=INFO
 
     Returns:

--- a/robo_trader/config.py
+++ b/robo_trader/config.py
@@ -19,6 +19,13 @@ from typing import Dict, List, Literal, Mapping, Optional
 from dotenv import load_dotenv
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from .gatea_containment import (
+    ALLOWED_STRATEGIES,
+    GateAContainmentError,
+    assert_gate_a_config,
+    validate_gate_a_environment,
+)
+
 from .logger import get_logger
 from .runtime_contract_constants import PAPER_SAFETY_EXECUTION_DOMAIN_SCOPE
 from .utils.config_validator import ConfigValidator, EnhancedTradingConfig
@@ -601,6 +608,10 @@ class RiskConfig(BaseModel):
     take_profit_pct: float = Field(
         default=0.05, gt=0, le=0.2, description="Default take profit percentage"
     )
+    enable_take_profit: bool = Field(
+        default=False,
+        description="Enable take-profit execution (disabled throughout Gate A)",
+    )
     use_trailing_stop: bool = Field(
         default=True, description="Use trailing stops instead of fixed stops"
     )
@@ -717,8 +728,16 @@ class StrategyConfig(BaseModel):
     """Strategy configuration."""
 
     enabled_strategies: List[str] = Field(
-        default=["momentum", "mean_reversion", "ml_enhanced", "microstructure", "pairs_trading"],
+        default=list(ALLOWED_STRATEGIES),
         description="List of enabled strategies",
+    )
+    enable_ai_discovery: bool = Field(
+        default=False,
+        description="Enable news/AI symbol discovery (disabled throughout Gate A)",
+    )
+    enable_ml_selectors: bool = Field(
+        default=False,
+        description="Enable ML strategy/model selection (disabled throughout Gate A)",
     )
     combination_method: str = Field(
         default="weighted",
@@ -864,6 +883,11 @@ class Config(BaseModel):
         if self.execution.mode == TradingMode.PAPER and not self.ibkr.readonly:
             raise ValueError("Paper mode requires IBKR read-only client permissions")
 
+        try:
+            assert_gate_a_config(self)
+        except GateAContainmentError as exc:
+            raise ValueError(f"Gate-A containment contradiction: {exc}") from exc
+
         # Ensure production has proper monitoring
         if self.environment == Environment.PRODUCTION:
             if not self.monitoring.enable_alerts:
@@ -893,6 +917,10 @@ def load_config_from_env() -> Config:
         ConfigValidationError: If configuration fails validation
     """
     load_dotenv()
+    try:
+        gate_a_environment = validate_gate_a_environment(os.environ)
+    except GateAContainmentError as exc:
+        raise ConfigValidationError(f"Gate-A containment contradiction: {exc}") from exc
     runtime_contract = load_runtime_contract_from_env()
     logger.info(
         "Validated runtime contract: %s",
@@ -912,6 +940,7 @@ def load_config_from_env() -> Config:
             "position_timeout_hours": int(os.getenv("EXECUTION_POSITION_TIMEOUT", "24")),
             "order_timeout_seconds": int(os.getenv("EXECUTION_ORDER_TIMEOUT", "30")),
             "enable_short_selling": os.getenv("EXECUTION_SHORT_SELLING", "false").lower() == "true",
+            "use_smart_execution": False,
         },
         "risk": {
             # Use validated values for critical risk parameters
@@ -933,6 +962,7 @@ def load_config_from_env() -> Config:
             # Use STOP_LOSS_PERCENT from .env (value is in %, convert to decimal)
             "stop_loss_pct": float(os.getenv("STOP_LOSS_PERCENT", "2.0")) / 100,
             "take_profit_pct": validator.validate_percentage("RISK_TAKE_PROFIT_PCT", 0.05),
+            "enable_take_profit": False,
             # Validated notional limits
             "max_order_notional": (
                 validator.validate_positive_float("RISK_MAX_ORDER_NOTIONAL", 10000, min_value=100)
@@ -977,9 +1007,9 @@ def load_config_from_env() -> Config:
             "ssl_mode": os.getenv("IBKR_SSL_MODE", "auto").strip().lower(),
         },
         "strategy": {
-            "enabled_strategies": os.getenv("STRATEGY_ENABLED", "momentum,mean_reversion").split(
-                ","
-            ),
+            "enabled_strategies": list(gate_a_environment.enabled_strategies),
+            "enable_ai_discovery": False,
+            "enable_ml_selectors": False,
             "combination_method": os.getenv("STRATEGY_COMBINATION", "weighted"),
             "min_confidence": float(os.getenv("STRATEGY_MIN_CONFIDENCE", "0.6")),
             "rebalance_frequency": os.getenv("STRATEGY_REBALANCE", "daily"),

--- a/robo_trader/core/engine.py
+++ b/robo_trader/core/engine.py
@@ -21,6 +21,7 @@ from robo_trader.connection_manager import ConnectionManager, IBKRClient
 from robo_trader.correlation import CorrelationTracker
 from robo_trader.database import TradingDatabase
 from robo_trader.execution import AbstractExecutor, LiveExecutor, PaperExecutor
+from robo_trader.gatea_containment import assert_quarantined_alternate_engine
 from robo_trader.logger import get_logger
 from robo_trader.portfolio import Portfolio
 from robo_trader.risk_manager import RiskManager, create_risk_manager_from_config
@@ -78,6 +79,7 @@ class TradingEngine:
         Args:
             config: Configuration object
         """
+        assert_quarantined_alternate_engine("robo_trader.core.engine.TradingEngine")
         self.config = config
         self.state = EngineState.INITIALIZING
 

--- a/robo_trader/execution.py
+++ b/robo_trader/execution.py
@@ -11,8 +11,12 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 if TYPE_CHECKING:
     from .smart_execution.smart_executor import ExecutionAlgorithm, SmartExecutor
 
-from robo_trader.logger import get_logger
 from robo_trader.gatea_containment import validate_gate_a_order
+from robo_trader.logger import get_logger
+from robo_trader.paper_execution_capability import (
+    PaperExecutionCapabilityError,
+    consume_paper_execution_capability,
+)
 
 logger = get_logger(__name__)
 
@@ -31,7 +35,6 @@ class Order:
     side: str  # "BUY" or "SELL"
     price: Optional[float | Decimal] = None  # None implies market
     order_ref: Optional[str] = None
-    intent_source: str = ""
     take_profit: Optional[float | Decimal] = None
 
 
@@ -91,7 +94,6 @@ class BaseExecutor(AbstractExecutor):
 
         admitted, reason = validate_gate_a_order(
             side=side,
-            intent_source=order.intent_source,
             take_profit=order.take_profit,
         )
         if not admitted:
@@ -190,15 +192,23 @@ class PaperExecutor(BaseExecutor):
         # Standard paper execution
         return self._place_simple_order(order)
 
-    def _place_simple_order(self, order: Order) -> ExecutionResult:
+    def _place_simple_order(
+        self,
+        order: Order,
+        *,
+        _capability: object | None = None,
+    ) -> ExecutionResult:
         """Place order with simple paper execution."""
         admitted, reason = validate_gate_a_order(
             side=order.side,
-            intent_source=order.intent_source,
             take_profit=order.take_profit,
         )
         if not admitted:
             return ExecutionResult(False, reason)
+        try:
+            consume_paper_execution_capability(self, order, _capability)
+        except PaperExecutionCapabilityError as exc:
+            return ExecutionResult(False, str(exc))
 
         base: Optional[float]
         exact_base: Optional[Decimal] = None

--- a/robo_trader/execution.py
+++ b/robo_trader/execution.py
@@ -9,9 +9,10 @@ from decimal import ROUND_HALF_EVEN, Decimal
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
 if TYPE_CHECKING:
-    from .smart_execution.smart_executor import ExecutionAlgorithm, ExecutionParams, SmartExecutor
+    from .smart_execution.smart_executor import ExecutionAlgorithm, SmartExecutor
 
 from robo_trader.logger import get_logger
+from robo_trader.gatea_containment import validate_gate_a_order
 
 logger = get_logger(__name__)
 
@@ -30,6 +31,8 @@ class Order:
     side: str  # "BUY" or "SELL"
     price: Optional[float | Decimal] = None  # None implies market
     order_ref: Optional[str] = None
+    intent_source: str = ""
+    take_profit: Optional[float | Decimal] = None
 
 
 class ExecutionResult:
@@ -58,7 +61,7 @@ class AbstractExecutor:
 class BaseExecutor(AbstractExecutor):
     """Base executor with common functionality for all executor types.
 
-    Provides shared validation, smart execution support, and algorithm selection.
+    Provides shared validation. Smart execution remains quarantined in Gate A.
     """
 
     def __init__(
@@ -66,6 +69,8 @@ class BaseExecutor(AbstractExecutor):
         use_smart_execution: bool = False,
         skip_execution_delays: bool = True,
     ) -> None:
+        if use_smart_execution:
+            raise ValueError("Gate-A containment disables smart execution")
         self.use_smart_execution = use_smart_execution
         self.skip_execution_delays = skip_execution_delays
         self.smart_executor = None
@@ -75,12 +80,6 @@ class BaseExecutor(AbstractExecutor):
         self._execution_cache_ts: Dict[str, dt.datetime] = {}
         self._execution_cache_max_age_seconds: float = 60.0
 
-        # Initialize smart executor if enabled
-        if use_smart_execution:
-            from .smart_execution.smart_executor import SmartExecutor
-
-            self.smart_executor = SmartExecutor()
-
     def validate_order(self, order: Order) -> Optional[ExecutionResult]:
         """Validate order parameters. Returns error result if invalid, None if valid."""
         if order.quantity <= 0:
@@ -89,6 +88,14 @@ class BaseExecutor(AbstractExecutor):
         side = order.side.upper()
         if side not in {"BUY", "SELL", "BUY_TO_COVER", "SELL_SHORT"}:
             return ExecutionResult(False, "Invalid order side")
+
+        admitted, reason = validate_gate_a_order(
+            side=side,
+            intent_source=order.intent_source,
+            take_profit=order.take_profit,
+        )
+        if not admitted:
+            return ExecutionResult(False, reason)
 
         # Check kill switch
         kill_switch_file = "data/kill_switch.lock"
@@ -116,36 +123,7 @@ class BaseExecutor(AbstractExecutor):
 
     async def _execute_smart_order_async(self, order: Order) -> ExecutionResult:
         """Execute order using smart algorithms (async)."""
-        from .smart_execution.smart_executor import ExecutionAlgorithm
-        from .smart_execution.smart_executor import ExecutionParams as ExecParams
-
-        # Select algorithm
-        algorithm = self._select_algorithm(order)
-
-        # Create execution parameters
-        params = ExecParams(
-            algorithm=algorithm,
-            duration_minutes=5 if order.quantity < 1000 else 15,
-            slice_count=min(10, max(1, order.quantity // 100)),
-            max_participation=0.15,
-            urgency=0.7 if order.price else 0.5,
-        )
-
-        # Create and execute plan
-        plan = await self.smart_executor.create_execution_plan(
-            symbol=order.symbol, side=order.side, quantity=order.quantity, params=params
-        )
-
-        # Execute with configurable delays
-        result = await self.smart_executor.execute_plan(
-            plan, self, skip_delays=self.skip_execution_delays
-        )
-
-        # Convert to ExecutionResult
-        if result.success:
-            return ExecutionResult(True, result.message, result.average_price)
-        else:
-            return ExecutionResult(False, result.message)
+        return ExecutionResult(False, "Gate-A containment disables smart execution")
 
     async def execute_order(
         self, symbol: str, side: str, quantity: int, order_type: str, limit_price: float = None
@@ -155,22 +133,22 @@ class BaseExecutor(AbstractExecutor):
 
 
 class PaperExecutor(BaseExecutor):
-    """Enhanced paper executor with smart execution support.
+    """Simple local-paper executor for the Gate-A runtime.
 
     Models symmetric slippage (in basis points) around the limit price for both
-    buy and sell orders. Supports smart execution algorithms when configured.
+    buy and sell orders. Smart execution inputs fail closed.
 
     Args:
         slippage_bps: Slippage in basis points to apply symmetrically to fills.
                       Defaults to 0.0 (no slippage).
-        smart_executor: Optional SmartExecutor for advanced execution algorithms.
-        use_smart_execution: Whether to use smart execution for orders.
+        smart_executor: Rejected while Gate-A containment is active.
+        use_smart_execution: Rejected when true during Gate A.
 
     Attributes:
         fills: Dictionary tracking all executed orders with timestamps and fill prices.
         slippage_bps: Configured slippage in basis points.
-        smart_executor: SmartExecutor instance for advanced algorithms.
-        use_smart_execution: Flag to enable smart execution.
+        smart_executor: Always ``None`` during Gate A.
+        use_smart_execution: Always ``False`` during Gate A.
     """
 
     def __init__(
@@ -180,11 +158,11 @@ class PaperExecutor(BaseExecutor):
         use_smart_execution: bool = False,
         skip_execution_delays: bool = True,
     ) -> None:
+        if smart_executor is not None:
+            raise ValueError("Gate-A containment disables smart execution")
         super().__init__(use_smart_execution, skip_execution_delays)
         self.fills: Dict[str, Tuple[dt.datetime, Order, float]] = {}
         self.slippage_bps = float(slippage_bps)
-        if smart_executor:
-            self.smart_executor = smart_executor
 
     def place_order(self, order: Order) -> ExecutionResult:
         """Place order with optional smart execution."""
@@ -193,9 +171,8 @@ class PaperExecutor(BaseExecutor):
         if validation_result:
             return validation_result
 
-        # Use smart execution if enabled and available
-        if self.use_smart_execution and self.smart_executor:
-            return self._place_smart_order(order)
+        if self.use_smart_execution or self.smart_executor is not None:
+            return ExecutionResult(False, "Gate-A containment disables smart execution")
 
         # Standard paper execution
         return self._place_simple_order(order)
@@ -207,23 +184,22 @@ class PaperExecutor(BaseExecutor):
         if validation_result:
             return validation_result
 
-        # Use smart execution if enabled and available
-        if self.use_smart_execution and self.smart_executor:
-            try:
-                return await self._execute_smart_order_async(order)
-            except Exception as e:
-                logger.warning(
-                    "Smart execution failed, falling back to simple",
-                    error=str(e),
-                    symbol=order.symbol,
-                )
-                return self._place_simple_order(order)
+        if self.use_smart_execution or self.smart_executor is not None:
+            return ExecutionResult(False, "Gate-A containment disables smart execution")
 
         # Standard paper execution
         return self._place_simple_order(order)
 
     def _place_simple_order(self, order: Order) -> ExecutionResult:
         """Place order with simple paper execution."""
+        admitted, reason = validate_gate_a_order(
+            side=order.side,
+            intent_source=order.intent_source,
+            take_profit=order.take_profit,
+        )
+        if not admitted:
+            return ExecutionResult(False, reason)
+
         base: Optional[float]
         exact_base: Optional[Decimal] = None
 
@@ -347,66 +323,17 @@ class PaperExecutor(BaseExecutor):
 
     def _place_smart_order(self, order: Order) -> ExecutionResult:
         """Place order using smart execution algorithms."""
-        try:
-            # Check if there's already an event loop running
-            try:
-                loop = asyncio.get_running_loop()
-                # We're in an async context but called synchronously
-                # Log warning and fall back to simple execution
-                logger.warning(
-                    "Smart execution called synchronously from async context, using simple execution",
-                    symbol=order.symbol,
-                )
-                return self._place_simple_order(order)
-            except RuntimeError:
-                # No event loop running, create one
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-                try:
-                    result = loop.run_until_complete(self._execute_smart_order_async(order))
-                    return result
-                finally:
-                    loop.close()
-        except Exception as e:
-            # Fallback to simple execution on error
-            logger.warning(
-                "Smart execution failed, falling back to simple", error=str(e), symbol=order.symbol
-            )
-            return self._place_simple_order(order)
+        return ExecutionResult(False, "Gate-A containment disables smart execution")
 
     async def _execute_smart_order_async(self, order: Order) -> ExecutionResult:
         """Execute order using smart algorithms (async)."""
-        result = await super()._execute_smart_order_async(order)
-
-        # Store fill if successful
-        if result.ok:
-            self.fills[f"{order.symbol}-{len(self.fills)+1}"] = (
-                dt.datetime.utcnow(),
-                order,
-                result.fill_price,
-            )
-
-        return result
+        return ExecutionResult(False, "Gate-A containment disables smart execution")
 
     async def execute_order(
         self, symbol: str, side: str, quantity: int, order_type: str, limit_price: float = None
     ) -> Dict[str, Any]:
         """Execute order for smart executor (async method for slices)."""
-        # Create an Order object
-        order = Order(symbol=symbol, quantity=quantity, side=side, price=limit_price)
-
-        # Execute using paper fills
-        result = self._place_simple_order(order)
-
-        # Return in the format expected by smart executor
-        if result.ok:
-            return {
-                "executed_quantity": quantity,
-                "price": result.fill_price,
-                "timestamp": dt.datetime.now(),
-            }
-        else:
-            return {"executed_quantity": 0, "price": 0, "timestamp": dt.datetime.now()}
+        return {"executed_quantity": 0, "price": 0, "timestamp": dt.datetime.now()}
 
 
 class LiveExecutor(BaseExecutor):

--- a/robo_trader/execution.py
+++ b/robo_trader/execution.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import datetime as dt
-import math
 import os
 from dataclasses import dataclass
-from decimal import ROUND_HALF_EVEN, Decimal
+from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
 if TYPE_CHECKING:
@@ -15,7 +14,7 @@ from robo_trader.gatea_containment import validate_gate_a_order
 from robo_trader.logger import get_logger
 from robo_trader.paper_execution_capability import (
     PaperExecutionCapabilityError,
-    consume_paper_execution_capability,
+    _execute_sealed_paper_fill,
 )
 
 logger = get_logger(__name__)
@@ -25,7 +24,6 @@ logger = get_logger(__name__)
 # cannot weaken it accidentally. PR 11 will replace this executor with a
 # reviewed broker lifecycle adapter rather than flipping this constant.
 LIVE_TRADING_CAPABILITY_ENABLED = False
-_PAPER_FILL_PRICE_TICK = Decimal("0.0001")
 
 
 @dataclass
@@ -206,130 +204,9 @@ class PaperExecutor(BaseExecutor):
         if not admitted:
             return ExecutionResult(False, reason)
         try:
-            consume_paper_execution_capability(self, order, _capability)
+            return _execute_sealed_paper_fill(self, order, _capability)
         except PaperExecutionCapabilityError as exc:
             return ExecutionResult(False, str(exc))
-
-        base: Optional[float]
-        exact_base: Optional[Decimal] = None
-
-        if order.price is not None:
-            if type(order.price) is Decimal:
-                if not order.price.is_finite() or order.price <= 0:
-                    logger.error(
-                        "Invalid exact price provided for paper order",
-                        symbol=order.symbol,
-                    )
-                    return ExecutionResult(False, "Invalid price for paper execution")
-                exact_base = order.price
-                base = float(exact_base)
-            else:
-                try:
-                    base = float(order.price)
-                except (TypeError, ValueError):
-                    logger.error(
-                        "Invalid price provided for paper order",
-                        symbol=order.symbol,
-                        price=order.price,
-                    )
-                    return ExecutionResult(False, "Invalid price for paper execution")
-            if not math.isfinite(base):
-                logger.error(
-                    "Non-finite price provided for paper order",
-                    symbol=order.symbol,
-                    price=order.price,
-                )
-                return ExecutionResult(False, "Non-finite price for paper execution")
-            if base <= 0:
-                logger.error(
-                    "Non-positive price provided for paper order",
-                    symbol=order.symbol,
-                    price=order.price,
-                )
-                return ExecutionResult(False, "Non-positive price for paper execution")
-            self._execution_cache[order.symbol] = base
-            self._execution_cache_ts[order.symbol] = dt.datetime.utcnow()
-        else:
-            base = self._execution_cache.get(order.symbol)
-            if base is None:
-                logger.error(
-                    "Missing reference price for market order in paper execution",
-                    symbol=order.symbol,
-                )
-                return ExecutionResult(False, "No reference price for market order")
-            # Stale-price fallback guard (TC-L3): if the last cached price is
-            # older than max-age, refuse the order rather than fill at stale data.
-            ts = self._execution_cache_ts.get(order.symbol)
-            if (
-                ts is None
-                or (dt.datetime.utcnow() - ts).total_seconds()
-                > self._execution_cache_max_age_seconds
-            ):
-                logger.error(
-                    "Stale cached reference price for market order in paper execution",
-                    symbol=order.symbol,
-                )
-                return ExecutionResult(False, "Stale reference price for market order")
-
-        fill_decimal: Decimal
-        if exact_base is not None:
-            # The safety adapter passes a bounded, tick-quantized Decimal.
-            # Preserve it through all slippage arithmetic; only the legacy
-            # ExecutionResult boundary converts the final paper fill to float.
-            slip_decimal = (
-                exact_base * Decimal(str(self.slippage_bps)) / Decimal("10000")
-                if self.slippage_bps
-                else Decimal("0")
-            )
-            unrounded_fill = (
-                exact_base + slip_decimal
-                if order.side.upper() in {"BUY", "BUY_TO_COVER"}
-                else exact_base - slip_decimal
-            )
-            if not unrounded_fill.is_finite() or unrounded_fill <= 0:
-                logger.error(
-                    "Paper slippage produced an invalid exact fill",
-                    symbol=order.symbol,
-                )
-                return ExecutionResult(False, "Invalid paper execution fill")
-            # Normalize the simulator's authoritative fill before either the
-            # durable exact-value path or its legacy float compatibility view
-            # observes it. Arbitrary finite float slippage otherwise produces
-            # a high-scale Decimal whose float round-trip no longer matches,
-            # after the fill has already been recorded.
-            fill_decimal = unrounded_fill.quantize(
-                _PAPER_FILL_PRICE_TICK,
-                rounding=ROUND_HALF_EVEN,
-            )
-            fill = float(fill_decimal)
-        else:
-            # Apply symmetric slippage in basis points
-            slip = base * (self.slippage_bps / 10_000.0) if self.slippage_bps else 0.0
-
-            # Handle all order sides including short selling
-            if order.side.upper() in {"BUY", "BUY_TO_COVER"}:
-                fill = base + slip
-            else:  # SELL or SELL_SHORT
-                fill = base - slip
-            fill_decimal = Decimal(str(fill))
-        if not math.isfinite(fill) or fill <= 0:
-            logger.error(
-                "Paper slippage produced an invalid fill",
-                symbol=order.symbol,
-            )
-            return ExecutionResult(False, "Invalid paper execution fill")
-
-        self.fills[f"{order.symbol}-{len(self.fills)+1}"] = (
-            dt.datetime.utcnow(),
-            order,
-            fill,
-        )
-        return ExecutionResult(
-            True,
-            "Paper fill",
-            fill,
-            exact_fill_price=fill_decimal,
-        )
 
     def _place_smart_order(self, order: Order) -> ExecutionResult:
         """Place order using smart execution algorithms."""

--- a/robo_trader/gatea_containment.py
+++ b/robo_trader/gatea_containment.py
@@ -1,0 +1,163 @@
+"""Machine-enforced Gate-A strategy and order containment.
+
+Gate A intentionally supports one narrow runtime profile: local paper execution,
+simple long entries from the baseline SMA strategy, and semantic reductions.
+Advanced entry producers stay unavailable until their full PR 7/11 contracts
+and evidence gates are implemented.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+GATE_A_PROFILE = "gate-a-simple-long-only-v1"
+BASELINE_ENTRY_SOURCE = "baseline_sma"
+ALLOWED_STRATEGIES = (BASELINE_ENTRY_SOURCE,)
+REDUCTION_SIDES = frozenset({"SELL", "BUY_TO_COVER"})
+
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+_FALSE_VALUES = frozenset({"0", "false", "no", "off"})
+_DISABLED_ENV_FLAGS = (
+    "AI_TRADING_ENABLED",
+    "EXECUTION_SHORT_SELLING",
+    "ML_ENHANCED_ENABLED",
+    "ML_SELECTOR_ENABLED",
+    "RISK_TAKE_PROFIT_ENABLED",
+    "SMART_EXECUTION_ENABLED",
+)
+
+
+class GateAContainmentError(ValueError):
+    """Configuration or intent would escape the Gate-A paper profile."""
+
+
+def _strict_bool(env: Mapping[str, str], name: str, *, default: bool = False) -> bool:
+    raw = env.get(name)
+    if raw is None:
+        return default
+    normalized = str(raw).strip().casefold()
+    if normalized in _TRUE_VALUES:
+        return True
+    if normalized in _FALSE_VALUES:
+        return False
+    raise GateAContainmentError(f"{name} must be an explicit boolean")
+
+
+def _strategy_list(raw: str, name: str) -> tuple[str, ...]:
+    strategies = tuple(item.strip().casefold() for item in raw.split(",") if item.strip())
+    if not strategies or len(strategies) != len(set(strategies)):
+        raise GateAContainmentError(f"{name} must contain unique nonempty strategies")
+    return strategies
+
+
+@dataclass(frozen=True, slots=True)
+class GateAEnvironment:
+    enabled_strategies: tuple[str, ...]
+
+
+def validate_gate_a_environment(env: Mapping[str, str]) -> GateAEnvironment:
+    """Reject every legacy toggle that contradicts the Gate-A profile."""
+
+    for name in _DISABLED_ENV_FLAGS:
+        if _strict_bool(env, name):
+            raise GateAContainmentError(f"{name}=true is disabled by {GATE_A_PROFILE}")
+
+    primary = env.get("STRATEGY_ENABLED")
+    legacy = env.get("STRATEGY_ENABLED_STRATEGIES")
+    primary_values = _strategy_list(primary, "STRATEGY_ENABLED") if primary is not None else None
+    legacy_values = (
+        _strategy_list(legacy, "STRATEGY_ENABLED_STRATEGIES") if legacy is not None else None
+    )
+    if primary_values is not None and legacy_values is not None and primary_values != legacy_values:
+        raise GateAContainmentError(
+            "STRATEGY_ENABLED and STRATEGY_ENABLED_STRATEGIES contradict each other"
+        )
+    enabled = primary_values or legacy_values or ALLOWED_STRATEGIES
+    if enabled != ALLOWED_STRATEGIES:
+        raise GateAContainmentError(
+            f"Gate A requires exactly {','.join(ALLOWED_STRATEGIES)}; configured={','.join(enabled)}"
+        )
+    return GateAEnvironment(enabled_strategies=enabled)
+
+
+def assert_gate_a_config(config: object) -> None:
+    """Validate direct or environment-built Config objects fail closed."""
+
+    execution = getattr(config, "execution", None)
+    strategy = getattr(config, "strategy", None)
+    risk = getattr(config, "risk", None)
+    mode = getattr(execution, "mode", None)
+    mode_value = getattr(mode, "value", mode)
+    enabled = tuple(
+        str(item).strip().casefold() for item in getattr(strategy, "enabled_strategies", ())
+    )
+    contradictions: list[str] = []
+    if mode_value not in {"paper", "backtest"}:
+        contradictions.append("execution.mode must be paper or offline backtest")
+    if getattr(execution, "enable_short_selling", None) is not False:
+        contradictions.append("new shorts must be disabled")
+    if getattr(execution, "use_smart_execution", None) is not False:
+        contradictions.append("smart execution must be disabled")
+    if enabled != ALLOWED_STRATEGIES:
+        contradictions.append("only baseline_sma may be enabled")
+    if getattr(strategy, "enable_ai_discovery", None) is not False:
+        contradictions.append("AI discovery must be disabled")
+    if getattr(strategy, "enable_ml_selectors", None) is not False:
+        contradictions.append("ML selectors must be disabled")
+    if getattr(risk, "enable_take_profit", None) is not False:
+        contradictions.append("take-profit execution must be disabled")
+    if contradictions:
+        raise GateAContainmentError("; ".join(contradictions))
+
+
+def assert_gate_a_runner_options(
+    *,
+    use_ml_strategy: bool,
+    use_ml_enhanced: bool | None,
+    use_smart_execution: bool | None,
+    env: Mapping[str, str],
+) -> None:
+    """Reject constructor/legacy environment attempts to enable advanced entries."""
+
+    validate_gate_a_environment(env)
+    if use_ml_strategy is not False:
+        raise GateAContainmentError("ML strategy selection is disabled by Gate A")
+    if use_ml_enhanced is True:
+        raise GateAContainmentError("ML-enhanced strategy selection is disabled by Gate A")
+    if use_smart_execution is True:
+        raise GateAContainmentError("smart execution is disabled by Gate A")
+
+
+def normalize_entry_source(source: object) -> str:
+    return str(source or "").strip().casefold()
+
+
+def validate_gate_a_order(
+    *,
+    side: object,
+    intent_source: object,
+    take_profit: object,
+) -> tuple[bool, str]:
+    """Admit one simple long entry shape or a semantic reduction."""
+
+    normalized_side = str(side or "").strip().upper()
+    if take_profit is not None:
+        return False, "Gate-A take-profit execution is quarantined"
+    if normalized_side in REDUCTION_SIDES:
+        return True, "Gate-A semantic reduction"
+    if normalized_side == "SELL_SHORT":
+        return False, "Gate-A profile blocks new short exposure"
+    if normalized_side != "BUY":
+        return False, "Gate-A profile rejects unsupported order side"
+    if normalize_entry_source(intent_source) != BASELINE_ENTRY_SOURCE:
+        return False, "Gate-A entry source is not the baseline SMA strategy"
+    return True, "Gate-A simple long entry"
+
+
+def assert_quarantined_alternate_engine(component: str) -> None:
+    """Prevent unused entry-capable engines from becoming a second runtime."""
+
+    raise GateAContainmentError(
+        f"{component} is quarantined by {GATE_A_PROFILE}; use robo_trader.runner_async.AsyncRunner"
+    )

--- a/robo_trader/gatea_containment.py
+++ b/robo_trader/gatea_containment.py
@@ -1,9 +1,9 @@
 """Machine-enforced Gate-A strategy and order containment.
 
-Gate A intentionally supports one narrow runtime profile: local paper execution,
-simple long entries from the baseline SMA strategy, and semantic reductions.
-Advanced entry producers stay unavailable until their full PR 7/11 contracts
-and evidence gates are implemented.
+This staging slice permits baseline SMA signal observation and semantic paper
+reductions, but it mints no authority for a risk-increasing order. Python code
+inside one interpreter is one trust domain, so an independently enforceable
+entry-risk boundary must land before even baseline BUY execution is enabled.
 """
 
 from __future__ import annotations
@@ -185,7 +185,7 @@ def validate_gate_a_order(
         return False, "Gate-A profile blocks new short exposure"
     if normalized_side != "BUY":
         return False, "Gate-A profile rejects unsupported order side"
-    return True, "Gate-A simple long candidate requires terminal capability"
+    return True, "Gate-A baseline candidate has no terminal authority in this staging slice"
 
 
 def assert_quarantined_alternate_engine(component: str) -> None:

--- a/robo_trader/gatea_containment.py
+++ b/robo_trader/gatea_containment.py
@@ -8,7 +8,7 @@ and evidence gates are implemented.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 
 GATE_A_PROFILE = "gate-a-simple-long-only-v1"
@@ -48,6 +48,32 @@ def _strategy_list(raw: str, name: str) -> tuple[str, ...]:
     strategies = tuple(item.strip().casefold() for item in raw.split(",") if item.strip())
     if not strategies or len(strategies) != len(set(strategies)):
         raise GateAContainmentError(f"{name} must contain unique nonempty strategies")
+    return strategies
+
+
+def validate_gate_a_portfolio_strategies(
+    value: object,
+    *,
+    name: str,
+) -> tuple[str, ...]:
+    """Validate an explicitly supplied per-portfolio strategy override."""
+
+    if type(value) is str:
+        strategies = _strategy_list(value, name)
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        if any(type(item) is not str for item in value):
+            raise GateAContainmentError(f"{name} must contain only strings")
+        strategies = tuple(item.strip().casefold() for item in value)
+        if (
+            not strategies
+            or any(not item for item in strategies)
+            or len(strategies) != len(set(strategies))
+        ):
+            raise GateAContainmentError(f"{name} must contain unique nonempty strategies")
+    else:
+        raise GateAContainmentError(f"{name} must be a string or sequence")
+    if strategies != ALLOWED_STRATEGIES:
+        raise GateAContainmentError(f"{name} requires exactly baseline_sma")
     return strategies
 
 
@@ -107,6 +133,20 @@ def assert_gate_a_config(config: object) -> None:
         contradictions.append("ML selectors must be disabled")
     if getattr(risk, "enable_take_profit", None) is not False:
         contradictions.append("take-profit execution must be disabled")
+    portfolio_configs = getattr(config, "portfolio_configs", ())
+    for index, portfolio in enumerate(portfolio_configs):
+        if not isinstance(portfolio, Mapping):
+            contradictions.append(f"portfolio_configs[{index}] must be a mapping")
+            continue
+        if "enabled_strategies" not in portfolio or portfolio["enabled_strategies"] is None:
+            continue
+        try:
+            validate_gate_a_portfolio_strategies(
+                portfolio["enabled_strategies"],
+                name=f"portfolio_configs[{index}].enabled_strategies",
+            )
+        except GateAContainmentError as exc:
+            contradictions.append(str(exc))
     if contradictions:
         raise GateAContainmentError("; ".join(contradictions))
 
@@ -129,17 +169,12 @@ def assert_gate_a_runner_options(
         raise GateAContainmentError("smart execution is disabled by Gate A")
 
 
-def normalize_entry_source(source: object) -> str:
-    return str(source or "").strip().casefold()
-
-
 def validate_gate_a_order(
     *,
     side: object,
-    intent_source: object,
     take_profit: object,
 ) -> tuple[bool, str]:
-    """Admit one simple long entry shape or a semantic reduction."""
+    """Validate Gate-A order shape before capability-backed submission."""
 
     normalized_side = str(side or "").strip().upper()
     if take_profit is not None:
@@ -150,9 +185,7 @@ def validate_gate_a_order(
         return False, "Gate-A profile blocks new short exposure"
     if normalized_side != "BUY":
         return False, "Gate-A profile rejects unsupported order side"
-    if normalize_entry_source(intent_source) != BASELINE_ENTRY_SOURCE:
-        return False, "Gate-A entry source is not the baseline SMA strategy"
-    return True, "Gate-A simple long entry"
+    return True, "Gate-A simple long candidate requires terminal capability"
 
 
 def assert_quarantined_alternate_engine(component: str) -> None:

--- a/robo_trader/multiuser/portfolio_config.py
+++ b/robo_trader/multiuser/portfolio_config.py
@@ -16,6 +16,7 @@ import os
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
+from ..gatea_containment import validate_gate_a_portfolio_strategies
 from ..logger import get_logger
 
 logger = get_logger(__name__)
@@ -93,6 +94,15 @@ class PortfolioConfig:
     enabled_strategies: Optional[List[str]] = None
     min_confidence: Optional[float] = None
 
+    def __post_init__(self) -> None:
+        if self.enabled_strategies is not None:
+            self.enabled_strategies = list(
+                validate_gate_a_portfolio_strategies(
+                    self.enabled_strategies,
+                    name=f"portfolio '{self.id}' enabled_strategies",
+                )
+            )
+
     def get_risk_param(self, param_name: str, global_default):
         """Get a risk parameter, falling back to global default if not overridden."""
         local_value = getattr(self, param_name, None)
@@ -127,11 +137,14 @@ class PortfolioConfig:
         if isinstance(symbols, str):
             symbols = [s.strip() for s in symbols.split(",") if s.strip()]
 
-        strategies = data.get("enabled_strategies")
-        if isinstance(strategies, str) and strategies:
-            strategies = [s.strip() for s in strategies.split(",") if s.strip()]
-        elif not strategies:
-            strategies = None
+        strategies = None
+        if "enabled_strategies" in data and data["enabled_strategies"] is not None:
+            strategies = list(
+                validate_gate_a_portfolio_strategies(
+                    data["enabled_strategies"],
+                    name=f"portfolio '{data.get('id', 'unknown')}' enabled_strategies",
+                )
+            )
 
         # Validate starting_cash with meaningful error
         try:
@@ -206,7 +219,9 @@ def load_portfolio_configs() -> List[PortfolioConfig]:
     """
     portfolios_json = os.getenv("PORTFOLIOS")
 
-    if portfolios_json:
+    if portfolios_json is not None:
+        if not portfolios_json.strip():
+            raise ValueError("PORTFOLIOS must not be empty when explicitly configured")
         try:
             raw_list = json.loads(portfolios_json)
             if not isinstance(raw_list, list) or len(raw_list) == 0:

--- a/robo_trader/order_manager.py
+++ b/robo_trader/order_manager.py
@@ -128,7 +128,7 @@ class OrderManager:
         }
 
         # Statistics
-        self.stats = {
+        self.stats: Dict[str, float] = {
             "total_orders": 0,
             "successful_fills": 0,
             "partial_fills": 0,
@@ -238,6 +238,20 @@ class OrderManager:
     async def _submit_with_retry(self, order: OrderDetails, executor) -> bool:
         """Submit order with exponential backoff retry."""
 
+        from .execution import PaperExecutor
+
+        if type(executor) is not PaperExecutor:
+            order.status = OrderStatus.ERROR
+            order.error_message = (
+                "Gate-A order manager requires the exact contained PaperExecutor; "
+                "simulated or alternate submission is disabled"
+            )
+            order.last_update = datetime.now()
+            self.pending_orders.discard(order.id)
+            self.stats["errors"] += 1
+            await self._trigger_callbacks("error", order)
+            return False
+
         for attempt in range(self.max_retries):
             try:
                 # Update retry count
@@ -269,14 +283,6 @@ class OrderManager:
                     else:
                         order.error_message = result.message
                         logger.warning(f"Order submission failed: {result.message}")
-                else:
-                    # Simulate submission for testing
-                    order.status = OrderStatus.SUBMITTED
-                    order.submitted_at = datetime.now()
-                    self.pending_orders.discard(order.id)
-                    self.active_orders.add(order.id)
-                    return True
-
             except Exception as e:
                 order.error_message = str(e)
                 logger.error(

--- a/robo_trader/paper_execution_capability.py
+++ b/robo_trader/paper_execution_capability.py
@@ -14,7 +14,7 @@ import datetime as dt
 import math
 import threading
 import weakref
-from dataclasses import dataclass
+from dataclasses import dataclass, replace as dataclass_replace
 from decimal import ROUND_HALF_EVEN, Decimal
 from enum import Enum
 from typing import TYPE_CHECKING, cast
@@ -45,761 +45,6 @@ class _OrderFingerprint:
     take_profit: object
 
 
-class _PaperExecutionCapability:
-    """Immutable opaque identity; validity lives in the private registry."""
-
-    __slots__ = ("__weakref__",)
-
-    def __new__(cls, *, _token: object | None = None):
-        if _token is not _CAPABILITY_TOKEN:
-            raise PaperExecutionCapabilityError(
-                "paper execution capabilities are minted only by a bound authority"
-            )
-        return super().__new__(cls)
-
-    def __copy__(self):
-        with _REGISTRY_LOCK:
-            record = _CAPABILITIES.get(self)
-            if type(record) is _CapabilityRecord:
-                record.consumed = True
-        raise PaperExecutionCapabilityError("paper execution capabilities cannot copy")
-
-    def __deepcopy__(self, _memo):
-        return self.__copy__()
-
-    def __reduce__(self):
-        with _REGISTRY_LOCK:
-            record = _CAPABILITIES.get(self)
-            if type(record) is _CapabilityRecord:
-                record.consumed = True
-        raise PaperExecutionCapabilityError("paper execution capabilities cannot serialize")
-
-
-class _GatewayExecutionBindingCapability:
-    """Opaque one-shot grant issued only during exact gateway registration."""
-
-    __slots__ = ("__weakref__",)
-
-    def __new__(cls, *, _token: object | None = None):
-        if _token is not _BIND_CAPABILITY_TOKEN:
-            raise PaperExecutionCapabilityError(
-                "gateway execution binding capabilities are issuer-only"
-            )
-        return super().__new__(cls)
-
-    def __copy__(self):
-        with _REGISTRY_LOCK:
-            record = _GATEWAY_BINDINGS.get(self)
-            if type(record) is _GatewayBindingRecord:
-                record.consumed = True
-        raise PaperExecutionCapabilityError("gateway execution binding capabilities cannot copy")
-
-    def __deepcopy__(self, _memo):
-        return self.__copy__()
-
-    def __reduce__(self):
-        with _REGISTRY_LOCK:
-            record = _GATEWAY_BINDINGS.get(self)
-            if type(record) is _GatewayBindingRecord:
-                record.consumed = True
-        raise PaperExecutionCapabilityError(
-            "gateway execution binding capabilities cannot serialize"
-        )
-
-
-class _GatewayReductionBindingCapability:
-    """Opaque one-shot grant for the reduction half of registration."""
-
-    __slots__ = ("__weakref__",)
-
-    def __new__(cls, *, _token: object | None = None):
-        if _token is not _REDUCTION_BIND_CAPABILITY_TOKEN:
-            raise PaperExecutionCapabilityError("reduction binding capability is issuer-only")
-        return super().__new__(cls)
-
-    def __copy__(self):
-        with _REGISTRY_LOCK:
-            record = _REDUCTION_BINDINGS.get(self)
-            if type(record) is _ReductionBindingRecord:
-                record.consumed = True
-        raise PaperExecutionCapabilityError("reduction binding capability cannot copy")
-
-    def __deepcopy__(self, _memo):
-        return self.__copy__()
-
-    def __reduce__(self):
-        raise PaperExecutionCapabilityError("reduction binding capability cannot serialize")
-
-
-class _BaselineTerminalDispatch:
-    __slots__ = ("__weakref__",)
-
-    def __new__(cls, *, _token: object | None = None):
-        if _token is not _TERMINAL_DISPATCH_TOKEN:
-            raise PaperExecutionCapabilityError("baseline terminal dispatch is issuer-only")
-        return super().__new__(cls)
-
-    def __copy__(self):
-        with _REGISTRY_LOCK:
-            record = _BASELINE_DISPATCHES.get(self)
-            if type(record) is _TerminalDispatchRecord:
-                record.consumed = True
-        raise PaperExecutionCapabilityError("baseline terminal dispatch cannot copy")
-
-    def __deepcopy__(self, _memo):
-        return self.__copy__()
-
-    def __reduce__(self):
-        with _REGISTRY_LOCK:
-            record = _BASELINE_DISPATCHES.get(self)
-            if type(record) is _TerminalDispatchRecord:
-                record.consumed = True
-        raise PaperExecutionCapabilityError("baseline terminal dispatch cannot serialize")
-
-
-class _ReductionTerminalDispatch:
-    __slots__ = ("__weakref__",)
-
-    def __new__(cls, *, _token: object | None = None):
-        if _token is not _TERMINAL_DISPATCH_TOKEN:
-            raise PaperExecutionCapabilityError("reduction terminal dispatch is issuer-only")
-        return super().__new__(cls)
-
-    def __copy__(self):
-        with _REGISTRY_LOCK:
-            record = _REDUCTION_DISPATCHES.get(self)
-            if type(record) is _TerminalDispatchRecord:
-                record.consumed = True
-        raise PaperExecutionCapabilityError("reduction terminal dispatch cannot copy")
-
-    def __deepcopy__(self, _memo):
-        return self.__copy__()
-
-    def __reduce__(self):
-        with _REGISTRY_LOCK:
-            record = _REDUCTION_DISPATCHES.get(self)
-            if type(record) is _TerminalDispatchRecord:
-                record.consumed = True
-        raise PaperExecutionCapabilityError("reduction terminal dispatch cannot serialize")
-
-
-@dataclass(slots=True)
-class _CapabilityRecord:
-    authority: object
-    executor: object
-    order: object
-    portfolio_id: str
-    kind: _CapabilityKind
-    fingerprint: _OrderFingerprint
-    pre_position_quantity: Decimal | None
-    consumed: bool = False
-    validated: bool = False
-    fill_consumed: bool = False
-
-
-@dataclass(slots=True)
-class _GatewayBindingRecord:
-    gateway: object
-    runtime_context: object
-    binding_session: object
-    executor: object
-    portfolio_id: str
-    consumed: bool = False
-
-
-@dataclass(slots=True)
-class _BaselineBindingRecord:
-    gateway: object
-    runtime_context: object
-    executor: object
-    portfolio_id: str
-
-
-@dataclass(slots=True)
-class _ReductionBindingRecord(_GatewayBindingRecord):
-    coordinator: object = None
-
-
-@dataclass(slots=True)
-class _ReductionAuthorityRecord:
-    gateway: object
-    runtime_context: object
-    executor: object
-    portfolio_id: str
-    coordinator: object
-    submitter: object | None = None
-
-
-@dataclass(slots=True)
-class _TerminalDispatchRecord:
-    binding: object | None
-    gateway: object | None
-    runtime_context: object | None
-    active_session: object | None
-    submitter: object | None
-    coordinator: object | None
-    executor: object
-    portfolio_id: str
-    fingerprint: _OrderFingerprint
-    pre_position_quantity: Decimal | None
-    consumed: bool = False
-
-
-_BIND_CAPABILITY_TOKEN = object()
-_REDUCTION_BIND_CAPABILITY_TOKEN = object()
-_REDUCTION_AUTHORITY_TOKEN = object()
-_BASELINE_BIND_TOKEN = object()
-_TERMINAL_DISPATCH_TOKEN = object()
-_CAPABILITY_TOKEN = object()
-_REGISTRY_LOCK = threading.Lock()
-_CAPABILITIES: weakref.WeakKeyDictionary[_PaperExecutionCapability, _CapabilityRecord] = (
-    weakref.WeakKeyDictionary()
-)
-_GATEWAY_BINDINGS: weakref.WeakKeyDictionary[
-    _GatewayExecutionBindingCapability, _GatewayBindingRecord
-] = weakref.WeakKeyDictionary()
-_BASELINE_BINDINGS: weakref.WeakKeyDictionary[
-    _GatewayBaselineExecutionBinding, _BaselineBindingRecord
-] = weakref.WeakKeyDictionary()
-_REDUCTION_BINDINGS: weakref.WeakKeyDictionary[
-    _GatewayReductionBindingCapability, _ReductionBindingRecord
-] = weakref.WeakKeyDictionary()
-_REDUCTION_AUTHORITIES: weakref.WeakKeyDictionary[
-    PaperReductionExecutionAuthority, _ReductionAuthorityRecord
-] = weakref.WeakKeyDictionary()
-_BASELINE_DISPATCHES: weakref.WeakKeyDictionary[
-    _BaselineTerminalDispatch, _TerminalDispatchRecord
-] = weakref.WeakKeyDictionary()
-_REDUCTION_DISPATCHES: weakref.WeakKeyDictionary[
-    _ReductionTerminalDispatch, _TerminalDispatchRecord
-] = weakref.WeakKeyDictionary()
-
-
-class PaperReductionExecutionAuthority:
-    """Opaque methodless identity for one gateway-bound reduction runtime."""
-
-    __slots__ = ("__weakref__",)
-
-    def __new__(cls, *, _token: object | None = None):
-        if _token is not _REDUCTION_AUTHORITY_TOKEN:
-            raise PaperExecutionCapabilityError("paper reduction authority is gateway-only")
-        return super().__new__(cls)
-
-    def __copy__(self):
-        raise PaperExecutionCapabilityError("paper reduction authority cannot copy")
-
-    def __deepcopy__(self, _memo):
-        return self.__copy__()
-
-    def __reduce__(self):
-        raise PaperExecutionCapabilityError("paper reduction authority cannot serialize")
-
-
-class _GatewayBaselineExecutionBinding:
-    """Opaque registry-backed identity for one baseline runtime binding."""
-
-    __slots__ = ("__weakref__",)
-
-    def __new__(cls, *, _token: object | None = None):
-        if _token is not _BASELINE_BIND_TOKEN:
-            raise PaperExecutionCapabilityError("baseline execution binding is gateway-only")
-        return super().__new__(cls)
-
-    def __copy__(self):
-        raise PaperExecutionCapabilityError("baseline execution binding cannot copy")
-
-    def __deepcopy__(self, _memo):
-        return self.__copy__()
-
-    def __reduce__(self):
-        raise PaperExecutionCapabilityError("baseline execution binding cannot serialize")
-
-
-def _issue_gateway_execution_binding_capability(
-    *,
-    gateway: object,
-    runtime_context: object,
-    binding_session: object,
-    executor: object,
-    portfolio_id: str,
-) -> _GatewayExecutionBindingCapability:
-    """Issue one bind grant only inside an exact started gateway session."""
-
-    _validate_gateway_binding_scope(
-        gateway=gateway,
-        runtime_context=runtime_context,
-        binding_session=binding_session,
-        executor=executor,
-        portfolio_id=portfolio_id,
-    )
-    if getattr(binding_session, "capability_issued", False):
-        raise PaperExecutionCapabilityError(
-            "gateway runtime binding session already issued its capability"
-        )
-    setattr(binding_session, "capability_issued", True)
-    capability = _GatewayExecutionBindingCapability(_token=_BIND_CAPABILITY_TOKEN)
-    with _REGISTRY_LOCK:
-        _GATEWAY_BINDINGS[capability] = _GatewayBindingRecord(
-            gateway=gateway,
-            runtime_context=runtime_context,
-            binding_session=binding_session,
-            executor=executor,
-            portfolio_id=portfolio_id,
-        )
-    return capability
-
-
-def _bind_gateway_baseline_execution(
-    *,
-    gateway: object,
-    runtime_context: object,
-    binding_session: object,
-    executor: object,
-    portfolio_id: str,
-    capability: object,
-) -> _GatewayBaselineExecutionBinding:
-    """Consume one exact gateway grant and seal the baseline binding."""
-
-    if type(capability) is not _GatewayExecutionBindingCapability:
-        raise PaperExecutionCapabilityError("gateway execution binding capability is invalid")
-    with _REGISTRY_LOCK:
-        record = _GATEWAY_BINDINGS.get(capability)
-        if type(record) is not _GatewayBindingRecord or record.consumed:
-            raise PaperExecutionCapabilityError(
-                "gateway execution binding capability is unknown or already consumed"
-            )
-        record.consumed = True
-    _validate_gateway_binding_scope(
-        gateway=gateway,
-        runtime_context=runtime_context,
-        binding_session=binding_session,
-        executor=executor,
-        portfolio_id=portfolio_id,
-    )
-    if (
-        record.gateway is not gateway
-        or record.runtime_context is not runtime_context
-        or record.binding_session is not binding_session
-        or record.executor is not executor
-        or record.portfolio_id != portfolio_id
-    ):
-        raise PaperExecutionCapabilityError(
-            "gateway execution binding capability does not match runtime"
-        )
-    binding = _GatewayBaselineExecutionBinding(_token=_BASELINE_BIND_TOKEN)
-    with _REGISTRY_LOCK:
-        _BASELINE_BINDINGS[binding] = _BaselineBindingRecord(
-            gateway=gateway,
-            runtime_context=runtime_context,
-            executor=executor,
-            portfolio_id=portfolio_id,
-        )
-    return binding
-
-
-def _issue_gateway_reduction_binding_capability(
-    *,
-    gateway: object,
-    runtime_context: object,
-    binding_session: object,
-    executor: object,
-    portfolio_id: str,
-    coordinator: object,
-) -> _GatewayReductionBindingCapability:
-    """Issue exactly one reduction binding grant in gateway registration."""
-
-    _validate_gateway_binding_scope(
-        gateway=gateway,
-        runtime_context=runtime_context,
-        binding_session=binding_session,
-        executor=executor,
-        portfolio_id=portfolio_id,
-    )
-    from .safety import SafetyRuntimeCoordinator
-
-    if (
-        type(coordinator) is not SafetyRuntimeCoordinator
-        or coordinator.started is not True
-        or getattr(gateway, "_coordinator", None) is not coordinator
-    ):
-        raise PaperExecutionCapabilityError("reduction coordinator binding is invalid")
-    if getattr(binding_session, "reduction_capability_issued", False):
-        raise PaperExecutionCapabilityError(
-            "gateway runtime binding session already issued reduction capability"
-        )
-    setattr(binding_session, "reduction_capability_issued", True)
-    capability = _GatewayReductionBindingCapability(_token=_REDUCTION_BIND_CAPABILITY_TOKEN)
-    with _REGISTRY_LOCK:
-        _REDUCTION_BINDINGS[capability] = _ReductionBindingRecord(
-            gateway=gateway,
-            runtime_context=runtime_context,
-            binding_session=binding_session,
-            executor=executor,
-            portfolio_id=portfolio_id,
-            coordinator=coordinator,
-        )
-    return capability
-
-
-def _bind_gateway_reduction_execution(
-    *,
-    gateway: object,
-    runtime_context: object,
-    binding_session: object,
-    executor: object,
-    portfolio_id: str,
-    coordinator: object,
-    capability: object,
-) -> PaperReductionExecutionAuthority:
-    """Consume one gateway grant and register a methodless reduction authority."""
-
-    if type(capability) is not _GatewayReductionBindingCapability:
-        raise PaperExecutionCapabilityError("reduction binding capability is invalid")
-    with _REGISTRY_LOCK:
-        record = _REDUCTION_BINDINGS.get(capability)
-        if type(record) is not _ReductionBindingRecord or record.consumed:
-            raise PaperExecutionCapabilityError(
-                "reduction binding capability is unknown or already consumed"
-            )
-        record.consumed = True
-    _validate_gateway_binding_scope(
-        gateway=gateway,
-        runtime_context=runtime_context,
-        binding_session=binding_session,
-        executor=executor,
-        portfolio_id=portfolio_id,
-    )
-    if (
-        record.gateway is not gateway
-        or record.runtime_context is not runtime_context
-        or record.binding_session is not binding_session
-        or record.executor is not executor
-        or record.portfolio_id != portfolio_id
-        or record.coordinator is not coordinator
-    ):
-        raise PaperExecutionCapabilityError("reduction binding does not match runtime")
-    authority = PaperReductionExecutionAuthority(_token=_REDUCTION_AUTHORITY_TOKEN)
-    with _REGISTRY_LOCK:
-        _REDUCTION_AUTHORITIES[authority] = _ReductionAuthorityRecord(
-            gateway=gateway,
-            runtime_context=runtime_context,
-            executor=executor,
-            portfolio_id=portfolio_id,
-            coordinator=coordinator,
-        )
-    return authority
-
-
-def _attach_gateway_reduction_submitter(
-    authority: object,
-    *,
-    submitter: object,
-    executor: object,
-    coordinator: object,
-    portfolio_id: str,
-) -> None:
-    """Bind the exact sealed submitter once, before the gateway publishes it."""
-
-    if type(authority) is not PaperReductionExecutionAuthority:
-        raise PaperExecutionCapabilityError("reduction authority is invalid")
-    with _REGISTRY_LOCK:
-        record = _REDUCTION_AUTHORITIES.get(authority)
-        if (
-            type(record) is not _ReductionAuthorityRecord
-            or record.submitter is not None
-            or record.executor is not executor
-            or record.coordinator is not coordinator
-            or record.portfolio_id != portfolio_id
-        ):
-            raise PaperExecutionCapabilityError("reduction submitter binding is invalid")
-        record.submitter = submitter
-
-
-def _reduction_authority_matches(
-    authority: object,
-    *,
-    executor: object,
-    coordinator: object,
-    portfolio_id: str,
-) -> bool:
-    with _REGISTRY_LOCK:
-        record = (
-            _REDUCTION_AUTHORITIES.get(authority)
-            if type(authority) is PaperReductionExecutionAuthority
-            else None
-        )
-        return bool(
-            type(record) is _ReductionAuthorityRecord
-            and record.executor is executor
-            and record.coordinator is coordinator
-            and record.portfolio_id == portfolio_id
-        )
-
-
-def _issue_gateway_baseline_terminal_dispatch(
-    binding: object,
-    *,
-    gateway: object,
-    runtime_context: object,
-    active_session: object,
-    order: object,
-) -> _BaselineTerminalDispatch:
-    """Register one terminal dispatch for the exact active entry session."""
-
-    from .paper_reduction_gateway import (
-        PaperReductionGateway,
-        _ActiveEntrySession,
-    )
-
-    task = asyncio.current_task()
-    sessions = getattr(gateway, "_active_entry_sessions", None)
-    fingerprint = _fingerprint_order(order)
-    if (
-        type(gateway) is not PaperReductionGateway
-        or gateway.started is not True
-        or getattr(gateway, "_runtime_context", None) is not runtime_context
-        or type(active_session) is not _ActiveEntrySession
-        or not isinstance(sessions, dict)
-        or task is None
-        or sessions.get(task) is not active_session
-        or active_session.consumed is not True
-    ):
-        raise PaperExecutionCapabilityError("baseline gateway session does not match binding")
-    if (
-        fingerprint.side != "BUY"
-        or fingerprint.take_profit is not None
-        or fingerprint.symbol != active_session.symbol
-        or fingerprint.price != active_session.quote.price
-    ):
-        raise PaperExecutionCapabilityError("baseline order does not match gateway session")
-    with _REGISTRY_LOCK:
-        binding_record = (
-            _BASELINE_BINDINGS.get(binding)
-            if type(binding) is _GatewayBaselineExecutionBinding
-            else None
-        )
-        if (
-            type(binding_record) is not _BaselineBindingRecord
-            or binding_record.gateway is not gateway
-            or binding_record.runtime_context is not runtime_context
-            or active_session.portfolio_id != binding_record.portfolio_id
-            or active_session.dispatch_issued is True
-        ):
-            raise PaperExecutionCapabilityError(
-                "baseline gateway session does not match binding or already issued"
-            )
-        active_session.dispatch_issued = True
-        dispatch = _BaselineTerminalDispatch(_token=_TERMINAL_DISPATCH_TOKEN)
-        _BASELINE_DISPATCHES[dispatch] = _TerminalDispatchRecord(
-            binding=binding,
-            gateway=gateway,
-            runtime_context=runtime_context,
-            active_session=active_session,
-            submitter=None,
-            coordinator=None,
-            executor=binding_record.executor,
-            portfolio_id=binding_record.portfolio_id,
-            fingerprint=fingerprint,
-            pre_position_quantity=None,
-        )
-    return dispatch
-
-
-def _make_gateway_baseline_submitter(terminal_sink):
-    """Capture the exact terminal sink outside mutable module/executor state."""
-
-    def _submit_gateway_baseline_once(
-        binding: object,
-        dispatch: object,
-        *,
-        gateway: object,
-        runtime_context: object,
-        active_session: object,
-        order: object,
-    ):
-        """Atomically burn one registered baseline dispatch before submission."""
-
-        if type(dispatch) is not _BaselineTerminalDispatch:
-            raise PaperExecutionCapabilityError("baseline terminal dispatch is invalid")
-        with _REGISTRY_LOCK:
-            record = _BASELINE_DISPATCHES.get(dispatch)
-            if type(record) is not _TerminalDispatchRecord or record.consumed:
-                raise PaperExecutionCapabilityError(
-                    "baseline terminal dispatch is unknown or already consumed"
-                )
-            record.consumed = True
-            expected_binding = record.binding
-            expected_gateway = record.gateway
-            expected_context = record.runtime_context
-            expected_session = record.active_session
-            executor = cast("PaperExecutor", record.executor)
-            portfolio_id = record.portfolio_id
-            expected_fingerprint = record.fingerprint
-            record.binding = None
-            record.gateway = None
-            record.runtime_context = None
-            record.active_session = None
-        fingerprint = _fingerprint_order(order)
-        if (
-            type(binding) is not _GatewayBaselineExecutionBinding
-            or expected_binding is not binding
-            or expected_gateway is not gateway
-            or expected_context is not runtime_context
-            or expected_session is not active_session
-            or fingerprint != expected_fingerprint
-        ):
-            raise PaperExecutionCapabilityError("baseline terminal dispatch does not match attempt")
-        capability = _PaperExecutionCapability(_token=_CAPABILITY_TOKEN)
-        with _REGISTRY_LOCK:
-            _CAPABILITIES[capability] = _CapabilityRecord(
-                authority=binding,
-                executor=executor,
-                order=order,
-                portfolio_id=portfolio_id,
-                kind=_CapabilityKind.BASELINE_ENTRY,
-                fingerprint=fingerprint,
-                pre_position_quantity=None,
-            )
-        # The sink is a closure cell, not an executor or module attribute. Its
-        # first operation atomically burns this exact capability.
-        return terminal_sink(executor, order, capability)
-
-    return _submit_gateway_baseline_once
-
-
-def _issue_gateway_reduction_terminal_dispatch(
-    authority: object,
-    *,
-    submitter: object,
-    executor: object,
-    coordinator: object,
-    final_allocation: object,
-    descriptor: object,
-    contract: object,
-    order: object,
-    pre_position_quantity: Decimal,
-) -> _ReductionTerminalDispatch:
-    """Register one dispatch after the coordinator envelope was claimed."""
-
-    from .safety.runtime import _consume_claimed_paper_submission_allocation
-
-    try:
-        _consume_claimed_paper_submission_allocation(
-            final_allocation,
-            coordinator=coordinator,
-            descriptor=descriptor,
-            contract=contract,
-        )
-    except (RuntimeError, TypeError) as exc:
-        raise PaperExecutionCapabilityError(
-            "reduction terminal dispatch lacks exact final allocation"
-        ) from exc
-    fingerprint = _fingerprint_order(order)
-    try:
-        from .paper_reduction_submitter import _map_order
-
-        expected_fingerprint = _fingerprint_order(_map_order(descriptor, contract))
-    except (RuntimeError, TypeError, ValueError) as exc:
-        raise PaperExecutionCapabilityError(
-            "reduction final allocation is not terminally representable"
-        ) from exc
-    if fingerprint != expected_fingerprint:
-        raise PaperExecutionCapabilityError(
-            "reduction order does not match the claimed final allocation"
-        )
-    _validate_reduction_bounds(fingerprint, pre_position_quantity)
-    with _REGISTRY_LOCK:
-        authority_record = (
-            _REDUCTION_AUTHORITIES.get(authority)
-            if type(authority) is PaperReductionExecutionAuthority
-            else None
-        )
-        if (
-            type(authority_record) is not _ReductionAuthorityRecord
-            or authority_record.submitter is not submitter
-            or authority_record.executor is not executor
-            or authority_record.coordinator is not coordinator
-        ):
-            raise PaperExecutionCapabilityError("reduction terminal issuer is not bound")
-        dispatch = _ReductionTerminalDispatch(_token=_TERMINAL_DISPATCH_TOKEN)
-        _REDUCTION_DISPATCHES[dispatch] = _TerminalDispatchRecord(
-            binding=authority,
-            gateway=authority_record.gateway,
-            runtime_context=authority_record.runtime_context,
-            active_session=None,
-            submitter=submitter,
-            coordinator=coordinator,
-            executor=executor,
-            portfolio_id=authority_record.portfolio_id,
-            fingerprint=fingerprint,
-            pre_position_quantity=pre_position_quantity,
-        )
-    return dispatch
-
-
-def _make_gateway_reduction_submitter(terminal_sink):
-    """Capture the exact terminal sink outside mutable module/executor state."""
-
-    def _submit_gateway_reduction_once(
-        authority: object,
-        dispatch: object,
-        *,
-        submitter: object,
-        order: object,
-        pre_position_quantity: Decimal,
-    ):
-        """Atomically burn one submitter-issued reduction dispatch."""
-
-        if type(dispatch) is not _ReductionTerminalDispatch:
-            raise PaperExecutionCapabilityError("reduction terminal dispatch is invalid")
-        with _REGISTRY_LOCK:
-            record = _REDUCTION_DISPATCHES.get(dispatch)
-            if type(record) is not _TerminalDispatchRecord or record.consumed:
-                raise PaperExecutionCapabilityError(
-                    "reduction terminal dispatch is unknown or already consumed"
-                )
-            record.consumed = True
-            expected_authority = record.binding
-            expected_submitter = record.submitter
-            executor = cast("PaperExecutor", record.executor)
-            portfolio_id = record.portfolio_id
-            expected_fingerprint = record.fingerprint
-            expected_pre_position = record.pre_position_quantity
-            record.binding = None
-            record.gateway = None
-            record.runtime_context = None
-            record.submitter = None
-            record.coordinator = None
-        fingerprint = _fingerprint_order(order)
-        _validate_reduction_bounds(fingerprint, pre_position_quantity)
-        if (
-            type(authority) is not PaperReductionExecutionAuthority
-            or expected_authority is not authority
-            or expected_submitter is not submitter
-            or fingerprint != expected_fingerprint
-            or pre_position_quantity != expected_pre_position
-        ):
-            raise PaperExecutionCapabilityError(
-                "reduction terminal dispatch does not match attempt"
-            )
-        capability = _PaperExecutionCapability(_token=_CAPABILITY_TOKEN)
-        with _REGISTRY_LOCK:
-            _CAPABILITIES[capability] = _CapabilityRecord(
-                authority=authority,
-                executor=executor,
-                order=order,
-                portfolio_id=portfolio_id,
-                kind=_CapabilityKind.REDUCTION,
-                fingerprint=fingerprint,
-                pre_position_quantity=pre_position_quantity,
-            )
-        # As above, capability transport ends at a closure-captured sink whose
-        # first operation is the irreversible consume.
-        return terminal_sink(executor, order, capability)
-
-    return _submit_gateway_reduction_once
-
-
 def _validate_gateway_binding_scope(
     *,
     gateway: object,
@@ -827,188 +72,6 @@ def _validate_gateway_binding_scope(
         or portfolio_id.strip() != portfolio_id
     ):
         raise PaperExecutionCapabilityError("gateway execution binding scope is invalid")
-
-
-def consume_paper_execution_capability(
-    executor: object,
-    order: object,
-    capability: object,
-) -> None:
-    """Consume and validate exact authority before terminal fill calculation."""
-
-    if type(capability) is not _PaperExecutionCapability:
-        raise PaperExecutionCapabilityError(
-            "terminal paper execution requires an exact submission capability"
-        )
-    with _REGISTRY_LOCK:
-        record = _CAPABILITIES.get(capability)
-        if type(record) is not _CapabilityRecord or record.consumed:
-            raise PaperExecutionCapabilityError(
-                "paper execution capability is unknown or already consumed"
-            )
-        # Burn first: mismatch, substitution, and downstream failure are all
-        # one-shot and cannot be retried with the same authority.
-        record.consumed = True
-
-    fingerprint = _fingerprint_order(order)
-    if record.executor is not executor or record.fingerprint != fingerprint:
-        raise PaperExecutionCapabilityError(
-            "paper execution capability does not match executor or order"
-        )
-    if record.kind is _CapabilityKind.BASELINE_ENTRY:
-        if fingerprint.side != "BUY" or fingerprint.take_profit is not None:
-            raise PaperExecutionCapabilityError("baseline entry capability is malformed")
-    else:
-        if record.kind is not _CapabilityKind.REDUCTION:
-            raise PaperExecutionCapabilityError("paper execution capability kind is unsupported")
-        if type(record.pre_position_quantity) is not Decimal:
-            raise PaperExecutionCapabilityError(
-                "reduction capability lacks exact position evidence"
-            )
-        _validate_reduction_bounds(fingerprint, record.pre_position_quantity)
-    with _REGISTRY_LOCK:
-        current = _CAPABILITIES.get(capability)
-        if current is not record or record.consumed is not True:
-            raise PaperExecutionCapabilityError("paper execution capability state changed")
-        record.validated = True
-
-
-def _apply_consumed_paper_fill(executor: object, order: object, capability: object):
-    """Apply a fill only for an exactly consumed, still-unfilled capability."""
-
-    if type(capability) is not _PaperExecutionCapability:
-        raise PaperExecutionCapabilityError(
-            "paper fill requires an exact consumed submission capability"
-        )
-    with _REGISTRY_LOCK:
-        record = _CAPABILITIES.get(capability)
-        if (
-            type(record) is not _CapabilityRecord
-            or record.consumed is not True
-            or record.validated is not True
-            or record.fill_consumed
-            or record.executor is not executor
-            or record.order is not order
-        ):
-            raise PaperExecutionCapabilityError(
-                "paper fill capability is unknown, unconsumed, mismatched, or already filled"
-            )
-        # Burn the fill edge before any validation, mutable state, or callback
-        # can raise. Retained traceback locals can never replay this fill.
-        record.fill_consumed = True
-
-    fingerprint = _fingerprint_order(order)
-    if record.fingerprint != fingerprint:
-        raise PaperExecutionCapabilityError("paper fill capability order fingerprint changed")
-
-    from .execution import ExecutionResult, Order, PaperExecutor
-
-    if type(executor) is not PaperExecutor or type(order) is not Order:
-        raise PaperExecutionCapabilityError(
-            "sealed paper fill requires the exact executor and order types"
-        )
-
-    base: float | None
-    exact_base: Decimal | None = None
-
-    if order.price is not None:
-        if type(order.price) is Decimal:
-            if not order.price.is_finite() or order.price <= 0:
-                return ExecutionResult(False, "Invalid price for paper execution")
-            exact_base = order.price
-            base = float(exact_base)
-        else:
-            try:
-                base = float(order.price)
-            except (TypeError, ValueError):
-                return ExecutionResult(False, "Invalid price for paper execution")
-        if not math.isfinite(base):
-            return ExecutionResult(False, "Non-finite price for paper execution")
-        if base <= 0:
-            return ExecutionResult(False, "Non-positive price for paper execution")
-        executor._execution_cache[order.symbol] = base
-        executor._execution_cache_ts[order.symbol] = dt.datetime.utcnow()
-    else:
-        base = executor._execution_cache.get(order.symbol)
-        if base is None:
-            return ExecutionResult(False, "No reference price for market order")
-        timestamp = executor._execution_cache_ts.get(order.symbol)
-        if (
-            timestamp is None
-            or (dt.datetime.utcnow() - timestamp).total_seconds()
-            > executor._execution_cache_max_age_seconds
-        ):
-            return ExecutionResult(False, "Stale reference price for market order")
-
-    fill_decimal: Decimal
-    if exact_base is not None:
-        slip_decimal = (
-            exact_base * Decimal(str(executor.slippage_bps)) / Decimal("10000")
-            if executor.slippage_bps
-            else Decimal("0")
-        )
-        unrounded_fill = (
-            exact_base + slip_decimal
-            if order.side.upper() in {"BUY", "BUY_TO_COVER"}
-            else exact_base - slip_decimal
-        )
-        if not unrounded_fill.is_finite() or unrounded_fill <= 0:
-            return ExecutionResult(False, "Invalid paper execution fill")
-        fill_decimal = unrounded_fill.quantize(
-            _PAPER_FILL_PRICE_TICK,
-            rounding=ROUND_HALF_EVEN,
-        )
-        fill = float(fill_decimal)
-    else:
-        slip = base * (executor.slippage_bps / 10_000.0) if executor.slippage_bps else 0.0
-        if order.side.upper() in {"BUY", "BUY_TO_COVER"}:
-            fill = base + slip
-        else:
-            fill = base - slip
-        fill_decimal = Decimal(str(fill))
-    if not math.isfinite(fill) or fill <= 0:
-        return ExecutionResult(False, "Invalid paper execution fill")
-
-    executor.fills[f"{order.symbol}-{len(executor.fills)+1}"] = (
-        dt.datetime.utcnow(),
-        order,
-        fill,
-    )
-    return ExecutionResult(
-        True,
-        "Paper fill",
-        fill,
-        exact_fill_price=fill_decimal,
-    )
-
-
-def _make_sealed_paper_fill_sink(consume, fill_core):
-    """Capture both authority consume and fill core outside module lookups."""
-
-    def _execute_sealed_paper_fill(
-        executor: object,
-        order: object,
-        capability: object,
-    ):
-        # This exact consume is the first operation and cannot be replaced by
-        # mutating the module global after import.
-        consume(executor, order, capability)
-        return fill_core(executor, order, capability)
-
-    return _execute_sealed_paper_fill
-
-
-_execute_sealed_paper_fill = _make_sealed_paper_fill_sink(
-    consume_paper_execution_capability,
-    _apply_consumed_paper_fill,
-)
-
-
-# Capture the terminal sink exactly once. The exported submitter functions are
-# closures whose sink reference is neither an executor method nor a mutable
-# module lookup at submission time.
-_submit_gateway_baseline_once = _make_gateway_baseline_submitter(_execute_sealed_paper_fill)
-_submit_gateway_reduction_once = _make_gateway_reduction_submitter(_execute_sealed_paper_fill)
 
 
 def _fingerprint_order(order: object) -> _OrderFingerprint:
@@ -1068,3 +131,902 @@ def _validate_reduction_bounds(
             raise PaperExecutionCapabilityError("BUY_TO_COVER reduction crosses zero")
     else:
         raise PaperExecutionCapabilityError("reduction capability admits only SELL or BUY_TO_COVER")
+
+
+def _build_sealed_capability_runtime():
+    """Create the only authority state used by the local-paper terminal sink.
+
+    Tokens, registries, record types, and state transitions deliberately live
+    only in this factory's closure. Importing this module exposes opaque
+    identities and validating operations, never the state needed to mint or
+    revive one of those identities.
+    """
+
+    fingerprint_order = _fingerprint_order
+    validate_reduction_bounds = _validate_reduction_bounds
+    validate_gateway_binding_scope = _validate_gateway_binding_scope
+    replace_record = dataclass_replace
+
+    bind_capability_token = object()
+    reduction_bind_capability_token = object()
+    reduction_authority_token = object()
+    baseline_bind_token = object()
+    terminal_dispatch_token = object()
+    capability_token = object()
+    registry_lock = threading.Lock()
+
+    @dataclass(frozen=True, slots=True)
+    class CapabilityRecord:
+        authority: object
+        executor: object
+        order: object
+        portfolio_id: str
+        kind: _CapabilityKind
+        fingerprint: _OrderFingerprint
+        pre_position_quantity: Decimal | None
+        consumed: bool = False
+        validated: bool = False
+        fill_consumed: bool = False
+
+    @dataclass(frozen=True, slots=True)
+    class GatewayBindingRecord:
+        gateway: object
+        runtime_context: object
+        binding_session: object
+        executor: object
+        portfolio_id: str
+        consumed: bool = False
+
+    @dataclass(frozen=True, slots=True)
+    class BaselineBindingRecord:
+        gateway: object
+        runtime_context: object
+        executor: object
+        portfolio_id: str
+
+    @dataclass(frozen=True, slots=True)
+    class ReductionBindingRecord(GatewayBindingRecord):
+        coordinator: object = None
+
+    @dataclass(frozen=True, slots=True)
+    class ReductionAuthorityRecord:
+        gateway: object
+        runtime_context: object
+        executor: object
+        portfolio_id: str
+        coordinator: object
+        submitter: object | None = None
+
+    @dataclass(frozen=True, slots=True)
+    class TerminalDispatchRecord:
+        binding: object | None
+        gateway: object | None
+        runtime_context: object | None
+        active_session: object | None
+        submitter: object | None
+        coordinator: object | None
+        executor: object
+        portfolio_id: str
+        fingerprint: _OrderFingerprint
+        pre_position_quantity: Decimal | None
+        consumed: bool = False
+
+    capabilities: weakref.WeakKeyDictionary[object, CapabilityRecord] = weakref.WeakKeyDictionary()
+    gateway_bindings: weakref.WeakKeyDictionary[object, GatewayBindingRecord] = (
+        weakref.WeakKeyDictionary()
+    )
+    baseline_bindings: weakref.WeakKeyDictionary[object, BaselineBindingRecord] = (
+        weakref.WeakKeyDictionary()
+    )
+    reduction_bindings: weakref.WeakKeyDictionary[object, ReductionBindingRecord] = (
+        weakref.WeakKeyDictionary()
+    )
+    reduction_authorities: weakref.WeakKeyDictionary[object, ReductionAuthorityRecord] = (
+        weakref.WeakKeyDictionary()
+    )
+    baseline_dispatches: weakref.WeakKeyDictionary[object, TerminalDispatchRecord] = (
+        weakref.WeakKeyDictionary()
+    )
+    reduction_dispatches: weakref.WeakKeyDictionary[object, TerminalDispatchRecord] = (
+        weakref.WeakKeyDictionary()
+    )
+
+    class PaperExecutionCapability:
+        __slots__ = ("__weakref__",)
+
+        def __new__(cls, *, _token: object | None = None):
+            if _token is not capability_token:
+                raise PaperExecutionCapabilityError(
+                    "paper execution capabilities are minted only by a bound authority"
+                )
+            return super().__new__(cls)
+
+        def __copy__(self):
+            with registry_lock:
+                record = capabilities.get(self)
+                if type(record) is CapabilityRecord:
+                    capabilities[self] = replace_record(record, consumed=True)
+            raise PaperExecutionCapabilityError("paper execution capabilities cannot copy")
+
+        def __deepcopy__(self, _memo):
+            return self.__copy__()
+
+        def __reduce__(self):
+            with registry_lock:
+                record = capabilities.get(self)
+                if type(record) is CapabilityRecord:
+                    capabilities[self] = replace_record(record, consumed=True)
+            raise PaperExecutionCapabilityError("paper execution capabilities cannot serialize")
+
+    class GatewayExecutionBindingCapability:
+        __slots__ = ("__weakref__",)
+
+        def __new__(cls, *, _token: object | None = None):
+            if _token is not bind_capability_token:
+                raise PaperExecutionCapabilityError(
+                    "gateway execution binding capabilities are issuer-only"
+                )
+            return super().__new__(cls)
+
+        def __copy__(self):
+            with registry_lock:
+                record = gateway_bindings.get(self)
+                if type(record) is GatewayBindingRecord:
+                    gateway_bindings[self] = replace_record(record, consumed=True)
+            raise PaperExecutionCapabilityError(
+                "gateway execution binding capabilities cannot copy"
+            )
+
+        def __deepcopy__(self, _memo):
+            return self.__copy__()
+
+        def __reduce__(self):
+            with registry_lock:
+                record = gateway_bindings.get(self)
+                if type(record) is GatewayBindingRecord:
+                    gateway_bindings[self] = replace_record(record, consumed=True)
+            raise PaperExecutionCapabilityError(
+                "gateway execution binding capabilities cannot serialize"
+            )
+
+    class GatewayReductionBindingCapability:
+        __slots__ = ("__weakref__",)
+
+        def __new__(cls, *, _token: object | None = None):
+            if _token is not reduction_bind_capability_token:
+                raise PaperExecutionCapabilityError("reduction binding capability is issuer-only")
+            return super().__new__(cls)
+
+        def __copy__(self):
+            with registry_lock:
+                record = reduction_bindings.get(self)
+                if type(record) is ReductionBindingRecord:
+                    reduction_bindings[self] = replace_record(record, consumed=True)
+            raise PaperExecutionCapabilityError("reduction binding capability cannot copy")
+
+        def __deepcopy__(self, _memo):
+            return self.__copy__()
+
+        def __reduce__(self):
+            raise PaperExecutionCapabilityError("reduction binding capability cannot serialize")
+
+    class BaselineTerminalDispatch:
+        __slots__ = ("__weakref__",)
+
+        def __new__(cls, *, _token: object | None = None):
+            if _token is not terminal_dispatch_token:
+                raise PaperExecutionCapabilityError("baseline terminal dispatch is issuer-only")
+            return super().__new__(cls)
+
+        def __copy__(self):
+            with registry_lock:
+                record = baseline_dispatches.get(self)
+                if type(record) is TerminalDispatchRecord:
+                    baseline_dispatches[self] = replace_record(record, consumed=True)
+            raise PaperExecutionCapabilityError("baseline terminal dispatch cannot copy")
+
+        def __deepcopy__(self, _memo):
+            return self.__copy__()
+
+        def __reduce__(self):
+            with registry_lock:
+                record = baseline_dispatches.get(self)
+                if type(record) is TerminalDispatchRecord:
+                    baseline_dispatches[self] = replace_record(record, consumed=True)
+            raise PaperExecutionCapabilityError("baseline terminal dispatch cannot serialize")
+
+    class ReductionTerminalDispatch:
+        __slots__ = ("__weakref__",)
+
+        def __new__(cls, *, _token: object | None = None):
+            if _token is not terminal_dispatch_token:
+                raise PaperExecutionCapabilityError("reduction terminal dispatch is issuer-only")
+            return super().__new__(cls)
+
+        def __copy__(self):
+            with registry_lock:
+                record = reduction_dispatches.get(self)
+                if type(record) is TerminalDispatchRecord:
+                    reduction_dispatches[self] = replace_record(record, consumed=True)
+            raise PaperExecutionCapabilityError("reduction terminal dispatch cannot copy")
+
+        def __deepcopy__(self, _memo):
+            return self.__copy__()
+
+        def __reduce__(self):
+            with registry_lock:
+                record = reduction_dispatches.get(self)
+                if type(record) is TerminalDispatchRecord:
+                    reduction_dispatches[self] = replace_record(record, consumed=True)
+            raise PaperExecutionCapabilityError("reduction terminal dispatch cannot serialize")
+
+    class ReductionExecutionAuthority:
+        __slots__ = ("__weakref__",)
+
+        def __new__(cls, *, _token: object | None = None):
+            if _token is not reduction_authority_token:
+                raise PaperExecutionCapabilityError("paper reduction authority is gateway-only")
+            return super().__new__(cls)
+
+        def __copy__(self):
+            raise PaperExecutionCapabilityError("paper reduction authority cannot copy")
+
+        def __deepcopy__(self, _memo):
+            return self.__copy__()
+
+        def __reduce__(self):
+            raise PaperExecutionCapabilityError("paper reduction authority cannot serialize")
+
+    class GatewayBaselineExecutionBinding:
+        __slots__ = ("__weakref__",)
+
+        def __new__(cls, *, _token: object | None = None):
+            if _token is not baseline_bind_token:
+                raise PaperExecutionCapabilityError("baseline execution binding is gateway-only")
+            return super().__new__(cls)
+
+        def __copy__(self):
+            raise PaperExecutionCapabilityError("baseline execution binding cannot copy")
+
+        def __deepcopy__(self, _memo):
+            return self.__copy__()
+
+        def __reduce__(self):
+            raise PaperExecutionCapabilityError("baseline execution binding cannot serialize")
+
+    def issue_gateway_execution_binding_capability(
+        *, gateway, runtime_context, binding_session, executor, portfolio_id
+    ):
+        validate_gateway_binding_scope(
+            gateway=gateway,
+            runtime_context=runtime_context,
+            binding_session=binding_session,
+            executor=executor,
+            portfolio_id=portfolio_id,
+        )
+        if getattr(binding_session, "capability_issued", False):
+            raise PaperExecutionCapabilityError(
+                "gateway runtime binding session already issued its capability"
+            )
+        setattr(binding_session, "capability_issued", True)
+        capability = GatewayExecutionBindingCapability(_token=bind_capability_token)
+        with registry_lock:
+            gateway_bindings[capability] = GatewayBindingRecord(
+                gateway, runtime_context, binding_session, executor, portfolio_id
+            )
+        return capability
+
+    def bind_gateway_baseline_execution(
+        *, gateway, runtime_context, binding_session, executor, portfolio_id, capability
+    ):
+        if type(capability) is not GatewayExecutionBindingCapability:
+            raise PaperExecutionCapabilityError("gateway execution binding capability is invalid")
+        with registry_lock:
+            record = gateway_bindings.get(capability)
+            if type(record) is not GatewayBindingRecord or record.consumed:
+                raise PaperExecutionCapabilityError(
+                    "gateway execution binding capability is unknown or already consumed"
+                )
+            gateway_bindings[capability] = replace_record(record, consumed=True)
+        validate_gateway_binding_scope(
+            gateway=gateway,
+            runtime_context=runtime_context,
+            binding_session=binding_session,
+            executor=executor,
+            portfolio_id=portfolio_id,
+        )
+        if (
+            record.gateway is not gateway
+            or record.runtime_context is not runtime_context
+            or record.binding_session is not binding_session
+            or record.executor is not executor
+            or record.portfolio_id != portfolio_id
+        ):
+            raise PaperExecutionCapabilityError(
+                "gateway execution binding capability does not match runtime"
+            )
+        binding = GatewayBaselineExecutionBinding(_token=baseline_bind_token)
+        with registry_lock:
+            baseline_bindings[binding] = BaselineBindingRecord(
+                gateway, runtime_context, executor, portfolio_id
+            )
+        return binding
+
+    def issue_gateway_reduction_binding_capability(
+        *, gateway, runtime_context, binding_session, executor, portfolio_id, coordinator
+    ):
+        validate_gateway_binding_scope(
+            gateway=gateway,
+            runtime_context=runtime_context,
+            binding_session=binding_session,
+            executor=executor,
+            portfolio_id=portfolio_id,
+        )
+        from .safety import SafetyRuntimeCoordinator
+
+        if (
+            type(coordinator) is not SafetyRuntimeCoordinator
+            or coordinator.started is not True
+            or getattr(gateway, "_coordinator", None) is not coordinator
+        ):
+            raise PaperExecutionCapabilityError("reduction coordinator binding is invalid")
+        if getattr(binding_session, "reduction_capability_issued", False):
+            raise PaperExecutionCapabilityError(
+                "gateway runtime binding session already issued reduction capability"
+            )
+        setattr(binding_session, "reduction_capability_issued", True)
+        capability = GatewayReductionBindingCapability(_token=reduction_bind_capability_token)
+        with registry_lock:
+            reduction_bindings[capability] = ReductionBindingRecord(
+                gateway,
+                runtime_context,
+                binding_session,
+                executor,
+                portfolio_id,
+                False,
+                coordinator,
+            )
+        return capability
+
+    def bind_gateway_reduction_execution(
+        *,
+        gateway,
+        runtime_context,
+        binding_session,
+        executor,
+        portfolio_id,
+        coordinator,
+        capability,
+    ):
+        if type(capability) is not GatewayReductionBindingCapability:
+            raise PaperExecutionCapabilityError("reduction binding capability is invalid")
+        with registry_lock:
+            record = reduction_bindings.get(capability)
+            if type(record) is not ReductionBindingRecord or record.consumed:
+                raise PaperExecutionCapabilityError(
+                    "reduction binding capability is unknown or already consumed"
+                )
+            reduction_bindings[capability] = replace_record(record, consumed=True)
+        validate_gateway_binding_scope(
+            gateway=gateway,
+            runtime_context=runtime_context,
+            binding_session=binding_session,
+            executor=executor,
+            portfolio_id=portfolio_id,
+        )
+        if (
+            record.gateway is not gateway
+            or record.runtime_context is not runtime_context
+            or record.binding_session is not binding_session
+            or record.executor is not executor
+            or record.portfolio_id != portfolio_id
+            or record.coordinator is not coordinator
+        ):
+            raise PaperExecutionCapabilityError("reduction binding does not match runtime")
+        authority = ReductionExecutionAuthority(_token=reduction_authority_token)
+        with registry_lock:
+            reduction_authorities[authority] = ReductionAuthorityRecord(
+                gateway, runtime_context, executor, portfolio_id, coordinator
+            )
+        return authority
+
+    def attach_gateway_reduction_submitter(
+        authority, *, submitter, executor, coordinator, portfolio_id
+    ):
+        if type(authority) is not ReductionExecutionAuthority:
+            raise PaperExecutionCapabilityError("reduction authority is invalid")
+        with registry_lock:
+            record = reduction_authorities.get(authority)
+            if (
+                type(record) is not ReductionAuthorityRecord
+                or record.submitter is not None
+                or record.executor is not executor
+                or record.coordinator is not coordinator
+                or record.portfolio_id != portfolio_id
+            ):
+                raise PaperExecutionCapabilityError("reduction submitter binding is invalid")
+            reduction_authorities[authority] = replace_record(record, submitter=submitter)
+
+    def reduction_authority_matches(authority, *, executor, coordinator, portfolio_id):
+        with registry_lock:
+            record = (
+                reduction_authorities.get(authority)
+                if type(authority) is ReductionExecutionAuthority
+                else None
+            )
+            return bool(
+                type(record) is ReductionAuthorityRecord
+                and record.executor is executor
+                and record.coordinator is coordinator
+                and record.portfolio_id == portfolio_id
+            )
+
+    def issue_gateway_baseline_terminal_dispatch(
+        binding, *, gateway, runtime_context, active_session, order
+    ):
+        from .paper_reduction_gateway import PaperReductionGateway, _ActiveEntrySession
+
+        task = asyncio.current_task()
+        sessions = getattr(gateway, "_active_entry_sessions", None)
+        fingerprint = fingerprint_order(order)
+        if (
+            type(gateway) is not PaperReductionGateway
+            or gateway.started is not True
+            or getattr(gateway, "_runtime_context", None) is not runtime_context
+            or type(active_session) is not _ActiveEntrySession
+            or not isinstance(sessions, dict)
+            or task is None
+            or sessions.get(task) is not active_session
+            or active_session.consumed is not True
+        ):
+            raise PaperExecutionCapabilityError("baseline gateway session does not match binding")
+        if (
+            fingerprint.side != "BUY"
+            or fingerprint.take_profit is not None
+            or fingerprint.symbol != active_session.symbol
+            or fingerprint.price != active_session.quote.price
+        ):
+            raise PaperExecutionCapabilityError("baseline order does not match gateway session")
+        with registry_lock:
+            binding_record = (
+                baseline_bindings.get(binding)
+                if type(binding) is GatewayBaselineExecutionBinding
+                else None
+            )
+            if (
+                type(binding_record) is not BaselineBindingRecord
+                or binding_record.gateway is not gateway
+                or binding_record.runtime_context is not runtime_context
+                or active_session.portfolio_id != binding_record.portfolio_id
+                or active_session.dispatch_issued is True
+            ):
+                raise PaperExecutionCapabilityError(
+                    "baseline gateway session does not match binding or already issued"
+                )
+            active_session.dispatch_issued = True
+            dispatch = BaselineTerminalDispatch(_token=terminal_dispatch_token)
+            baseline_dispatches[dispatch] = TerminalDispatchRecord(
+                binding,
+                gateway,
+                runtime_context,
+                active_session,
+                None,
+                None,
+                binding_record.executor,
+                binding_record.portfolio_id,
+                fingerprint,
+                None,
+            )
+        return dispatch
+
+    def consume_paper_execution_capability(executor, order, capability):
+        if type(capability) is not PaperExecutionCapability:
+            raise PaperExecutionCapabilityError(
+                "terminal paper execution requires an exact submission capability"
+            )
+        with registry_lock:
+            record = capabilities.get(capability)
+            if type(record) is not CapabilityRecord or record.consumed:
+                raise PaperExecutionCapabilityError(
+                    "paper execution capability is unknown or already consumed"
+                )
+            record = replace_record(record, consumed=True)
+            capabilities[capability] = record
+        fingerprint = fingerprint_order(order)
+        if record.executor is not executor or record.fingerprint != fingerprint:
+            raise PaperExecutionCapabilityError(
+                "paper execution capability does not match executor or order"
+            )
+        if record.kind is _CapabilityKind.BASELINE_ENTRY:
+            if fingerprint.side != "BUY" or fingerprint.take_profit is not None:
+                raise PaperExecutionCapabilityError("baseline entry capability is malformed")
+        else:
+            if record.kind is not _CapabilityKind.REDUCTION:
+                raise PaperExecutionCapabilityError(
+                    "paper execution capability kind is unsupported"
+                )
+            if type(record.pre_position_quantity) is not Decimal:
+                raise PaperExecutionCapabilityError(
+                    "reduction capability lacks exact position evidence"
+                )
+            validate_reduction_bounds(fingerprint, record.pre_position_quantity)
+        with registry_lock:
+            current = capabilities.get(capability)
+            if current is not record or record.consumed is not True:
+                raise PaperExecutionCapabilityError("paper execution capability state changed")
+            record = replace_record(record, validated=True)
+            capabilities[capability] = record
+
+    def apply_consumed_paper_fill(executor, order, capability):
+        if type(capability) is not PaperExecutionCapability:
+            raise PaperExecutionCapabilityError(
+                "paper fill requires an exact consumed submission capability"
+            )
+        with registry_lock:
+            record = capabilities.get(capability)
+            if (
+                type(record) is not CapabilityRecord
+                or record.consumed is not True
+                or record.validated is not True
+                or record.fill_consumed
+                or record.executor is not executor
+                or record.order is not order
+            ):
+                raise PaperExecutionCapabilityError(
+                    "paper fill capability is unknown, unconsumed, mismatched, or already filled"
+                )
+            expected_fingerprint = record.fingerprint
+            capabilities[capability] = replace_record(record, fill_consumed=True)
+            del record
+        fingerprint = fingerprint_order(order)
+        if expected_fingerprint != fingerprint:
+            raise PaperExecutionCapabilityError("paper fill capability order fingerprint changed")
+
+        from .execution import ExecutionResult, Order, PaperExecutor
+
+        if type(executor) is not PaperExecutor or type(order) is not Order:
+            raise PaperExecutionCapabilityError(
+                "sealed paper fill requires the exact executor and order types"
+            )
+        exact_base = None
+        if order.price is not None:
+            if type(order.price) is Decimal:
+                if not order.price.is_finite() or order.price <= 0:
+                    return ExecutionResult(False, "Invalid price for paper execution")
+                exact_base = order.price
+                base = float(exact_base)
+            else:
+                try:
+                    base = float(order.price)
+                except (TypeError, ValueError):
+                    return ExecutionResult(False, "Invalid price for paper execution")
+            if not math.isfinite(base):
+                return ExecutionResult(False, "Non-finite price for paper execution")
+            if base <= 0:
+                return ExecutionResult(False, "Non-positive price for paper execution")
+            executor._execution_cache[order.symbol] = base
+            executor._execution_cache_ts[order.symbol] = dt.datetime.utcnow()
+        else:
+            base = executor._execution_cache.get(order.symbol)
+            if base is None:
+                return ExecutionResult(False, "No reference price for market order")
+            timestamp = executor._execution_cache_ts.get(order.symbol)
+            if (
+                timestamp is None
+                or (dt.datetime.utcnow() - timestamp).total_seconds()
+                > executor._execution_cache_max_age_seconds
+            ):
+                return ExecutionResult(False, "Stale reference price for market order")
+        if exact_base is not None:
+            slip_decimal = (
+                exact_base * Decimal(str(executor.slippage_bps)) / Decimal("10000")
+                if executor.slippage_bps
+                else Decimal("0")
+            )
+            unrounded_fill = (
+                exact_base + slip_decimal
+                if order.side.upper() in {"BUY", "BUY_TO_COVER"}
+                else exact_base - slip_decimal
+            )
+            if not unrounded_fill.is_finite() or unrounded_fill <= 0:
+                return ExecutionResult(False, "Invalid paper execution fill")
+            fill_decimal = unrounded_fill.quantize(_PAPER_FILL_PRICE_TICK, rounding=ROUND_HALF_EVEN)
+            fill = float(fill_decimal)
+        else:
+            slip = base * (executor.slippage_bps / 10_000.0) if executor.slippage_bps else 0.0
+            fill = base + slip if order.side.upper() in {"BUY", "BUY_TO_COVER"} else base - slip
+            fill_decimal = Decimal(str(fill))
+        if not math.isfinite(fill) or fill <= 0:
+            return ExecutionResult(False, "Invalid paper execution fill")
+        executor.fills[f"{order.symbol}-{len(executor.fills)+1}"] = (
+            dt.datetime.utcnow(),
+            order,
+            fill,
+        )
+        return ExecutionResult(
+            True,
+            "Paper fill",
+            fill,
+            exact_fill_price=fill_decimal,
+        )
+
+    def execute_sealed_paper_fill(executor, order, capability):
+        consume_paper_execution_capability(executor, order, capability)
+        return apply_consumed_paper_fill(executor, order, capability)
+
+    terminal_sink = execute_sealed_paper_fill
+
+    def _submit_gateway_baseline_once(
+        binding,
+        dispatch,
+        *,
+        gateway,
+        runtime_context,
+        active_session,
+        order,
+    ):
+        if type(dispatch) is not BaselineTerminalDispatch:
+            raise PaperExecutionCapabilityError("baseline terminal dispatch is invalid")
+        with registry_lock:
+            record = baseline_dispatches.get(dispatch)
+            if type(record) is not TerminalDispatchRecord or record.consumed:
+                raise PaperExecutionCapabilityError(
+                    "baseline terminal dispatch is unknown or already consumed"
+                )
+            expected_binding = record.binding
+            expected_gateway = record.gateway
+            expected_context = record.runtime_context
+            expected_session = record.active_session
+            executor = cast("PaperExecutor", record.executor)
+            portfolio_id = record.portfolio_id
+            expected_fingerprint = record.fingerprint
+            baseline_dispatches[dispatch] = replace_record(
+                record,
+                consumed=True,
+                binding=None,
+                gateway=None,
+                runtime_context=None,
+                active_session=None,
+            )
+        fingerprint = fingerprint_order(order)
+        if (
+            type(binding) is not GatewayBaselineExecutionBinding
+            or expected_binding is not binding
+            or expected_gateway is not gateway
+            or expected_context is not runtime_context
+            or expected_session is not active_session
+            or fingerprint != expected_fingerprint
+        ):
+            raise PaperExecutionCapabilityError("baseline terminal dispatch does not match attempt")
+        capability = PaperExecutionCapability(_token=capability_token)
+        with registry_lock:
+            capabilities[capability] = CapabilityRecord(
+                binding,
+                executor,
+                order,
+                portfolio_id,
+                _CapabilityKind.BASELINE_ENTRY,
+                fingerprint,
+                None,
+            )
+        return terminal_sink(executor, order, capability)
+
+    def expected_reduction_fingerprint(descriptor, contract):
+        from .runtime_contract_constants import PAPER_SAFETY_EXECUTION_DOMAIN_SCOPE
+        from .safety.models import OrderSide, OrderType, TimeInForce
+
+        if (
+            descriptor.execution_domain_scope != PAPER_SAFETY_EXECUTION_DOMAIN_SCOPE
+            or descriptor.con_id != contract.con_id
+            or descriptor.side not in {OrderSide.SELL, OrderSide.BUY_TO_COVER}
+            or type(descriptor.quantity) is not Decimal
+            or not descriptor.quantity.is_finite()
+            or descriptor.quantity <= 0
+            or descriptor.quantity > Decimal("2147483647")
+            or descriptor.quantity != descriptor.quantity.to_integral_value()
+            or descriptor.attempt_number != 1
+            or type(descriptor.attempt_number) is not int
+            or descriptor.slice_count != 1
+            or type(descriptor.slice_count) is not int
+            or descriptor.bracket is not False
+            or descriptor.time_in_force is not TimeInForce.DAY
+            or descriptor.outside_regular_hours is not False
+        ):
+            raise PaperExecutionCapabilityError(
+                "reduction final allocation is not terminally representable"
+            )
+        if descriptor.order_type is OrderType.MARKET:
+            if descriptor.limit_price is not None or descriptor.stop_price is not None:
+                raise PaperExecutionCapabilityError(
+                    "reduction final allocation is not terminally representable"
+                )
+            price = None
+        elif descriptor.order_type is OrderType.LIMIT:
+            if (
+                type(descriptor.limit_price) is not Decimal
+                or not descriptor.limit_price.is_finite()
+                or descriptor.limit_price <= 0
+                or descriptor.limit_price > Decimal("1000000")
+                or descriptor.limit_price != descriptor.limit_price.quantize(Decimal("0.0001"))
+                or descriptor.stop_price is not None
+            ):
+                raise PaperExecutionCapabilityError(
+                    "reduction final allocation is not terminally representable"
+                )
+            price = descriptor.limit_price
+        else:
+            raise PaperExecutionCapabilityError(
+                "reduction final allocation is not terminally representable"
+            )
+        return _OrderFingerprint(
+            symbol=contract.symbol,
+            quantity=int(descriptor.quantity),
+            side=descriptor.side.value,
+            price=price,
+            order_ref=descriptor.order_ref,
+            take_profit=None,
+        )
+
+    from .safety.runtime import (
+        _consume_claimed_paper_submission_allocation as consume_claimed_allocation,
+    )
+
+    def issue_gateway_reduction_terminal_dispatch(
+        authority,
+        *,
+        submitter,
+        executor,
+        coordinator,
+        final_allocation,
+        descriptor,
+        contract,
+        order,
+        pre_position_quantity,
+    ):
+        try:
+            claimed_pre_position_quantity = consume_claimed_allocation(
+                final_allocation,
+                coordinator=coordinator,
+                descriptor=descriptor,
+                contract=contract,
+                pre_position_quantity=pre_position_quantity,
+            )
+        except (RuntimeError, TypeError) as exc:
+            raise PaperExecutionCapabilityError(
+                "reduction terminal dispatch lacks exact final allocation"
+            ) from exc
+        fingerprint = fingerprint_order(order)
+        expected_fingerprint = expected_reduction_fingerprint(descriptor, contract)
+        if fingerprint != expected_fingerprint:
+            raise PaperExecutionCapabilityError(
+                "reduction order does not match the claimed final allocation"
+            )
+        validate_reduction_bounds(fingerprint, claimed_pre_position_quantity)
+        with registry_lock:
+            authority_record = (
+                reduction_authorities.get(authority)
+                if type(authority) is ReductionExecutionAuthority
+                else None
+            )
+            if (
+                type(authority_record) is not ReductionAuthorityRecord
+                or authority_record.submitter is not submitter
+                or authority_record.executor is not executor
+                or authority_record.coordinator is not coordinator
+            ):
+                raise PaperExecutionCapabilityError("reduction terminal issuer is not bound")
+            dispatch = ReductionTerminalDispatch(_token=terminal_dispatch_token)
+            reduction_dispatches[dispatch] = TerminalDispatchRecord(
+                authority,
+                authority_record.gateway,
+                authority_record.runtime_context,
+                None,
+                submitter,
+                coordinator,
+                executor,
+                authority_record.portfolio_id,
+                fingerprint,
+                claimed_pre_position_quantity,
+            )
+        return dispatch
+
+    def _submit_gateway_reduction_once(
+        authority, dispatch, *, submitter, order, pre_position_quantity
+    ):
+        if type(dispatch) is not ReductionTerminalDispatch:
+            raise PaperExecutionCapabilityError("reduction terminal dispatch is invalid")
+        with registry_lock:
+            record = reduction_dispatches.get(dispatch)
+            if type(record) is not TerminalDispatchRecord or record.consumed:
+                raise PaperExecutionCapabilityError(
+                    "reduction terminal dispatch is unknown or already consumed"
+                )
+            expected_authority = record.binding
+            expected_submitter = record.submitter
+            executor = cast("PaperExecutor", record.executor)
+            portfolio_id = record.portfolio_id
+            expected_fingerprint = record.fingerprint
+            expected_pre_position = record.pre_position_quantity
+            reduction_dispatches[dispatch] = replace_record(
+                record,
+                consumed=True,
+                binding=None,
+                gateway=None,
+                runtime_context=None,
+                submitter=None,
+                coordinator=None,
+            )
+        fingerprint = fingerprint_order(order)
+        validate_reduction_bounds(fingerprint, pre_position_quantity)
+        if (
+            type(authority) is not ReductionExecutionAuthority
+            or expected_authority is not authority
+            or expected_submitter is not submitter
+            or fingerprint != expected_fingerprint
+            or pre_position_quantity != expected_pre_position
+        ):
+            raise PaperExecutionCapabilityError(
+                "reduction terminal dispatch does not match attempt"
+            )
+        capability = PaperExecutionCapability(_token=capability_token)
+        with registry_lock:
+            capabilities[capability] = CapabilityRecord(
+                authority,
+                executor,
+                order,
+                portfolio_id,
+                _CapabilityKind.REDUCTION,
+                fingerprint,
+                pre_position_quantity,
+            )
+        return terminal_sink(executor, order, capability)
+
+    return (
+        PaperExecutionCapability,
+        GatewayExecutionBindingCapability,
+        GatewayReductionBindingCapability,
+        BaselineTerminalDispatch,
+        ReductionTerminalDispatch,
+        ReductionExecutionAuthority,
+        GatewayBaselineExecutionBinding,
+        issue_gateway_execution_binding_capability,
+        bind_gateway_baseline_execution,
+        issue_gateway_reduction_binding_capability,
+        bind_gateway_reduction_execution,
+        attach_gateway_reduction_submitter,
+        reduction_authority_matches,
+        issue_gateway_baseline_terminal_dispatch,
+        _submit_gateway_baseline_once,
+        issue_gateway_reduction_terminal_dispatch,
+        _submit_gateway_reduction_once,
+        consume_paper_execution_capability,
+        apply_consumed_paper_fill,
+        execute_sealed_paper_fill,
+    )
+
+
+(
+    _PaperExecutionCapability,
+    _GatewayExecutionBindingCapability,
+    _GatewayReductionBindingCapability,
+    _BaselineTerminalDispatch,
+    _ReductionTerminalDispatch,
+    PaperReductionExecutionAuthority,
+    _GatewayBaselineExecutionBinding,
+    _issue_gateway_execution_binding_capability,
+    _bind_gateway_baseline_execution,
+    _issue_gateway_reduction_binding_capability,
+    _bind_gateway_reduction_execution,
+    _attach_gateway_reduction_submitter,
+    _reduction_authority_matches,
+    _issue_gateway_baseline_terminal_dispatch,
+    _submit_gateway_baseline_once,
+    _issue_gateway_reduction_terminal_dispatch,
+    _submit_gateway_reduction_once,
+    consume_paper_execution_capability,
+    _apply_consumed_paper_fill,
+    _execute_sealed_paper_fill,
+) = _build_sealed_capability_runtime()
+
+# Prevent callers from constructing a second authority universe.
+del _build_sealed_capability_runtime

--- a/robo_trader/paper_execution_capability.py
+++ b/robo_trader/paper_execution_capability.py
@@ -28,6 +28,10 @@ class PaperExecutionCapabilityError(RuntimeError):
     """A terminal paper submission lacked exact one-shot authority."""
 
 
+class PaperBaselineAdmissionError(PaperExecutionCapabilityError):
+    """Baseline intent, session, or order admission failed closed."""
+
+
 _PAPER_FILL_PRICE_TICK = Decimal("0.0001")
 
 
@@ -170,7 +174,10 @@ def _build_sealed_capability_runtime():
     reduction_bind_capability_token = object()
     reduction_authority_token = object()
     baseline_bind_token = object()
+    baseline_handle_token = object()
+    baseline_intent_token = object()
     terminal_dispatch_token = object()
+    baseline_session_token = object()
     capability_token = object()
     registry_lock = threading.Lock()
 
@@ -202,6 +209,17 @@ def _build_sealed_capability_runtime():
         runtime_context: object
         executor: object
         portfolio_id: str
+        entry_handle: object
+
+    @dataclass(frozen=True, slots=True)
+    class BaselineIntentRecord:
+        binding: object
+        gateway: object
+        runtime_context: object
+        portfolio_id: str
+        symbol: str
+        handle: object
+        consumed: bool = False
 
     @dataclass(frozen=True, slots=True)
     class ReductionBindingRecord(GatewayBindingRecord):
@@ -230,6 +248,19 @@ def _build_sealed_capability_runtime():
         pre_position_quantity: Decimal | None
         consumed: bool = False
 
+    @dataclass(frozen=True, slots=True)
+    class BaselineSessionRecord:
+        binding: object
+        gateway: object
+        runtime_context: object
+        portfolio_id: str
+        symbol: str
+        quote: object
+        task: asyncio.Task
+        consumed: bool = False
+        dispatch_issued: bool = False
+        closed: bool = False
+
     capabilities: weakref.WeakKeyDictionary[object, CapabilityRecord] = weakref.WeakKeyDictionary()
     gateway_bindings: weakref.WeakKeyDictionary[object, GatewayBindingRecord] = (
         weakref.WeakKeyDictionary()
@@ -249,6 +280,66 @@ def _build_sealed_capability_runtime():
     reduction_dispatches: weakref.WeakKeyDictionary[object, TerminalDispatchRecord] = (
         weakref.WeakKeyDictionary()
     )
+    baseline_sessions: weakref.WeakKeyDictionary[object, BaselineSessionRecord] = (
+        weakref.WeakKeyDictionary()
+    )
+    baseline_intents: weakref.WeakKeyDictionary[object, BaselineIntentRecord] = (
+        weakref.WeakKeyDictionary()
+    )
+    active_baseline_sessions: dict[tuple[object, asyncio.Task], object] = {}
+
+    class GatewayBaselineEntrySession:
+        """Opaque one-shot entry scope whose authority remains closure-owned."""
+
+        __slots__ = ("__weakref__",)
+
+        def __new__(cls, *, _token: object | None = None):
+            if _token is not baseline_session_token:
+                raise PaperExecutionCapabilityError("baseline entry session is gateway-only")
+            return super().__new__(cls)
+
+        def __copy__(self):
+            raise PaperExecutionCapabilityError("baseline entry session cannot copy")
+
+        def __deepcopy__(self, _memo):
+            return self.__copy__()
+
+        def __reduce__(self):
+            raise PaperExecutionCapabilityError("baseline entry session cannot serialize")
+
+    class GatewayBaselineEntryHandle:
+        __slots__ = ("__weakref__",)
+
+        def __new__(cls, *, _token: object | None = None):
+            if _token is not baseline_handle_token:
+                raise PaperExecutionCapabilityError("baseline entry handle is gateway-only")
+            return super().__new__(cls)
+
+        def __copy__(self):
+            raise PaperExecutionCapabilityError("baseline entry handle cannot copy")
+
+        def __deepcopy__(self, _memo):
+            return self.__copy__()
+
+        def __reduce__(self):
+            raise PaperExecutionCapabilityError("baseline entry handle cannot serialize")
+
+    class GatewayBaselineEntryIntent:
+        __slots__ = ("__weakref__",)
+
+        def __new__(cls, *, _token: object | None = None):
+            if _token is not baseline_intent_token:
+                raise PaperExecutionCapabilityError("baseline entry intent is gateway-only")
+            return super().__new__(cls)
+
+        def __copy__(self):
+            raise PaperExecutionCapabilityError("baseline entry intent cannot copy")
+
+        def __deepcopy__(self, _memo):
+            return self.__copy__()
+
+        def __reduce__(self):
+            raise PaperExecutionCapabilityError("baseline entry intent cannot serialize")
 
     class PaperExecutionCapability:
         __slots__ = ("__weakref__",)
@@ -465,9 +556,10 @@ def _build_sealed_capability_runtime():
                 "gateway execution binding capability does not match runtime"
             )
         binding = GatewayBaselineExecutionBinding(_token=baseline_bind_token)
+        entry_handle = GatewayBaselineEntryHandle(_token=baseline_handle_token)
         with registry_lock:
             baseline_bindings[binding] = BaselineBindingRecord(
-                gateway, runtime_context, executor, portfolio_id
+                gateway, runtime_context, executor, portfolio_id, entry_handle
             )
         return binding
 
@@ -580,32 +672,40 @@ def _build_sealed_capability_runtime():
                 and record.portfolio_id == portfolio_id
             )
 
-    def issue_gateway_baseline_terminal_dispatch(
-        binding, *, gateway, runtime_context, active_session, order
-    ):
-        from .paper_reduction_gateway import PaperReductionGateway, _ActiveEntrySession
+    def get_gateway_baseline_entry_handle(binding, *, gateway, runtime_context):
+        with registry_lock:
+            record = (
+                baseline_bindings.get(binding)
+                if type(binding) is GatewayBaselineExecutionBinding
+                else None
+            )
+            if (
+                type(record) is not BaselineBindingRecord
+                or record.gateway is not gateway
+                or record.runtime_context is not runtime_context
+                or type(record.entry_handle) is not GatewayBaselineEntryHandle
+            ):
+                raise PaperExecutionCapabilityError("baseline entry handle binding is invalid")
+            return record.entry_handle
 
-        task = asyncio.current_task()
-        sessions = getattr(gateway, "_active_entry_sessions", None)
-        fingerprint = fingerprint_order(order)
+    def issue_gateway_baseline_entry_intent(
+        binding,
+        *,
+        gateway,
+        runtime_context,
+        portfolio_id,
+        symbol,
+        handle,
+    ):
         if (
-            type(gateway) is not PaperReductionGateway
-            or gateway.started is not True
-            or getattr(gateway, "_runtime_context", None) is not runtime_context
-            or type(active_session) is not _ActiveEntrySession
-            or not isinstance(sessions, dict)
-            or task is None
-            or sessions.get(task) is not active_session
-            or active_session.consumed is not True
+            type(portfolio_id) is not str
+            or not portfolio_id
+            or portfolio_id.strip() != portfolio_id
+            or type(symbol) is not str
+            or not symbol
+            or symbol.strip() != symbol
         ):
-            raise PaperExecutionCapabilityError("baseline gateway session does not match binding")
-        if (
-            fingerprint.side != "BUY"
-            or fingerprint.take_profit is not None
-            or fingerprint.symbol != active_session.symbol
-            or fingerprint.price != active_session.quote.price
-        ):
-            raise PaperExecutionCapabilityError("baseline order does not match gateway session")
+            raise PaperBaselineAdmissionError("baseline entry intent request is malformed")
         with registry_lock:
             binding_record = (
                 baseline_bindings.get(binding)
@@ -616,19 +716,186 @@ def _build_sealed_capability_runtime():
                 type(binding_record) is not BaselineBindingRecord
                 or binding_record.gateway is not gateway
                 or binding_record.runtime_context is not runtime_context
-                or active_session.portfolio_id != binding_record.portfolio_id
-                or active_session.dispatch_issued is True
+                or binding_record.portfolio_id != portfolio_id
+                or type(handle) is not GatewayBaselineEntryHandle
+                or handle is not binding_record.entry_handle
             ):
+                raise PaperBaselineAdmissionError("baseline entry intent request is malformed")
+            intent = GatewayBaselineEntryIntent(_token=baseline_intent_token)
+            baseline_intents[intent] = BaselineIntentRecord(
+                binding,
+                gateway,
+                runtime_context,
+                portfolio_id,
+                symbol,
+                handle,
+            )
+        return intent
+
+    def begin_gateway_baseline_entry_session(
+        binding, *, gateway, runtime_context, portfolio_id, symbol, quote
+    ):
+        """Mint one task-bound session without exposing its registry or record type."""
+
+        from .market_data_contract import BrokerProtectiveQuote
+        from .paper_reduction_gateway import PaperReductionGateway
+
+        task = asyncio.current_task()
+        if (
+            type(gateway) is not PaperReductionGateway
+            or gateway.started is not True
+            or getattr(gateway, "_runtime_context", None) is not runtime_context
+            or type(task) is not asyncio.Task
+            or type(portfolio_id) is not str
+            or not portfolio_id
+            or portfolio_id.strip() != portfolio_id
+            or type(symbol) is not str
+            or not symbol
+            or symbol.strip() != symbol
+            or type(quote) is not BrokerProtectiveQuote
+            or quote.symbol != symbol
+        ):
+            raise PaperExecutionCapabilityError("baseline entry session scope is malformed")
+        key = (gateway, task)
+        with registry_lock:
+            binding_record = (
+                baseline_bindings.get(binding)
+                if type(binding) is GatewayBaselineExecutionBinding
+                else None
+            )
+            if (
+                type(binding_record) is not BaselineBindingRecord
+                or binding_record.gateway is not gateway
+                or binding_record.runtime_context is not runtime_context
+                or binding_record.portfolio_id != portfolio_id
+                or key in active_baseline_sessions
+            ):
+                raise PaperExecutionCapabilityError(
+                    "baseline entry session does not match binding or is nested"
+                )
+            session = GatewayBaselineEntrySession(_token=baseline_session_token)
+            baseline_sessions[session] = BaselineSessionRecord(
+                binding,
+                gateway,
+                runtime_context,
+                portfolio_id,
+                symbol,
+                quote,
+                task,
+            )
+            active_baseline_sessions[key] = session
+        return session
+
+    def end_gateway_baseline_entry_session(binding, session, *, gateway, runtime_context) -> None:
+        """Close the exact session and remove all task-addressable authority."""
+
+        task = asyncio.current_task()
+        key = (gateway, task) if type(task) is asyncio.Task else None
+        with registry_lock:
+            record = (
+                baseline_sessions.get(session)
+                if type(session) is GatewayBaselineEntrySession
+                else None
+            )
+            if (
+                type(record) is not BaselineSessionRecord
+                or record.binding is not binding
+                or record.gateway is not gateway
+                or record.runtime_context is not runtime_context
+                or record.task is not task
+                or record.closed
+                or key is None
+                or active_baseline_sessions.get(key) is not session
+            ):
+                raise PaperExecutionCapabilityError("baseline entry session close is invalid")
+            baseline_sessions[session] = replace_record(record, closed=True)
+            active_baseline_sessions.pop(key, None)
+
+    def issue_gateway_baseline_terminal_dispatch(
+        binding, *, gateway, runtime_context, intent, order
+    ):
+        from .paper_reduction_gateway import PaperReductionGateway
+
+        task = asyncio.current_task()
+        key = (gateway, task) if type(task) is asyncio.Task else None
+        # Locate and burn the sealed session before inspecting caller-controlled
+        # order fields. A malformed probe cannot preserve submission authority.
+        with registry_lock:
+            session = active_baseline_sessions.get(key) if key is not None else None
+            session_record = (
+                baseline_sessions.get(session)
+                if type(session) is GatewayBaselineEntrySession
+                else None
+            )
+            binding_record = (
+                baseline_bindings.get(binding)
+                if type(binding) is GatewayBaselineExecutionBinding
+                else None
+            )
+            intent_record = (
+                baseline_intents.get(intent) if type(intent) is GatewayBaselineEntryIntent else None
+            )
+            if type(intent_record) is not BaselineIntentRecord or intent_record.consumed:
+                raise PaperBaselineAdmissionError(
+                    "baseline entry intent is invalid or already consumed"
+                )
+            # Burn recognized producer authority before testing any caller-
+            # selected runtime, session, or order association.
+            baseline_intents[intent] = replace_record(intent_record, consumed=True)
+            if (
+                type(binding_record) is not BaselineBindingRecord
+                or intent_record.binding is not binding
+                or intent_record.gateway is not gateway
+                or intent_record.runtime_context is not runtime_context
+                or intent_record.portfolio_id != binding_record.portfolio_id
+                or intent_record.handle is not binding_record.entry_handle
+            ):
+                raise PaperBaselineAdmissionError("baseline entry intent does not match runtime")
+            if (
+                type(gateway) is not PaperReductionGateway
+                or gateway.started is not True
+                or getattr(gateway, "_runtime_context", None) is not runtime_context
+                or type(session_record) is not BaselineSessionRecord
+                or session_record.binding is not binding
+                or session_record.gateway is not gateway
+                or session_record.runtime_context is not runtime_context
+                or session_record.task is not task
+                or session_record.consumed
+                or session_record.closed
+                or type(binding_record) is not BaselineBindingRecord
+                or binding_record.gateway is not gateway
+                or binding_record.runtime_context is not runtime_context
+                or session_record.portfolio_id != binding_record.portfolio_id
+                or intent_record.portfolio_id != session_record.portfolio_id
+                or intent_record.symbol != session_record.symbol
+            ):
+                raise PaperBaselineAdmissionError("baseline gateway session does not match binding")
+            burned_record = replace_record(session_record, consumed=True)
+            baseline_sessions[session] = burned_record
+        fingerprint = fingerprint_order(order)
+        if (
+            fingerprint.side != "BUY"
+            or fingerprint.take_profit is not None
+            or fingerprint.symbol != burned_record.symbol
+            or fingerprint.price != burned_record.quote.price
+        ):
+            raise PaperBaselineAdmissionError("baseline order does not match gateway session")
+        with registry_lock:
+            current = baseline_sessions.get(session)
+            if current is not burned_record or burned_record.dispatch_issued:
                 raise PaperExecutionCapabilityError(
                     "baseline gateway session does not match binding or already issued"
                 )
-            active_session.dispatch_issued = True
+            baseline_sessions[session] = replace_record(
+                burned_record,
+                dispatch_issued=True,
+            )
             dispatch = BaselineTerminalDispatch(_token=terminal_dispatch_token)
             baseline_dispatches[dispatch] = TerminalDispatchRecord(
                 binding,
                 gateway,
                 runtime_context,
-                active_session,
+                session,
                 None,
                 None,
                 binding_record.executor,
@@ -781,7 +1048,6 @@ def _build_sealed_capability_runtime():
         *,
         gateway,
         runtime_context,
-        active_session,
         order,
     ):
         if type(dispatch) is not BaselineTerminalDispatch:
@@ -807,6 +1073,14 @@ def _build_sealed_capability_runtime():
                 runtime_context=None,
                 active_session=None,
             )
+            task = asyncio.current_task()
+            key = (gateway, task) if type(task) is asyncio.Task else None
+            active_session = active_baseline_sessions.get(key) if key is not None else None
+            session_record = (
+                baseline_sessions.get(active_session)
+                if type(active_session) is GatewayBaselineEntrySession
+                else None
+            )
         fingerprint = fingerprint_order(order)
         if (
             type(binding) is not GatewayBaselineExecutionBinding
@@ -814,6 +1088,14 @@ def _build_sealed_capability_runtime():
             or expected_gateway is not gateway
             or expected_context is not runtime_context
             or expected_session is not active_session
+            or type(session_record) is not BaselineSessionRecord
+            or session_record.binding is not binding
+            or session_record.gateway is not gateway
+            or session_record.runtime_context is not runtime_context
+            or session_record.task is not task
+            or session_record.consumed is not True
+            or session_record.dispatch_issued is not True
+            or session_record.closed
             or fingerprint != expected_fingerprint
         ):
             raise PaperExecutionCapabilityError("baseline terminal dispatch does not match attempt")
@@ -1015,6 +1297,10 @@ def _build_sealed_capability_runtime():
         bind_gateway_reduction_execution,
         attach_gateway_reduction_submitter,
         reduction_authority_matches,
+        get_gateway_baseline_entry_handle,
+        issue_gateway_baseline_entry_intent,
+        begin_gateway_baseline_entry_session,
+        end_gateway_baseline_entry_session,
         issue_gateway_baseline_terminal_dispatch,
         _submit_gateway_baseline_once,
         issue_gateway_reduction_terminal_dispatch,
@@ -1039,6 +1325,10 @@ def _build_sealed_capability_runtime():
     _bind_gateway_reduction_execution,
     _attach_gateway_reduction_submitter,
     _reduction_authority_matches,
+    _get_gateway_baseline_entry_handle,
+    _issue_gateway_baseline_entry_intent,
+    _begin_gateway_baseline_entry_session,
+    _end_gateway_baseline_entry_session,
     _issue_gateway_baseline_terminal_dispatch,
     _submit_gateway_baseline_once,
     _issue_gateway_reduction_terminal_dispatch,

--- a/robo_trader/paper_execution_capability.py
+++ b/robo_trader/paper_execution_capability.py
@@ -1,15 +1,13 @@
-"""One-shot capabilities for the terminal local-paper execution sink.
+"""One-shot integrity capabilities for exposure-reducing paper fills.
 
-The account gateway consumes a one-shot runtime binding grant before it can
-bind baseline execution. The resulting baseline binding has no submission
-method; only an exact active gateway entry session can derive a terminal
-capability. Reduction authority remains separately constrained by the sealed
-coordinator submission adapter and exact pre-position evidence.
+This staging module deliberately contains no baseline BUY issuer or terminal
+entry path. Semantic reductions remain constrained by the coordinator's final
+allocation and exact pre-position evidence. Python closure state is treated as
+implementation integrity, never as isolation from hostile same-process code.
 """
 
 from __future__ import annotations
 
-import asyncio
 import datetime as dt
 import math
 import threading
@@ -28,15 +26,10 @@ class PaperExecutionCapabilityError(RuntimeError):
     """A terminal paper submission lacked exact one-shot authority."""
 
 
-class PaperBaselineAdmissionError(PaperExecutionCapabilityError):
-    """Baseline intent, session, or order admission failed closed."""
-
-
 _PAPER_FILL_PRICE_TICK = Decimal("0.0001")
 
 
 class _CapabilityKind(Enum):
-    BASELINE_ENTRY = "baseline-entry"
     REDUCTION = "reduction"
 
 
@@ -139,45 +132,22 @@ def _validate_reduction_bounds(
 
 
 def _build_sealed_capability_runtime():
-    """Create the only authority state used by the local-paper terminal sink.
+    """Build one-shot integrity state for exposure-reducing paper fills.
 
-    Tokens, registries, record types, and state transitions deliberately live
-    only in this factory's closure. Importing this module exposes opaque
-    identities and validating operations, never the state needed to mint or
-    revive one of those identities.
+    Python code in one interpreter is one trust domain: closure cells are
+    introspectable and are not a security-isolation boundary. This runtime
+    therefore mints capabilities only for semantic reductions. Baseline BUY
+    authority remains unavailable until admission is enforced outside that
+    shared trust domain or by an independently verified integrated boundary.
     """
 
     fingerprint_order = _fingerprint_order
     validate_reduction_bounds = _validate_reduction_bounds
     validate_gateway_binding_scope = _validate_gateway_binding_scope
     replace_record = dataclass_replace
-    # Capture the OS primitive inside the sealed runtime so the terminal
-    # cross-process kill-switch check cannot be replaced through a gateway or
-    # executor attribute. The remaining lstat-to-fill interval is synchronous
-    # and intentionally contains no caller callback.
-    from os import lstat as terminal_lstat
-
-    terminal_entry_lock_path = "data/kill_switch.lock"
-
-    def require_terminal_entry_lock_clear() -> None:
-        try:
-            terminal_lstat(terminal_entry_lock_path)
-        except FileNotFoundError:
-            return
-        except OSError as exc:
-            raise PaperExecutionCapabilityError(
-                "terminal kill-switch lock state is unavailable"
-            ) from exc
-        raise PaperExecutionCapabilityError("terminal kill-switch lock is active")
-
-    bind_capability_token = object()
     reduction_bind_capability_token = object()
     reduction_authority_token = object()
-    baseline_bind_token = object()
-    baseline_handle_token = object()
-    baseline_intent_token = object()
     terminal_dispatch_token = object()
-    baseline_session_token = object()
     capability_token = object()
     registry_lock = threading.Lock()
 
@@ -195,34 +165,13 @@ def _build_sealed_capability_runtime():
         fill_consumed: bool = False
 
     @dataclass(frozen=True, slots=True)
-    class GatewayBindingRecord:
+    class ReductionBindingRecord:
         gateway: object
         runtime_context: object
         binding_session: object
         executor: object
         portfolio_id: str
         consumed: bool = False
-
-    @dataclass(frozen=True, slots=True)
-    class BaselineBindingRecord:
-        gateway: object
-        runtime_context: object
-        executor: object
-        portfolio_id: str
-        entry_handle: object
-
-    @dataclass(frozen=True, slots=True)
-    class BaselineIntentRecord:
-        binding: object
-        gateway: object
-        runtime_context: object
-        portfolio_id: str
-        symbol: str
-        handle: object
-        consumed: bool = False
-
-    @dataclass(frozen=True, slots=True)
-    class ReductionBindingRecord(GatewayBindingRecord):
         coordinator: object = None
 
     @dataclass(frozen=True, slots=True)
@@ -248,98 +197,16 @@ def _build_sealed_capability_runtime():
         pre_position_quantity: Decimal | None
         consumed: bool = False
 
-    @dataclass(frozen=True, slots=True)
-    class BaselineSessionRecord:
-        binding: object
-        gateway: object
-        runtime_context: object
-        portfolio_id: str
-        symbol: str
-        quote: object
-        task: asyncio.Task
-        consumed: bool = False
-        dispatch_issued: bool = False
-        closed: bool = False
-
     capabilities: weakref.WeakKeyDictionary[object, CapabilityRecord] = weakref.WeakKeyDictionary()
-    gateway_bindings: weakref.WeakKeyDictionary[object, GatewayBindingRecord] = (
-        weakref.WeakKeyDictionary()
-    )
-    baseline_bindings: weakref.WeakKeyDictionary[object, BaselineBindingRecord] = (
-        weakref.WeakKeyDictionary()
-    )
     reduction_bindings: weakref.WeakKeyDictionary[object, ReductionBindingRecord] = (
         weakref.WeakKeyDictionary()
     )
     reduction_authorities: weakref.WeakKeyDictionary[object, ReductionAuthorityRecord] = (
         weakref.WeakKeyDictionary()
     )
-    baseline_dispatches: weakref.WeakKeyDictionary[object, TerminalDispatchRecord] = (
-        weakref.WeakKeyDictionary()
-    )
     reduction_dispatches: weakref.WeakKeyDictionary[object, TerminalDispatchRecord] = (
         weakref.WeakKeyDictionary()
     )
-    baseline_sessions: weakref.WeakKeyDictionary[object, BaselineSessionRecord] = (
-        weakref.WeakKeyDictionary()
-    )
-    baseline_intents: weakref.WeakKeyDictionary[object, BaselineIntentRecord] = (
-        weakref.WeakKeyDictionary()
-    )
-    active_baseline_sessions: dict[tuple[object, asyncio.Task], object] = {}
-
-    class GatewayBaselineEntrySession:
-        """Opaque one-shot entry scope whose authority remains closure-owned."""
-
-        __slots__ = ("__weakref__",)
-
-        def __new__(cls, *, _token: object | None = None):
-            if _token is not baseline_session_token:
-                raise PaperExecutionCapabilityError("baseline entry session is gateway-only")
-            return super().__new__(cls)
-
-        def __copy__(self):
-            raise PaperExecutionCapabilityError("baseline entry session cannot copy")
-
-        def __deepcopy__(self, _memo):
-            return self.__copy__()
-
-        def __reduce__(self):
-            raise PaperExecutionCapabilityError("baseline entry session cannot serialize")
-
-    class GatewayBaselineEntryHandle:
-        __slots__ = ("__weakref__",)
-
-        def __new__(cls, *, _token: object | None = None):
-            if _token is not baseline_handle_token:
-                raise PaperExecutionCapabilityError("baseline entry handle is gateway-only")
-            return super().__new__(cls)
-
-        def __copy__(self):
-            raise PaperExecutionCapabilityError("baseline entry handle cannot copy")
-
-        def __deepcopy__(self, _memo):
-            return self.__copy__()
-
-        def __reduce__(self):
-            raise PaperExecutionCapabilityError("baseline entry handle cannot serialize")
-
-    class GatewayBaselineEntryIntent:
-        __slots__ = ("__weakref__",)
-
-        def __new__(cls, *, _token: object | None = None):
-            if _token is not baseline_intent_token:
-                raise PaperExecutionCapabilityError("baseline entry intent is gateway-only")
-            return super().__new__(cls)
-
-        def __copy__(self):
-            raise PaperExecutionCapabilityError("baseline entry intent cannot copy")
-
-        def __deepcopy__(self, _memo):
-            return self.__copy__()
-
-        def __reduce__(self):
-            raise PaperExecutionCapabilityError("baseline entry intent cannot serialize")
 
     class PaperExecutionCapability:
         __slots__ = ("__weakref__",)
@@ -368,37 +235,6 @@ def _build_sealed_capability_runtime():
                     capabilities[self] = replace_record(record, consumed=True)
             raise PaperExecutionCapabilityError("paper execution capabilities cannot serialize")
 
-    class GatewayExecutionBindingCapability:
-        __slots__ = ("__weakref__",)
-
-        def __new__(cls, *, _token: object | None = None):
-            if _token is not bind_capability_token:
-                raise PaperExecutionCapabilityError(
-                    "gateway execution binding capabilities are issuer-only"
-                )
-            return super().__new__(cls)
-
-        def __copy__(self):
-            with registry_lock:
-                record = gateway_bindings.get(self)
-                if type(record) is GatewayBindingRecord:
-                    gateway_bindings[self] = replace_record(record, consumed=True)
-            raise PaperExecutionCapabilityError(
-                "gateway execution binding capabilities cannot copy"
-            )
-
-        def __deepcopy__(self, _memo):
-            return self.__copy__()
-
-        def __reduce__(self):
-            with registry_lock:
-                record = gateway_bindings.get(self)
-                if type(record) is GatewayBindingRecord:
-                    gateway_bindings[self] = replace_record(record, consumed=True)
-            raise PaperExecutionCapabilityError(
-                "gateway execution binding capabilities cannot serialize"
-            )
-
     class GatewayReductionBindingCapability:
         __slots__ = ("__weakref__",)
 
@@ -419,31 +255,6 @@ def _build_sealed_capability_runtime():
 
         def __reduce__(self):
             raise PaperExecutionCapabilityError("reduction binding capability cannot serialize")
-
-    class BaselineTerminalDispatch:
-        __slots__ = ("__weakref__",)
-
-        def __new__(cls, *, _token: object | None = None):
-            if _token is not terminal_dispatch_token:
-                raise PaperExecutionCapabilityError("baseline terminal dispatch is issuer-only")
-            return super().__new__(cls)
-
-        def __copy__(self):
-            with registry_lock:
-                record = baseline_dispatches.get(self)
-                if type(record) is TerminalDispatchRecord:
-                    baseline_dispatches[self] = replace_record(record, consumed=True)
-            raise PaperExecutionCapabilityError("baseline terminal dispatch cannot copy")
-
-        def __deepcopy__(self, _memo):
-            return self.__copy__()
-
-        def __reduce__(self):
-            with registry_lock:
-                record = baseline_dispatches.get(self)
-                if type(record) is TerminalDispatchRecord:
-                    baseline_dispatches[self] = replace_record(record, consumed=True)
-            raise PaperExecutionCapabilityError("baseline terminal dispatch cannot serialize")
 
     class ReductionTerminalDispatch:
         __slots__ = ("__weakref__",)
@@ -486,82 +297,6 @@ def _build_sealed_capability_runtime():
 
         def __reduce__(self):
             raise PaperExecutionCapabilityError("paper reduction authority cannot serialize")
-
-    class GatewayBaselineExecutionBinding:
-        __slots__ = ("__weakref__",)
-
-        def __new__(cls, *, _token: object | None = None):
-            if _token is not baseline_bind_token:
-                raise PaperExecutionCapabilityError("baseline execution binding is gateway-only")
-            return super().__new__(cls)
-
-        def __copy__(self):
-            raise PaperExecutionCapabilityError("baseline execution binding cannot copy")
-
-        def __deepcopy__(self, _memo):
-            return self.__copy__()
-
-        def __reduce__(self):
-            raise PaperExecutionCapabilityError("baseline execution binding cannot serialize")
-
-    def issue_gateway_execution_binding_capability(
-        *, gateway, runtime_context, binding_session, executor, portfolio_id
-    ):
-        validate_gateway_binding_scope(
-            gateway=gateway,
-            runtime_context=runtime_context,
-            binding_session=binding_session,
-            executor=executor,
-            portfolio_id=portfolio_id,
-        )
-        if getattr(binding_session, "capability_issued", False):
-            raise PaperExecutionCapabilityError(
-                "gateway runtime binding session already issued its capability"
-            )
-        setattr(binding_session, "capability_issued", True)
-        capability = GatewayExecutionBindingCapability(_token=bind_capability_token)
-        with registry_lock:
-            gateway_bindings[capability] = GatewayBindingRecord(
-                gateway, runtime_context, binding_session, executor, portfolio_id
-            )
-        return capability
-
-    def bind_gateway_baseline_execution(
-        *, gateway, runtime_context, binding_session, executor, portfolio_id, capability
-    ):
-        if type(capability) is not GatewayExecutionBindingCapability:
-            raise PaperExecutionCapabilityError("gateway execution binding capability is invalid")
-        with registry_lock:
-            record = gateway_bindings.get(capability)
-            if type(record) is not GatewayBindingRecord or record.consumed:
-                raise PaperExecutionCapabilityError(
-                    "gateway execution binding capability is unknown or already consumed"
-                )
-            gateway_bindings[capability] = replace_record(record, consumed=True)
-        validate_gateway_binding_scope(
-            gateway=gateway,
-            runtime_context=runtime_context,
-            binding_session=binding_session,
-            executor=executor,
-            portfolio_id=portfolio_id,
-        )
-        if (
-            record.gateway is not gateway
-            or record.runtime_context is not runtime_context
-            or record.binding_session is not binding_session
-            or record.executor is not executor
-            or record.portfolio_id != portfolio_id
-        ):
-            raise PaperExecutionCapabilityError(
-                "gateway execution binding capability does not match runtime"
-            )
-        binding = GatewayBaselineExecutionBinding(_token=baseline_bind_token)
-        entry_handle = GatewayBaselineEntryHandle(_token=baseline_handle_token)
-        with registry_lock:
-            baseline_bindings[binding] = BaselineBindingRecord(
-                gateway, runtime_context, executor, portfolio_id, entry_handle
-            )
-        return binding
 
     def issue_gateway_reduction_binding_capability(
         *, gateway, runtime_context, binding_session, executor, portfolio_id, coordinator
@@ -672,239 +407,6 @@ def _build_sealed_capability_runtime():
                 and record.portfolio_id == portfolio_id
             )
 
-    def get_gateway_baseline_entry_handle(binding, *, gateway, runtime_context):
-        with registry_lock:
-            record = (
-                baseline_bindings.get(binding)
-                if type(binding) is GatewayBaselineExecutionBinding
-                else None
-            )
-            if (
-                type(record) is not BaselineBindingRecord
-                or record.gateway is not gateway
-                or record.runtime_context is not runtime_context
-                or type(record.entry_handle) is not GatewayBaselineEntryHandle
-            ):
-                raise PaperExecutionCapabilityError("baseline entry handle binding is invalid")
-            return record.entry_handle
-
-    def issue_gateway_baseline_entry_intent(
-        binding,
-        *,
-        gateway,
-        runtime_context,
-        portfolio_id,
-        symbol,
-        handle,
-    ):
-        if (
-            type(portfolio_id) is not str
-            or not portfolio_id
-            or portfolio_id.strip() != portfolio_id
-            or type(symbol) is not str
-            or not symbol
-            or symbol.strip() != symbol
-        ):
-            raise PaperBaselineAdmissionError("baseline entry intent request is malformed")
-        with registry_lock:
-            binding_record = (
-                baseline_bindings.get(binding)
-                if type(binding) is GatewayBaselineExecutionBinding
-                else None
-            )
-            if (
-                type(binding_record) is not BaselineBindingRecord
-                or binding_record.gateway is not gateway
-                or binding_record.runtime_context is not runtime_context
-                or binding_record.portfolio_id != portfolio_id
-                or type(handle) is not GatewayBaselineEntryHandle
-                or handle is not binding_record.entry_handle
-            ):
-                raise PaperBaselineAdmissionError("baseline entry intent request is malformed")
-            intent = GatewayBaselineEntryIntent(_token=baseline_intent_token)
-            baseline_intents[intent] = BaselineIntentRecord(
-                binding,
-                gateway,
-                runtime_context,
-                portfolio_id,
-                symbol,
-                handle,
-            )
-        return intent
-
-    def begin_gateway_baseline_entry_session(
-        binding, *, gateway, runtime_context, portfolio_id, symbol, quote
-    ):
-        """Mint one task-bound session without exposing its registry or record type."""
-
-        from .market_data_contract import BrokerProtectiveQuote
-        from .paper_reduction_gateway import PaperReductionGateway
-
-        task = asyncio.current_task()
-        if (
-            type(gateway) is not PaperReductionGateway
-            or gateway.started is not True
-            or getattr(gateway, "_runtime_context", None) is not runtime_context
-            or type(task) is not asyncio.Task
-            or type(portfolio_id) is not str
-            or not portfolio_id
-            or portfolio_id.strip() != portfolio_id
-            or type(symbol) is not str
-            or not symbol
-            or symbol.strip() != symbol
-            or type(quote) is not BrokerProtectiveQuote
-            or quote.symbol != symbol
-        ):
-            raise PaperExecutionCapabilityError("baseline entry session scope is malformed")
-        key = (gateway, task)
-        with registry_lock:
-            binding_record = (
-                baseline_bindings.get(binding)
-                if type(binding) is GatewayBaselineExecutionBinding
-                else None
-            )
-            if (
-                type(binding_record) is not BaselineBindingRecord
-                or binding_record.gateway is not gateway
-                or binding_record.runtime_context is not runtime_context
-                or binding_record.portfolio_id != portfolio_id
-                or key in active_baseline_sessions
-            ):
-                raise PaperExecutionCapabilityError(
-                    "baseline entry session does not match binding or is nested"
-                )
-            session = GatewayBaselineEntrySession(_token=baseline_session_token)
-            baseline_sessions[session] = BaselineSessionRecord(
-                binding,
-                gateway,
-                runtime_context,
-                portfolio_id,
-                symbol,
-                quote,
-                task,
-            )
-            active_baseline_sessions[key] = session
-        return session
-
-    def end_gateway_baseline_entry_session(binding, session, *, gateway, runtime_context) -> None:
-        """Close the exact session and remove all task-addressable authority."""
-
-        task = asyncio.current_task()
-        key = (gateway, task) if type(task) is asyncio.Task else None
-        with registry_lock:
-            record = (
-                baseline_sessions.get(session)
-                if type(session) is GatewayBaselineEntrySession
-                else None
-            )
-            if (
-                type(record) is not BaselineSessionRecord
-                or record.binding is not binding
-                or record.gateway is not gateway
-                or record.runtime_context is not runtime_context
-                or record.task is not task
-                or record.closed
-                or key is None
-                or active_baseline_sessions.get(key) is not session
-            ):
-                raise PaperExecutionCapabilityError("baseline entry session close is invalid")
-            baseline_sessions[session] = replace_record(record, closed=True)
-            active_baseline_sessions.pop(key, None)
-
-    def issue_gateway_baseline_terminal_dispatch(
-        binding, *, gateway, runtime_context, intent, order
-    ):
-        from .paper_reduction_gateway import PaperReductionGateway
-
-        task = asyncio.current_task()
-        key = (gateway, task) if type(task) is asyncio.Task else None
-        # Locate and burn the sealed session before inspecting caller-controlled
-        # order fields. A malformed probe cannot preserve submission authority.
-        with registry_lock:
-            session = active_baseline_sessions.get(key) if key is not None else None
-            session_record = (
-                baseline_sessions.get(session)
-                if type(session) is GatewayBaselineEntrySession
-                else None
-            )
-            binding_record = (
-                baseline_bindings.get(binding)
-                if type(binding) is GatewayBaselineExecutionBinding
-                else None
-            )
-            intent_record = (
-                baseline_intents.get(intent) if type(intent) is GatewayBaselineEntryIntent else None
-            )
-            if type(intent_record) is not BaselineIntentRecord or intent_record.consumed:
-                raise PaperBaselineAdmissionError(
-                    "baseline entry intent is invalid or already consumed"
-                )
-            # Burn recognized producer authority before testing any caller-
-            # selected runtime, session, or order association.
-            baseline_intents[intent] = replace_record(intent_record, consumed=True)
-            if (
-                type(binding_record) is not BaselineBindingRecord
-                or intent_record.binding is not binding
-                or intent_record.gateway is not gateway
-                or intent_record.runtime_context is not runtime_context
-                or intent_record.portfolio_id != binding_record.portfolio_id
-                or intent_record.handle is not binding_record.entry_handle
-            ):
-                raise PaperBaselineAdmissionError("baseline entry intent does not match runtime")
-            if (
-                type(gateway) is not PaperReductionGateway
-                or gateway.started is not True
-                or getattr(gateway, "_runtime_context", None) is not runtime_context
-                or type(session_record) is not BaselineSessionRecord
-                or session_record.binding is not binding
-                or session_record.gateway is not gateway
-                or session_record.runtime_context is not runtime_context
-                or session_record.task is not task
-                or session_record.consumed
-                or session_record.closed
-                or type(binding_record) is not BaselineBindingRecord
-                or binding_record.gateway is not gateway
-                or binding_record.runtime_context is not runtime_context
-                or session_record.portfolio_id != binding_record.portfolio_id
-                or intent_record.portfolio_id != session_record.portfolio_id
-                or intent_record.symbol != session_record.symbol
-            ):
-                raise PaperBaselineAdmissionError("baseline gateway session does not match binding")
-            burned_record = replace_record(session_record, consumed=True)
-            baseline_sessions[session] = burned_record
-        fingerprint = fingerprint_order(order)
-        if (
-            fingerprint.side != "BUY"
-            or fingerprint.take_profit is not None
-            or fingerprint.symbol != burned_record.symbol
-            or fingerprint.price != burned_record.quote.price
-        ):
-            raise PaperBaselineAdmissionError("baseline order does not match gateway session")
-        with registry_lock:
-            current = baseline_sessions.get(session)
-            if current is not burned_record or burned_record.dispatch_issued:
-                raise PaperExecutionCapabilityError(
-                    "baseline gateway session does not match binding or already issued"
-                )
-            baseline_sessions[session] = replace_record(
-                burned_record,
-                dispatch_issued=True,
-            )
-            dispatch = BaselineTerminalDispatch(_token=terminal_dispatch_token)
-            baseline_dispatches[dispatch] = TerminalDispatchRecord(
-                binding,
-                gateway,
-                runtime_context,
-                session,
-                None,
-                None,
-                binding_record.executor,
-                binding_record.portfolio_id,
-                fingerprint,
-                None,
-            )
-        return dispatch
-
     def consume_paper_execution_capability(executor, order, capability):
         if type(capability) is not PaperExecutionCapability:
             raise PaperExecutionCapabilityError(
@@ -923,19 +425,13 @@ def _build_sealed_capability_runtime():
             raise PaperExecutionCapabilityError(
                 "paper execution capability does not match executor or order"
             )
-        if record.kind is _CapabilityKind.BASELINE_ENTRY:
-            if fingerprint.side != "BUY" or fingerprint.take_profit is not None:
-                raise PaperExecutionCapabilityError("baseline entry capability is malformed")
-        else:
-            if record.kind is not _CapabilityKind.REDUCTION:
-                raise PaperExecutionCapabilityError(
-                    "paper execution capability kind is unsupported"
-                )
-            if type(record.pre_position_quantity) is not Decimal:
-                raise PaperExecutionCapabilityError(
-                    "reduction capability lacks exact position evidence"
-                )
-            validate_reduction_bounds(fingerprint, record.pre_position_quantity)
+        if record.kind is not _CapabilityKind.REDUCTION:
+            raise PaperExecutionCapabilityError("paper execution capability kind is unsupported")
+        if type(record.pre_position_quantity) is not Decimal:
+            raise PaperExecutionCapabilityError(
+                "reduction capability lacks exact position evidence"
+            )
+        validate_reduction_bounds(fingerprint, record.pre_position_quantity)
         with registry_lock:
             current = capabilities.get(capability)
             if current is not record or record.consumed is not True:
@@ -1041,77 +537,6 @@ def _build_sealed_capability_runtime():
         return apply_consumed_paper_fill(executor, order, capability)
 
     terminal_sink = execute_sealed_paper_fill
-
-    def _submit_gateway_baseline_once(
-        binding,
-        dispatch,
-        *,
-        gateway,
-        runtime_context,
-        order,
-    ):
-        if type(dispatch) is not BaselineTerminalDispatch:
-            raise PaperExecutionCapabilityError("baseline terminal dispatch is invalid")
-        with registry_lock:
-            record = baseline_dispatches.get(dispatch)
-            if type(record) is not TerminalDispatchRecord or record.consumed:
-                raise PaperExecutionCapabilityError(
-                    "baseline terminal dispatch is unknown or already consumed"
-                )
-            expected_binding = record.binding
-            expected_gateway = record.gateway
-            expected_context = record.runtime_context
-            expected_session = record.active_session
-            executor = cast("PaperExecutor", record.executor)
-            portfolio_id = record.portfolio_id
-            expected_fingerprint = record.fingerprint
-            baseline_dispatches[dispatch] = replace_record(
-                record,
-                consumed=True,
-                binding=None,
-                gateway=None,
-                runtime_context=None,
-                active_session=None,
-            )
-            task = asyncio.current_task()
-            key = (gateway, task) if type(task) is asyncio.Task else None
-            active_session = active_baseline_sessions.get(key) if key is not None else None
-            session_record = (
-                baseline_sessions.get(active_session)
-                if type(active_session) is GatewayBaselineEntrySession
-                else None
-            )
-        fingerprint = fingerprint_order(order)
-        if (
-            type(binding) is not GatewayBaselineExecutionBinding
-            or expected_binding is not binding
-            or expected_gateway is not gateway
-            or expected_context is not runtime_context
-            or expected_session is not active_session
-            or type(session_record) is not BaselineSessionRecord
-            or session_record.binding is not binding
-            or session_record.gateway is not gateway
-            or session_record.runtime_context is not runtime_context
-            or session_record.task is not task
-            or session_record.consumed is not True
-            or session_record.dispatch_issued is not True
-            or session_record.closed
-            or fingerprint != expected_fingerprint
-        ):
-            raise PaperExecutionCapabilityError("baseline terminal dispatch does not match attempt")
-        require_terminal_entry_lock_clear()
-        capability = PaperExecutionCapability(_token=capability_token)
-        with registry_lock:
-            capabilities[capability] = CapabilityRecord(
-                binding,
-                executor,
-                order,
-                portfolio_id,
-                _CapabilityKind.BASELINE_ENTRY,
-                fingerprint,
-                None,
-            )
-        return terminal_sink(executor, order, capability)
 
     def expected_reduction_fingerprint(descriptor, contract):
         from .runtime_contract_constants import PAPER_SAFETY_EXECUTION_DOMAIN_SCOPE
@@ -1285,24 +710,13 @@ def _build_sealed_capability_runtime():
 
     return (
         PaperExecutionCapability,
-        GatewayExecutionBindingCapability,
         GatewayReductionBindingCapability,
-        BaselineTerminalDispatch,
         ReductionTerminalDispatch,
         ReductionExecutionAuthority,
-        GatewayBaselineExecutionBinding,
-        issue_gateway_execution_binding_capability,
-        bind_gateway_baseline_execution,
         issue_gateway_reduction_binding_capability,
         bind_gateway_reduction_execution,
         attach_gateway_reduction_submitter,
         reduction_authority_matches,
-        get_gateway_baseline_entry_handle,
-        issue_gateway_baseline_entry_intent,
-        begin_gateway_baseline_entry_session,
-        end_gateway_baseline_entry_session,
-        issue_gateway_baseline_terminal_dispatch,
-        _submit_gateway_baseline_once,
         issue_gateway_reduction_terminal_dispatch,
         _submit_gateway_reduction_once,
         consume_paper_execution_capability,
@@ -1313,24 +727,13 @@ def _build_sealed_capability_runtime():
 
 (
     _PaperExecutionCapability,
-    _GatewayExecutionBindingCapability,
     _GatewayReductionBindingCapability,
-    _BaselineTerminalDispatch,
     _ReductionTerminalDispatch,
     PaperReductionExecutionAuthority,
-    _GatewayBaselineExecutionBinding,
-    _issue_gateway_execution_binding_capability,
-    _bind_gateway_baseline_execution,
     _issue_gateway_reduction_binding_capability,
     _bind_gateway_reduction_execution,
     _attach_gateway_reduction_submitter,
     _reduction_authority_matches,
-    _get_gateway_baseline_entry_handle,
-    _issue_gateway_baseline_entry_intent,
-    _begin_gateway_baseline_entry_session,
-    _end_gateway_baseline_entry_session,
-    _issue_gateway_baseline_terminal_dispatch,
-    _submit_gateway_baseline_once,
     _issue_gateway_reduction_terminal_dispatch,
     _submit_gateway_reduction_once,
     consume_paper_execution_capability,

--- a/robo_trader/paper_execution_capability.py
+++ b/robo_trader/paper_execution_capability.py
@@ -1,18 +1,21 @@
 """One-shot capabilities for the terminal local-paper execution sink.
 
-Only the account gateway binds an authority to a registered ``PaperExecutor``.
-The authority never exposes a reusable execution method: it mints an immutable
-capability for one exact order and the terminal sink consumes that capability
-before performing any other work.
+The account gateway consumes a one-shot runtime binding grant before it can
+bind baseline execution. The resulting baseline binding has no submission
+method; only an exact active gateway entry session can derive a terminal
+capability. Reduction authority remains separately constrained by the sealed
+coordinator submission adapter and exact pre-position evidence.
 """
 
 from __future__ import annotations
 
+import asyncio
 import threading
 import weakref
 from dataclasses import dataclass
 from decimal import Decimal
 from enum import Enum
+from typing import Any
 
 
 class PaperExecutionCapabilityError(RuntimeError):
@@ -47,9 +50,32 @@ class _PaperExecutionCapability:
         return super().__new__(cls)
 
 
+class _GatewayExecutionBindingCapability:
+    """Opaque one-shot grant issued only during exact gateway registration."""
+
+    __slots__ = ("__weakref__",)
+
+    def __new__(cls, *, _token: object | None = None):
+        if _token is not _BIND_CAPABILITY_TOKEN:
+            raise PaperExecutionCapabilityError(
+                "gateway execution binding capabilities are issuer-only"
+            )
+        return super().__new__(cls)
+
+    def __copy__(self):
+        with _REGISTRY_LOCK:
+            record = _GATEWAY_BINDINGS.get(self)
+            if type(record) is _GatewayBindingRecord:
+                record.consumed = True
+        raise PaperExecutionCapabilityError("gateway execution binding capabilities cannot copy")
+
+    def __deepcopy__(self, _memo):
+        return self.__copy__()
+
+
 @dataclass(slots=True)
 class _CapabilityRecord:
-    authority: "PaperExecutionAuthority"
+    authority: object
     executor: object
     portfolio_id: str
     kind: _CapabilityKind
@@ -58,18 +84,36 @@ class _CapabilityRecord:
     consumed: bool = False
 
 
-_BIND_TOKEN = object()
+@dataclass(slots=True)
+class _GatewayBindingRecord:
+    gateway: object
+    runtime_context: object
+    binding_session: object
+    executor: object
+    portfolio_id: str
+    consumed: bool = False
+
+
+_REDUCTION_BIND_TOKEN = object()
+_BIND_CAPABILITY_TOKEN = object()
+_BASELINE_BIND_TOKEN = object()
 _CAPABILITY_TOKEN = object()
 _REGISTRY_LOCK = threading.Lock()
 _CAPABILITIES: weakref.WeakKeyDictionary[_PaperExecutionCapability, _CapabilityRecord] = (
     weakref.WeakKeyDictionary()
 )
+_GATEWAY_BINDINGS: weakref.WeakKeyDictionary[
+    _GatewayExecutionBindingCapability, _GatewayBindingRecord
+] = weakref.WeakKeyDictionary()
 
 
-class PaperExecutionAuthority:
-    """Sealed executor/portfolio binding owned by the account gateway."""
+class PaperReductionExecutionAuthority:
+    """Sealed executor/portfolio binding for coordinator-authorized reductions."""
 
     __slots__ = ("__executor", "__portfolio_id", "__sealed")
+    __executor: Any
+    __portfolio_id: str
+    __sealed: bool
 
     def __init__(
         self,
@@ -78,9 +122,9 @@ class PaperExecutionAuthority:
         *,
         _token: object | None = None,
     ) -> None:
-        if _token is not _BIND_TOKEN:
+        if _token is not _REDUCTION_BIND_TOKEN:
             raise PaperExecutionCapabilityError(
-                "paper execution authority must be bound by the account gateway"
+                "paper reduction authority must be bound by its sealed submitter"
             )
         if (
             not isinstance(portfolio_id, str)
@@ -88,69 +132,250 @@ class PaperExecutionAuthority:
             or portfolio_id.strip() != portfolio_id
         ):
             raise PaperExecutionCapabilityError("paper execution portfolio scope is malformed")
-        object.__setattr__(self, "_PaperExecutionAuthority__executor", executor)
-        object.__setattr__(self, "_PaperExecutionAuthority__portfolio_id", portfolio_id)
-        object.__setattr__(self, "_PaperExecutionAuthority__sealed", True)
+        object.__setattr__(self, "_PaperReductionExecutionAuthority__executor", executor)
+        object.__setattr__(self, "_PaperReductionExecutionAuthority__portfolio_id", portfolio_id)
+        object.__setattr__(self, "_PaperReductionExecutionAuthority__sealed", True)
 
     def __setattr__(self, name: str, value: object) -> None:
-        if getattr(self, "_PaperExecutionAuthority__sealed", False):
-            raise AttributeError("PaperExecutionAuthority is sealed")
+        if getattr(self, "_PaperReductionExecutionAuthority__sealed", False):
+            raise AttributeError("PaperReductionExecutionAuthority is sealed")
         object.__setattr__(self, name, value)
 
     def _is_bound_to(self, executor: object, portfolio_id: str) -> bool:
         return self.__executor is executor and self.__portfolio_id == portfolio_id
 
-    def _submit_baseline_once(self, order: object):
+    def _submit_reduction_once(self, order: object, *, pre_position_quantity: Decimal):
         fingerprint = _fingerprint_order(order)
-        if fingerprint.side != "BUY" or fingerprint.take_profit is not None:
-            raise PaperExecutionCapabilityError(
-                "baseline authority admits only simple long BUY orders"
+        _validate_reduction_bounds(fingerprint, pre_position_quantity)
+        capability = _PaperExecutionCapability(_token=_CAPABILITY_TOKEN)
+        with _REGISTRY_LOCK:
+            _CAPABILITIES[capability] = _CapabilityRecord(
+                authority=self,
+                executor=self.__executor,
+                portfolio_id=self.__portfolio_id,
+                kind=_CapabilityKind.REDUCTION,
+                fingerprint=fingerprint,
+                pre_position_quantity=pre_position_quantity,
             )
-        capability = self._mint(
+        return self.__executor._place_simple_order(
+            order,
+            _capability=capability,
+        )
+
+
+class _GatewayBaselineExecutionBinding:
+    """Sealed baseline binding with no submission method of its own."""
+
+    __slots__ = (
+        "_executor",
+        "_gateway",
+        "_portfolio_id",
+        "_runtime_context",
+        "__sealed",
+    )
+    _executor: Any
+    _gateway: object
+    _portfolio_id: str
+    _runtime_context: object
+    __sealed: bool
+
+    def __init__(
+        self,
+        *,
+        gateway: object,
+        runtime_context: object,
+        executor: object,
+        portfolio_id: str,
+        _token: object | None = None,
+    ) -> None:
+        if _token is not _BASELINE_BIND_TOKEN:
+            raise PaperExecutionCapabilityError("baseline execution binding is gateway-only")
+        object.__setattr__(self, "_gateway", gateway)
+        object.__setattr__(self, "_runtime_context", runtime_context)
+        object.__setattr__(self, "_executor", executor)
+        object.__setattr__(self, "_portfolio_id", portfolio_id)
+        object.__setattr__(self, "_GatewayBaselineExecutionBinding__sealed", True)
+
+    def __setattr__(self, name: str, value: object) -> None:
+        if getattr(self, "_GatewayBaselineExecutionBinding__sealed", False):
+            raise AttributeError("GatewayBaselineExecutionBinding is sealed")
+        object.__setattr__(self, name, value)
+
+
+def _bind_paper_reduction_execution_authority(
+    executor: object,
+    portfolio_id: str,
+) -> PaperReductionExecutionAuthority:
+    """Private reduction-submitter binding hook."""
+
+    return PaperReductionExecutionAuthority(
+        executor,
+        portfolio_id,
+        _token=_REDUCTION_BIND_TOKEN,
+    )
+
+
+def _issue_gateway_execution_binding_capability(
+    *,
+    gateway: object,
+    runtime_context: object,
+    binding_session: object,
+    executor: object,
+    portfolio_id: str,
+) -> _GatewayExecutionBindingCapability:
+    """Issue one bind grant only inside an exact started gateway session."""
+
+    _validate_gateway_binding_scope(
+        gateway=gateway,
+        runtime_context=runtime_context,
+        binding_session=binding_session,
+        executor=executor,
+        portfolio_id=portfolio_id,
+    )
+    if getattr(binding_session, "capability_issued", False):
+        raise PaperExecutionCapabilityError(
+            "gateway runtime binding session already issued its capability"
+        )
+    setattr(binding_session, "capability_issued", True)
+    capability = _GatewayExecutionBindingCapability(_token=_BIND_CAPABILITY_TOKEN)
+    with _REGISTRY_LOCK:
+        _GATEWAY_BINDINGS[capability] = _GatewayBindingRecord(
+            gateway=gateway,
+            runtime_context=runtime_context,
+            binding_session=binding_session,
+            executor=executor,
+            portfolio_id=portfolio_id,
+        )
+    return capability
+
+
+def _bind_gateway_baseline_execution(
+    *,
+    gateway: object,
+    runtime_context: object,
+    binding_session: object,
+    executor: object,
+    portfolio_id: str,
+    capability: object,
+) -> _GatewayBaselineExecutionBinding:
+    """Consume one exact gateway grant and seal the baseline binding."""
+
+    if type(capability) is not _GatewayExecutionBindingCapability:
+        raise PaperExecutionCapabilityError("gateway execution binding capability is invalid")
+    with _REGISTRY_LOCK:
+        record = _GATEWAY_BINDINGS.get(capability)
+        if type(record) is not _GatewayBindingRecord or record.consumed:
+            raise PaperExecutionCapabilityError(
+                "gateway execution binding capability is unknown or already consumed"
+            )
+        record.consumed = True
+    _validate_gateway_binding_scope(
+        gateway=gateway,
+        runtime_context=runtime_context,
+        binding_session=binding_session,
+        executor=executor,
+        portfolio_id=portfolio_id,
+    )
+    if (
+        record.gateway is not gateway
+        or record.runtime_context is not runtime_context
+        or record.binding_session is not binding_session
+        or record.executor is not executor
+        or record.portfolio_id != portfolio_id
+    ):
+        raise PaperExecutionCapabilityError(
+            "gateway execution binding capability does not match runtime"
+        )
+    return _GatewayBaselineExecutionBinding(
+        gateway=gateway,
+        runtime_context=runtime_context,
+        executor=executor,
+        portfolio_id=portfolio_id,
+        _token=_BASELINE_BIND_TOKEN,
+    )
+
+
+def _submit_gateway_baseline_once(
+    binding: object,
+    *,
+    gateway: object,
+    runtime_context: object,
+    active_session: object,
+    order: object,
+):
+    """Submit a BUY only from the exact active gateway entry session."""
+
+    from .paper_reduction_gateway import (
+        PaperReductionGateway,
+        _ActiveEntrySession,
+    )
+
+    if type(binding) is not _GatewayBaselineExecutionBinding:
+        raise PaperExecutionCapabilityError("baseline execution binding is invalid")
+    task = asyncio.current_task()
+    sessions = getattr(gateway, "_active_entry_sessions", None)
+    if (
+        type(gateway) is not PaperReductionGateway
+        or gateway.started is not True
+        or binding._gateway is not gateway
+        or binding._runtime_context is not runtime_context
+        or getattr(gateway, "_runtime_context", None) is not runtime_context
+        or type(active_session) is not _ActiveEntrySession
+        or not isinstance(sessions, dict)
+        or task is None
+        or sessions.get(task) is not active_session
+        or active_session.consumed is not True
+        or active_session.portfolio_id != binding._portfolio_id
+    ):
+        raise PaperExecutionCapabilityError("baseline gateway session does not match binding")
+    fingerprint = _fingerprint_order(order)
+    if (
+        fingerprint.side != "BUY"
+        or fingerprint.take_profit is not None
+        or fingerprint.symbol != active_session.symbol
+        or fingerprint.price != active_session.quote.price
+    ):
+        raise PaperExecutionCapabilityError("baseline order does not match gateway session")
+    capability = _PaperExecutionCapability(_token=_CAPABILITY_TOKEN)
+    with _REGISTRY_LOCK:
+        _CAPABILITIES[capability] = _CapabilityRecord(
+            authority=binding,
+            executor=binding._executor,
+            portfolio_id=binding._portfolio_id,
             kind=_CapabilityKind.BASELINE_ENTRY,
             fingerprint=fingerprint,
             pre_position_quantity=None,
         )
-        return self.__executor._place_simple_order(order, _capability=capability)
-
-    def _submit_reduction_once(self, order: object, *, pre_position_quantity: Decimal):
-        fingerprint = _fingerprint_order(order)
-        _validate_reduction_bounds(fingerprint, pre_position_quantity)
-        capability = self._mint(
-            kind=_CapabilityKind.REDUCTION,
-            fingerprint=fingerprint,
-            pre_position_quantity=pre_position_quantity,
-        )
-        return self.__executor._place_simple_order(order, _capability=capability)
-
-    def _mint(
-        self,
-        *,
-        kind: _CapabilityKind,
-        fingerprint: _OrderFingerprint,
-        pre_position_quantity: Decimal | None,
-    ) -> _PaperExecutionCapability:
-        capability = _PaperExecutionCapability(_token=_CAPABILITY_TOKEN)
-        record = _CapabilityRecord(
-            authority=self,
-            executor=self.__executor,
-            portfolio_id=self.__portfolio_id,
-            kind=kind,
-            fingerprint=fingerprint,
-            pre_position_quantity=pre_position_quantity,
-        )
-        with _REGISTRY_LOCK:
-            _CAPABILITIES[capability] = record
-        return capability
+    return binding._executor._place_simple_order(order, _capability=capability)
 
 
-def _bind_paper_execution_authority(
+def _validate_gateway_binding_scope(
+    *,
+    gateway: object,
+    runtime_context: object,
+    binding_session: object,
     executor: object,
     portfolio_id: str,
-) -> PaperExecutionAuthority:
-    """Private account-gateway binding hook."""
+) -> None:
+    from .execution import PaperExecutor
+    from .paper_reduction_gateway import PaperReductionGateway, _PaperRuntimeBindingSession
 
-    return PaperExecutionAuthority(executor, portfolio_id, _token=_BIND_TOKEN)
+    if (
+        type(gateway) is not PaperReductionGateway
+        or gateway.started is not True
+        or getattr(gateway, "_runtime_context", None) is not runtime_context
+        or getattr(gateway, "_active_runtime_binding_session", None) is not binding_session
+        or type(binding_session) is not _PaperRuntimeBindingSession
+        or binding_session.gateway is not gateway
+        or binding_session.runtime_context is not runtime_context
+        or binding_session.executor is not executor
+        or binding_session.portfolio_id != portfolio_id
+        or type(executor) is not PaperExecutor
+        or type(portfolio_id) is not str
+        or not portfolio_id
+        or portfolio_id.strip() != portfolio_id
+    ):
+        raise PaperExecutionCapabilityError("gateway execution binding scope is invalid")
 
 
 def consume_paper_execution_capability(

--- a/robo_trader/paper_execution_capability.py
+++ b/robo_trader/paper_execution_capability.py
@@ -15,7 +15,10 @@ import weakref
 from dataclasses import dataclass
 from decimal import Decimal
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from .execution import PaperExecutor
 
 
 class PaperExecutionCapabilityError(RuntimeError):
@@ -73,6 +76,48 @@ class _GatewayExecutionBindingCapability:
         return self.__copy__()
 
 
+class _GatewayReductionBindingCapability:
+    """Opaque one-shot grant for the reduction half of registration."""
+
+    __slots__ = ("__weakref__",)
+
+    def __new__(cls, *, _token: object | None = None):
+        if _token is not _REDUCTION_BIND_CAPABILITY_TOKEN:
+            raise PaperExecutionCapabilityError("reduction binding capability is issuer-only")
+        return super().__new__(cls)
+
+    def __copy__(self):
+        with _REGISTRY_LOCK:
+            record = _REDUCTION_BINDINGS.get(self)
+            if type(record) is _ReductionBindingRecord:
+                record.consumed = True
+        raise PaperExecutionCapabilityError("reduction binding capability cannot copy")
+
+    def __deepcopy__(self, _memo):
+        return self.__copy__()
+
+    def __reduce__(self):
+        raise PaperExecutionCapabilityError("reduction binding capability cannot serialize")
+
+
+class _BaselineTerminalDispatch:
+    __slots__ = ("__weakref__",)
+
+    def __new__(cls, *, _token: object | None = None):
+        if _token is not _TERMINAL_DISPATCH_TOKEN:
+            raise PaperExecutionCapabilityError("baseline terminal dispatch is issuer-only")
+        return super().__new__(cls)
+
+
+class _ReductionTerminalDispatch:
+    __slots__ = ("__weakref__",)
+
+    def __new__(cls, *, _token: object | None = None):
+        if _token is not _TERMINAL_DISPATCH_TOKEN:
+            raise PaperExecutionCapabilityError("reduction terminal dispatch is issuer-only")
+        return super().__new__(cls)
+
+
 @dataclass(slots=True)
 class _CapabilityRecord:
     authority: object
@@ -94,9 +139,49 @@ class _GatewayBindingRecord:
     consumed: bool = False
 
 
-_REDUCTION_BIND_TOKEN = object()
+@dataclass(slots=True)
+class _BaselineBindingRecord:
+    gateway: object
+    runtime_context: object
+    executor: object
+    portfolio_id: str
+
+
+@dataclass(slots=True)
+class _ReductionBindingRecord(_GatewayBindingRecord):
+    coordinator: object = None
+
+
+@dataclass(slots=True)
+class _ReductionAuthorityRecord:
+    gateway: object
+    runtime_context: object
+    executor: object
+    portfolio_id: str
+    coordinator: object
+    submitter: object | None = None
+
+
+@dataclass(slots=True)
+class _TerminalDispatchRecord:
+    binding: object | None
+    gateway: object | None
+    runtime_context: object | None
+    active_session: object | None
+    submitter: object | None
+    coordinator: object | None
+    executor: object
+    portfolio_id: str
+    fingerprint: _OrderFingerprint
+    pre_position_quantity: Decimal | None
+    consumed: bool = False
+
+
 _BIND_CAPABILITY_TOKEN = object()
+_REDUCTION_BIND_CAPABILITY_TOKEN = object()
+_REDUCTION_AUTHORITY_TOKEN = object()
 _BASELINE_BIND_TOKEN = object()
+_TERMINAL_DISPATCH_TOKEN = object()
 _CAPABILITY_TOKEN = object()
 _REGISTRY_LOCK = threading.Lock()
 _CAPABILITIES: weakref.WeakKeyDictionary[_PaperExecutionCapability, _CapabilityRecord] = (
@@ -105,114 +190,61 @@ _CAPABILITIES: weakref.WeakKeyDictionary[_PaperExecutionCapability, _CapabilityR
 _GATEWAY_BINDINGS: weakref.WeakKeyDictionary[
     _GatewayExecutionBindingCapability, _GatewayBindingRecord
 ] = weakref.WeakKeyDictionary()
+_BASELINE_BINDINGS: weakref.WeakKeyDictionary[
+    _GatewayBaselineExecutionBinding, _BaselineBindingRecord
+] = weakref.WeakKeyDictionary()
+_REDUCTION_BINDINGS: weakref.WeakKeyDictionary[
+    _GatewayReductionBindingCapability, _ReductionBindingRecord
+] = weakref.WeakKeyDictionary()
+_REDUCTION_AUTHORITIES: weakref.WeakKeyDictionary[
+    PaperReductionExecutionAuthority, _ReductionAuthorityRecord
+] = weakref.WeakKeyDictionary()
+_BASELINE_DISPATCHES: weakref.WeakKeyDictionary[
+    _BaselineTerminalDispatch, _TerminalDispatchRecord
+] = weakref.WeakKeyDictionary()
+_REDUCTION_DISPATCHES: weakref.WeakKeyDictionary[
+    _ReductionTerminalDispatch, _TerminalDispatchRecord
+] = weakref.WeakKeyDictionary()
 
 
 class PaperReductionExecutionAuthority:
-    """Sealed executor/portfolio binding for coordinator-authorized reductions."""
+    """Opaque methodless identity for one gateway-bound reduction runtime."""
 
-    __slots__ = ("__executor", "__portfolio_id", "__sealed")
-    __executor: Any
-    __portfolio_id: str
-    __sealed: bool
+    __slots__ = ("__weakref__",)
 
-    def __init__(
-        self,
-        executor: object,
-        portfolio_id: str,
-        *,
-        _token: object | None = None,
-    ) -> None:
-        if _token is not _REDUCTION_BIND_TOKEN:
-            raise PaperExecutionCapabilityError(
-                "paper reduction authority must be bound by its sealed submitter"
-            )
-        if (
-            not isinstance(portfolio_id, str)
-            or not portfolio_id
-            or portfolio_id.strip() != portfolio_id
-        ):
-            raise PaperExecutionCapabilityError("paper execution portfolio scope is malformed")
-        object.__setattr__(self, "_PaperReductionExecutionAuthority__executor", executor)
-        object.__setattr__(self, "_PaperReductionExecutionAuthority__portfolio_id", portfolio_id)
-        object.__setattr__(self, "_PaperReductionExecutionAuthority__sealed", True)
+    def __new__(cls, *, _token: object | None = None):
+        if _token is not _REDUCTION_AUTHORITY_TOKEN:
+            raise PaperExecutionCapabilityError("paper reduction authority is gateway-only")
+        return super().__new__(cls)
 
-    def __setattr__(self, name: str, value: object) -> None:
-        if getattr(self, "_PaperReductionExecutionAuthority__sealed", False):
-            raise AttributeError("PaperReductionExecutionAuthority is sealed")
-        object.__setattr__(self, name, value)
+    def __copy__(self):
+        raise PaperExecutionCapabilityError("paper reduction authority cannot copy")
 
-    def _is_bound_to(self, executor: object, portfolio_id: str) -> bool:
-        return self.__executor is executor and self.__portfolio_id == portfolio_id
+    def __deepcopy__(self, _memo):
+        return self.__copy__()
 
-    def _submit_reduction_once(self, order: object, *, pre_position_quantity: Decimal):
-        fingerprint = _fingerprint_order(order)
-        _validate_reduction_bounds(fingerprint, pre_position_quantity)
-        capability = _PaperExecutionCapability(_token=_CAPABILITY_TOKEN)
-        with _REGISTRY_LOCK:
-            _CAPABILITIES[capability] = _CapabilityRecord(
-                authority=self,
-                executor=self.__executor,
-                portfolio_id=self.__portfolio_id,
-                kind=_CapabilityKind.REDUCTION,
-                fingerprint=fingerprint,
-                pre_position_quantity=pre_position_quantity,
-            )
-        return self.__executor._place_simple_order(
-            order,
-            _capability=capability,
-        )
+    def __reduce__(self):
+        raise PaperExecutionCapabilityError("paper reduction authority cannot serialize")
 
 
 class _GatewayBaselineExecutionBinding:
-    """Sealed baseline binding with no submission method of its own."""
+    """Opaque registry-backed identity for one baseline runtime binding."""
 
-    __slots__ = (
-        "_executor",
-        "_gateway",
-        "_portfolio_id",
-        "_runtime_context",
-        "__sealed",
-    )
-    _executor: Any
-    _gateway: object
-    _portfolio_id: str
-    _runtime_context: object
-    __sealed: bool
+    __slots__ = ("__weakref__",)
 
-    def __init__(
-        self,
-        *,
-        gateway: object,
-        runtime_context: object,
-        executor: object,
-        portfolio_id: str,
-        _token: object | None = None,
-    ) -> None:
+    def __new__(cls, *, _token: object | None = None):
         if _token is not _BASELINE_BIND_TOKEN:
             raise PaperExecutionCapabilityError("baseline execution binding is gateway-only")
-        object.__setattr__(self, "_gateway", gateway)
-        object.__setattr__(self, "_runtime_context", runtime_context)
-        object.__setattr__(self, "_executor", executor)
-        object.__setattr__(self, "_portfolio_id", portfolio_id)
-        object.__setattr__(self, "_GatewayBaselineExecutionBinding__sealed", True)
+        return super().__new__(cls)
 
-    def __setattr__(self, name: str, value: object) -> None:
-        if getattr(self, "_GatewayBaselineExecutionBinding__sealed", False):
-            raise AttributeError("GatewayBaselineExecutionBinding is sealed")
-        object.__setattr__(self, name, value)
+    def __copy__(self):
+        raise PaperExecutionCapabilityError("baseline execution binding cannot copy")
 
+    def __deepcopy__(self, _memo):
+        return self.__copy__()
 
-def _bind_paper_reduction_execution_authority(
-    executor: object,
-    portfolio_id: str,
-) -> PaperReductionExecutionAuthority:
-    """Private reduction-submitter binding hook."""
-
-    return PaperReductionExecutionAuthority(
-        executor,
-        portfolio_id,
-        _token=_REDUCTION_BIND_TOKEN,
-    )
+    def __reduce__(self):
+        raise PaperExecutionCapabilityError("baseline execution binding cannot serialize")
 
 
 def _issue_gateway_execution_binding_capability(
@@ -286,49 +318,185 @@ def _bind_gateway_baseline_execution(
         raise PaperExecutionCapabilityError(
             "gateway execution binding capability does not match runtime"
         )
-    return _GatewayBaselineExecutionBinding(
+    binding = _GatewayBaselineExecutionBinding(_token=_BASELINE_BIND_TOKEN)
+    with _REGISTRY_LOCK:
+        _BASELINE_BINDINGS[binding] = _BaselineBindingRecord(
+            gateway=gateway,
+            runtime_context=runtime_context,
+            executor=executor,
+            portfolio_id=portfolio_id,
+        )
+    return binding
+
+
+def _issue_gateway_reduction_binding_capability(
+    *,
+    gateway: object,
+    runtime_context: object,
+    binding_session: object,
+    executor: object,
+    portfolio_id: str,
+    coordinator: object,
+) -> _GatewayReductionBindingCapability:
+    """Issue exactly one reduction binding grant in gateway registration."""
+
+    _validate_gateway_binding_scope(
         gateway=gateway,
         runtime_context=runtime_context,
+        binding_session=binding_session,
         executor=executor,
         portfolio_id=portfolio_id,
-        _token=_BASELINE_BIND_TOKEN,
     )
+    from .safety import SafetyRuntimeCoordinator
+
+    if (
+        type(coordinator) is not SafetyRuntimeCoordinator
+        or coordinator.started is not True
+        or getattr(gateway, "_coordinator", None) is not coordinator
+    ):
+        raise PaperExecutionCapabilityError("reduction coordinator binding is invalid")
+    if getattr(binding_session, "reduction_capability_issued", False):
+        raise PaperExecutionCapabilityError(
+            "gateway runtime binding session already issued reduction capability"
+        )
+    setattr(binding_session, "reduction_capability_issued", True)
+    capability = _GatewayReductionBindingCapability(_token=_REDUCTION_BIND_CAPABILITY_TOKEN)
+    with _REGISTRY_LOCK:
+        _REDUCTION_BINDINGS[capability] = _ReductionBindingRecord(
+            gateway=gateway,
+            runtime_context=runtime_context,
+            binding_session=binding_session,
+            executor=executor,
+            portfolio_id=portfolio_id,
+            coordinator=coordinator,
+        )
+    return capability
 
 
-def _submit_gateway_baseline_once(
+def _bind_gateway_reduction_execution(
+    *,
+    gateway: object,
+    runtime_context: object,
+    binding_session: object,
+    executor: object,
+    portfolio_id: str,
+    coordinator: object,
+    capability: object,
+) -> PaperReductionExecutionAuthority:
+    """Consume one gateway grant and register a methodless reduction authority."""
+
+    if type(capability) is not _GatewayReductionBindingCapability:
+        raise PaperExecutionCapabilityError("reduction binding capability is invalid")
+    with _REGISTRY_LOCK:
+        record = _REDUCTION_BINDINGS.get(capability)
+        if type(record) is not _ReductionBindingRecord or record.consumed:
+            raise PaperExecutionCapabilityError(
+                "reduction binding capability is unknown or already consumed"
+            )
+        record.consumed = True
+    _validate_gateway_binding_scope(
+        gateway=gateway,
+        runtime_context=runtime_context,
+        binding_session=binding_session,
+        executor=executor,
+        portfolio_id=portfolio_id,
+    )
+    if (
+        record.gateway is not gateway
+        or record.runtime_context is not runtime_context
+        or record.binding_session is not binding_session
+        or record.executor is not executor
+        or record.portfolio_id != portfolio_id
+        or record.coordinator is not coordinator
+    ):
+        raise PaperExecutionCapabilityError("reduction binding does not match runtime")
+    authority = PaperReductionExecutionAuthority(_token=_REDUCTION_AUTHORITY_TOKEN)
+    with _REGISTRY_LOCK:
+        _REDUCTION_AUTHORITIES[authority] = _ReductionAuthorityRecord(
+            gateway=gateway,
+            runtime_context=runtime_context,
+            executor=executor,
+            portfolio_id=portfolio_id,
+            coordinator=coordinator,
+        )
+    return authority
+
+
+def _attach_gateway_reduction_submitter(
+    authority: object,
+    *,
+    submitter: object,
+    executor: object,
+    coordinator: object,
+    portfolio_id: str,
+) -> None:
+    """Bind the exact sealed submitter once, before the gateway publishes it."""
+
+    if type(authority) is not PaperReductionExecutionAuthority:
+        raise PaperExecutionCapabilityError("reduction authority is invalid")
+    with _REGISTRY_LOCK:
+        record = _REDUCTION_AUTHORITIES.get(authority)
+        if (
+            type(record) is not _ReductionAuthorityRecord
+            or record.submitter is not None
+            or record.executor is not executor
+            or record.coordinator is not coordinator
+            or record.portfolio_id != portfolio_id
+        ):
+            raise PaperExecutionCapabilityError("reduction submitter binding is invalid")
+        record.submitter = submitter
+
+
+def _reduction_authority_matches(
+    authority: object,
+    *,
+    executor: object,
+    coordinator: object,
+    portfolio_id: str,
+) -> bool:
+    with _REGISTRY_LOCK:
+        record = (
+            _REDUCTION_AUTHORITIES.get(authority)
+            if type(authority) is PaperReductionExecutionAuthority
+            else None
+        )
+        return bool(
+            type(record) is _ReductionAuthorityRecord
+            and record.executor is executor
+            and record.coordinator is coordinator
+            and record.portfolio_id == portfolio_id
+        )
+
+
+def _issue_gateway_baseline_terminal_dispatch(
     binding: object,
     *,
     gateway: object,
     runtime_context: object,
     active_session: object,
     order: object,
-):
-    """Submit a BUY only from the exact active gateway entry session."""
+) -> _BaselineTerminalDispatch:
+    """Register one terminal dispatch for the exact active entry session."""
 
     from .paper_reduction_gateway import (
         PaperReductionGateway,
         _ActiveEntrySession,
     )
 
-    if type(binding) is not _GatewayBaselineExecutionBinding:
-        raise PaperExecutionCapabilityError("baseline execution binding is invalid")
     task = asyncio.current_task()
     sessions = getattr(gateway, "_active_entry_sessions", None)
+    fingerprint = _fingerprint_order(order)
     if (
         type(gateway) is not PaperReductionGateway
         or gateway.started is not True
-        or binding._gateway is not gateway
-        or binding._runtime_context is not runtime_context
         or getattr(gateway, "_runtime_context", None) is not runtime_context
         or type(active_session) is not _ActiveEntrySession
         or not isinstance(sessions, dict)
         or task is None
         or sessions.get(task) is not active_session
         or active_session.consumed is not True
-        or active_session.portfolio_id != binding._portfolio_id
     ):
         raise PaperExecutionCapabilityError("baseline gateway session does not match binding")
-    fingerprint = _fingerprint_order(order)
     if (
         fingerprint.side != "BUY"
         or fingerprint.take_profit is not None
@@ -336,17 +504,214 @@ def _submit_gateway_baseline_once(
         or fingerprint.price != active_session.quote.price
     ):
         raise PaperExecutionCapabilityError("baseline order does not match gateway session")
+    with _REGISTRY_LOCK:
+        binding_record = (
+            _BASELINE_BINDINGS.get(binding)
+            if type(binding) is _GatewayBaselineExecutionBinding
+            else None
+        )
+        if (
+            type(binding_record) is not _BaselineBindingRecord
+            or binding_record.gateway is not gateway
+            or binding_record.runtime_context is not runtime_context
+            or active_session.portfolio_id != binding_record.portfolio_id
+            or active_session.dispatch_issued is True
+        ):
+            raise PaperExecutionCapabilityError(
+                "baseline gateway session does not match binding or already issued"
+            )
+        active_session.dispatch_issued = True
+        dispatch = _BaselineTerminalDispatch(_token=_TERMINAL_DISPATCH_TOKEN)
+        _BASELINE_DISPATCHES[dispatch] = _TerminalDispatchRecord(
+            binding=binding,
+            gateway=gateway,
+            runtime_context=runtime_context,
+            active_session=active_session,
+            submitter=None,
+            coordinator=None,
+            executor=binding_record.executor,
+            portfolio_id=binding_record.portfolio_id,
+            fingerprint=fingerprint,
+            pre_position_quantity=None,
+        )
+    return dispatch
+
+
+def _submit_gateway_baseline_once(
+    binding: object,
+    dispatch: object,
+    *,
+    gateway: object,
+    runtime_context: object,
+    active_session: object,
+    order: object,
+):
+    """Atomically burn one registered baseline dispatch before submission."""
+
+    if type(dispatch) is not _BaselineTerminalDispatch:
+        raise PaperExecutionCapabilityError("baseline terminal dispatch is invalid")
+    with _REGISTRY_LOCK:
+        record = _BASELINE_DISPATCHES.get(dispatch)
+        if type(record) is not _TerminalDispatchRecord or record.consumed:
+            raise PaperExecutionCapabilityError(
+                "baseline terminal dispatch is unknown or already consumed"
+            )
+        record.consumed = True
+        expected_binding = record.binding
+        expected_gateway = record.gateway
+        expected_context = record.runtime_context
+        expected_session = record.active_session
+        executor = cast("PaperExecutor", record.executor)
+        portfolio_id = record.portfolio_id
+        expected_fingerprint = record.fingerprint
+        record.binding = None
+        record.gateway = None
+        record.runtime_context = None
+        record.active_session = None
+    fingerprint = _fingerprint_order(order)
+    if (
+        type(binding) is not _GatewayBaselineExecutionBinding
+        or expected_binding is not binding
+        or expected_gateway is not gateway
+        or expected_context is not runtime_context
+        or expected_session is not active_session
+        or fingerprint != expected_fingerprint
+    ):
+        raise PaperExecutionCapabilityError("baseline terminal dispatch does not match attempt")
     capability = _PaperExecutionCapability(_token=_CAPABILITY_TOKEN)
     with _REGISTRY_LOCK:
         _CAPABILITIES[capability] = _CapabilityRecord(
             authority=binding,
-            executor=binding._executor,
-            portfolio_id=binding._portfolio_id,
+            executor=executor,
+            portfolio_id=portfolio_id,
             kind=_CapabilityKind.BASELINE_ENTRY,
             fingerprint=fingerprint,
             pre_position_quantity=None,
         )
-    return binding._executor._place_simple_order(order, _capability=capability)
+    return executor._place_simple_order(order, _capability=capability)
+
+
+def _issue_gateway_reduction_terminal_dispatch(
+    authority: object,
+    *,
+    submitter: object,
+    executor: object,
+    coordinator: object,
+    final_allocation: object,
+    descriptor: object,
+    contract: object,
+    order: object,
+    pre_position_quantity: Decimal,
+) -> _ReductionTerminalDispatch:
+    """Register one dispatch after the coordinator envelope was claimed."""
+
+    from .safety.runtime import _consume_claimed_paper_submission_allocation
+
+    try:
+        _consume_claimed_paper_submission_allocation(
+            final_allocation,
+            coordinator=coordinator,
+            descriptor=descriptor,
+            contract=contract,
+        )
+    except (RuntimeError, TypeError) as exc:
+        raise PaperExecutionCapabilityError(
+            "reduction terminal dispatch lacks exact final allocation"
+        ) from exc
+    fingerprint = _fingerprint_order(order)
+    try:
+        from .paper_reduction_submitter import _map_order
+
+        expected_fingerprint = _fingerprint_order(_map_order(descriptor, contract))
+    except (RuntimeError, TypeError, ValueError) as exc:
+        raise PaperExecutionCapabilityError(
+            "reduction final allocation is not terminally representable"
+        ) from exc
+    if fingerprint != expected_fingerprint:
+        raise PaperExecutionCapabilityError(
+            "reduction order does not match the claimed final allocation"
+        )
+    _validate_reduction_bounds(fingerprint, pre_position_quantity)
+    with _REGISTRY_LOCK:
+        authority_record = (
+            _REDUCTION_AUTHORITIES.get(authority)
+            if type(authority) is PaperReductionExecutionAuthority
+            else None
+        )
+        if (
+            type(authority_record) is not _ReductionAuthorityRecord
+            or authority_record.submitter is not submitter
+            or authority_record.executor is not executor
+            or authority_record.coordinator is not coordinator
+        ):
+            raise PaperExecutionCapabilityError("reduction terminal issuer is not bound")
+        dispatch = _ReductionTerminalDispatch(_token=_TERMINAL_DISPATCH_TOKEN)
+        _REDUCTION_DISPATCHES[dispatch] = _TerminalDispatchRecord(
+            binding=authority,
+            gateway=authority_record.gateway,
+            runtime_context=authority_record.runtime_context,
+            active_session=None,
+            submitter=submitter,
+            coordinator=coordinator,
+            executor=executor,
+            portfolio_id=authority_record.portfolio_id,
+            fingerprint=fingerprint,
+            pre_position_quantity=pre_position_quantity,
+        )
+    return dispatch
+
+
+def _submit_gateway_reduction_once(
+    authority: object,
+    dispatch: object,
+    *,
+    submitter: object,
+    order: object,
+    pre_position_quantity: Decimal,
+):
+    """Atomically burn one submitter-issued reduction dispatch."""
+
+    if type(dispatch) is not _ReductionTerminalDispatch:
+        raise PaperExecutionCapabilityError("reduction terminal dispatch is invalid")
+    with _REGISTRY_LOCK:
+        record = _REDUCTION_DISPATCHES.get(dispatch)
+        if type(record) is not _TerminalDispatchRecord or record.consumed:
+            raise PaperExecutionCapabilityError(
+                "reduction terminal dispatch is unknown or already consumed"
+            )
+        record.consumed = True
+        expected_authority = record.binding
+        expected_submitter = record.submitter
+        executor = cast("PaperExecutor", record.executor)
+        portfolio_id = record.portfolio_id
+        expected_fingerprint = record.fingerprint
+        expected_pre_position = record.pre_position_quantity
+        record.binding = None
+        record.gateway = None
+        record.runtime_context = None
+        record.submitter = None
+        record.coordinator = None
+    fingerprint = _fingerprint_order(order)
+    _validate_reduction_bounds(fingerprint, pre_position_quantity)
+    if (
+        type(authority) is not PaperReductionExecutionAuthority
+        or expected_authority is not authority
+        or expected_submitter is not submitter
+        or fingerprint != expected_fingerprint
+        or pre_position_quantity != expected_pre_position
+    ):
+        raise PaperExecutionCapabilityError("reduction terminal dispatch does not match attempt")
+    capability = _PaperExecutionCapability(_token=_CAPABILITY_TOKEN)
+    with _REGISTRY_LOCK:
+        _CAPABILITIES[capability] = _CapabilityRecord(
+            authority=authority,
+            executor=executor,
+            portfolio_id=portfolio_id,
+            kind=_CapabilityKind.REDUCTION,
+            fingerprint=fingerprint,
+            pre_position_quantity=pre_position_quantity,
+        )
+    return executor._place_simple_order(order, _capability=capability)
 
 
 def _validate_gateway_binding_scope(

--- a/robo_trader/paper_execution_capability.py
+++ b/robo_trader/paper_execution_capability.py
@@ -147,6 +147,24 @@ def _build_sealed_capability_runtime():
     validate_reduction_bounds = _validate_reduction_bounds
     validate_gateway_binding_scope = _validate_gateway_binding_scope
     replace_record = dataclass_replace
+    # Capture the OS primitive inside the sealed runtime so the terminal
+    # cross-process kill-switch check cannot be replaced through a gateway or
+    # executor attribute. The remaining lstat-to-fill interval is synchronous
+    # and intentionally contains no caller callback.
+    from os import lstat as terminal_lstat
+
+    terminal_entry_lock_path = "data/kill_switch.lock"
+
+    def require_terminal_entry_lock_clear() -> None:
+        try:
+            terminal_lstat(terminal_entry_lock_path)
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            raise PaperExecutionCapabilityError(
+                "terminal kill-switch lock state is unavailable"
+            ) from exc
+        raise PaperExecutionCapabilityError("terminal kill-switch lock is active")
 
     bind_capability_token = object()
     reduction_bind_capability_token = object()
@@ -799,6 +817,7 @@ def _build_sealed_capability_runtime():
             or fingerprint != expected_fingerprint
         ):
             raise PaperExecutionCapabilityError("baseline terminal dispatch does not match attempt")
+        require_terminal_entry_lock_clear()
         capability = PaperExecutionCapability(_token=capability_token)
         with registry_lock:
             capabilities[capability] = CapabilityRecord(

--- a/robo_trader/paper_execution_capability.py
+++ b/robo_trader/paper_execution_capability.py
@@ -10,10 +10,12 @@ coordinator submission adapter and exact pre-position evidence.
 from __future__ import annotations
 
 import asyncio
+import datetime as dt
+import math
 import threading
 import weakref
 from dataclasses import dataclass
-from decimal import Decimal
+from decimal import ROUND_HALF_EVEN, Decimal
 from enum import Enum
 from typing import TYPE_CHECKING, cast
 
@@ -23,6 +25,9 @@ if TYPE_CHECKING:
 
 class PaperExecutionCapabilityError(RuntimeError):
     """A terminal paper submission lacked exact one-shot authority."""
+
+
+_PAPER_FILL_PRICE_TICK = Decimal("0.0001")
 
 
 class _CapabilityKind(Enum):
@@ -52,6 +57,23 @@ class _PaperExecutionCapability:
             )
         return super().__new__(cls)
 
+    def __copy__(self):
+        with _REGISTRY_LOCK:
+            record = _CAPABILITIES.get(self)
+            if type(record) is _CapabilityRecord:
+                record.consumed = True
+        raise PaperExecutionCapabilityError("paper execution capabilities cannot copy")
+
+    def __deepcopy__(self, _memo):
+        return self.__copy__()
+
+    def __reduce__(self):
+        with _REGISTRY_LOCK:
+            record = _CAPABILITIES.get(self)
+            if type(record) is _CapabilityRecord:
+                record.consumed = True
+        raise PaperExecutionCapabilityError("paper execution capabilities cannot serialize")
+
 
 class _GatewayExecutionBindingCapability:
     """Opaque one-shot grant issued only during exact gateway registration."""
@@ -74,6 +96,15 @@ class _GatewayExecutionBindingCapability:
 
     def __deepcopy__(self, _memo):
         return self.__copy__()
+
+    def __reduce__(self):
+        with _REGISTRY_LOCK:
+            record = _GATEWAY_BINDINGS.get(self)
+            if type(record) is _GatewayBindingRecord:
+                record.consumed = True
+        raise PaperExecutionCapabilityError(
+            "gateway execution binding capabilities cannot serialize"
+        )
 
 
 class _GatewayReductionBindingCapability:
@@ -108,6 +139,23 @@ class _BaselineTerminalDispatch:
             raise PaperExecutionCapabilityError("baseline terminal dispatch is issuer-only")
         return super().__new__(cls)
 
+    def __copy__(self):
+        with _REGISTRY_LOCK:
+            record = _BASELINE_DISPATCHES.get(self)
+            if type(record) is _TerminalDispatchRecord:
+                record.consumed = True
+        raise PaperExecutionCapabilityError("baseline terminal dispatch cannot copy")
+
+    def __deepcopy__(self, _memo):
+        return self.__copy__()
+
+    def __reduce__(self):
+        with _REGISTRY_LOCK:
+            record = _BASELINE_DISPATCHES.get(self)
+            if type(record) is _TerminalDispatchRecord:
+                record.consumed = True
+        raise PaperExecutionCapabilityError("baseline terminal dispatch cannot serialize")
+
 
 class _ReductionTerminalDispatch:
     __slots__ = ("__weakref__",)
@@ -117,16 +165,36 @@ class _ReductionTerminalDispatch:
             raise PaperExecutionCapabilityError("reduction terminal dispatch is issuer-only")
         return super().__new__(cls)
 
+    def __copy__(self):
+        with _REGISTRY_LOCK:
+            record = _REDUCTION_DISPATCHES.get(self)
+            if type(record) is _TerminalDispatchRecord:
+                record.consumed = True
+        raise PaperExecutionCapabilityError("reduction terminal dispatch cannot copy")
+
+    def __deepcopy__(self, _memo):
+        return self.__copy__()
+
+    def __reduce__(self):
+        with _REGISTRY_LOCK:
+            record = _REDUCTION_DISPATCHES.get(self)
+            if type(record) is _TerminalDispatchRecord:
+                record.consumed = True
+        raise PaperExecutionCapabilityError("reduction terminal dispatch cannot serialize")
+
 
 @dataclass(slots=True)
 class _CapabilityRecord:
     authority: object
     executor: object
+    order: object
     portfolio_id: str
     kind: _CapabilityKind
     fingerprint: _OrderFingerprint
     pre_position_quantity: Decimal | None
     consumed: bool = False
+    validated: bool = False
+    fill_consumed: bool = False
 
 
 @dataclass(slots=True)
@@ -537,58 +605,66 @@ def _issue_gateway_baseline_terminal_dispatch(
     return dispatch
 
 
-def _submit_gateway_baseline_once(
-    binding: object,
-    dispatch: object,
-    *,
-    gateway: object,
-    runtime_context: object,
-    active_session: object,
-    order: object,
-):
-    """Atomically burn one registered baseline dispatch before submission."""
+def _make_gateway_baseline_submitter(terminal_sink):
+    """Capture the exact terminal sink outside mutable module/executor state."""
 
-    if type(dispatch) is not _BaselineTerminalDispatch:
-        raise PaperExecutionCapabilityError("baseline terminal dispatch is invalid")
-    with _REGISTRY_LOCK:
-        record = _BASELINE_DISPATCHES.get(dispatch)
-        if type(record) is not _TerminalDispatchRecord or record.consumed:
-            raise PaperExecutionCapabilityError(
-                "baseline terminal dispatch is unknown or already consumed"
-            )
-        record.consumed = True
-        expected_binding = record.binding
-        expected_gateway = record.gateway
-        expected_context = record.runtime_context
-        expected_session = record.active_session
-        executor = cast("PaperExecutor", record.executor)
-        portfolio_id = record.portfolio_id
-        expected_fingerprint = record.fingerprint
-        record.binding = None
-        record.gateway = None
-        record.runtime_context = None
-        record.active_session = None
-    fingerprint = _fingerprint_order(order)
-    if (
-        type(binding) is not _GatewayBaselineExecutionBinding
-        or expected_binding is not binding
-        or expected_gateway is not gateway
-        or expected_context is not runtime_context
-        or expected_session is not active_session
-        or fingerprint != expected_fingerprint
+    def _submit_gateway_baseline_once(
+        binding: object,
+        dispatch: object,
+        *,
+        gateway: object,
+        runtime_context: object,
+        active_session: object,
+        order: object,
     ):
-        raise PaperExecutionCapabilityError("baseline terminal dispatch does not match attempt")
-    capability = _PaperExecutionCapability(_token=_CAPABILITY_TOKEN)
-    with _REGISTRY_LOCK:
-        _CAPABILITIES[capability] = _CapabilityRecord(
-            authority=binding,
-            executor=executor,
-            portfolio_id=portfolio_id,
-            kind=_CapabilityKind.BASELINE_ENTRY,
-            fingerprint=fingerprint,
-            pre_position_quantity=None,
-        )
-    return executor._place_simple_order(order, _capability=capability)
+        """Atomically burn one registered baseline dispatch before submission."""
+
+        if type(dispatch) is not _BaselineTerminalDispatch:
+            raise PaperExecutionCapabilityError("baseline terminal dispatch is invalid")
+        with _REGISTRY_LOCK:
+            record = _BASELINE_DISPATCHES.get(dispatch)
+            if type(record) is not _TerminalDispatchRecord or record.consumed:
+                raise PaperExecutionCapabilityError(
+                    "baseline terminal dispatch is unknown or already consumed"
+                )
+            record.consumed = True
+            expected_binding = record.binding
+            expected_gateway = record.gateway
+            expected_context = record.runtime_context
+            expected_session = record.active_session
+            executor = cast("PaperExecutor", record.executor)
+            portfolio_id = record.portfolio_id
+            expected_fingerprint = record.fingerprint
+            record.binding = None
+            record.gateway = None
+            record.runtime_context = None
+            record.active_session = None
+        fingerprint = _fingerprint_order(order)
+        if (
+            type(binding) is not _GatewayBaselineExecutionBinding
+            or expected_binding is not binding
+            or expected_gateway is not gateway
+            or expected_context is not runtime_context
+            or expected_session is not active_session
+            or fingerprint != expected_fingerprint
+        ):
+            raise PaperExecutionCapabilityError("baseline terminal dispatch does not match attempt")
+        capability = _PaperExecutionCapability(_token=_CAPABILITY_TOKEN)
+        with _REGISTRY_LOCK:
+            _CAPABILITIES[capability] = _CapabilityRecord(
+                authority=binding,
+                executor=executor,
+                order=order,
+                portfolio_id=portfolio_id,
+                kind=_CapabilityKind.BASELINE_ENTRY,
+                fingerprint=fingerprint,
+                pre_position_quantity=None,
+            )
+        # The sink is a closure cell, not an executor or module attribute. Its
+        # first operation atomically burns this exact capability.
+        return terminal_sink(executor, order, capability)
+
+    return _submit_gateway_baseline_once
 
 
 def _issue_gateway_reduction_terminal_dispatch(
@@ -661,57 +737,67 @@ def _issue_gateway_reduction_terminal_dispatch(
     return dispatch
 
 
-def _submit_gateway_reduction_once(
-    authority: object,
-    dispatch: object,
-    *,
-    submitter: object,
-    order: object,
-    pre_position_quantity: Decimal,
-):
-    """Atomically burn one submitter-issued reduction dispatch."""
+def _make_gateway_reduction_submitter(terminal_sink):
+    """Capture the exact terminal sink outside mutable module/executor state."""
 
-    if type(dispatch) is not _ReductionTerminalDispatch:
-        raise PaperExecutionCapabilityError("reduction terminal dispatch is invalid")
-    with _REGISTRY_LOCK:
-        record = _REDUCTION_DISPATCHES.get(dispatch)
-        if type(record) is not _TerminalDispatchRecord or record.consumed:
-            raise PaperExecutionCapabilityError(
-                "reduction terminal dispatch is unknown or already consumed"
-            )
-        record.consumed = True
-        expected_authority = record.binding
-        expected_submitter = record.submitter
-        executor = cast("PaperExecutor", record.executor)
-        portfolio_id = record.portfolio_id
-        expected_fingerprint = record.fingerprint
-        expected_pre_position = record.pre_position_quantity
-        record.binding = None
-        record.gateway = None
-        record.runtime_context = None
-        record.submitter = None
-        record.coordinator = None
-    fingerprint = _fingerprint_order(order)
-    _validate_reduction_bounds(fingerprint, pre_position_quantity)
-    if (
-        type(authority) is not PaperReductionExecutionAuthority
-        or expected_authority is not authority
-        or expected_submitter is not submitter
-        or fingerprint != expected_fingerprint
-        or pre_position_quantity != expected_pre_position
+    def _submit_gateway_reduction_once(
+        authority: object,
+        dispatch: object,
+        *,
+        submitter: object,
+        order: object,
+        pre_position_quantity: Decimal,
     ):
-        raise PaperExecutionCapabilityError("reduction terminal dispatch does not match attempt")
-    capability = _PaperExecutionCapability(_token=_CAPABILITY_TOKEN)
-    with _REGISTRY_LOCK:
-        _CAPABILITIES[capability] = _CapabilityRecord(
-            authority=authority,
-            executor=executor,
-            portfolio_id=portfolio_id,
-            kind=_CapabilityKind.REDUCTION,
-            fingerprint=fingerprint,
-            pre_position_quantity=pre_position_quantity,
-        )
-    return executor._place_simple_order(order, _capability=capability)
+        """Atomically burn one submitter-issued reduction dispatch."""
+
+        if type(dispatch) is not _ReductionTerminalDispatch:
+            raise PaperExecutionCapabilityError("reduction terminal dispatch is invalid")
+        with _REGISTRY_LOCK:
+            record = _REDUCTION_DISPATCHES.get(dispatch)
+            if type(record) is not _TerminalDispatchRecord or record.consumed:
+                raise PaperExecutionCapabilityError(
+                    "reduction terminal dispatch is unknown or already consumed"
+                )
+            record.consumed = True
+            expected_authority = record.binding
+            expected_submitter = record.submitter
+            executor = cast("PaperExecutor", record.executor)
+            portfolio_id = record.portfolio_id
+            expected_fingerprint = record.fingerprint
+            expected_pre_position = record.pre_position_quantity
+            record.binding = None
+            record.gateway = None
+            record.runtime_context = None
+            record.submitter = None
+            record.coordinator = None
+        fingerprint = _fingerprint_order(order)
+        _validate_reduction_bounds(fingerprint, pre_position_quantity)
+        if (
+            type(authority) is not PaperReductionExecutionAuthority
+            or expected_authority is not authority
+            or expected_submitter is not submitter
+            or fingerprint != expected_fingerprint
+            or pre_position_quantity != expected_pre_position
+        ):
+            raise PaperExecutionCapabilityError(
+                "reduction terminal dispatch does not match attempt"
+            )
+        capability = _PaperExecutionCapability(_token=_CAPABILITY_TOKEN)
+        with _REGISTRY_LOCK:
+            _CAPABILITIES[capability] = _CapabilityRecord(
+                authority=authority,
+                executor=executor,
+                order=order,
+                portfolio_id=portfolio_id,
+                kind=_CapabilityKind.REDUCTION,
+                fingerprint=fingerprint,
+                pre_position_quantity=pre_position_quantity,
+            )
+        # As above, capability transport ends at a closure-captured sink whose
+        # first operation is the irreversible consume.
+        return terminal_sink(executor, order, capability)
+
+    return _submit_gateway_reduction_once
 
 
 def _validate_gateway_binding_scope(
@@ -772,12 +858,157 @@ def consume_paper_execution_capability(
     if record.kind is _CapabilityKind.BASELINE_ENTRY:
         if fingerprint.side != "BUY" or fingerprint.take_profit is not None:
             raise PaperExecutionCapabilityError("baseline entry capability is malformed")
-        return
-    if record.kind is not _CapabilityKind.REDUCTION:
-        raise PaperExecutionCapabilityError("paper execution capability kind is unsupported")
-    if type(record.pre_position_quantity) is not Decimal:
-        raise PaperExecutionCapabilityError("reduction capability lacks exact position evidence")
-    _validate_reduction_bounds(fingerprint, record.pre_position_quantity)
+    else:
+        if record.kind is not _CapabilityKind.REDUCTION:
+            raise PaperExecutionCapabilityError("paper execution capability kind is unsupported")
+        if type(record.pre_position_quantity) is not Decimal:
+            raise PaperExecutionCapabilityError(
+                "reduction capability lacks exact position evidence"
+            )
+        _validate_reduction_bounds(fingerprint, record.pre_position_quantity)
+    with _REGISTRY_LOCK:
+        current = _CAPABILITIES.get(capability)
+        if current is not record or record.consumed is not True:
+            raise PaperExecutionCapabilityError("paper execution capability state changed")
+        record.validated = True
+
+
+def _apply_consumed_paper_fill(executor: object, order: object, capability: object):
+    """Apply a fill only for an exactly consumed, still-unfilled capability."""
+
+    if type(capability) is not _PaperExecutionCapability:
+        raise PaperExecutionCapabilityError(
+            "paper fill requires an exact consumed submission capability"
+        )
+    with _REGISTRY_LOCK:
+        record = _CAPABILITIES.get(capability)
+        if (
+            type(record) is not _CapabilityRecord
+            or record.consumed is not True
+            or record.validated is not True
+            or record.fill_consumed
+            or record.executor is not executor
+            or record.order is not order
+        ):
+            raise PaperExecutionCapabilityError(
+                "paper fill capability is unknown, unconsumed, mismatched, or already filled"
+            )
+        # Burn the fill edge before any validation, mutable state, or callback
+        # can raise. Retained traceback locals can never replay this fill.
+        record.fill_consumed = True
+
+    fingerprint = _fingerprint_order(order)
+    if record.fingerprint != fingerprint:
+        raise PaperExecutionCapabilityError("paper fill capability order fingerprint changed")
+
+    from .execution import ExecutionResult, Order, PaperExecutor
+
+    if type(executor) is not PaperExecutor or type(order) is not Order:
+        raise PaperExecutionCapabilityError(
+            "sealed paper fill requires the exact executor and order types"
+        )
+
+    base: float | None
+    exact_base: Decimal | None = None
+
+    if order.price is not None:
+        if type(order.price) is Decimal:
+            if not order.price.is_finite() or order.price <= 0:
+                return ExecutionResult(False, "Invalid price for paper execution")
+            exact_base = order.price
+            base = float(exact_base)
+        else:
+            try:
+                base = float(order.price)
+            except (TypeError, ValueError):
+                return ExecutionResult(False, "Invalid price for paper execution")
+        if not math.isfinite(base):
+            return ExecutionResult(False, "Non-finite price for paper execution")
+        if base <= 0:
+            return ExecutionResult(False, "Non-positive price for paper execution")
+        executor._execution_cache[order.symbol] = base
+        executor._execution_cache_ts[order.symbol] = dt.datetime.utcnow()
+    else:
+        base = executor._execution_cache.get(order.symbol)
+        if base is None:
+            return ExecutionResult(False, "No reference price for market order")
+        timestamp = executor._execution_cache_ts.get(order.symbol)
+        if (
+            timestamp is None
+            or (dt.datetime.utcnow() - timestamp).total_seconds()
+            > executor._execution_cache_max_age_seconds
+        ):
+            return ExecutionResult(False, "Stale reference price for market order")
+
+    fill_decimal: Decimal
+    if exact_base is not None:
+        slip_decimal = (
+            exact_base * Decimal(str(executor.slippage_bps)) / Decimal("10000")
+            if executor.slippage_bps
+            else Decimal("0")
+        )
+        unrounded_fill = (
+            exact_base + slip_decimal
+            if order.side.upper() in {"BUY", "BUY_TO_COVER"}
+            else exact_base - slip_decimal
+        )
+        if not unrounded_fill.is_finite() or unrounded_fill <= 0:
+            return ExecutionResult(False, "Invalid paper execution fill")
+        fill_decimal = unrounded_fill.quantize(
+            _PAPER_FILL_PRICE_TICK,
+            rounding=ROUND_HALF_EVEN,
+        )
+        fill = float(fill_decimal)
+    else:
+        slip = base * (executor.slippage_bps / 10_000.0) if executor.slippage_bps else 0.0
+        if order.side.upper() in {"BUY", "BUY_TO_COVER"}:
+            fill = base + slip
+        else:
+            fill = base - slip
+        fill_decimal = Decimal(str(fill))
+    if not math.isfinite(fill) or fill <= 0:
+        return ExecutionResult(False, "Invalid paper execution fill")
+
+    executor.fills[f"{order.symbol}-{len(executor.fills)+1}"] = (
+        dt.datetime.utcnow(),
+        order,
+        fill,
+    )
+    return ExecutionResult(
+        True,
+        "Paper fill",
+        fill,
+        exact_fill_price=fill_decimal,
+    )
+
+
+def _make_sealed_paper_fill_sink(consume, fill_core):
+    """Capture both authority consume and fill core outside module lookups."""
+
+    def _execute_sealed_paper_fill(
+        executor: object,
+        order: object,
+        capability: object,
+    ):
+        # This exact consume is the first operation and cannot be replaced by
+        # mutating the module global after import.
+        consume(executor, order, capability)
+        return fill_core(executor, order, capability)
+
+    return _execute_sealed_paper_fill
+
+
+_execute_sealed_paper_fill = _make_sealed_paper_fill_sink(
+    consume_paper_execution_capability,
+    _apply_consumed_paper_fill,
+)
+
+
+# Capture the terminal sink exactly once. The exported submitter functions are
+# closures whose sink reference is neither an executor method nor a mutable
+# module lookup at submission time.
+_submit_gateway_baseline_once = _make_gateway_baseline_submitter(_execute_sealed_paper_fill)
+_submit_gateway_reduction_once = _make_gateway_reduction_submitter(_execute_sealed_paper_fill)
 
 
 def _fingerprint_order(order: object) -> _OrderFingerprint:

--- a/robo_trader/paper_execution_capability.py
+++ b/robo_trader/paper_execution_capability.py
@@ -1,0 +1,249 @@
+"""One-shot capabilities for the terminal local-paper execution sink.
+
+Only the account gateway binds an authority to a registered ``PaperExecutor``.
+The authority never exposes a reusable execution method: it mints an immutable
+capability for one exact order and the terminal sink consumes that capability
+before performing any other work.
+"""
+
+from __future__ import annotations
+
+import threading
+import weakref
+from dataclasses import dataclass
+from decimal import Decimal
+from enum import Enum
+
+
+class PaperExecutionCapabilityError(RuntimeError):
+    """A terminal paper submission lacked exact one-shot authority."""
+
+
+class _CapabilityKind(Enum):
+    BASELINE_ENTRY = "baseline-entry"
+    REDUCTION = "reduction"
+
+
+@dataclass(frozen=True, slots=True)
+class _OrderFingerprint:
+    symbol: str
+    quantity: int
+    side: str
+    price: object
+    order_ref: str | None
+    take_profit: object
+
+
+class _PaperExecutionCapability:
+    """Immutable opaque identity; validity lives in the private registry."""
+
+    __slots__ = ("__weakref__",)
+
+    def __new__(cls, *, _token: object | None = None):
+        if _token is not _CAPABILITY_TOKEN:
+            raise PaperExecutionCapabilityError(
+                "paper execution capabilities are minted only by a bound authority"
+            )
+        return super().__new__(cls)
+
+
+@dataclass(slots=True)
+class _CapabilityRecord:
+    authority: "PaperExecutionAuthority"
+    executor: object
+    portfolio_id: str
+    kind: _CapabilityKind
+    fingerprint: _OrderFingerprint
+    pre_position_quantity: Decimal | None
+    consumed: bool = False
+
+
+_BIND_TOKEN = object()
+_CAPABILITY_TOKEN = object()
+_REGISTRY_LOCK = threading.Lock()
+_CAPABILITIES: weakref.WeakKeyDictionary[_PaperExecutionCapability, _CapabilityRecord] = (
+    weakref.WeakKeyDictionary()
+)
+
+
+class PaperExecutionAuthority:
+    """Sealed executor/portfolio binding owned by the account gateway."""
+
+    __slots__ = ("__executor", "__portfolio_id", "__sealed")
+
+    def __init__(
+        self,
+        executor: object,
+        portfolio_id: str,
+        *,
+        _token: object | None = None,
+    ) -> None:
+        if _token is not _BIND_TOKEN:
+            raise PaperExecutionCapabilityError(
+                "paper execution authority must be bound by the account gateway"
+            )
+        if (
+            not isinstance(portfolio_id, str)
+            or not portfolio_id
+            or portfolio_id.strip() != portfolio_id
+        ):
+            raise PaperExecutionCapabilityError("paper execution portfolio scope is malformed")
+        object.__setattr__(self, "_PaperExecutionAuthority__executor", executor)
+        object.__setattr__(self, "_PaperExecutionAuthority__portfolio_id", portfolio_id)
+        object.__setattr__(self, "_PaperExecutionAuthority__sealed", True)
+
+    def __setattr__(self, name: str, value: object) -> None:
+        if getattr(self, "_PaperExecutionAuthority__sealed", False):
+            raise AttributeError("PaperExecutionAuthority is sealed")
+        object.__setattr__(self, name, value)
+
+    def _is_bound_to(self, executor: object, portfolio_id: str) -> bool:
+        return self.__executor is executor and self.__portfolio_id == portfolio_id
+
+    def _submit_baseline_once(self, order: object):
+        fingerprint = _fingerprint_order(order)
+        if fingerprint.side != "BUY" or fingerprint.take_profit is not None:
+            raise PaperExecutionCapabilityError(
+                "baseline authority admits only simple long BUY orders"
+            )
+        capability = self._mint(
+            kind=_CapabilityKind.BASELINE_ENTRY,
+            fingerprint=fingerprint,
+            pre_position_quantity=None,
+        )
+        return self.__executor._place_simple_order(order, _capability=capability)
+
+    def _submit_reduction_once(self, order: object, *, pre_position_quantity: Decimal):
+        fingerprint = _fingerprint_order(order)
+        _validate_reduction_bounds(fingerprint, pre_position_quantity)
+        capability = self._mint(
+            kind=_CapabilityKind.REDUCTION,
+            fingerprint=fingerprint,
+            pre_position_quantity=pre_position_quantity,
+        )
+        return self.__executor._place_simple_order(order, _capability=capability)
+
+    def _mint(
+        self,
+        *,
+        kind: _CapabilityKind,
+        fingerprint: _OrderFingerprint,
+        pre_position_quantity: Decimal | None,
+    ) -> _PaperExecutionCapability:
+        capability = _PaperExecutionCapability(_token=_CAPABILITY_TOKEN)
+        record = _CapabilityRecord(
+            authority=self,
+            executor=self.__executor,
+            portfolio_id=self.__portfolio_id,
+            kind=kind,
+            fingerprint=fingerprint,
+            pre_position_quantity=pre_position_quantity,
+        )
+        with _REGISTRY_LOCK:
+            _CAPABILITIES[capability] = record
+        return capability
+
+
+def _bind_paper_execution_authority(
+    executor: object,
+    portfolio_id: str,
+) -> PaperExecutionAuthority:
+    """Private account-gateway binding hook."""
+
+    return PaperExecutionAuthority(executor, portfolio_id, _token=_BIND_TOKEN)
+
+
+def consume_paper_execution_capability(
+    executor: object,
+    order: object,
+    capability: object,
+) -> None:
+    """Consume and validate exact authority before terminal fill calculation."""
+
+    if type(capability) is not _PaperExecutionCapability:
+        raise PaperExecutionCapabilityError(
+            "terminal paper execution requires an exact submission capability"
+        )
+    with _REGISTRY_LOCK:
+        record = _CAPABILITIES.get(capability)
+        if type(record) is not _CapabilityRecord or record.consumed:
+            raise PaperExecutionCapabilityError(
+                "paper execution capability is unknown or already consumed"
+            )
+        # Burn first: mismatch, substitution, and downstream failure are all
+        # one-shot and cannot be retried with the same authority.
+        record.consumed = True
+
+    fingerprint = _fingerprint_order(order)
+    if record.executor is not executor or record.fingerprint != fingerprint:
+        raise PaperExecutionCapabilityError(
+            "paper execution capability does not match executor or order"
+        )
+    if record.kind is _CapabilityKind.BASELINE_ENTRY:
+        if fingerprint.side != "BUY" or fingerprint.take_profit is not None:
+            raise PaperExecutionCapabilityError("baseline entry capability is malformed")
+        return
+    if record.kind is not _CapabilityKind.REDUCTION:
+        raise PaperExecutionCapabilityError("paper execution capability kind is unsupported")
+    if type(record.pre_position_quantity) is not Decimal:
+        raise PaperExecutionCapabilityError("reduction capability lacks exact position evidence")
+    _validate_reduction_bounds(fingerprint, record.pre_position_quantity)
+
+
+def _fingerprint_order(order: object) -> _OrderFingerprint:
+    from .execution import Order
+
+    if type(order) is not Order:
+        raise PaperExecutionCapabilityError("terminal order must be exactly Order")
+    if (
+        type(order.symbol) is not str
+        or not order.symbol
+        or order.symbol.strip() != order.symbol
+        or type(order.quantity) is not int
+        or order.quantity <= 0
+        or type(order.side) is not str
+        or order.side != order.side.upper()
+    ):
+        raise PaperExecutionCapabilityError("terminal order identity is malformed")
+    if order.order_ref is not None and type(order.order_ref) is not str:
+        raise PaperExecutionCapabilityError("terminal order reference is malformed")
+    return _OrderFingerprint(
+        symbol=order.symbol,
+        quantity=order.quantity,
+        side=order.side,
+        price=order.price,
+        order_ref=order.order_ref,
+        take_profit=order.take_profit,
+    )
+
+
+def _validate_reduction_bounds(
+    fingerprint: _OrderFingerprint,
+    pre_position_quantity: Decimal,
+) -> None:
+    if (
+        type(pre_position_quantity) is not Decimal
+        or not pre_position_quantity.is_finite()
+        or type(fingerprint.quantity) is not int
+        or fingerprint.quantity <= 0
+    ):
+        raise PaperExecutionCapabilityError("reduction position evidence is malformed")
+    quantity = Decimal(fingerprint.quantity)
+    if fingerprint.side == "SELL":
+        if pre_position_quantity <= 0 or quantity > pre_position_quantity:
+            raise PaperExecutionCapabilityError(
+                "SELL reduction would create or cross into short exposure"
+            )
+        final_quantity = pre_position_quantity - quantity
+        if final_quantity < 0:
+            raise PaperExecutionCapabilityError("SELL reduction crosses zero")
+    elif fingerprint.side == "BUY_TO_COVER":
+        if pre_position_quantity >= 0 or quantity > pre_position_quantity.copy_abs():
+            raise PaperExecutionCapabilityError(
+                "BUY_TO_COVER reduction would create or cross into long exposure"
+            )
+        final_quantity = pre_position_quantity + quantity
+        if final_quantity > 0:
+            raise PaperExecutionCapabilityError("BUY_TO_COVER reduction crosses zero")
+    else:
+        raise PaperExecutionCapabilityError("reduction capability admits only SELL or BUY_TO_COVER")

--- a/robo_trader/paper_execution_capability.py
+++ b/robo_trader/paper_execution_capability.py
@@ -14,7 +14,8 @@ import datetime as dt
 import math
 import threading
 import weakref
-from dataclasses import dataclass, replace as dataclass_replace
+from dataclasses import dataclass
+from dataclasses import replace as dataclass_replace
 from decimal import ROUND_HALF_EVEN, Decimal
 from enum import Enum
 from typing import TYPE_CHECKING, cast

--- a/robo_trader/paper_reduction_gateway.py
+++ b/robo_trader/paper_reduction_gateway.py
@@ -26,19 +26,9 @@ from .database_async import AsyncTradingDatabase
 from .execution import ExecutionResult, Order, PaperExecutor
 from .market_data_contract import BrokerProtectiveQuote
 from .paper_execution_capability import (
-    PaperBaselineAdmissionError,
     PaperReductionExecutionAuthority,
-    _begin_gateway_baseline_entry_session,
-    _bind_gateway_baseline_execution,
     _bind_gateway_reduction_execution,
-    _end_gateway_baseline_entry_session,
-    _GatewayBaselineExecutionBinding,
-    _get_gateway_baseline_entry_handle,
-    _issue_gateway_baseline_entry_intent,
-    _issue_gateway_baseline_terminal_dispatch,
-    _issue_gateway_execution_binding_capability,
     _issue_gateway_reduction_binding_capability,
-    _submit_gateway_baseline_once,
 )
 from .paper_reduction_submitter import (
     LocalPaperOrderStatus,
@@ -83,8 +73,6 @@ _REFERENCE_PRICE_TICK = Decimal("0.0001")
 class _PaperRuntimeBinding:
     submitter: PaperReductionSubmitter
     reduction_execution_authority: PaperReductionExecutionAuthority
-    baseline_execution_binding: _GatewayBaselineExecutionBinding
-    baseline_entry_handle: object
     protective_quote_producer: object
     settlement_participant: PaperRuntimeSettlementParticipant
 
@@ -95,7 +83,6 @@ class _PaperRuntimeBindingSession:
     runtime_context: RuntimeSafetyContext
     executor: PaperExecutor
     portfolio_id: str
-    capability_issued: bool = False
     reduction_capability_issued: bool = False
 
 
@@ -675,7 +662,7 @@ class PaperReductionGateway:
         *,
         protective_quote_producer: object,
         settlement_participant: PaperRuntimeSettlementParticipant,
-    ) -> object:
+    ) -> None:
         """Bind one portfolio's executor, quote producer, and projection owner."""
 
         if (
@@ -712,7 +699,7 @@ class PaperReductionGateway:
                 and existing.protective_quote_producer is protective_quote_producer
                 and existing.settlement_participant is settlement_participant
             ):
-                return existing.baseline_entry_handle
+                return None
             raise PaperReductionGatewayError("portfolio paper runtime is already registered")
         attached = self._protective_quote_producers.get(portfolio_id)
         if attached is not protective_quote_producer:
@@ -733,21 +720,6 @@ class PaperReductionGateway:
         )
         self._active_runtime_binding_session = binding_session
         try:
-            binding_capability = _issue_gateway_execution_binding_capability(
-                gateway=self,
-                runtime_context=self._runtime_context,
-                binding_session=binding_session,
-                executor=executor,
-                portfolio_id=portfolio_id,
-            )
-            baseline_execution_binding = _bind_gateway_baseline_execution(
-                gateway=self,
-                runtime_context=self._runtime_context,
-                binding_session=binding_session,
-                executor=executor,
-                portfolio_id=portfolio_id,
-                capability=binding_capability,
-            )
             reduction_binding_capability = _issue_gateway_reduction_binding_capability(
                 gateway=self,
                 runtime_context=self._runtime_context,
@@ -768,11 +740,6 @@ class PaperReductionGateway:
         finally:
             if self._active_runtime_binding_session is binding_session:
                 self._active_runtime_binding_session = None
-        baseline_entry_handle = _get_gateway_baseline_entry_handle(
-            baseline_execution_binding,
-            gateway=self,
-            runtime_context=self._runtime_context,
-        )
         self._bindings[portfolio_id] = _PaperRuntimeBinding(
             submitter=_bind_paper_reduction_submitter(
                 executor,
@@ -781,36 +748,10 @@ class PaperReductionGateway:
                 portfolio_id,
             ),
             reduction_execution_authority=reduction_execution_authority,
-            baseline_execution_binding=baseline_execution_binding,
-            baseline_entry_handle=baseline_entry_handle,
             protective_quote_producer=protective_quote_producer,
             settlement_participant=settlement_participant,
         )
-        return baseline_entry_handle
-
-    def issue_baseline_entry_intent(
-        self,
-        *,
-        portfolio_id: str,
-        symbol: str,
-        handle: object,
-    ) -> object:
-        """Mint one opaque intent at the canonical baseline producer branch."""
-
-        binding = self._bindings.get(portfolio_id)
-        if type(binding) is not _PaperRuntimeBinding:
-            raise PaperReductionGatewayError("baseline entry intent request is malformed")
-        try:
-            return _issue_gateway_baseline_entry_intent(
-                binding.baseline_execution_binding,
-                gateway=self,
-                runtime_context=self._runtime_context,
-                portfolio_id=portfolio_id,
-                symbol=symbol,
-                handle=handle,
-            )
-        except PaperBaselineAdmissionError as exc:
-            raise PaperReductionGatewayError(str(exc)) from exc
+        return None
 
     @asynccontextmanager
     async def serialize_entry(
@@ -875,36 +816,15 @@ class PaperReductionGateway:
                         raise PaperReductionGatewayError(
                             "entry blocked while a protective reduction is pending"
                         )
-            task = asyncio.current_task()
-            session: object | None = None
-            session_binding: object | None = None
             if portfolio_id is not None:
                 binding = self._bindings.get(portfolio_id)
                 if type(binding) is not _PaperRuntimeBinding:
                     raise PaperReductionGatewayError(
                         "entry portfolio has no registered paper runtime binding"
                     )
-                if type(task) is not asyncio.Task or symbol is None or current_quote is None:
+                if symbol is None or current_quote is None:
                     raise PaperReductionGatewayError("entry serialization scope is malformed")
-                session_binding = binding.baseline_execution_binding
-                session = _begin_gateway_baseline_entry_session(
-                    session_binding,
-                    gateway=self,
-                    runtime_context=self._runtime_context,
-                    portfolio_id=portfolio_id,
-                    symbol=symbol,
-                    quote=current_quote,
-                )
-            try:
-                yield current_quote
-            finally:
-                if session is not None and session_binding is not None:
-                    _end_gateway_baseline_entry_session(
-                        session_binding,
-                        session,
-                        gateway=self,
-                        runtime_context=self._runtime_context,
-                    )
+            yield current_quote
 
     def submit_baseline_entry(
         self,
@@ -913,30 +833,11 @@ class PaperReductionGateway:
         portfolio_id: str,
         intent: object,
     ) -> ExecutionResult:
-        """Derive one terminal capability inside an active entry session."""
+        """Deny every BUY until admission is independently enforceable."""
 
-        binding = self._bindings.get(portfolio_id)
-        if type(binding) is not _PaperRuntimeBinding:
-            raise PaperReductionGatewayError("baseline entry intent does not match runtime")
-        # The sealed issuer burns the task-bound session before it validates
-        # any caller-controlled order field. Keep order validation there so a
-        # malformed probe cannot preserve terminal entry authority.
-        try:
-            terminal_dispatch = _issue_gateway_baseline_terminal_dispatch(
-                binding.baseline_execution_binding,
-                gateway=self,
-                runtime_context=self._runtime_context,
-                intent=intent,
-                order=order,
-            )
-        except PaperBaselineAdmissionError as exc:
-            raise PaperReductionGatewayError(str(exc)) from exc
-        return _submit_gateway_baseline_once(
-            binding.baseline_execution_binding,
-            terminal_dispatch,
-            gateway=self,
-            runtime_context=self._runtime_context,
-            order=order,
+        del order, portfolio_id, intent
+        raise PaperReductionGatewayError(
+            "Gate-A baseline entry authority is disabled pending integrated risk admission"
         )
 
     async def submit_reduction(

--- a/robo_trader/paper_reduction_gateway.py
+++ b/robo_trader/paper_reduction_gateway.py
@@ -14,6 +14,7 @@ import logging
 import os
 import stat
 import time
+import weakref
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from decimal import ROUND_HALF_EVEN, Decimal, InvalidOperation
@@ -23,8 +24,12 @@ from typing import AsyncIterator, Awaitable, Callable, Optional
 from .broker_safety_evidence import BrokerContractSafetySnapshot
 from .clients.subprocess_ibkr_client import SubprocessIBKRClient
 from .database_async import AsyncTradingDatabase
-from .execution import Order, PaperExecutor
+from .execution import ExecutionResult, Order, PaperExecutor
 from .market_data_contract import BrokerProtectiveQuote
+from .paper_execution_capability import (
+    PaperExecutionAuthority,
+    _bind_paper_execution_authority,
+)
 from .paper_reduction_submitter import (
     LocalPaperOrderStatus,
     LocalPaperTerminalOutcome,
@@ -67,8 +72,51 @@ _REFERENCE_PRICE_TICK = Decimal("0.0001")
 @dataclass(frozen=True, slots=True)
 class _PaperRuntimeBinding:
     submitter: PaperReductionSubmitter
+    execution_authority: PaperExecutionAuthority
+    baseline_entry_handle: "_BaselineEntryHandle"
     protective_quote_producer: object
     settlement_participant: PaperRuntimeSettlementParticipant
+
+
+_ENTRY_HANDLE_TOKEN = object()
+
+
+class _BaselineEntryHandle:
+    """Opaque identity returned only when a canonical runtime is registered."""
+
+    __slots__ = ()
+
+    def __new__(cls, *, _token: object | None = None):
+        if _token is not _ENTRY_HANDLE_TOKEN:
+            raise PaperReductionGatewayError("baseline entry handles are gateway-issued")
+        return super().__new__(cls)
+
+
+class _BaselineEntryIntent:
+    """Immutable opaque identity minted for one baseline producer result."""
+
+    __slots__ = ("__weakref__",)
+
+    def __new__(cls, *, _token: object | None = None):
+        if _token is not _ENTRY_HANDLE_TOKEN:
+            raise PaperReductionGatewayError("baseline entry intents are gateway-issued")
+        return super().__new__(cls)
+
+
+@dataclass(slots=True)
+class _BaselineEntryIntentRecord:
+    portfolio_id: str
+    symbol: str
+    handle: _BaselineEntryHandle
+    consumed: bool = False
+
+
+@dataclass(slots=True)
+class _ActiveEntrySession:
+    portfolio_id: str
+    symbol: str
+    quote: BrokerProtectiveQuote
+    consumed: bool = False
 
 
 class PaperReductionGateway:
@@ -131,6 +179,10 @@ class PaperReductionGateway:
         )
         self._account_order_gate = asyncio.Lock()
         self._bindings: dict[str, _PaperRuntimeBinding] = {}
+        self._baseline_entry_intents: weakref.WeakKeyDictionary[
+            _BaselineEntryIntent, _BaselineEntryIntentRecord
+        ] = weakref.WeakKeyDictionary()
+        self._active_entry_sessions: dict[asyncio.Task, _ActiveEntrySession] = {}
         self._started = False
         self._diagnostic_recovery_required = False
         self._terminal_quarantine_reason: str | None = None
@@ -646,7 +698,7 @@ class PaperReductionGateway:
         *,
         protective_quote_producer: object,
         settlement_participant: PaperRuntimeSettlementParticipant,
-    ) -> None:
+    ) -> _BaselineEntryHandle:
         """Bind one portfolio's executor, quote producer, and projection owner."""
 
         if (
@@ -675,30 +727,69 @@ class PaperReductionGateway:
         existing = self._bindings.get(portfolio_id)
         if existing is not None:
             if (
-                existing.submitter._is_bound_to(executor, self._coordinator)
+                existing.submitter._is_bound_to(
+                    executor,
+                    self._coordinator,
+                    existing.execution_authority,
+                )
                 and existing.protective_quote_producer is protective_quote_producer
                 and existing.settlement_participant is settlement_participant
             ):
-                return
+                return existing.baseline_entry_handle
             raise PaperReductionGatewayError("portfolio paper runtime is already registered")
         attached = self._protective_quote_producers.get(portfolio_id)
         if attached is not protective_quote_producer:
             raise PaperReductionGatewayError(
                 "paper runtime quote producer was not provisionally attached"
             )
+        execution_authority = _bind_paper_execution_authority(executor, portfolio_id)
+        baseline_entry_handle = _BaselineEntryHandle(_token=_ENTRY_HANDLE_TOKEN)
         self._bindings[portfolio_id] = _PaperRuntimeBinding(
             submitter=_bind_paper_reduction_submitter(
                 executor,
                 self._coordinator,
+                execution_authority,
+                portfolio_id,
             ),
+            execution_authority=execution_authority,
+            baseline_entry_handle=baseline_entry_handle,
             protective_quote_producer=protective_quote_producer,
             settlement_participant=settlement_participant,
         )
+        return baseline_entry_handle
+
+    def issue_baseline_entry_intent(
+        self,
+        *,
+        portfolio_id: str,
+        symbol: str,
+        handle: object,
+    ) -> _BaselineEntryIntent:
+        """Mint one opaque intent at the canonical baseline producer branch."""
+
+        binding = self._bindings.get(portfolio_id)
+        if (
+            type(binding) is not _PaperRuntimeBinding
+            or handle is not binding.baseline_entry_handle
+            or type(symbol) is not str
+            or not symbol
+            or symbol.strip() != symbol
+        ):
+            raise PaperReductionGatewayError("baseline entry intent request is malformed")
+        intent = _BaselineEntryIntent(_token=_ENTRY_HANDLE_TOKEN)
+        self._baseline_entry_intents[intent] = _BaselineEntryIntentRecord(
+            portfolio_id=portfolio_id,
+            symbol=symbol,
+            handle=binding.baseline_entry_handle,
+        )
+        return intent
 
     @asynccontextmanager
     async def serialize_entry(
         self,
         symbol: str | None = None,
+        *,
+        portfolio_id: str | None = None,
     ) -> AsyncIterator[BrokerProtectiveQuote | None]:
         """Refresh entry evidence and hold it stable through paper dispatch."""
 
@@ -756,7 +847,77 @@ class PaperReductionGateway:
                         raise PaperReductionGatewayError(
                             "entry blocked while a protective reduction is pending"
                         )
-            yield current_quote
+            task = asyncio.current_task()
+            session: _ActiveEntrySession | None = None
+            if portfolio_id is not None:
+                binding = self._bindings.get(portfolio_id)
+                if type(binding) is not _PaperRuntimeBinding:
+                    raise PaperReductionGatewayError(
+                        "entry portfolio has no registered paper runtime binding"
+                    )
+                if type(task) is not asyncio.Task or symbol is None or current_quote is None:
+                    raise PaperReductionGatewayError("entry serialization scope is malformed")
+                sessions = getattr(self, "_active_entry_sessions", None)
+                if not isinstance(sessions, dict):
+                    raise PaperReductionGatewayError("entry session registry is unavailable")
+                if task in sessions:
+                    raise PaperReductionGatewayError("nested entry serialization is forbidden")
+                session = _ActiveEntrySession(portfolio_id, symbol, current_quote)
+                sessions[task] = session
+            try:
+                yield current_quote
+            finally:
+                if session is not None and task is not None:
+                    sessions = getattr(self, "_active_entry_sessions", {})
+                    if sessions.get(task) is session:
+                        sessions.pop(task, None)
+
+    def submit_baseline_entry(
+        self,
+        *,
+        order: Order,
+        portfolio_id: str,
+        intent: object,
+    ) -> ExecutionResult:
+        """Derive one terminal capability inside an active entry session."""
+
+        binding = self._bindings.get(portfolio_id)
+        record = (
+            self._baseline_entry_intents.get(intent)
+            if type(intent) is _BaselineEntryIntent
+            else None
+        )
+        if type(record) is not _BaselineEntryIntentRecord or record.consumed:
+            raise PaperReductionGatewayError("baseline entry intent is invalid or already consumed")
+        # Burn first: substitution and malformed session/order probes cannot
+        # reuse a recognized producer intent.
+        record.consumed = True
+        if (
+            type(binding) is not _PaperRuntimeBinding
+            or record.portfolio_id != portfolio_id
+            or record.handle is not binding.baseline_entry_handle
+        ):
+            raise PaperReductionGatewayError("baseline entry intent does not match runtime")
+        task = asyncio.current_task()
+        sessions = getattr(self, "_active_entry_sessions", None)
+        session = sessions.get(task) if isinstance(sessions, dict) and task is not None else None
+        if type(session) is not _ActiveEntrySession or session.consumed:
+            raise PaperReductionGatewayError("no active one-shot entry serialization session")
+        # Burn the session before validating caller-controlled order data.
+        session.consumed = True
+        if (
+            type(order) is not Order
+            or order.side != "BUY"
+            or type(order.quantity) is not int
+            or order.quantity <= 0
+            or order.symbol != record.symbol
+            or order.symbol != session.symbol
+            or type(order.price) is not Decimal
+            or order.price != session.quote.price
+            or order.take_profit is not None
+        ):
+            raise PaperReductionGatewayError("baseline entry order does not match session evidence")
+        return binding.execution_authority._submit_baseline_once(order)
 
     async def submit_reduction(
         self,
@@ -889,7 +1050,22 @@ class PaperReductionGateway:
                     proof,
                 )
                 try:
-                    outcome = binding.submitter._submit_once(envelope)
+                    allocation = next(
+                        (
+                            row
+                            for row in final_allocation.allocations
+                            if row.portfolio_id == portfolio_id
+                        ),
+                        None,
+                    )
+                    if allocation is None:
+                        raise PaperReductionGatewayError(
+                            "authorized portfolio allocation disappeared before submission"
+                        )
+                    outcome = binding.submitter._submit_once(
+                        envelope,
+                        pre_position_quantity=allocation.quantity,
+                    )
                 except BaseException as error:
                     self._latch_terminal_quarantine(
                         portfolio_id,

--- a/robo_trader/paper_reduction_gateway.py
+++ b/robo_trader/paper_reduction_gateway.py
@@ -14,7 +14,6 @@ import logging
 import os
 import stat
 import time
-import weakref
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from decimal import ROUND_HALF_EVEN, Decimal, InvalidOperation
@@ -27,10 +26,15 @@ from .database_async import AsyncTradingDatabase
 from .execution import ExecutionResult, Order, PaperExecutor
 from .market_data_contract import BrokerProtectiveQuote
 from .paper_execution_capability import (
+    PaperBaselineAdmissionError,
     PaperReductionExecutionAuthority,
+    _begin_gateway_baseline_entry_session,
     _bind_gateway_baseline_execution,
     _bind_gateway_reduction_execution,
+    _end_gateway_baseline_entry_session,
     _GatewayBaselineExecutionBinding,
+    _get_gateway_baseline_entry_handle,
+    _issue_gateway_baseline_entry_intent,
     _issue_gateway_baseline_terminal_dispatch,
     _issue_gateway_execution_binding_capability,
     _issue_gateway_reduction_binding_capability,
@@ -80,51 +84,9 @@ class _PaperRuntimeBinding:
     submitter: PaperReductionSubmitter
     reduction_execution_authority: PaperReductionExecutionAuthority
     baseline_execution_binding: _GatewayBaselineExecutionBinding
-    baseline_entry_handle: "_BaselineEntryHandle"
+    baseline_entry_handle: object
     protective_quote_producer: object
     settlement_participant: PaperRuntimeSettlementParticipant
-
-
-_ENTRY_HANDLE_TOKEN = object()
-
-
-class _BaselineEntryHandle:
-    """Opaque identity returned only when a canonical runtime is registered."""
-
-    __slots__ = ()
-
-    def __new__(cls, *, _token: object | None = None):
-        if _token is not _ENTRY_HANDLE_TOKEN:
-            raise PaperReductionGatewayError("baseline entry handles are gateway-issued")
-        return super().__new__(cls)
-
-
-class _BaselineEntryIntent:
-    """Immutable opaque identity minted for one baseline producer result."""
-
-    __slots__ = ("__weakref__",)
-
-    def __new__(cls, *, _token: object | None = None):
-        if _token is not _ENTRY_HANDLE_TOKEN:
-            raise PaperReductionGatewayError("baseline entry intents are gateway-issued")
-        return super().__new__(cls)
-
-
-@dataclass(slots=True)
-class _BaselineEntryIntentRecord:
-    portfolio_id: str
-    symbol: str
-    handle: _BaselineEntryHandle
-    consumed: bool = False
-
-
-@dataclass(slots=True)
-class _ActiveEntrySession:
-    portfolio_id: str
-    symbol: str
-    quote: BrokerProtectiveQuote
-    consumed: bool = False
-    dispatch_issued: bool = False
 
 
 @dataclass(slots=True)
@@ -198,10 +160,6 @@ class PaperReductionGateway:
         self._account_order_gate = asyncio.Lock()
         self._bindings: dict[str, _PaperRuntimeBinding] = {}
         self._active_runtime_binding_session: _PaperRuntimeBindingSession | None = None
-        self._baseline_entry_intents: weakref.WeakKeyDictionary[
-            _BaselineEntryIntent, _BaselineEntryIntentRecord
-        ] = weakref.WeakKeyDictionary()
-        self._active_entry_sessions: dict[asyncio.Task, _ActiveEntrySession] = {}
         self._started = False
         self._diagnostic_recovery_required = False
         self._terminal_quarantine_reason: str | None = None
@@ -717,7 +675,7 @@ class PaperReductionGateway:
         *,
         protective_quote_producer: object,
         settlement_participant: PaperRuntimeSettlementParticipant,
-    ) -> _BaselineEntryHandle:
+    ) -> object:
         """Bind one portfolio's executor, quote producer, and projection owner."""
 
         if (
@@ -810,7 +768,11 @@ class PaperReductionGateway:
         finally:
             if self._active_runtime_binding_session is binding_session:
                 self._active_runtime_binding_session = None
-        baseline_entry_handle = _BaselineEntryHandle(_token=_ENTRY_HANDLE_TOKEN)
+        baseline_entry_handle = _get_gateway_baseline_entry_handle(
+            baseline_execution_binding,
+            gateway=self,
+            runtime_context=self._runtime_context,
+        )
         self._bindings[portfolio_id] = _PaperRuntimeBinding(
             submitter=_bind_paper_reduction_submitter(
                 executor,
@@ -832,25 +794,23 @@ class PaperReductionGateway:
         portfolio_id: str,
         symbol: str,
         handle: object,
-    ) -> _BaselineEntryIntent:
+    ) -> object:
         """Mint one opaque intent at the canonical baseline producer branch."""
 
         binding = self._bindings.get(portfolio_id)
-        if (
-            type(binding) is not _PaperRuntimeBinding
-            or handle is not binding.baseline_entry_handle
-            or type(symbol) is not str
-            or not symbol
-            or symbol.strip() != symbol
-        ):
+        if type(binding) is not _PaperRuntimeBinding:
             raise PaperReductionGatewayError("baseline entry intent request is malformed")
-        intent = _BaselineEntryIntent(_token=_ENTRY_HANDLE_TOKEN)
-        self._baseline_entry_intents[intent] = _BaselineEntryIntentRecord(
-            portfolio_id=portfolio_id,
-            symbol=symbol,
-            handle=binding.baseline_entry_handle,
-        )
-        return intent
+        try:
+            return _issue_gateway_baseline_entry_intent(
+                binding.baseline_execution_binding,
+                gateway=self,
+                runtime_context=self._runtime_context,
+                portfolio_id=portfolio_id,
+                symbol=symbol,
+                handle=handle,
+            )
+        except PaperBaselineAdmissionError as exc:
+            raise PaperReductionGatewayError(str(exc)) from exc
 
     @asynccontextmanager
     async def serialize_entry(
@@ -916,7 +876,8 @@ class PaperReductionGateway:
                             "entry blocked while a protective reduction is pending"
                         )
             task = asyncio.current_task()
-            session: _ActiveEntrySession | None = None
+            session: object | None = None
+            session_binding: object | None = None
             if portfolio_id is not None:
                 binding = self._bindings.get(portfolio_id)
                 if type(binding) is not _PaperRuntimeBinding:
@@ -925,20 +886,25 @@ class PaperReductionGateway:
                     )
                 if type(task) is not asyncio.Task or symbol is None or current_quote is None:
                     raise PaperReductionGatewayError("entry serialization scope is malformed")
-                sessions = getattr(self, "_active_entry_sessions", None)
-                if not isinstance(sessions, dict):
-                    raise PaperReductionGatewayError("entry session registry is unavailable")
-                if task in sessions:
-                    raise PaperReductionGatewayError("nested entry serialization is forbidden")
-                session = _ActiveEntrySession(portfolio_id, symbol, current_quote)
-                sessions[task] = session
+                session_binding = binding.baseline_execution_binding
+                session = _begin_gateway_baseline_entry_session(
+                    session_binding,
+                    gateway=self,
+                    runtime_context=self._runtime_context,
+                    portfolio_id=portfolio_id,
+                    symbol=symbol,
+                    quote=current_quote,
+                )
             try:
                 yield current_quote
             finally:
-                if session is not None and task is not None:
-                    sessions = getattr(self, "_active_entry_sessions", {})
-                    if sessions.get(task) is session:
-                        sessions.pop(task, None)
+                if session is not None and session_binding is not None:
+                    _end_gateway_baseline_entry_session(
+                        session_binding,
+                        session,
+                        gateway=self,
+                        runtime_context=self._runtime_context,
+                    )
 
     def submit_baseline_entry(
         self,
@@ -950,54 +916,26 @@ class PaperReductionGateway:
         """Derive one terminal capability inside an active entry session."""
 
         binding = self._bindings.get(portfolio_id)
-        record = (
-            self._baseline_entry_intents.get(intent)
-            if type(intent) is _BaselineEntryIntent
-            else None
-        )
-        if type(record) is not _BaselineEntryIntentRecord or record.consumed:
-            raise PaperReductionGatewayError("baseline entry intent is invalid or already consumed")
-        # Burn first: substitution and malformed session/order probes cannot
-        # reuse a recognized producer intent.
-        record.consumed = True
-        if (
-            type(binding) is not _PaperRuntimeBinding
-            or record.portfolio_id != portfolio_id
-            or record.handle is not binding.baseline_entry_handle
-        ):
+        if type(binding) is not _PaperRuntimeBinding:
             raise PaperReductionGatewayError("baseline entry intent does not match runtime")
-        task = asyncio.current_task()
-        sessions = getattr(self, "_active_entry_sessions", None)
-        session = sessions.get(task) if isinstance(sessions, dict) and task is not None else None
-        if type(session) is not _ActiveEntrySession or session.consumed:
-            raise PaperReductionGatewayError("no active one-shot entry serialization session")
-        # Burn the session before validating caller-controlled order data.
-        session.consumed = True
-        if (
-            type(order) is not Order
-            or order.side != "BUY"
-            or type(order.quantity) is not int
-            or order.quantity <= 0
-            or order.symbol != record.symbol
-            or order.symbol != session.symbol
-            or type(order.price) is not Decimal
-            or order.price != session.quote.price
-            or order.take_profit is not None
-        ):
-            raise PaperReductionGatewayError("baseline entry order does not match session evidence")
-        terminal_dispatch = _issue_gateway_baseline_terminal_dispatch(
-            binding.baseline_execution_binding,
-            gateway=self,
-            runtime_context=self._runtime_context,
-            active_session=session,
-            order=order,
-        )
+        # The sealed issuer burns the task-bound session before it validates
+        # any caller-controlled order field. Keep order validation there so a
+        # malformed probe cannot preserve terminal entry authority.
+        try:
+            terminal_dispatch = _issue_gateway_baseline_terminal_dispatch(
+                binding.baseline_execution_binding,
+                gateway=self,
+                runtime_context=self._runtime_context,
+                intent=intent,
+                order=order,
+            )
+        except PaperBaselineAdmissionError as exc:
+            raise PaperReductionGatewayError(str(exc)) from exc
         return _submit_gateway_baseline_once(
             binding.baseline_execution_binding,
             terminal_dispatch,
             gateway=self,
             runtime_context=self._runtime_context,
-            active_session=session,
             order=order,
         )
 

--- a/robo_trader/paper_reduction_gateway.py
+++ b/robo_trader/paper_reduction_gateway.py
@@ -29,9 +29,11 @@ from .market_data_contract import BrokerProtectiveQuote
 from .paper_execution_capability import (
     PaperReductionExecutionAuthority,
     _bind_gateway_baseline_execution,
-    _bind_paper_reduction_execution_authority,
+    _bind_gateway_reduction_execution,
     _GatewayBaselineExecutionBinding,
+    _issue_gateway_baseline_terminal_dispatch,
     _issue_gateway_execution_binding_capability,
+    _issue_gateway_reduction_binding_capability,
     _submit_gateway_baseline_once,
 )
 from .paper_reduction_submitter import (
@@ -122,6 +124,7 @@ class _ActiveEntrySession:
     symbol: str
     quote: BrokerProtectiveQuote
     consumed: bool = False
+    dispatch_issued: bool = False
 
 
 @dataclass(slots=True)
@@ -131,6 +134,7 @@ class _PaperRuntimeBindingSession:
     executor: PaperExecutor
     portfolio_id: str
     capability_issued: bool = False
+    reduction_capability_issued: bool = False
 
 
 class PaperReductionGateway:
@@ -786,13 +790,26 @@ class PaperReductionGateway:
                 portfolio_id=portfolio_id,
                 capability=binding_capability,
             )
+            reduction_binding_capability = _issue_gateway_reduction_binding_capability(
+                gateway=self,
+                runtime_context=self._runtime_context,
+                binding_session=binding_session,
+                executor=executor,
+                portfolio_id=portfolio_id,
+                coordinator=self._coordinator,
+            )
+            reduction_execution_authority = _bind_gateway_reduction_execution(
+                gateway=self,
+                runtime_context=self._runtime_context,
+                binding_session=binding_session,
+                executor=executor,
+                portfolio_id=portfolio_id,
+                coordinator=self._coordinator,
+                capability=reduction_binding_capability,
+            )
         finally:
             if self._active_runtime_binding_session is binding_session:
                 self._active_runtime_binding_session = None
-        reduction_execution_authority = _bind_paper_reduction_execution_authority(
-            executor,
-            portfolio_id,
-        )
         baseline_entry_handle = _BaselineEntryHandle(_token=_ENTRY_HANDLE_TOKEN)
         self._bindings[portfolio_id] = _PaperRuntimeBinding(
             submitter=_bind_paper_reduction_submitter(
@@ -968,8 +985,16 @@ class PaperReductionGateway:
             or order.take_profit is not None
         ):
             raise PaperReductionGatewayError("baseline entry order does not match session evidence")
+        terminal_dispatch = _issue_gateway_baseline_terminal_dispatch(
+            binding.baseline_execution_binding,
+            gateway=self,
+            runtime_context=self._runtime_context,
+            active_session=session,
+            order=order,
+        )
         return _submit_gateway_baseline_once(
             binding.baseline_execution_binding,
+            terminal_dispatch,
             gateway=self,
             runtime_context=self._runtime_context,
             active_session=session,

--- a/robo_trader/paper_reduction_gateway.py
+++ b/robo_trader/paper_reduction_gateway.py
@@ -27,8 +27,12 @@ from .database_async import AsyncTradingDatabase
 from .execution import ExecutionResult, Order, PaperExecutor
 from .market_data_contract import BrokerProtectiveQuote
 from .paper_execution_capability import (
-    PaperExecutionAuthority,
-    _bind_paper_execution_authority,
+    PaperReductionExecutionAuthority,
+    _bind_gateway_baseline_execution,
+    _bind_paper_reduction_execution_authority,
+    _GatewayBaselineExecutionBinding,
+    _issue_gateway_execution_binding_capability,
+    _submit_gateway_baseline_once,
 )
 from .paper_reduction_submitter import (
     LocalPaperOrderStatus,
@@ -72,7 +76,8 @@ _REFERENCE_PRICE_TICK = Decimal("0.0001")
 @dataclass(frozen=True, slots=True)
 class _PaperRuntimeBinding:
     submitter: PaperReductionSubmitter
-    execution_authority: PaperExecutionAuthority
+    reduction_execution_authority: PaperReductionExecutionAuthority
+    baseline_execution_binding: _GatewayBaselineExecutionBinding
     baseline_entry_handle: "_BaselineEntryHandle"
     protective_quote_producer: object
     settlement_participant: PaperRuntimeSettlementParticipant
@@ -117,6 +122,15 @@ class _ActiveEntrySession:
     symbol: str
     quote: BrokerProtectiveQuote
     consumed: bool = False
+
+
+@dataclass(slots=True)
+class _PaperRuntimeBindingSession:
+    gateway: "PaperReductionGateway"
+    runtime_context: RuntimeSafetyContext
+    executor: PaperExecutor
+    portfolio_id: str
+    capability_issued: bool = False
 
 
 class PaperReductionGateway:
@@ -179,6 +193,7 @@ class PaperReductionGateway:
         )
         self._account_order_gate = asyncio.Lock()
         self._bindings: dict[str, _PaperRuntimeBinding] = {}
+        self._active_runtime_binding_session: _PaperRuntimeBindingSession | None = None
         self._baseline_entry_intents: weakref.WeakKeyDictionary[
             _BaselineEntryIntent, _BaselineEntryIntentRecord
         ] = weakref.WeakKeyDictionary()
@@ -730,7 +745,7 @@ class PaperReductionGateway:
                 existing.submitter._is_bound_to(
                     executor,
                     self._coordinator,
-                    existing.execution_authority,
+                    existing.reduction_execution_authority,
                 )
                 and existing.protective_quote_producer is protective_quote_producer
                 and existing.settlement_participant is settlement_participant
@@ -742,16 +757,52 @@ class PaperReductionGateway:
             raise PaperReductionGatewayError(
                 "paper runtime quote producer was not provisionally attached"
             )
-        execution_authority = _bind_paper_execution_authority(executor, portfolio_id)
+        if not self._started:
+            raise PaperReductionGatewayError(
+                "paper runtime registration requires a started gateway"
+            )
+        if self._active_runtime_binding_session is not None:
+            raise PaperReductionGatewayError("paper runtime registration session is already active")
+        binding_session = _PaperRuntimeBindingSession(
+            gateway=self,
+            runtime_context=self._runtime_context,
+            executor=executor,
+            portfolio_id=portfolio_id,
+        )
+        self._active_runtime_binding_session = binding_session
+        try:
+            binding_capability = _issue_gateway_execution_binding_capability(
+                gateway=self,
+                runtime_context=self._runtime_context,
+                binding_session=binding_session,
+                executor=executor,
+                portfolio_id=portfolio_id,
+            )
+            baseline_execution_binding = _bind_gateway_baseline_execution(
+                gateway=self,
+                runtime_context=self._runtime_context,
+                binding_session=binding_session,
+                executor=executor,
+                portfolio_id=portfolio_id,
+                capability=binding_capability,
+            )
+        finally:
+            if self._active_runtime_binding_session is binding_session:
+                self._active_runtime_binding_session = None
+        reduction_execution_authority = _bind_paper_reduction_execution_authority(
+            executor,
+            portfolio_id,
+        )
         baseline_entry_handle = _BaselineEntryHandle(_token=_ENTRY_HANDLE_TOKEN)
         self._bindings[portfolio_id] = _PaperRuntimeBinding(
             submitter=_bind_paper_reduction_submitter(
                 executor,
                 self._coordinator,
-                execution_authority,
+                reduction_execution_authority,
                 portfolio_id,
             ),
-            execution_authority=execution_authority,
+            reduction_execution_authority=reduction_execution_authority,
+            baseline_execution_binding=baseline_execution_binding,
             baseline_entry_handle=baseline_entry_handle,
             protective_quote_producer=protective_quote_producer,
             settlement_participant=settlement_participant,
@@ -917,7 +968,13 @@ class PaperReductionGateway:
             or order.take_profit is not None
         ):
             raise PaperReductionGatewayError("baseline entry order does not match session evidence")
-        return binding.execution_authority._submit_baseline_once(order)
+        return _submit_gateway_baseline_once(
+            binding.baseline_execution_binding,
+            gateway=self,
+            runtime_context=self._runtime_context,
+            active_session=session,
+            order=order,
+        )
 
     async def submit_reduction(
         self,

--- a/robo_trader/paper_reduction_submitter.py
+++ b/robo_trader/paper_reduction_submitter.py
@@ -35,6 +35,7 @@ from .safety.runtime import (
     AuthoritativeContract,
     ConsumedPaperSubmissionEnvelope,
     SafetyRuntimeCoordinator,
+    _retire_claimed_paper_submission_allocation,
 )
 
 _BIND_TOKEN = object()
@@ -281,34 +282,18 @@ class PaperReductionSubmitter:
                 "bound coordinator is no longer SafetyRuntimeCoordinator"
             )
 
-        # Claim first. Every subsequent failure remains one-shot and cannot
-        # cause a second paper fill through replay or concurrent reuse.
-        try:
-            descriptor, contract, final_allocation = coordinator._claim_consumed_paper_submission(
-                envelope
-            )
-        except (RuntimeError, TypeError, ValidationError) as exc:
-            raise PaperReductionSubmissionError("paper submission envelope claim failed") from exc
-
-        safe_descriptor = _snapshot_descriptor(descriptor)
-        safe_contract = _snapshot_contract(contract)
-        _validate_executor_configuration(executor)
-        order = _map_order(safe_descriptor, safe_contract)
-
-        # This is deliberately the adapter's sole execution call. It bypasses
-        # legacy soft gates only after final safety revalidation and durable
-        # permit consumption; there is no validation, smart, fallback, or retry.
-        terminal_dispatch = _issue_gateway_reduction_terminal_dispatch(
+        safe_descriptor, order, terminal_dispatch = _claim_and_issue_terminal_dispatch(
             self.__authority,
             submitter=self,
             executor=executor,
             coordinator=coordinator,
-            final_allocation=final_allocation,
-            descriptor=descriptor,
-            contract=contract,
-            order=order,
+            envelope=envelope,
             pre_position_quantity=pre_position_quantity,
         )
+
+        # This is deliberately the adapter's sole execution call. It bypasses
+        # legacy soft gates only after final safety revalidation and durable
+        # permit consumption; there is no validation, smart, fallback, or retry.
         result = _submit_gateway_reduction_once(
             self.__authority,
             terminal_dispatch,
@@ -317,6 +302,50 @@ class PaperReductionSubmitter:
             pre_position_quantity=pre_position_quantity,
         )
         return _terminal_outcome(result, safe_descriptor)
+
+
+def _claim_and_issue_terminal_dispatch(
+    authority: PaperReductionExecutionAuthority,
+    *,
+    submitter: PaperReductionSubmitter,
+    executor: PaperExecutor,
+    coordinator: SafetyRuntimeCoordinator,
+    envelope: ConsumedPaperSubmissionEnvelope,
+    pre_position_quantity: Decimal,
+) -> tuple[SubmissionDescriptor, Order, object]:
+    """Own one claimed allocation until it is issued or safely retired."""
+
+    try:
+        descriptor, contract, final_allocation = coordinator._claim_consumed_paper_submission(
+            envelope
+        )
+    except (RuntimeError, TypeError, ValidationError) as exc:
+        raise PaperReductionSubmissionError("paper submission envelope claim failed") from exc
+
+    try:
+        safe_descriptor = _snapshot_descriptor(descriptor)
+        safe_contract = _snapshot_contract(contract)
+        _validate_executor_configuration(executor)
+        order = _map_order(safe_descriptor, safe_contract)
+        terminal_dispatch = _issue_gateway_reduction_terminal_dispatch(
+            authority,
+            submitter=submitter,
+            executor=executor,
+            coordinator=coordinator,
+            final_allocation=final_allocation,
+            descriptor=descriptor,
+            contract=contract,
+            order=order,
+            pre_position_quantity=pre_position_quantity,
+        )
+        return safe_descriptor, order, terminal_dispatch
+    finally:
+        _retire_claimed_paper_submission_allocation(
+            final_allocation,
+            coordinator=coordinator,
+            descriptor=descriptor,
+            contract=contract,
+        )
 
 
 def _bind_paper_reduction_submitter(

--- a/robo_trader/paper_reduction_submitter.py
+++ b/robo_trader/paper_reduction_submitter.py
@@ -15,7 +15,13 @@ from enum import Enum
 from typing import Optional
 
 from .execution import ExecutionResult, Order, PaperExecutor
-from .paper_execution_capability import PaperReductionExecutionAuthority
+from .paper_execution_capability import (
+    PaperReductionExecutionAuthority,
+    _attach_gateway_reduction_submitter,
+    _issue_gateway_reduction_terminal_dispatch,
+    _reduction_authority_matches,
+    _submit_gateway_reduction_once,
+)
 from .runtime_contract_constants import PAPER_SAFETY_EXECUTION_DOMAIN_SCOPE
 from .safety.models import (
     EvidenceStatus,
@@ -220,15 +226,23 @@ class PaperReductionSubmitter:
             )
         if not coordinator.started:
             raise PaperReductionSubmissionError("coordinator must be started before binding")
-        if type(
-            execution_authority
-        ) is not PaperReductionExecutionAuthority or not execution_authority._is_bound_to(
-            executor, portfolio_id
+        if not _reduction_authority_matches(
+            execution_authority,
+            executor=executor,
+            coordinator=coordinator,
+            portfolio_id=portfolio_id,
         ):
             raise PaperReductionSubmissionError("execution authority is malformed")
         self.__executor = executor
         self.__coordinator = coordinator
         self.__authority = execution_authority
+        _attach_gateway_reduction_submitter(
+            execution_authority,
+            submitter=self,
+            executor=executor,
+            coordinator=coordinator,
+            portfolio_id=portfolio_id,
+        )
         self.__sealed = True
 
     def __setattr__(self, name: str, value: object) -> None:
@@ -270,7 +284,9 @@ class PaperReductionSubmitter:
         # Claim first. Every subsequent failure remains one-shot and cannot
         # cause a second paper fill through replay or concurrent reuse.
         try:
-            descriptor, contract = coordinator._claim_consumed_paper_submission(envelope)
+            descriptor, contract, final_allocation = coordinator._claim_consumed_paper_submission(
+                envelope
+            )
         except (RuntimeError, TypeError, ValidationError) as exc:
             raise PaperReductionSubmissionError("paper submission envelope claim failed") from exc
 
@@ -282,8 +298,22 @@ class PaperReductionSubmitter:
         # This is deliberately the adapter's sole execution call. It bypasses
         # legacy soft gates only after final safety revalidation and durable
         # permit consumption; there is no validation, smart, fallback, or retry.
-        result = self.__authority._submit_reduction_once(
-            order,
+        terminal_dispatch = _issue_gateway_reduction_terminal_dispatch(
+            self.__authority,
+            submitter=self,
+            executor=executor,
+            coordinator=coordinator,
+            final_allocation=final_allocation,
+            descriptor=descriptor,
+            contract=contract,
+            order=order,
+            pre_position_quantity=pre_position_quantity,
+        )
+        result = _submit_gateway_reduction_once(
+            self.__authority,
+            terminal_dispatch,
+            submitter=self,
+            order=order,
             pre_position_quantity=pre_position_quantity,
         )
         return _terminal_outcome(result, safe_descriptor)
@@ -301,10 +331,11 @@ def _bind_paper_reduction_submitter(
         raise PaperReductionSubmissionError("executor must be exactly PaperExecutor")
     if type(coordinator) is not SafetyRuntimeCoordinator:
         raise PaperReductionSubmissionError("coordinator must be exactly SafetyRuntimeCoordinator")
-    if type(
-        execution_authority
-    ) is not PaperReductionExecutionAuthority or not execution_authority._is_bound_to(
-        executor, portfolio_id
+    if not _reduction_authority_matches(
+        execution_authority,
+        executor=executor,
+        coordinator=coordinator,
+        portfolio_id=portfolio_id,
     ):
         raise PaperReductionSubmissionError("execution authority binding does not match")
     return PaperReductionSubmitter(

--- a/robo_trader/paper_reduction_submitter.py
+++ b/robo_trader/paper_reduction_submitter.py
@@ -15,6 +15,7 @@ from enum import Enum
 from typing import Optional
 
 from .execution import ExecutionResult, Order, PaperExecutor
+from .paper_execution_capability import PaperExecutionAuthority
 from .runtime_contract_constants import PAPER_SAFETY_EXECUTION_DOMAIN_SCOPE
 from .safety.models import (
     EvidenceStatus,
@@ -196,12 +197,14 @@ class LocalPaperTerminalOutcome:
 class PaperReductionSubmitter:
     """Capability-narrow adapter for exactly one simple paper submission."""
 
-    __slots__ = ("__coordinator", "__executor", "__sealed")
+    __slots__ = ("__authority", "__coordinator", "__executor", "__sealed")
 
     def __init__(
         self,
         executor: PaperExecutor,
         coordinator: SafetyRuntimeCoordinator,
+        execution_authority: PaperExecutionAuthority,
+        portfolio_id: str,
         *,
         _token: Optional[object] = None,
     ) -> None:
@@ -217,8 +220,15 @@ class PaperReductionSubmitter:
             )
         if not coordinator.started:
             raise PaperReductionSubmissionError("coordinator must be started before binding")
+        if type(
+            execution_authority
+        ) is not PaperExecutionAuthority or not execution_authority._is_bound_to(
+            executor, portfolio_id
+        ):
+            raise PaperReductionSubmissionError("execution authority is malformed")
         self.__executor = executor
         self.__coordinator = coordinator
+        self.__authority = execution_authority
         self.__sealed = True
 
     def __setattr__(self, name: str, value: object) -> None:
@@ -230,14 +240,21 @@ class PaperReductionSubmitter:
         self,
         executor: PaperExecutor,
         coordinator: SafetyRuntimeCoordinator,
+        execution_authority: PaperExecutionAuthority,
     ) -> bool:
         """Support idempotent reconnect registration without exposing authority."""
 
-        return self.__executor is executor and self.__coordinator is coordinator
+        return (
+            self.__executor is executor
+            and self.__coordinator is coordinator
+            and self.__authority is execution_authority
+        )
 
     def _submit_once(
         self,
         envelope: ConsumedPaperSubmissionEnvelope,
+        *,
+        pre_position_quantity: Decimal,
     ) -> LocalPaperTerminalOutcome:
         """Claim and submit one exact coordinator-consumed envelope."""
 
@@ -265,17 +282,38 @@ class PaperReductionSubmitter:
         # This is deliberately the adapter's sole execution call. It bypasses
         # legacy soft gates only after final safety revalidation and durable
         # permit consumption; there is no validation, smart, fallback, or retry.
-        result = executor._place_simple_order(order)
+        result = self.__authority._submit_reduction_once(
+            order,
+            pre_position_quantity=pre_position_quantity,
+        )
         return _terminal_outcome(result, safe_descriptor)
 
 
 def _bind_paper_reduction_submitter(
     executor: PaperExecutor,
     coordinator: SafetyRuntimeCoordinator,
+    execution_authority: PaperExecutionAuthority,
+    portfolio_id: str,
 ) -> PaperReductionSubmitter:
     """Bind the private one-shot adapter to exact executor and coordinator."""
 
-    return PaperReductionSubmitter(executor, coordinator, _token=_BIND_TOKEN)
+    if type(executor) is not PaperExecutor:
+        raise PaperReductionSubmissionError("executor must be exactly PaperExecutor")
+    if type(coordinator) is not SafetyRuntimeCoordinator:
+        raise PaperReductionSubmissionError("coordinator must be exactly SafetyRuntimeCoordinator")
+    if type(
+        execution_authority
+    ) is not PaperExecutionAuthority or not execution_authority._is_bound_to(
+        executor, portfolio_id
+    ):
+        raise PaperReductionSubmissionError("execution authority binding does not match")
+    return PaperReductionSubmitter(
+        executor,
+        coordinator,
+        execution_authority,
+        portfolio_id,
+        _token=_BIND_TOKEN,
+    )
 
 
 def _validate_executor_configuration(executor: PaperExecutor) -> None:

--- a/robo_trader/paper_reduction_submitter.py
+++ b/robo_trader/paper_reduction_submitter.py
@@ -15,7 +15,7 @@ from enum import Enum
 from typing import Optional
 
 from .execution import ExecutionResult, Order, PaperExecutor
-from .paper_execution_capability import PaperExecutionAuthority
+from .paper_execution_capability import PaperReductionExecutionAuthority
 from .runtime_contract_constants import PAPER_SAFETY_EXECUTION_DOMAIN_SCOPE
 from .safety.models import (
     EvidenceStatus,
@@ -203,7 +203,7 @@ class PaperReductionSubmitter:
         self,
         executor: PaperExecutor,
         coordinator: SafetyRuntimeCoordinator,
-        execution_authority: PaperExecutionAuthority,
+        execution_authority: PaperReductionExecutionAuthority,
         portfolio_id: str,
         *,
         _token: Optional[object] = None,
@@ -222,7 +222,7 @@ class PaperReductionSubmitter:
             raise PaperReductionSubmissionError("coordinator must be started before binding")
         if type(
             execution_authority
-        ) is not PaperExecutionAuthority or not execution_authority._is_bound_to(
+        ) is not PaperReductionExecutionAuthority or not execution_authority._is_bound_to(
             executor, portfolio_id
         ):
             raise PaperReductionSubmissionError("execution authority is malformed")
@@ -240,7 +240,7 @@ class PaperReductionSubmitter:
         self,
         executor: PaperExecutor,
         coordinator: SafetyRuntimeCoordinator,
-        execution_authority: PaperExecutionAuthority,
+        execution_authority: PaperReductionExecutionAuthority,
     ) -> bool:
         """Support idempotent reconnect registration without exposing authority."""
 
@@ -292,7 +292,7 @@ class PaperReductionSubmitter:
 def _bind_paper_reduction_submitter(
     executor: PaperExecutor,
     coordinator: SafetyRuntimeCoordinator,
-    execution_authority: PaperExecutionAuthority,
+    execution_authority: PaperReductionExecutionAuthority,
     portfolio_id: str,
 ) -> PaperReductionSubmitter:
     """Bind the private one-shot adapter to exact executor and coordinator."""
@@ -303,7 +303,7 @@ def _bind_paper_reduction_submitter(
         raise PaperReductionSubmissionError("coordinator must be exactly SafetyRuntimeCoordinator")
     if type(
         execution_authority
-    ) is not PaperExecutionAuthority or not execution_authority._is_bound_to(
+    ) is not PaperReductionExecutionAuthority or not execution_authority._is_bound_to(
         executor, portfolio_id
     ):
         raise PaperReductionSubmissionError("execution authority binding does not match")

--- a/robo_trader/runner/__init__.py
+++ b/robo_trader/runner/__init__.py
@@ -9,9 +9,9 @@ Architecture:
 - portfolio_tracker.py: Position tracking and P&L calculation ✅
 
 Current Status:
-All 5 modules have been extracted from runner_async.py. These modules can be
-used independently or the AsyncRunner will continue to use its internal methods
-for backwards compatibility.
+Data-only helpers remain reusable. The extracted SignalGenerator and
+TradeExecutor constructors are quarantined during Gate A because they form an
+alternate entry-capable runtime. AsyncRunner is the only admitted engine.
 
 Migration Plan:
 1. ✅ Extract data fetching logic (DataFetcher class)
@@ -22,16 +22,6 @@ Migration Plan:
 6. [ ] Refactor AsyncRunner to use extracted modules (optional future work)
 
 Usage:
-    # Use extracted modules directly
-    from robo_trader.runner import (
-        DataFetcher,
-        SubprocessManager,
-        SignalGenerator,
-        TradeExecutor,
-        PortfolioTracker,
-    )
-
-    # Or use the full AsyncRunner (backwards compatible)
     from robo_trader.runner import AsyncRunner
 """
 

--- a/robo_trader/runner/signal_generator.py
+++ b/robo_trader/runner/signal_generator.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Protocol
 
 import pandas as pd
 
+from ..gatea_containment import assert_quarantined_alternate_engine
 from ..logger import get_logger
 from ..monitoring.performance import Timer
 
@@ -110,6 +111,7 @@ class SignalGenerator:
         use_ml_strategy: bool = False,
         use_correlation_sizing: bool = False,
     ):
+        assert_quarantined_alternate_engine("robo_trader.runner.SignalGenerator")
         self.ml_enhanced_strategy = ml_enhanced_strategy
         self.ml_strategy = ml_strategy
         self.ai_analyst = ai_analyst

--- a/robo_trader/runner/trade_executor.py
+++ b/robo_trader/runner/trade_executor.py
@@ -19,6 +19,7 @@ from datetime import datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Protocol
 
+from ..gatea_containment import assert_quarantined_alternate_engine
 from ..logger import get_logger
 
 if TYPE_CHECKING:
@@ -121,6 +122,7 @@ class TradeExecutor:
         use_advanced_risk: bool = True,
         use_correlation_sizing: bool = False,
     ):
+        assert_quarantined_alternate_engine("robo_trader.runner.TradeExecutor")
         self.portfolio = portfolio
         self.risk = risk_manager
         self.db = db

--- a/robo_trader/runner_async.py
+++ b/robo_trader/runner_async.py
@@ -897,6 +897,20 @@ class AsyncRunner:
         Returns:
             (True, reason) if trading should be blocked, else (False, "").
         """
+        # The lock file is the deny-by-default cross-process signal.  It must
+        # be checked independently of the in-memory KillSwitch because another
+        # process can create it after this runner's state was loaded.  A
+        # metadata error is uncertainty about a hard safety signal, so entries
+        # fail closed.  Semantic reductions bypass this entry-only gate above.
+        try:
+            Path("data/kill_switch.lock").lstat()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logger.error("Kill-switch lock state is unavailable: %s", type(exc).__name__)
+            return True, "Kill switch lock state unavailable"
+        else:
+            return True, "Kill switch lock active"
         try:
             freeze_reason = getattr(self, "_emergency_entry_freeze_reason", None)
             if freeze_reason:
@@ -1720,6 +1734,18 @@ class AsyncRunner:
                     if not self._entry_session_is_canonical(order.symbol, broker_quote):
                         return self._rejected_order_result(
                             "Entry blocked: canonical session evidence expired during final admission"
+                        )
+                    # ``serialize_entry`` and ``portfolio.equity`` both await.
+                    # Recheck the in-memory and cross-process kill-switch state
+                    # at the final synchronous boundary before the one-shot
+                    # entry authority is consumed.  The gateway intentionally
+                    # bypasses PaperExecutor.place_order(), so this preserves
+                    # the terminal lock-file protection formerly supplied by
+                    # BaseExecutor.validate_order().
+                    blocked, reason = self._trading_blocked()
+                    if blocked:
+                        return self._rejected_order_result(
+                            f"Entry blocked at terminal safety gate: {reason}"
                         )
                     with Timer("order_execution", self.monitor):
                         result = gateway.submit_baseline_entry(

--- a/robo_trader/runner_async.py
+++ b/robo_trader/runner_async.py
@@ -39,6 +39,12 @@ from .config import RuntimeContract, load_config
 from .correlation import CorrelationTracker
 from .database_async import AsyncTradingDatabase
 from .execution import ExecutionResult, Order, PaperExecutor
+from .gatea_containment import (
+    GateAContainmentError,
+    assert_gate_a_config,
+    assert_gate_a_runner_options,
+    validate_gate_a_order,
+)
 from .logger import get_logger
 from .market_data_contract import (
     BrokerProtectiveQuote,
@@ -489,6 +495,12 @@ class AsyncRunner:
         shared_database: Optional[AsyncTradingDatabase] = None,
         paper_reduction_gateway: Optional[PaperReductionGateway] = None,
     ):
+        assert_gate_a_runner_options(
+            use_ml_strategy=use_ml_strategy,
+            use_ml_enhanced=use_ml_enhanced,
+            use_smart_execution=use_smart_execution,
+            env=os.environ,
+        )
         if safety_runtime is not None and (
             type(safety_runtime) is not SafetyRuntimeCoordinator or not safety_runtime.started
         ):
@@ -518,19 +530,9 @@ class AsyncRunner:
         self.max_concurrent_symbols = max_concurrent_symbols
         self.use_correlation_sizing = use_correlation_sizing
         self.max_correlation = max_correlation
-        self.use_ml_strategy = use_ml_strategy
-        # Auto-detect ML enhanced if not explicitly set
-        if use_ml_enhanced is None:
-            self.use_ml_enhanced = os.getenv("ML_ENHANCED_ENABLED", "true").lower() == "true"
-        else:
-            self.use_ml_enhanced = use_ml_enhanced
-        # Auto-detect smart execution if not explicitly set
-        if use_smart_execution is None:
-            self.use_smart_execution = (
-                os.getenv("SMART_EXECUTION_ENABLED", "true").lower() == "true"
-            )
-        else:
-            self.use_smart_execution = use_smart_execution
+        self.use_ml_strategy = False
+        self.use_ml_enhanced = False
+        self.use_smart_execution = False
 
         # Auto-detect advanced risk management if not explicitly set
         if use_advanced_risk is None:
@@ -664,7 +666,7 @@ class AsyncRunner:
 
         # AI Analyst for news-driven trading
         self.ai_analyst = None
-        self.use_ai_trading = os.getenv("AI_TRADING_ENABLED", "true").lower() == "true"
+        self.use_ai_trading = False
         self.news_cache = {}  # Cache recent news to avoid re-fetching
         self.last_news_fetch = None
         self._ai_opportunities = {}  # AI-identified buying opportunities
@@ -1496,6 +1498,14 @@ class AsyncRunner:
         if not is_reduction and side not in {"BUY", "SELL_SHORT"}:
             return self._rejected_order_result("Unsupported order side")
 
+        contained, containment_reason = validate_gate_a_order(
+            side=side,
+            intent_source=order.intent_source,
+            take_profit=order.take_profit,
+        )
+        if not contained:
+            return self._rejected_order_result(containment_reason)
+
         # Semantic reductions bypass entry-only soft stops, but only after the
         # account-wide gateway proves the exact broker contract/read-only
         # transport and the complete local simulator allocation. The gateway
@@ -1656,6 +1666,8 @@ class AsyncRunner:
                         side=side,
                         price=broker_quote.price,
                         order_ref=order.order_ref,
+                        intent_source=order.intent_source,
+                        take_profit=order.take_profit,
                     )
                     portfolio = getattr(self, "portfolio", None)
                     risk = getattr(self, "risk", None)
@@ -2237,6 +2249,10 @@ class AsyncRunner:
                     return
 
         self.cfg = load_config()
+        try:
+            assert_gate_a_config(self.cfg)
+        except GateAContainmentError as exc:
+            raise RuntimeError(f"Gate-A containment contradiction: {exc}") from exc
 
         # B-12 (branch audit, HIGH): belt-and-suspenders on top of
         # config.py's gating — if anything is overriding config to set
@@ -4503,9 +4519,14 @@ class AsyncRunner:
                 df,
             )
 
+        # Provenance is carried to the central order sink. Only the baseline
+        # branch below can produce the one Gate-A entry source.
+        entry_intent_source = "unclassified"
+
         # Generate trading signal
         with Timer("signal_generation", self.monitor, instance=symbol):
             if self.use_ml_enhanced and self.ml_enhanced_strategy:
+                entry_intent_source = "ml_enhanced"
                 # Use ML Enhanced strategy for signal generation
                 signal_obj = await self.ml_enhanced_strategy.analyze(symbol, df)
 
@@ -4585,6 +4606,7 @@ class AsyncRunner:
                             confidence = 0.5
                         else:
                             signal_value = 1  # BUY
+                            entry_intent_source = "ai_discovery"
                             confidence = opp_conf
                             logger.info(
                                 f"🎯 AI OPPORTUNITY BUY for {symbol}: "
@@ -4674,6 +4696,7 @@ class AsyncRunner:
                                     # default to HOLD; do NOT escalate to BUY
                                 elif ai_buy and ai_conf_ok:
                                     signal_value = 1
+                                    entry_intent_source = "ai_analyst"
                                     confidence = analysis.confidence
                                     logger.info(
                                         f"AI BUY signal for {symbol} "
@@ -4750,6 +4773,7 @@ class AsyncRunner:
                             int(sma_signals["signal"].iloc[-1]) if len(sma_signals) > 0 else 0
                         )
                         if signal_value != 0:
+                            entry_intent_source = "baseline_sma"
                             confidence = 0.6
                             logger.info(f"SMA crossover signal for {symbol}: {signal_value}")
 
@@ -4764,6 +4788,7 @@ class AsyncRunner:
                     index=[df.index[-1]] if len(df) > 0 else [pd.Timestamp.now()],
                 )
             elif self.use_ml_strategy and self.ml_strategy:
+                entry_intent_source = "ml_selector"
                 # Use ML strategy for signal generation
                 # Prepare market data in the format expected by ML strategy
                 market_data_dict = {
@@ -4799,6 +4824,7 @@ class AsyncRunner:
                 )
             else:
                 # Use traditional SMA crossover strategy
+                entry_intent_source = "baseline_sma"
                 signals = sma_crossover_signals(
                     pd.DataFrame({"close": df["close"]}),
                     fast=self.sma_fast,
@@ -4856,6 +4882,7 @@ class AsyncRunner:
 
                         # Override signal if mean reversion is stronger
                         if mr_signal.strength > 0.7:
+                            entry_intent_source = "mean_reversion"
                             signal_value = 1 if mr_signal.signal_type.value == "BUY" else -1
                             signals.iloc[-1]["signal"] = signal_value
 
@@ -5192,7 +5219,13 @@ class AsyncRunner:
                         # _place_order_with_circuit_breaker via _trading_blocked().
 
                         res = await self._place_order_with_circuit_breaker(
-                            Order(symbol=symbol, quantity=qty, side="BUY", price=price)
+                            Order(
+                                symbol=symbol,
+                                quantity=qty,
+                                side="BUY",
+                                price=price,
+                                intent_source=entry_intent_source,
+                            )
                         )
                         if res.ok:
                             exact_fill_price = self._exact_entry_fill_price(res)

--- a/robo_trader/runner_async.py
+++ b/robo_trader/runner_async.py
@@ -1735,19 +1735,15 @@ class AsyncRunner:
                         return self._rejected_order_result(
                             "Entry blocked: canonical session evidence expired during final admission"
                         )
-                    # ``serialize_entry`` and ``portfolio.equity`` both await.
-                    # Recheck the in-memory and cross-process kill-switch state
-                    # at the final synchronous boundary before the one-shot
-                    # entry authority is consumed.  The gateway intentionally
-                    # bypasses PaperExecutor.place_order(), so this preserves
-                    # the terminal lock-file protection formerly supplied by
-                    # BaseExecutor.validate_order().
-                    blocked, reason = self._trading_blocked()
-                    if blocked:
-                        return self._rejected_order_result(
-                            f"Entry blocked at terminal safety gate: {reason}"
-                        )
                     with Timer("order_execution", self.monitor):
+                        # Timer.__enter__ invokes the mutable monitor callback.
+                        # Recheck only after that callback and immediately before
+                        # the one-shot entry authority can be consumed.
+                        blocked, reason = self._trading_blocked()
+                        if blocked:
+                            return self._rejected_order_result(
+                                f"Entry blocked at terminal safety gate: {reason}"
+                            )
                         result = gateway.submit_baseline_entry(
                             order=exact_order,
                             portfolio_id=self.portfolio_id,

--- a/robo_trader/runner_async.py
+++ b/robo_trader/runner_async.py
@@ -518,6 +518,7 @@ class AsyncRunner:
         self._shared_database = shared_database
         self._owns_database = shared_database is None
         self.paper_reduction_gateway = paper_reduction_gateway
+        self._baseline_entry_handle = None
         self.portfolio_id = portfolio_id
         self.duration = duration
         self.bar_size = bar_size
@@ -1470,6 +1471,7 @@ class AsyncRunner:
         order: Order,
         *,
         protective_quote: Optional[ProtectiveQuoteEvidence] = None,
+        _entry_intent: object | None = None,
     ):
         """
         Execute order with circuit breaker protection.
@@ -1500,11 +1502,16 @@ class AsyncRunner:
 
         contained, containment_reason = validate_gate_a_order(
             side=side,
-            intent_source=order.intent_source,
             take_profit=order.take_profit,
         )
         if not contained:
             return self._rejected_order_result(containment_reason)
+        if side == "BUY":
+            registered_entry_handle = getattr(self, "_baseline_entry_handle", None)
+            if registered_entry_handle is None or _entry_intent is None:
+                return self._rejected_order_result(
+                    "Gate-A entry lacks canonical baseline runtime authority"
+                )
 
         # Semantic reductions bypass entry-only soft stops, but only after the
         # account-wide gateway proves the exact broker contract/read-only
@@ -1644,7 +1651,10 @@ class AsyncRunner:
                 # Hold the same account-wide lock used by reductions. This
                 # prevents an entry from changing the simulator allocation
                 # between a reduction's initial and final evidence snapshots.
-                async with gateway.serialize_entry(order.symbol) as broker_quote:
+                async with gateway.serialize_entry(
+                    order.symbol,
+                    portfolio_id=self.portfolio_id,
+                ) as broker_quote:
                     if type(broker_quote) is not BrokerProtectiveQuote:
                         return self._rejected_order_result(
                             "Entry blocked: refreshed broker quote unavailable"
@@ -1666,7 +1676,6 @@ class AsyncRunner:
                         side=side,
                         price=broker_quote.price,
                         order_ref=order.order_ref,
-                        intent_source=order.intent_source,
                         take_profit=order.take_profit,
                     )
                     portfolio = getattr(self, "portfolio", None)
@@ -1713,7 +1722,11 @@ class AsyncRunner:
                             "Entry blocked: canonical session evidence expired during final admission"
                         )
                     with Timer("order_execution", self.monitor):
-                        result = self.executor.place_order(exact_order)
+                        result = gateway.submit_baseline_entry(
+                            order=exact_order,
+                            portfolio_id=self.portfolio_id,
+                            intent=_entry_intent,
+                        )
 
             # Record success/failure with circuit breaker
             if result.ok:
@@ -2812,7 +2825,7 @@ class AsyncRunner:
             self._paper_settlement_participant = participant
         if type(participant) is not PaperRuntimeSettlementParticipant:
             raise RuntimeError("active paper runtime settlement participant is malformed")
-        gateway.register_paper_executor(
+        self._baseline_entry_handle = gateway.register_paper_executor(
             self.portfolio_id,
             self.executor,
             protective_quote_producer=self.stop_loss_monitor,
@@ -4519,14 +4532,13 @@ class AsyncRunner:
                 df,
             )
 
-        # Provenance is carried to the central order sink. Only the baseline
-        # branch below can produce the one Gate-A entry source.
-        entry_intent_source = "unclassified"
+        # Only the canonical baseline branch below can mint an opaque entry
+        # intent. Alternate producers never receive reusable terminal authority.
+        baseline_entry_intent = None
 
         # Generate trading signal
         with Timer("signal_generation", self.monitor, instance=symbol):
             if self.use_ml_enhanced and self.ml_enhanced_strategy:
-                entry_intent_source = "ml_enhanced"
                 # Use ML Enhanced strategy for signal generation
                 signal_obj = await self.ml_enhanced_strategy.analyze(symbol, df)
 
@@ -4606,7 +4618,6 @@ class AsyncRunner:
                             confidence = 0.5
                         else:
                             signal_value = 1  # BUY
-                            entry_intent_source = "ai_discovery"
                             confidence = opp_conf
                             logger.info(
                                 f"🎯 AI OPPORTUNITY BUY for {symbol}: "
@@ -4696,7 +4707,6 @@ class AsyncRunner:
                                     # default to HOLD; do NOT escalate to BUY
                                 elif ai_buy and ai_conf_ok:
                                     signal_value = 1
-                                    entry_intent_source = "ai_analyst"
                                     confidence = analysis.confidence
                                     logger.info(
                                         f"AI BUY signal for {symbol} "
@@ -4773,7 +4783,6 @@ class AsyncRunner:
                             int(sma_signals["signal"].iloc[-1]) if len(sma_signals) > 0 else 0
                         )
                         if signal_value != 0:
-                            entry_intent_source = "baseline_sma"
                             confidence = 0.6
                             logger.info(f"SMA crossover signal for {symbol}: {signal_value}")
 
@@ -4788,7 +4797,6 @@ class AsyncRunner:
                     index=[df.index[-1]] if len(df) > 0 else [pd.Timestamp.now()],
                 )
             elif self.use_ml_strategy and self.ml_strategy:
-                entry_intent_source = "ml_selector"
                 # Use ML strategy for signal generation
                 # Prepare market data in the format expected by ML strategy
                 market_data_dict = {
@@ -4824,11 +4832,24 @@ class AsyncRunner:
                 )
             else:
                 # Use traditional SMA crossover strategy
-                entry_intent_source = "baseline_sma"
                 signals = sma_crossover_signals(
                     pd.DataFrame({"close": df["close"]}),
                     fast=self.sma_fast,
                     slow=self.sma_slow,
+                )
+                entry_gateway = self.paper_reduction_gateway
+                if entry_gateway is None:
+                    return self._blocked_result(
+                        symbol,
+                        0,
+                        latest_price,
+                        "Execution blocked: paper entry gateway unavailable",
+                        df,
+                    )
+                baseline_entry_intent = entry_gateway.issue_baseline_entry_intent(
+                    portfolio_id=self.portfolio_id,
+                    symbol=symbol,
+                    handle=self._baseline_entry_handle,
                 )
 
         # Generate mean reversion signals if enabled
@@ -4882,7 +4903,7 @@ class AsyncRunner:
 
                         # Override signal if mean reversion is stronger
                         if mr_signal.strength > 0.7:
-                            entry_intent_source = "mean_reversion"
+                            baseline_entry_intent = None
                             signal_value = 1 if mr_signal.signal_type.value == "BUY" else -1
                             signals.iloc[-1]["signal"] = signal_value
 
@@ -5224,8 +5245,8 @@ class AsyncRunner:
                                 quantity=qty,
                                 side="BUY",
                                 price=price,
-                                intent_source=entry_intent_source,
-                            )
+                            ),
+                            _entry_intent=baseline_entry_intent,
                         )
                         if res.ok:
                             exact_fill_price = self._exact_entry_fill_price(res)
@@ -7875,20 +7896,9 @@ async def run_continuous(
                 )
 
                 # Load portfolio configurations
-                from .multiuser.portfolio_config import PortfolioConfig, load_portfolio_configs
+                from .multiuser.portfolio_config import load_portfolio_configs
 
-                try:
-                    portfolio_configs = load_portfolio_configs()
-                except Exception as pc_err:
-                    logger.warning(f"Failed to load portfolio configs: {pc_err}, using default")
-                    portfolio_configs = [
-                        PortfolioConfig(
-                            id="default",
-                            name="Default Portfolio",
-                            starting_cash=default_cash or 100000,
-                            symbols=symbols or [],
-                        )
-                    ]
+                portfolio_configs = load_portfolio_configs()
 
                 active_portfolios = [pc for pc in portfolio_configs if pc.active]
                 logger.info(

--- a/robo_trader/runner_async.py
+++ b/robo_trader/runner_async.py
@@ -1524,7 +1524,7 @@ class AsyncRunner:
             registered_entry_handle = getattr(self, "_baseline_entry_handle", None)
             if registered_entry_handle is None or _entry_intent is None:
                 return self._rejected_order_result(
-                    "Gate-A entry lacks canonical baseline runtime authority"
+                    "Gate-A baseline entry authority is disabled pending risk integration"
                 )
 
         # Semantic reductions bypass entry-only soft stops, but only after the
@@ -2847,12 +2847,16 @@ class AsyncRunner:
             self._paper_settlement_participant = participant
         if type(participant) is not PaperRuntimeSettlementParticipant:
             raise RuntimeError("active paper runtime settlement participant is malformed")
-        self._baseline_entry_handle = gateway.register_paper_executor(
+        gateway.register_paper_executor(
             self.portfolio_id,
             self.executor,
             protective_quote_producer=self.stop_loss_monitor,
             settlement_participant=participant,
         )
+        # Gate-A staging is deliberately non-authorizing for new exposure.
+        # Same-process Python objects cannot be treated as an isolation
+        # boundary, so no reachable entry handle is published.
+        self._baseline_entry_handle = None
         gateway.start_protective_feed()
         self._setup_complete = True
         logger.info("AsyncRunner setup complete")
@@ -4859,20 +4863,10 @@ class AsyncRunner:
                     fast=self.sma_fast,
                     slow=self.sma_slow,
                 )
-                entry_gateway = self.paper_reduction_gateway
-                if entry_gateway is None:
-                    return self._blocked_result(
-                        symbol,
-                        0,
-                        latest_price,
-                        "Execution blocked: paper entry gateway unavailable",
-                        df,
-                    )
-                baseline_entry_intent = entry_gateway.issue_baseline_entry_intent(
-                    portfolio_id=self.portfolio_id,
-                    symbol=symbol,
-                    handle=self._baseline_entry_handle,
-                )
+                # PR117 containment remains non-authorizing. Baseline signals
+                # may be observed, but no BUY intent is minted until the
+                # integrated risk-admission boundary is independently enforced.
+                baseline_entry_intent = None
 
         # Generate mean reversion signals if enabled
         if MEAN_REVERSION_AVAILABLE and self.mean_reversion_strategy:

--- a/robo_trader/safety/runtime.py
+++ b/robo_trader/safety/runtime.py
@@ -902,6 +902,34 @@ def _consume_claimed_paper_submission_allocation(
         )
 
 
+def _retire_claimed_paper_submission_allocation(
+    allocation: object,
+    *,
+    coordinator: object,
+    descriptor: object,
+    contract: object,
+) -> bool:
+    """Retire an unissued exact allocation without ever making it reusable."""
+
+    if (
+        type(allocation) is not _ClaimedPaperSubmissionAllocation
+        or type(coordinator) is not SafetyRuntimeCoordinator
+    ):
+        return False
+    with _CLAIMED_PAPER_ALLOCATION_REGISTRY_LOCK:
+        registered = _CLAIMED_PAPER_ALLOCATION_REGISTRY.get(id(allocation))
+        if (
+            registered is None
+            or registered[0]() is not allocation
+            or registered[1] is not coordinator._coordinator_token
+            or registered[2] is not descriptor
+            or registered[3] is not contract
+        ):
+            return False
+        _CLAIMED_PAPER_ALLOCATION_REGISTRY.pop(id(allocation), None)
+        return True
+
+
 def _final_evidence_digest(proof: FinalSubmissionEvidenceProof) -> str:
     payload = canonical_json(
         {

--- a/robo_trader/safety/runtime.py
+++ b/robo_trader/safety/runtime.py
@@ -615,7 +615,6 @@ class RuntimeAuthorization:
 
 _FINAL_EVIDENCE_PROOF_MARKER = object()
 _CONSUMED_ENVELOPE_MARKER = object()
-_CLAIMED_PAPER_ALLOCATION_TOKEN = object()
 _RUNTIME_AUTHORIZATION_REGISTRY_LOCK = threading.RLock()
 _RUNTIME_AUTHORIZATION_REGISTRY: dict[
     int, tuple[weakref.ReferenceType[RuntimeAuthorization], str]
@@ -627,16 +626,6 @@ _FINAL_EVIDENCE_REGISTRY: dict[
 _CONSUMED_ENVELOPE_REGISTRY_LOCK = threading.RLock()
 _CONSUMED_ENVELOPE_REGISTRY: dict[
     int, tuple[weakref.ReferenceType["ConsumedPaperSubmissionEnvelope"], str]
-] = {}
-_CLAIMED_PAPER_ALLOCATION_REGISTRY_LOCK = threading.RLock()
-_CLAIMED_PAPER_ALLOCATION_REGISTRY: dict[
-    int,
-    tuple[
-        weakref.ReferenceType["_ClaimedPaperSubmissionAllocation"],
-        object,
-        SubmissionDescriptor,
-        AuthoritativeContract,
-    ],
 ] = {}
 
 
@@ -776,6 +765,7 @@ class FinalSubmissionEvidenceProof:
     contract_snapshot_id: str
     contract_transport_generation: str
     final_evidence_fingerprint: str
+    pre_position_quantity: Decimal
     expires_at: datetime
     _contract: AuthoritativeContract = field(repr=False, compare=False)
     _coordinator_token: object = field(repr=False, compare=False)
@@ -787,6 +777,11 @@ class FinalSubmissionEvidenceProof:
                 "FinalSubmissionEvidenceProof requires trusted final evidence production"
             )
         object.__setattr__(self, "expires_at", _utc(self.expires_at, "expires_at"))
+        object.__setattr__(
+            self,
+            "pre_position_quantity",
+            _decimal(self.pre_position_quantity, "pre_position_quantity"),
+        )
 
     def __copy__(self):
         raise TypeError("FinalSubmissionEvidenceProof cannot be copied")
@@ -810,6 +805,7 @@ class ConsumedPaperSubmissionEnvelope:
     contract_snapshot_id: str
     contract_transport_generation: str
     final_evidence_fingerprint: str
+    pre_position_quantity: Decimal
     _descriptor: SubmissionDescriptor = field(repr=False, compare=False)
     _contract: AuthoritativeContract = field(repr=False, compare=False)
     _coordinator_token: object = field(repr=False, compare=False)
@@ -820,6 +816,11 @@ class ConsumedPaperSubmissionEnvelope:
             raise RuntimeSafetyError(
                 "ConsumedPaperSubmissionEnvelope requires coordinator permit consumption"
             )
+        object.__setattr__(
+            self,
+            "pre_position_quantity",
+            _decimal(self.pre_position_quantity, "pre_position_quantity"),
+        )
 
     def __copy__(self):
         raise TypeError("ConsumedPaperSubmissionEnvelope cannot be copied")
@@ -831,103 +832,134 @@ class ConsumedPaperSubmissionEnvelope:
         raise TypeError("ConsumedPaperSubmissionEnvelope cannot be serialized")
 
 
-class _ClaimedPaperSubmissionAllocation:
-    """Opaque one-shot identity emitted only after coordinator envelope claim."""
+def _make_claimed_paper_allocation_state():
+    """Build closure-owned one-shot state for final allocation claims."""
 
-    __slots__ = ("__weakref__",)
+    issue_token = object()
+    registry_lock = threading.RLock()
+    registry: dict[
+        int,
+        tuple[
+            weakref.ReferenceType[object],
+            object,
+            SubmissionDescriptor,
+            AuthoritativeContract,
+            Decimal,
+        ],
+    ] = {}
 
-    def __new__(cls, *, _token: object | None = None):
-        if _token is not _CLAIMED_PAPER_ALLOCATION_TOKEN:
-            raise RuntimeSafetyError("claimed paper allocation is coordinator-only")
-        return super().__new__(cls)
+    class _ClaimedPaperSubmissionAllocation:
+        """Opaque identity emitted only after an exact coordinator claim."""
 
-    def __copy__(self):
-        raise TypeError("claimed paper allocation cannot be copied")
+        __slots__ = ("__weakref__",)
 
-    def __deepcopy__(self, _memo):
-        return self.__copy__()
+        def __new__(cls, *, _token: object | None = None):
+            if _token is not issue_token:
+                raise RuntimeSafetyError("claimed paper allocation is coordinator-only")
+            return super().__new__(cls)
 
-    def __reduce__(self):
-        raise TypeError("claimed paper allocation cannot be serialized")
+        def __copy__(self):
+            raise TypeError("claimed paper allocation cannot be copied")
 
+        def __deepcopy__(self, _memo):
+            return self.__copy__()
 
-def _register_claimed_paper_submission_allocation(
-    allocation: _ClaimedPaperSubmissionAllocation,
-    *,
-    coordinator_token: object,
-    descriptor: SubmissionDescriptor,
-    contract: AuthoritativeContract,
-) -> None:
-    object_id = id(allocation)
+        def __reduce__(self):
+            raise TypeError("claimed paper allocation cannot be serialized")
 
-    def discard(reference: weakref.ReferenceType[_ClaimedPaperSubmissionAllocation]) -> None:
-        with _CLAIMED_PAPER_ALLOCATION_REGISTRY_LOCK:
-            registered = _CLAIMED_PAPER_ALLOCATION_REGISTRY.get(object_id)
-            if registered is not None and registered[0] is reference:
-                _CLAIMED_PAPER_ALLOCATION_REGISTRY.pop(object_id, None)
+    def issue(
+        *,
+        coordinator_token: object,
+        descriptor: SubmissionDescriptor,
+        contract: AuthoritativeContract,
+        pre_position_quantity: Decimal,
+    ) -> _ClaimedPaperSubmissionAllocation:
+        allocation = _ClaimedPaperSubmissionAllocation(_token=issue_token)
+        object_id = id(allocation)
 
-    reference = weakref.ref(allocation, discard)
-    with _CLAIMED_PAPER_ALLOCATION_REGISTRY_LOCK:
-        _CLAIMED_PAPER_ALLOCATION_REGISTRY[object_id] = (
-            reference,
-            coordinator_token,
-            descriptor,
-            contract,
-        )
+        def discard(reference: weakref.ReferenceType[object]) -> None:
+            with registry_lock:
+                registered = registry.get(object_id)
+                if registered is not None and registered[0] is reference:
+                    registry.pop(object_id, None)
 
+        reference = weakref.ref(allocation, discard)
+        with registry_lock:
+            registry[object_id] = (
+                reference,
+                coordinator_token,
+                descriptor,
+                contract,
+                pre_position_quantity,
+            )
+        return allocation
 
-def _consume_claimed_paper_submission_allocation(
-    allocation: object,
-    *,
-    coordinator: object,
-    descriptor: object,
-    contract: object,
-) -> None:
-    """Burn and verify the exact final allocation before terminal dispatch."""
+    def consume(
+        allocation: object,
+        *,
+        coordinator: object,
+        descriptor: object,
+        contract: object,
+        pre_position_quantity: Decimal,
+    ) -> Decimal:
+        """Burn and verify the exact final allocation before dispatch."""
 
-    if type(allocation) is not _ClaimedPaperSubmissionAllocation:
-        raise RuntimeSafetyError("exact claimed paper allocation is required")
-    with _CLAIMED_PAPER_ALLOCATION_REGISTRY_LOCK:
-        registered = _CLAIMED_PAPER_ALLOCATION_REGISTRY.pop(id(allocation), None)
-    if (
-        registered is None
-        or registered[0]() is not allocation
-        or type(coordinator) is not SafetyRuntimeCoordinator
-        or registered[1] is not coordinator._coordinator_token
-        or registered[2] is not descriptor
-        or registered[3] is not contract
-    ):
-        raise RuntimeSafetyError(
-            "claimed paper allocation is forged, changed, replayed, or foreign"
-        )
-
-
-def _retire_claimed_paper_submission_allocation(
-    allocation: object,
-    *,
-    coordinator: object,
-    descriptor: object,
-    contract: object,
-) -> bool:
-    """Retire an unissued exact allocation without ever making it reusable."""
-
-    if (
-        type(allocation) is not _ClaimedPaperSubmissionAllocation
-        or type(coordinator) is not SafetyRuntimeCoordinator
-    ):
-        return False
-    with _CLAIMED_PAPER_ALLOCATION_REGISTRY_LOCK:
-        registered = _CLAIMED_PAPER_ALLOCATION_REGISTRY.get(id(allocation))
+        if type(allocation) is not _ClaimedPaperSubmissionAllocation:
+            raise RuntimeSafetyError("exact claimed paper allocation is required")
+        with registry_lock:
+            registered = registry.pop(id(allocation), None)
         if (
             registered is None
             or registered[0]() is not allocation
+            or type(coordinator) is not SafetyRuntimeCoordinator
             or registered[1] is not coordinator._coordinator_token
             or registered[2] is not descriptor
             or registered[3] is not contract
+            or type(pre_position_quantity) is not Decimal
+            or registered[4] != pre_position_quantity
+        ):
+            raise RuntimeSafetyError(
+                "claimed paper allocation is forged, changed, replayed, foreign, or mismatched"
+            )
+        return registered[4]
+
+    def retire(
+        allocation: object,
+        *,
+        coordinator: object,
+        descriptor: object,
+        contract: object,
+    ) -> bool:
+        """Retire an unissued exact allocation without making it reusable."""
+
+        if (
+            type(allocation) is not _ClaimedPaperSubmissionAllocation
+            or type(coordinator) is not SafetyRuntimeCoordinator
         ):
             return False
-        _CLAIMED_PAPER_ALLOCATION_REGISTRY.pop(id(allocation), None)
-        return True
+        with registry_lock:
+            registered = registry.get(id(allocation))
+            if (
+                registered is None
+                or registered[0]() is not allocation
+                or registered[1] is not coordinator._coordinator_token
+                or registered[2] is not descriptor
+                or registered[3] is not contract
+            ):
+                return False
+            registry.pop(id(allocation), None)
+            return True
+
+    return _ClaimedPaperSubmissionAllocation, issue, consume, retire
+
+
+(
+    _ClaimedPaperSubmissionAllocation,
+    _issue_claimed_paper_submission_allocation,
+    _consume_claimed_paper_submission_allocation,
+    _retire_claimed_paper_submission_allocation,
+) = _make_claimed_paper_allocation_state()
+del _make_claimed_paper_allocation_state
 
 
 def _final_evidence_digest(proof: FinalSubmissionEvidenceProof) -> str:
@@ -942,6 +974,7 @@ def _final_evidence_digest(proof: FinalSubmissionEvidenceProof) -> str:
             "execution_domain_scope": proof.execution_domain_scope,
             "expires_at": proof.expires_at,
             "final_evidence_fingerprint": proof.final_evidence_fingerprint,
+            "pre_position_quantity": proof.pre_position_quantity,
             "symbol": proof.symbol,
         }
     )
@@ -960,6 +993,7 @@ def _envelope_digest(envelope: ConsumedPaperSubmissionEnvelope) -> str:
             "descriptor_fingerprint": envelope.descriptor_fingerprint,
             "execution_domain_scope": envelope.execution_domain_scope,
             "final_evidence_fingerprint": envelope.final_evidence_fingerprint,
+            "pre_position_quantity": envelope.pre_position_quantity,
             "symbol": envelope.symbol,
         }
     )
@@ -1428,6 +1462,7 @@ class SafetyRuntimeCoordinator:
                 contract_snapshot_id=contract.snapshot_id,
                 contract_transport_generation=contract.transport_generation,
                 final_evidence_fingerprint=final_evidence_fingerprint,
+                pre_position_quantity=allocation.position_quantity,
                 expires_at=expires_at,
                 _contract=contract,
                 _coordinator_token=self._coordinator_token,
@@ -1470,6 +1505,7 @@ class SafetyRuntimeCoordinator:
                 != final_evidence._contract.transport_generation
                 or final_evidence.contract_transport_generation
                 != authorization.contract.transport_generation
+                or type(final_evidence.pre_position_quantity) is not Decimal
             ):
                 raise RuntimeSafetyError(
                     "final evidence proof does not match authorized submission"
@@ -1513,6 +1549,7 @@ class SafetyRuntimeCoordinator:
                 contract_snapshot_id=final_evidence.contract_snapshot_id,
                 contract_transport_generation=(final_evidence.contract_transport_generation),
                 final_evidence_fingerprint=(final_evidence.final_evidence_fingerprint),
+                pre_position_quantity=final_evidence.pre_position_quantity,
                 _descriptor=descriptor,
                 _contract=final_evidence._contract,
                 _coordinator_token=self._coordinator_token,
@@ -1551,12 +1588,11 @@ class SafetyRuntimeCoordinator:
                 or contract.transport_generation != envelope.contract_transport_generation
             ):
                 raise RuntimeSafetyError("claimed paper envelope lineage is inconsistent")
-            allocation = _ClaimedPaperSubmissionAllocation(_token=_CLAIMED_PAPER_ALLOCATION_TOKEN)
-            _register_claimed_paper_submission_allocation(
-                allocation,
+            allocation = _issue_claimed_paper_submission_allocation(
                 coordinator_token=self._coordinator_token,
                 descriptor=descriptor,
                 contract=contract,
+                pre_position_quantity=envelope.pre_position_quantity,
             )
             return descriptor, contract, allocation
 

--- a/robo_trader/safety/runtime.py
+++ b/robo_trader/safety/runtime.py
@@ -615,6 +615,7 @@ class RuntimeAuthorization:
 
 _FINAL_EVIDENCE_PROOF_MARKER = object()
 _CONSUMED_ENVELOPE_MARKER = object()
+_CLAIMED_PAPER_ALLOCATION_TOKEN = object()
 _RUNTIME_AUTHORIZATION_REGISTRY_LOCK = threading.RLock()
 _RUNTIME_AUTHORIZATION_REGISTRY: dict[
     int, tuple[weakref.ReferenceType[RuntimeAuthorization], str]
@@ -626,6 +627,16 @@ _FINAL_EVIDENCE_REGISTRY: dict[
 _CONSUMED_ENVELOPE_REGISTRY_LOCK = threading.RLock()
 _CONSUMED_ENVELOPE_REGISTRY: dict[
     int, tuple[weakref.ReferenceType["ConsumedPaperSubmissionEnvelope"], str]
+] = {}
+_CLAIMED_PAPER_ALLOCATION_REGISTRY_LOCK = threading.RLock()
+_CLAIMED_PAPER_ALLOCATION_REGISTRY: dict[
+    int,
+    tuple[
+        weakref.ReferenceType["_ClaimedPaperSubmissionAllocation"],
+        object,
+        SubmissionDescriptor,
+        AuthoritativeContract,
+    ],
 ] = {}
 
 
@@ -818,6 +829,77 @@ class ConsumedPaperSubmissionEnvelope:
 
     def __reduce__(self):
         raise TypeError("ConsumedPaperSubmissionEnvelope cannot be serialized")
+
+
+class _ClaimedPaperSubmissionAllocation:
+    """Opaque one-shot identity emitted only after coordinator envelope claim."""
+
+    __slots__ = ("__weakref__",)
+
+    def __new__(cls, *, _token: object | None = None):
+        if _token is not _CLAIMED_PAPER_ALLOCATION_TOKEN:
+            raise RuntimeSafetyError("claimed paper allocation is coordinator-only")
+        return super().__new__(cls)
+
+    def __copy__(self):
+        raise TypeError("claimed paper allocation cannot be copied")
+
+    def __deepcopy__(self, _memo):
+        return self.__copy__()
+
+    def __reduce__(self):
+        raise TypeError("claimed paper allocation cannot be serialized")
+
+
+def _register_claimed_paper_submission_allocation(
+    allocation: _ClaimedPaperSubmissionAllocation,
+    *,
+    coordinator_token: object,
+    descriptor: SubmissionDescriptor,
+    contract: AuthoritativeContract,
+) -> None:
+    object_id = id(allocation)
+
+    def discard(reference: weakref.ReferenceType[_ClaimedPaperSubmissionAllocation]) -> None:
+        with _CLAIMED_PAPER_ALLOCATION_REGISTRY_LOCK:
+            registered = _CLAIMED_PAPER_ALLOCATION_REGISTRY.get(object_id)
+            if registered is not None and registered[0] is reference:
+                _CLAIMED_PAPER_ALLOCATION_REGISTRY.pop(object_id, None)
+
+    reference = weakref.ref(allocation, discard)
+    with _CLAIMED_PAPER_ALLOCATION_REGISTRY_LOCK:
+        _CLAIMED_PAPER_ALLOCATION_REGISTRY[object_id] = (
+            reference,
+            coordinator_token,
+            descriptor,
+            contract,
+        )
+
+
+def _consume_claimed_paper_submission_allocation(
+    allocation: object,
+    *,
+    coordinator: object,
+    descriptor: object,
+    contract: object,
+) -> None:
+    """Burn and verify the exact final allocation before terminal dispatch."""
+
+    if type(allocation) is not _ClaimedPaperSubmissionAllocation:
+        raise RuntimeSafetyError("exact claimed paper allocation is required")
+    with _CLAIMED_PAPER_ALLOCATION_REGISTRY_LOCK:
+        registered = _CLAIMED_PAPER_ALLOCATION_REGISTRY.pop(id(allocation), None)
+    if (
+        registered is None
+        or registered[0]() is not allocation
+        or type(coordinator) is not SafetyRuntimeCoordinator
+        or registered[1] is not coordinator._coordinator_token
+        or registered[2] is not descriptor
+        or registered[3] is not contract
+    ):
+        raise RuntimeSafetyError(
+            "claimed paper allocation is forged, changed, replayed, or foreign"
+        )
 
 
 def _final_evidence_digest(proof: FinalSubmissionEvidenceProof) -> str:
@@ -1414,7 +1496,11 @@ class SafetyRuntimeCoordinator:
     def _claim_consumed_paper_submission(
         self,
         envelope: ConsumedPaperSubmissionEnvelope,
-    ) -> tuple[SubmissionDescriptor, AuthoritativeContract]:
+    ) -> tuple[
+        SubmissionDescriptor,
+        AuthoritativeContract,
+        _ClaimedPaperSubmissionAllocation,
+    ]:
         """Atomically claim the exact envelope for the bound paper adapter."""
 
         with self._startup_lock:
@@ -1437,7 +1523,14 @@ class SafetyRuntimeCoordinator:
                 or contract.transport_generation != envelope.contract_transport_generation
             ):
                 raise RuntimeSafetyError("claimed paper envelope lineage is inconsistent")
-            return descriptor, contract
+            allocation = _ClaimedPaperSubmissionAllocation(_token=_CLAIMED_PAPER_ALLOCATION_TOKEN)
+            _register_claimed_paper_submission_allocation(
+                allocation,
+                coordinator_token=self._coordinator_token,
+                descriptor=descriptor,
+                contract=contract,
+            )
+            return descriptor, contract, allocation
 
     def release_after_local_paper_settlement(
         self,

--- a/robo_trader/safety/runtime.py
+++ b/robo_trader/safety/runtime.py
@@ -832,9 +832,12 @@ class ConsumedPaperSubmissionEnvelope:
         raise TypeError("ConsumedPaperSubmissionEnvelope cannot be serialized")
 
 
-def _make_claimed_paper_allocation_state():
+def _make_claimed_paper_allocation_state(claim_envelope):
     """Build closure-owned one-shot state for final allocation claims."""
 
+    # Threat boundary: closure capability hygiene constrains supported call paths;
+    # it cannot isolate arbitrary same-interpreter code. Hostile plugins or
+    # broker-write authority require a separate process-isolation boundary.
     issue_token = object()
     registry_lock = threading.RLock()
     registry: dict[
@@ -867,13 +870,37 @@ def _make_claimed_paper_allocation_state():
         def __reduce__(self):
             raise TypeError("claimed paper allocation cannot be serialized")
 
-    def issue(
+    def claim_and_issue(
+        envelope: object,
         *,
-        coordinator_token: object,
-        descriptor: SubmissionDescriptor,
-        contract: AuthoritativeContract,
-        pre_position_quantity: Decimal,
-    ) -> _ClaimedPaperSubmissionAllocation:
+        coordinator: object,
+    ) -> tuple[
+        SubmissionDescriptor,
+        AuthoritativeContract,
+        _ClaimedPaperSubmissionAllocation,
+    ]:
+        """Claim one exact envelope and mint its sole allocation identity."""
+
+        if type(coordinator) is not SafetyRuntimeCoordinator:
+            raise RuntimeSafetyError("exact paper safety coordinator is required")
+        descriptor, contract = claim_envelope(
+            envelope,
+            coordinator_token=coordinator._coordinator_token,
+        )
+        if (
+            envelope.execution_domain_scope != coordinator._identity.execution_domain_scope
+            or envelope.account_scope != coordinator._identity.account_scope
+            or descriptor.execution_domain_scope != envelope.execution_domain_scope
+            or descriptor.account_scope != envelope.account_scope
+            or descriptor.con_id != envelope.con_id
+            or descriptor.fingerprint() != envelope.descriptor_fingerprint
+            or contract.con_id != envelope.con_id
+            or contract.symbol != envelope.symbol
+            or contract.snapshot_id != envelope.contract_snapshot_id
+            or contract.transport_generation != envelope.contract_transport_generation
+        ):
+            raise RuntimeSafetyError("claimed paper envelope lineage is inconsistent")
+
         allocation = _ClaimedPaperSubmissionAllocation(_token=issue_token)
         object_id = id(allocation)
 
@@ -887,12 +914,12 @@ def _make_claimed_paper_allocation_state():
         with registry_lock:
             registry[object_id] = (
                 reference,
-                coordinator_token,
+                coordinator._coordinator_token,
                 descriptor,
                 contract,
-                pre_position_quantity,
+                envelope.pre_position_quantity,
             )
-        return allocation
+        return descriptor, contract, allocation
 
     def consume(
         allocation: object,
@@ -950,16 +977,7 @@ def _make_claimed_paper_allocation_state():
             registry.pop(id(allocation), None)
             return True
 
-    return _ClaimedPaperSubmissionAllocation, issue, consume, retire
-
-
-(
-    _ClaimedPaperSubmissionAllocation,
-    _issue_claimed_paper_submission_allocation,
-    _consume_claimed_paper_submission_allocation,
-    _retire_claimed_paper_submission_allocation,
-) = _make_claimed_paper_allocation_state()
-del _make_claimed_paper_allocation_state
+    return _ClaimedPaperSubmissionAllocation, claim_and_issue, consume, retire
 
 
 def _final_evidence_digest(proof: FinalSubmissionEvidenceProof) -> str:
@@ -1072,6 +1090,15 @@ def _claim_consumed_envelope(
             )
         _CONSUMED_ENVELOPE_REGISTRY.pop(id(envelope), None)
         return envelope._descriptor, envelope._contract
+
+
+(
+    _ClaimedPaperSubmissionAllocation,
+    _claim_and_issue_paper_submission_allocation,
+    _consume_claimed_paper_submission_allocation,
+    _retire_claimed_paper_submission_allocation,
+) = _make_claimed_paper_allocation_state(_claim_consumed_envelope)
+del _make_claimed_paper_allocation_state
 
 
 @dataclass(frozen=True)
@@ -1571,30 +1598,10 @@ class SafetyRuntimeCoordinator:
         with self._startup_lock:
             if not self._started:
                 raise RuntimeNotStarted("successful journal replay is required")
-            descriptor, contract = _claim_consumed_envelope(
+            return _claim_and_issue_paper_submission_allocation(
                 envelope,
-                coordinator_token=self._coordinator_token,
+                coordinator=self,
             )
-            if (
-                envelope.execution_domain_scope != self._identity.execution_domain_scope
-                or envelope.account_scope != self._identity.account_scope
-                or descriptor.execution_domain_scope != envelope.execution_domain_scope
-                or descriptor.account_scope != envelope.account_scope
-                or descriptor.con_id != envelope.con_id
-                or descriptor.fingerprint() != envelope.descriptor_fingerprint
-                or contract.con_id != envelope.con_id
-                or contract.symbol != envelope.symbol
-                or contract.snapshot_id != envelope.contract_snapshot_id
-                or contract.transport_generation != envelope.contract_transport_generation
-            ):
-                raise RuntimeSafetyError("claimed paper envelope lineage is inconsistent")
-            allocation = _issue_claimed_paper_submission_allocation(
-                coordinator_token=self._coordinator_token,
-                descriptor=descriptor,
-                contract=contract,
-                pre_position_quantity=envelope.pre_position_quantity,
-            )
-            return descriptor, contract, allocation
 
     def release_after_local_paper_settlement(
         self,

--- a/scripts/docker-deploy.sh
+++ b/scripts/docker-deploy.sh
@@ -46,7 +46,7 @@ create_env_file() {
 # Trading Configuration
 TRADING_MODE=paper
 TRADING_SYMBOLS=AAPL,NVDA,TSLA,GOOGL,MSFT
-STRATEGY_ENABLED_STRATEGIES=momentum,mean_reversion
+STRATEGY_ENABLED_STRATEGIES=baseline_sma
 
 # IBKR Configuration
 IBKR_HOST=host.docker.internal

--- a/tests/integration/test_runner_death_recovery.py
+++ b/tests/integration/test_runner_death_recovery.py
@@ -158,6 +158,8 @@ def test_runner_death_triggers_full_defense_stack(tmp_path, monkeypatch):
     app_mod = _reload_app_with_env(
         monkeypatch,
         DASH_AUTH_ENABLED="false",
+        STRATEGY_ENABLED="baseline_sma",
+        STRATEGY_ENABLED_STRATEGIES="baseline_sma",
     )
     client = app_mod.app.test_client()
 

--- a/tests/paper_execution_test_support.py
+++ b/tests/paper_execution_test_support.py
@@ -73,6 +73,7 @@ class GatewayBoundReductionHarness:
             _CAPABILITIES[capability] = _CapabilityRecord(
                 authority=self.authority,
                 executor=self.executor,
+                order=order,
                 portfolio_id=self.portfolio_id,
                 kind=_CapabilityKind.REDUCTION,
                 fingerprint=_fingerprint_order(order),

--- a/tests/paper_execution_test_support.py
+++ b/tests/paper_execution_test_support.py
@@ -2,42 +2,159 @@
 
 from __future__ import annotations
 
+import hashlib
+import math
+import tempfile
 import threading
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from decimal import Decimal
+from pathlib import Path
 
 from robo_trader.execution import ExecutionResult, Order, PaperExecutor
 from robo_trader.paper_execution_capability import (
-    _CAPABILITIES,
-    _CAPABILITY_TOKEN,
-    _REDUCTION_DISPATCHES,
-    _REGISTRY_LOCK,
-    _TERMINAL_DISPATCH_TOKEN,
     PaperReductionExecutionAuthority,
-    _attach_gateway_reduction_submitter,
     _bind_gateway_reduction_execution,
-    _CapabilityKind,
-    _CapabilityRecord,
-    _fingerprint_order,
     _issue_gateway_reduction_binding_capability,
-    _PaperExecutionCapability,
-    _ReductionTerminalDispatch,
-    _TerminalDispatchRecord,
 )
 from robo_trader.paper_reduction_gateway import (
     PaperReductionGateway,
     _PaperRuntimeBindingSession,
 )
-from robo_trader.safety.runtime import SafetyRuntimeCoordinator
+from robo_trader.paper_reduction_submitter import (
+    PaperReductionSubmissionError,
+    _bind_paper_reduction_submitter,
+    _claim_and_issue_terminal_dispatch,
+)
+from robo_trader.safety.journal import SafetyJournal
+from robo_trader.safety.models import (
+    EvidenceStatus,
+    OrderSide,
+    OrderType,
+    ReconciliationStatus,
+    TimeInForce,
+    TransportState,
+)
+from robo_trader.safety.runtime import (
+    AccountPosition,
+    AuthoritativeContract,
+    OpenOrderSnapshot,
+    PaperExecutionIdentity,
+    PortfolioAllocation,
+    RuntimeOrderRequest,
+    SafetyRuntimeCoordinator,
+    _assemble_coherent_safety_snapshot,
+)
+
+_ACCOUNT_SCOPE = "acct_v1_" + hashlib.sha256(b"paper-execution-test-support").hexdigest()
 
 
-@dataclass(frozen=True)
+@dataclass
 class GatewayBoundReductionHarness:
     executor: PaperExecutor
     coordinator: SafetyRuntimeCoordinator
     authority: PaperReductionExecutionAuthority
     submitter_identity: object
     portfolio_id: str
+    clock: datetime
+    _counter: int = 0
+
+    def _envelope(self, order: Order, pre_position_quantity: Decimal):
+        self._counter += 1
+        con_id = 100_000 + self._counter
+        generation = f"test-generation-{self._counter}"
+        contract = AuthoritativeContract(
+            con_id=con_id,
+            symbol=order.symbol,
+            local_symbol=order.symbol,
+            security_type="STK",
+            currency="USD",
+            exchange="SMART",
+            primary_exchange="NASDAQ",
+            trading_class="NMS",
+            observed_at=self.clock,
+            snapshot_id=f"contract-{self._counter}",
+            source="test-qualified-contract-cache",
+            broker_timestamp=self.clock,
+            retrieval_timestamp=self.clock,
+            transport_generation=generation,
+            status=EvidenceStatus.AUTHORITATIVE,
+        )
+        if order.side == "SELL":
+            side = OrderSide.SELL
+        elif order.side == "BUY_TO_COVER":
+            side = OrderSide.BUY_TO_COVER
+        else:
+            raise PaperReductionSubmissionError("test harness admits only reductions")
+        if order.order_ref is None:
+            order.order_ref = f"paper-test-{self._counter}"
+        if order.price is None:
+            order_type = OrderType.MARKET
+            limit_price = None
+        else:
+            if type(order.price) is Decimal:
+                limit_price = order.price
+            else:
+                numeric = float(order.price)
+                if not math.isfinite(numeric):
+                    raise PaperReductionSubmissionError("paper test price is non-finite")
+                limit_price = Decimal(str(numeric))
+                order.price = limit_price
+            order_type = OrderType.LIMIT
+        request = RuntimeOrderRequest(
+            portfolio_id=self.portfolio_id,
+            contract=contract,
+            side=side,
+            quantity=Decimal(order.quantity),
+            order_type=order_type,
+            limit_price=limit_price,
+            time_in_force=TimeInForce.DAY,
+            outside_regular_hours=False,
+            order_ref=order.order_ref,
+            reason="test protective reduction",
+            strategy="test-stop-loss",
+        )
+        snapshot = _assemble_coherent_safety_snapshot(
+            execution_domain_scope="paper-simulator-v1",
+            account_scope=_ACCOUNT_SCOPE,
+            observed_at=self.clock,
+            snapshot_id=f"account-{self._counter}",
+            source="test-broker-account-snapshot",
+            allocation_observed_at=self.clock,
+            allocation_snapshot_id=f"allocation-{self._counter}",
+            allocation_source="test-allocation-database",
+            allocation_database_path="/tmp/isolated-paper-execution-test.db",
+            allocation_database_identity="test-ledger-identity",
+            allocation_database_device=101,
+            allocation_database_inode=202,
+            runtime_fingerprint="0123456789abcdef",
+            ibc_proof_id="ibc-proof-v1-" + ("a" * 64),
+            reconciliation_observed_at=self.clock,
+            reconciliation_snapshot_id=f"reconciliation-{self._counter}",
+            transport_generation=generation,
+            account_positions=(AccountPosition(con_id, order.symbol, pre_position_quantity),),
+            portfolio_allocations=(
+                PortfolioAllocation(
+                    self.portfolio_id,
+                    con_id,
+                    order.symbol,
+                    pre_position_quantity,
+                ),
+            ),
+            open_orders=OpenOrderSnapshot(
+                observed_at=self.clock,
+                snapshot_id=f"open-orders-{self._counter}",
+                transport_generation=generation,
+            ),
+            transport_state=TransportState.CONNECTED,
+            reconciliation_status=ReconciliationStatus.PASSED,
+        )
+        authorization = self.coordinator.authorize(f"paper-test-{self._counter}", request, snapshot)
+        proof = self.coordinator._bind_fresh_final_evidence_proof(authorization, contract, snapshot)
+        envelope = self.coordinator._consume_authorization_for_paper_submission(
+            authorization, proof
+        )
+        return envelope
 
     def issue(
         self,
@@ -45,21 +162,16 @@ class GatewayBoundReductionHarness:
         *,
         pre_position_quantity: Decimal,
     ) -> object:
-        fingerprint = _fingerprint_order(order)
-        dispatch = _ReductionTerminalDispatch(_token=_TERMINAL_DISPATCH_TOKEN)
-        with _REGISTRY_LOCK:
-            _REDUCTION_DISPATCHES[dispatch] = _TerminalDispatchRecord(
-                binding=self.authority,
-                gateway=None,
-                runtime_context=None,
-                active_session=None,
-                submitter=self.submitter_identity,
-                coordinator=self.coordinator,
-                executor=self.executor,
-                portfolio_id=self.portfolio_id,
-                fingerprint=fingerprint,
-                pre_position_quantity=pre_position_quantity,
-            )
+        envelope = self._envelope(order, pre_position_quantity)
+        _, mapped_order, dispatch = _claim_and_issue_terminal_dispatch(
+            self.authority,
+            submitter=self.submitter_identity,
+            executor=self.executor,
+            coordinator=self.coordinator,
+            envelope=envelope,
+            pre_position_quantity=pre_position_quantity,
+        )
+        assert mapped_order.symbol == order.symbol
         return dispatch
 
     def submit(
@@ -68,18 +180,22 @@ class GatewayBoundReductionHarness:
         *,
         pre_position_quantity: Decimal,
     ) -> ExecutionResult:
-        capability = _PaperExecutionCapability(_token=_CAPABILITY_TOKEN)
-        with _REGISTRY_LOCK:
-            _CAPABILITIES[capability] = _CapabilityRecord(
-                authority=self.authority,
-                executor=self.executor,
-                order=order,
-                portfolio_id=self.portfolio_id,
-                kind=_CapabilityKind.REDUCTION,
-                fingerprint=_fingerprint_order(order),
+        from robo_trader.paper_execution_capability import _submit_gateway_reduction_once
+
+        try:
+            dispatch = self.issue(
+                order,
                 pre_position_quantity=pre_position_quantity,
             )
-        return self.executor._place_simple_order(order, _capability=capability)
+            return _submit_gateway_reduction_once(
+                self.authority,
+                dispatch,
+                submitter=self.submitter_identity,
+                order=order,
+                pre_position_quantity=pre_position_quantity,
+            )
+        except (RuntimeError, TypeError, ValueError) as exc:
+            return ExecutionResult(False, f"reduction exposure rejected: {exc}")
 
 
 def bind_gateway_reduction_harness(
@@ -89,19 +205,25 @@ def bind_gateway_reduction_harness(
     coordinator: SafetyRuntimeCoordinator | None = None,
 ) -> GatewayBoundReductionHarness:
     """Exercise the exact one-shot registration functions without I/O."""
-
+    now = datetime.now(timezone.utc)
+    if coordinator is None:
+        temp_root = Path(tempfile.mkdtemp(prefix="paper-execution-test-"))
+        identity = PaperExecutionIdentity("paper-simulator-v1", _ACCOUNT_SCOPE)
+        journal = SafetyJournal(temp_root / "safety.db", clock=lambda: now)
+        journal.initialize(
+            execution_domain_scope=identity.execution_domain_scope,
+            account_scope=identity.account_scope,
+        )
+        coordinator = SafetyRuntimeCoordinator(identity, journal, clock=lambda: now)
+        coordinator.start()
     authority, coordinator = bind_gateway_reduction_authority(
-        executor,
-        portfolio_id,
-        coordinator=coordinator,
+        executor, portfolio_id, coordinator=coordinator
     )
-    submitter_identity = object()
-    _attach_gateway_reduction_submitter(
+    submitter_identity = _bind_paper_reduction_submitter(
+        executor,
+        coordinator,
         authority,
-        submitter=submitter_identity,
-        executor=executor,
-        coordinator=coordinator,
-        portfolio_id=portfolio_id,
+        portfolio_id,
     )
     return GatewayBoundReductionHarness(
         executor=executor,
@@ -109,6 +231,7 @@ def bind_gateway_reduction_harness(
         authority=authority,
         submitter_identity=submitter_identity,
         portfolio_id=portfolio_id,
+        clock=now,
     )
 
 

--- a/tests/paper_execution_test_support.py
+++ b/tests/paper_execution_test_support.py
@@ -1,0 +1,160 @@
+"""Test-only construction of an exact gateway registration lifecycle."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from decimal import Decimal
+
+from robo_trader.execution import ExecutionResult, Order, PaperExecutor
+from robo_trader.paper_execution_capability import (
+    PaperReductionExecutionAuthority,
+    _CapabilityKind,
+    _CapabilityRecord,
+    _CAPABILITIES,
+    _CAPABILITY_TOKEN,
+    _PaperExecutionCapability,
+    _REDUCTION_DISPATCHES,
+    _REGISTRY_LOCK,
+    _ReductionTerminalDispatch,
+    _TERMINAL_DISPATCH_TOKEN,
+    _TerminalDispatchRecord,
+    _attach_gateway_reduction_submitter,
+    _bind_gateway_reduction_execution,
+    _fingerprint_order,
+    _issue_gateway_reduction_binding_capability,
+)
+from robo_trader.paper_reduction_gateway import (
+    PaperReductionGateway,
+    _PaperRuntimeBindingSession,
+)
+from robo_trader.safety.runtime import SafetyRuntimeCoordinator
+
+
+@dataclass(frozen=True)
+class GatewayBoundReductionHarness:
+    executor: PaperExecutor
+    coordinator: SafetyRuntimeCoordinator
+    authority: PaperReductionExecutionAuthority
+    submitter_identity: object
+    portfolio_id: str
+
+    def issue(
+        self,
+        order: Order,
+        *,
+        pre_position_quantity: Decimal,
+    ) -> object:
+        fingerprint = _fingerprint_order(order)
+        dispatch = _ReductionTerminalDispatch(_token=_TERMINAL_DISPATCH_TOKEN)
+        with _REGISTRY_LOCK:
+            _REDUCTION_DISPATCHES[dispatch] = _TerminalDispatchRecord(
+                binding=self.authority,
+                gateway=None,
+                runtime_context=None,
+                active_session=None,
+                submitter=self.submitter_identity,
+                coordinator=self.coordinator,
+                executor=self.executor,
+                portfolio_id=self.portfolio_id,
+                fingerprint=fingerprint,
+                pre_position_quantity=pre_position_quantity,
+            )
+        return dispatch
+
+    def submit(
+        self,
+        order: Order,
+        *,
+        pre_position_quantity: Decimal,
+    ) -> ExecutionResult:
+        capability = _PaperExecutionCapability(_token=_CAPABILITY_TOKEN)
+        with _REGISTRY_LOCK:
+            _CAPABILITIES[capability] = _CapabilityRecord(
+                authority=self.authority,
+                executor=self.executor,
+                portfolio_id=self.portfolio_id,
+                kind=_CapabilityKind.REDUCTION,
+                fingerprint=_fingerprint_order(order),
+                pre_position_quantity=pre_position_quantity,
+            )
+        return self.executor._place_simple_order(order, _capability=capability)
+
+
+def bind_gateway_reduction_harness(
+    executor: PaperExecutor,
+    portfolio_id: str,
+    *,
+    coordinator: SafetyRuntimeCoordinator | None = None,
+) -> GatewayBoundReductionHarness:
+    """Exercise the exact one-shot registration functions without I/O."""
+
+    authority, coordinator = bind_gateway_reduction_authority(
+        executor,
+        portfolio_id,
+        coordinator=coordinator,
+    )
+    submitter_identity = object()
+    _attach_gateway_reduction_submitter(
+        authority,
+        submitter=submitter_identity,
+        executor=executor,
+        coordinator=coordinator,
+        portfolio_id=portfolio_id,
+    )
+    return GatewayBoundReductionHarness(
+        executor=executor,
+        coordinator=coordinator,
+        authority=authority,
+        submitter_identity=submitter_identity,
+        portfolio_id=portfolio_id,
+    )
+
+
+def bind_gateway_reduction_authority(
+    executor: PaperExecutor,
+    portfolio_id: str,
+    *,
+    coordinator: SafetyRuntimeCoordinator | None = None,
+) -> tuple[PaperReductionExecutionAuthority, SafetyRuntimeCoordinator]:
+    """Return an unattached authority from one exact registration session."""
+
+    if coordinator is None:
+        coordinator = SafetyRuntimeCoordinator.__new__(SafetyRuntimeCoordinator)
+        coordinator._startup_lock = threading.RLock()
+        coordinator._started = True
+        coordinator._coordinator_token = object()
+
+    gateway = PaperReductionGateway.__new__(PaperReductionGateway)
+    gateway._started = True
+    gateway._runtime_context = object()
+    gateway._coordinator = coordinator
+    session = _PaperRuntimeBindingSession(
+        gateway=gateway,
+        runtime_context=gateway._runtime_context,
+        executor=executor,
+        portfolio_id=portfolio_id,
+    )
+    gateway._active_runtime_binding_session = session
+    try:
+        capability = _issue_gateway_reduction_binding_capability(
+            gateway=gateway,
+            runtime_context=gateway._runtime_context,
+            binding_session=session,
+            executor=executor,
+            portfolio_id=portfolio_id,
+            coordinator=coordinator,
+        )
+        authority = _bind_gateway_reduction_execution(
+            gateway=gateway,
+            runtime_context=gateway._runtime_context,
+            binding_session=session,
+            executor=executor,
+            portfolio_id=portfolio_id,
+            coordinator=coordinator,
+            capability=capability,
+        )
+    finally:
+        gateway._active_runtime_binding_session = None
+
+    return authority, coordinator

--- a/tests/paper_execution_test_support.py
+++ b/tests/paper_execution_test_support.py
@@ -8,21 +8,21 @@ from decimal import Decimal
 
 from robo_trader.execution import ExecutionResult, Order, PaperExecutor
 from robo_trader.paper_execution_capability import (
-    PaperReductionExecutionAuthority,
-    _CapabilityKind,
-    _CapabilityRecord,
     _CAPABILITIES,
     _CAPABILITY_TOKEN,
-    _PaperExecutionCapability,
     _REDUCTION_DISPATCHES,
     _REGISTRY_LOCK,
-    _ReductionTerminalDispatch,
     _TERMINAL_DISPATCH_TOKEN,
-    _TerminalDispatchRecord,
+    PaperReductionExecutionAuthority,
     _attach_gateway_reduction_submitter,
     _bind_gateway_reduction_execution,
+    _CapabilityKind,
+    _CapabilityRecord,
     _fingerprint_order,
     _issue_gateway_reduction_binding_capability,
+    _PaperExecutionCapability,
+    _ReductionTerminalDispatch,
+    _TerminalDispatchRecord,
 )
 from robo_trader.paper_reduction_gateway import (
     PaperReductionGateway,

--- a/tests/security/test_connected_account_containment.py
+++ b/tests/security/test_connected_account_containment.py
@@ -37,6 +37,11 @@ class _AccountClient:
 def _runner() -> AsyncRunner:
     runner = object.__new__(AsyncRunner)
     runner.cfg = SimpleNamespace(
+        execution=SimpleNamespace(
+            mode="paper",
+            enable_short_selling=False,
+            use_smart_execution=False,
+        ),
         ibkr=SimpleNamespace(
             account=EXPECTED_ACCOUNT,
             host="127.0.0.1",
@@ -50,6 +55,12 @@ def _runner() -> AsyncRunner:
             stop_loss_pct=0.02,
             use_trailing_stop=True,
             trailing_stop_pct=0.05,
+            enable_take_profit=False,
+        ),
+        strategy=SimpleNamespace(
+            enabled_strategies=["baseline_sma"],
+            enable_ai_discovery=False,
+            enable_ml_selectors=False,
         ),
     )
     runner._client_id = 123

--- a/tests/security/test_trading_core.py
+++ b/tests/security/test_trading_core.py
@@ -20,14 +20,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from robo_trader.execution import ExecutionResult, Order, PaperExecutor
-from robo_trader.paper_execution_capability import (
-    _bind_paper_reduction_execution_authority,
-)
 from robo_trader.paper_reduction_submitter import (
     LocalPaperOrderStatus,
     LocalPaperOutcomeProvenance,
     LocalPaperTerminalOutcome,
 )
+from tests.paper_execution_test_support import bind_gateway_reduction_harness
 from robo_trader.portfolio import Portfolio
 from robo_trader.protective_quote_evidence import ProtectiveQuoteSource
 from robo_trader.risk.advanced_risk import AdvancedRiskManager, KillSwitch
@@ -219,7 +217,7 @@ def test_validate_order_rejects_nan_quantity() -> None:
 
 def test_paper_executor_rejects_nan_price() -> None:
     px = PaperExecutor()
-    res = _bind_paper_reduction_execution_authority(px, "test")._submit_reduction_once(
+    res = bind_gateway_reduction_harness(px, "test").submit(
         Order("AAPL", quantity=1, side="BUY_TO_COVER", price=float("nan")),
         pre_position_quantity=Decimal("-1"),
     )
@@ -338,8 +336,8 @@ def test_pairs_buy_calls_validate_order() -> None:
 def test_paper_executor_rejects_stale_cached_price(monkeypatch: pytest.MonkeyPatch) -> None:
     px = PaperExecutor()
     # Seed cache with a price ~ now
-    authority = _bind_paper_reduction_execution_authority(px, "test")
-    res = authority._submit_reduction_once(
+    harness = bind_gateway_reduction_harness(px, "test")
+    res = harness.submit(
         Order("AAPL", quantity=1, side="BUY_TO_COVER", price=100.0),
         pre_position_quantity=Decimal("-1"),
     )
@@ -351,7 +349,7 @@ def test_paper_executor_rejects_stale_cached_price(monkeypatch: pytest.MonkeyPat
     px._execution_cache_ts["AAPL"] = dt.datetime.utcnow() - dt.timedelta(seconds=120)
 
     # Now a market order (price=None) should fail with a staleness error
-    res = authority._submit_reduction_once(
+    res = harness.submit(
         Order("AAPL", quantity=1, side="BUY_TO_COVER", price=None),
         pre_position_quantity=Decimal("-1"),
     )

--- a/tests/security/test_trading_core.py
+++ b/tests/security/test_trading_core.py
@@ -25,7 +25,6 @@ from robo_trader.paper_reduction_submitter import (
     LocalPaperOutcomeProvenance,
     LocalPaperTerminalOutcome,
 )
-from tests.paper_execution_test_support import bind_gateway_reduction_harness
 from robo_trader.portfolio import Portfolio
 from robo_trader.protective_quote_evidence import ProtectiveQuoteSource
 from robo_trader.risk.advanced_risk import AdvancedRiskManager, KillSwitch
@@ -35,6 +34,7 @@ from robo_trader.risk_manager import (
     create_risk_manager_from_config,
 )
 from robo_trader.stop_loss_monitor import StopLossMonitor, StopStatus, StopType
+from tests.paper_execution_test_support import bind_gateway_reduction_harness
 
 # ---------------------------------------------------------------------------
 # Test doubles

--- a/tests/security/test_trading_core.py
+++ b/tests/security/test_trading_core.py
@@ -20,6 +20,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from robo_trader.execution import ExecutionResult, Order, PaperExecutor
+from robo_trader.paper_execution_capability import _bind_paper_execution_authority
 from robo_trader.paper_reduction_submitter import (
     LocalPaperOrderStatus,
     LocalPaperOutcomeProvenance,
@@ -216,14 +217,8 @@ def test_validate_order_rejects_nan_quantity() -> None:
 
 def test_paper_executor_rejects_nan_price() -> None:
     px = PaperExecutor()
-    res = px._place_simple_order(
-        Order(
-            "AAPL",
-            quantity=1,
-            side="BUY",
-            price=float("nan"),
-            intent_source="baseline_sma",
-        )
+    res = _bind_paper_execution_authority(px, "test")._submit_baseline_once(
+        Order("AAPL", quantity=1, side="BUY", price=float("nan"))
     )
     assert not res.ok
     assert "non-finite" in res.message.lower() or "invalid" in res.message.lower()
@@ -340,9 +335,8 @@ def test_pairs_buy_calls_validate_order() -> None:
 def test_paper_executor_rejects_stale_cached_price(monkeypatch: pytest.MonkeyPatch) -> None:
     px = PaperExecutor()
     # Seed cache with a price ~ now
-    res = px._place_simple_order(
-        Order("AAPL", quantity=1, side="BUY", price=100.0, intent_source="baseline_sma")
-    )
+    authority = _bind_paper_execution_authority(px, "test")
+    res = authority._submit_baseline_once(Order("AAPL", quantity=1, side="BUY", price=100.0))
     assert res.ok
 
     # Force the cache timestamp to be very old
@@ -351,9 +345,7 @@ def test_paper_executor_rejects_stale_cached_price(monkeypatch: pytest.MonkeyPat
     px._execution_cache_ts["AAPL"] = dt.datetime.utcnow() - dt.timedelta(seconds=120)
 
     # Now a market order (price=None) should fail with a staleness error
-    res = px._place_simple_order(
-        Order("AAPL", quantity=1, side="BUY", price=None, intent_source="baseline_sma")
-    )
+    res = authority._submit_baseline_once(Order("AAPL", quantity=1, side="BUY", price=None))
     assert not res.ok
     assert "stale" in res.message.lower()
 

--- a/tests/security/test_trading_core.py
+++ b/tests/security/test_trading_core.py
@@ -216,7 +216,15 @@ def test_validate_order_rejects_nan_quantity() -> None:
 
 def test_paper_executor_rejects_nan_price() -> None:
     px = PaperExecutor()
-    res = px._place_simple_order(Order("AAPL", quantity=1, side="BUY", price=float("nan")))
+    res = px._place_simple_order(
+        Order(
+            "AAPL",
+            quantity=1,
+            side="BUY",
+            price=float("nan"),
+            intent_source="baseline_sma",
+        )
+    )
     assert not res.ok
     assert "non-finite" in res.message.lower() or "invalid" in res.message.lower()
 
@@ -332,7 +340,9 @@ def test_pairs_buy_calls_validate_order() -> None:
 def test_paper_executor_rejects_stale_cached_price(monkeypatch: pytest.MonkeyPatch) -> None:
     px = PaperExecutor()
     # Seed cache with a price ~ now
-    res = px._place_simple_order(Order("AAPL", quantity=1, side="BUY", price=100.0))
+    res = px._place_simple_order(
+        Order("AAPL", quantity=1, side="BUY", price=100.0, intent_source="baseline_sma")
+    )
     assert res.ok
 
     # Force the cache timestamp to be very old
@@ -341,7 +351,9 @@ def test_paper_executor_rejects_stale_cached_price(monkeypatch: pytest.MonkeyPat
     px._execution_cache_ts["AAPL"] = dt.datetime.utcnow() - dt.timedelta(seconds=120)
 
     # Now a market order (price=None) should fail with a staleness error
-    res = px._place_simple_order(Order("AAPL", quantity=1, side="BUY", price=None))
+    res = px._place_simple_order(
+        Order("AAPL", quantity=1, side="BUY", price=None, intent_source="baseline_sma")
+    )
     assert not res.ok
     assert "stale" in res.message.lower()
 

--- a/tests/security/test_trading_core.py
+++ b/tests/security/test_trading_core.py
@@ -20,7 +20,9 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from robo_trader.execution import ExecutionResult, Order, PaperExecutor
-from robo_trader.paper_execution_capability import _bind_paper_execution_authority
+from robo_trader.paper_execution_capability import (
+    _bind_paper_reduction_execution_authority,
+)
 from robo_trader.paper_reduction_submitter import (
     LocalPaperOrderStatus,
     LocalPaperOutcomeProvenance,
@@ -217,8 +219,9 @@ def test_validate_order_rejects_nan_quantity() -> None:
 
 def test_paper_executor_rejects_nan_price() -> None:
     px = PaperExecutor()
-    res = _bind_paper_execution_authority(px, "test")._submit_baseline_once(
-        Order("AAPL", quantity=1, side="BUY", price=float("nan"))
+    res = _bind_paper_reduction_execution_authority(px, "test")._submit_reduction_once(
+        Order("AAPL", quantity=1, side="BUY_TO_COVER", price=float("nan")),
+        pre_position_quantity=Decimal("-1"),
     )
     assert not res.ok
     assert "non-finite" in res.message.lower() or "invalid" in res.message.lower()
@@ -335,8 +338,11 @@ def test_pairs_buy_calls_validate_order() -> None:
 def test_paper_executor_rejects_stale_cached_price(monkeypatch: pytest.MonkeyPatch) -> None:
     px = PaperExecutor()
     # Seed cache with a price ~ now
-    authority = _bind_paper_execution_authority(px, "test")
-    res = authority._submit_baseline_once(Order("AAPL", quantity=1, side="BUY", price=100.0))
+    authority = _bind_paper_reduction_execution_authority(px, "test")
+    res = authority._submit_reduction_once(
+        Order("AAPL", quantity=1, side="BUY_TO_COVER", price=100.0),
+        pre_position_quantity=Decimal("-1"),
+    )
     assert res.ok
 
     # Force the cache timestamp to be very old
@@ -345,7 +351,10 @@ def test_paper_executor_rejects_stale_cached_price(monkeypatch: pytest.MonkeyPat
     px._execution_cache_ts["AAPL"] = dt.datetime.utcnow() - dt.timedelta(seconds=120)
 
     # Now a market order (price=None) should fail with a staleness error
-    res = authority._submit_baseline_once(Order("AAPL", quantity=1, side="BUY", price=None))
+    res = authority._submit_reduction_once(
+        Order("AAPL", quantity=1, side="BUY_TO_COVER", price=None),
+        pre_position_quantity=Decimal("-1"),
+    )
     assert not res.ok
     assert "stale" in res.message.lower()
 

--- a/tests/test_kill_switch_log_throttle.py
+++ b/tests/test_kill_switch_log_throttle.py
@@ -46,20 +46,29 @@ def _make_runner_with_triggered_kill_switch():
     runner.rate_limiter = MagicMock()
     runner.executor = MagicMock()
     runner.monitor = MagicMock()
+    runner._baseline_entry_handle = object()
+    runner._baseline_entry_intent = object()
     return runner
+
+
+async def _place(runner: AsyncRunner, order: Order):
+    return await runner._place_order_with_circuit_breaker(
+        order,
+        _entry_intent=(runner._baseline_entry_intent if order.side == "BUY" else None),
+    )
 
 
 @pytest.mark.asyncio
 async def test_kill_switch_log_fires_once_then_throttles():
     """10 rapid blocked calls for the same (symbol, action) → log fires exactly once."""
     runner = _make_runner_with_triggered_kill_switch()
-    order = Order(symbol="AAPL", quantity=10, side="BUY", price=150.0, intent_source="baseline_sma")
+    order = Order(symbol="AAPL", quantity=10, side="BUY", price=150.0)
 
     # Freeze monotonic time so all 10 calls fall in the same throttle window.
     with patch("robo_trader.runner_async.time.monotonic", return_value=1000.0):
         with patch("robo_trader.runner_async.logger") as mock_logger:
             for _ in range(10):
-                result = await runner._place_order_with_circuit_breaker(order)
+                result = await _place(runner, order)
                 # Order MUST be blocked on every call (functionality preserved)
                 assert result.ok is False
                 assert "Trading blocked" in result.message
@@ -80,12 +89,12 @@ async def test_kill_switch_log_fires_once_then_throttles():
 async def test_kill_switch_log_fires_again_after_throttle_window():
     """After 61s elapses, the log should fire again for the same (symbol, action)."""
     runner = _make_runner_with_triggered_kill_switch()
-    order = Order(symbol="AAPL", quantity=10, side="BUY", price=150.0, intent_source="baseline_sma")
+    order = Order(symbol="AAPL", quantity=10, side="BUY", price=150.0)
 
     # First call at t=1000 fires the log
     with patch("robo_trader.runner_async.time.monotonic", return_value=1000.0):
         with patch("robo_trader.runner_async.logger") as mock_logger_1:
-            result1 = await runner._place_order_with_circuit_breaker(order)
+            result1 = await _place(runner, order)
     assert result1.ok is False
     first_log_count = sum(
         1
@@ -98,7 +107,7 @@ async def test_kill_switch_log_fires_again_after_throttle_window():
     with patch("robo_trader.runner_async.time.monotonic", return_value=1030.0):
         with patch("robo_trader.runner_async.logger") as mock_logger_2:
             for _ in range(10):
-                result = await runner._place_order_with_circuit_breaker(order)
+                result = await _place(runner, order)
                 assert result.ok is False
     suppressed_log_count = sum(
         1
@@ -110,7 +119,7 @@ async def test_kill_switch_log_fires_again_after_throttle_window():
     # 61s after first log → throttle window elapsed → must log again
     with patch("robo_trader.runner_async.time.monotonic", return_value=1061.0):
         with patch("robo_trader.runner_async.logger") as mock_logger_3:
-            result3 = await runner._place_order_with_circuit_breaker(order)
+            result3 = await _place(runner, order)
     assert result3.ok is False
     third_log_count = sum(
         1
@@ -127,14 +136,12 @@ async def test_short_containment_precedes_kill_switch_log_throttle():
     """A disabled short never enters the kill-switch logging path."""
     runner = _make_runner_with_triggered_kill_switch()
     sell_order = Order(symbol="AAPL", quantity=10, side="SELL_SHORT", price=150.0)
-    buy_order = Order(
-        symbol="AAPL", quantity=10, side="BUY", price=150.0, intent_source="baseline_sma"
-    )
+    buy_order = Order(symbol="AAPL", quantity=10, side="BUY", price=150.0)
 
     with patch("robo_trader.runner_async.time.monotonic", return_value=1000.0):
         with patch("robo_trader.runner_async.logger") as mock_logger:
-            sell_res = await runner._place_order_with_circuit_breaker(sell_order)
-            buy_res = await runner._place_order_with_circuit_breaker(buy_order)
+            sell_res = await _place(runner, sell_order)
+            buy_res = await _place(runner, buy_order)
 
     # Both blocked
     assert sell_res.ok is False
@@ -153,17 +160,13 @@ async def test_short_containment_precedes_kill_switch_log_throttle():
 async def test_kill_switch_log_keyed_by_symbol_distinct_symbols_both_log():
     """Distinct entry symbols receive independent throttled logs."""
     runner = _make_runner_with_triggered_kill_switch()
-    aapl_order = Order(
-        symbol="AAPL", quantity=10, side="BUY", price=150.0, intent_source="baseline_sma"
-    )
-    tsla_order = Order(
-        symbol="TSLA", quantity=10, side="BUY", price=200.0, intent_source="baseline_sma"
-    )
+    aapl_order = Order(symbol="AAPL", quantity=10, side="BUY", price=150.0)
+    tsla_order = Order(symbol="TSLA", quantity=10, side="BUY", price=200.0)
 
     with patch("robo_trader.runner_async.time.monotonic", return_value=1000.0):
         with patch("robo_trader.runner_async.logger") as mock_logger:
-            await runner._place_order_with_circuit_breaker(aapl_order)
-            await runner._place_order_with_circuit_breaker(tsla_order)
+            await _place(runner, aapl_order)
+            await _place(runner, tsla_order)
 
     gate_log_calls = [
         c
@@ -177,11 +180,11 @@ async def test_kill_switch_log_keyed_by_symbol_distinct_symbols_both_log():
 async def test_order_blocked_on_every_call_even_when_log_suppressed():
     """Functionality preserved: every call returns ok=False even if log suppressed."""
     runner = _make_runner_with_triggered_kill_switch()
-    order = Order(symbol="AAPL", quantity=10, side="BUY", price=150.0, intent_source="baseline_sma")
+    order = Order(symbol="AAPL", quantity=10, side="BUY", price=150.0)
 
     with patch("robo_trader.runner_async.time.monotonic", return_value=1000.0):
         for i in range(50):
-            result = await runner._place_order_with_circuit_breaker(order)
+            result = await _place(runner, order)
             assert result.ok is False, f"Call {i} should be blocked, got {result}"
             assert "Trading blocked" in result.message
             assert result.fill_price is None

--- a/tests/test_kill_switch_log_throttle.py
+++ b/tests/test_kill_switch_log_throttle.py
@@ -53,7 +53,7 @@ def _make_runner_with_triggered_kill_switch():
 async def test_kill_switch_log_fires_once_then_throttles():
     """10 rapid blocked calls for the same (symbol, action) → log fires exactly once."""
     runner = _make_runner_with_triggered_kill_switch()
-    order = Order(symbol="AAPL", quantity=10, side="BUY", price=150.0)
+    order = Order(symbol="AAPL", quantity=10, side="BUY", price=150.0, intent_source="baseline_sma")
 
     # Freeze monotonic time so all 10 calls fall in the same throttle window.
     with patch("robo_trader.runner_async.time.monotonic", return_value=1000.0):
@@ -80,7 +80,7 @@ async def test_kill_switch_log_fires_once_then_throttles():
 async def test_kill_switch_log_fires_again_after_throttle_window():
     """After 61s elapses, the log should fire again for the same (symbol, action)."""
     runner = _make_runner_with_triggered_kill_switch()
-    order = Order(symbol="AAPL", quantity=10, side="BUY", price=150.0)
+    order = Order(symbol="AAPL", quantity=10, side="BUY", price=150.0, intent_source="baseline_sma")
 
     # First call at t=1000 fires the log
     with patch("robo_trader.runner_async.time.monotonic", return_value=1000.0):
@@ -123,11 +123,13 @@ async def test_kill_switch_log_fires_again_after_throttle_window():
 
 
 @pytest.mark.asyncio
-async def test_kill_switch_log_keyed_by_symbol_and_action():
-    """(AAPL, SELL_SHORT) and (AAPL, BUY) are distinct keys — both log."""
+async def test_short_containment_precedes_kill_switch_log_throttle():
+    """A disabled short never enters the kill-switch logging path."""
     runner = _make_runner_with_triggered_kill_switch()
     sell_order = Order(symbol="AAPL", quantity=10, side="SELL_SHORT", price=150.0)
-    buy_order = Order(symbol="AAPL", quantity=10, side="BUY", price=150.0)
+    buy_order = Order(
+        symbol="AAPL", quantity=10, side="BUY", price=150.0, intent_source="baseline_sma"
+    )
 
     with patch("robo_trader.runner_async.time.monotonic", return_value=1000.0):
         with patch("robo_trader.runner_async.logger") as mock_logger:
@@ -136,6 +138,7 @@ async def test_kill_switch_log_keyed_by_symbol_and_action():
 
     # Both blocked
     assert sell_res.ok is False
+    assert "blocks new short exposure" in sell_res.message
     assert buy_res.ok is False
 
     gate_log_calls = [
@@ -143,17 +146,19 @@ async def test_kill_switch_log_keyed_by_symbol_and_action():
         for c in mock_logger.error.call_args_list
         if "Order blocked by trading_blocked gate" in c.args[0]
     ]
-    assert (
-        len(gate_log_calls) == 2
-    ), f"Expected one log for each entry side; got {len(gate_log_calls)}"
+    assert len(gate_log_calls) == 1
 
 
 @pytest.mark.asyncio
 async def test_kill_switch_log_keyed_by_symbol_distinct_symbols_both_log():
     """Distinct entry symbols receive independent throttled logs."""
     runner = _make_runner_with_triggered_kill_switch()
-    aapl_order = Order(symbol="AAPL", quantity=10, side="BUY", price=150.0)
-    tsla_order = Order(symbol="TSLA", quantity=10, side="BUY", price=200.0)
+    aapl_order = Order(
+        symbol="AAPL", quantity=10, side="BUY", price=150.0, intent_source="baseline_sma"
+    )
+    tsla_order = Order(
+        symbol="TSLA", quantity=10, side="BUY", price=200.0, intent_source="baseline_sma"
+    )
 
     with patch("robo_trader.runner_async.time.monotonic", return_value=1000.0):
         with patch("robo_trader.runner_async.logger") as mock_logger:
@@ -172,7 +177,7 @@ async def test_kill_switch_log_keyed_by_symbol_distinct_symbols_both_log():
 async def test_order_blocked_on_every_call_even_when_log_suppressed():
     """Functionality preserved: every call returns ok=False even if log suppressed."""
     runner = _make_runner_with_triggered_kill_switch()
-    order = Order(symbol="AAPL", quantity=10, side="BUY", price=150.0)
+    order = Order(symbol="AAPL", quantity=10, side="BUY", price=150.0, intent_source="baseline_sma")
 
     with patch("robo_trader.runner_async.time.monotonic", return_value=1000.0):
         for i in range(50):

--- a/tests/test_multiuser.py
+++ b/tests/test_multiuser.py
@@ -45,7 +45,7 @@ class TestPortfolioConfig:
             starting_cash=75000,
             symbols=["NVDA", "TSLA"],
             max_position_pct=0.04,
-            enabled_strategies=["momentum", "ml_enhanced"],
+            enabled_strategies=["baseline_sma"],
         )
         d = original.to_dict()
         restored = PortfolioConfig.from_dict(d)
@@ -1196,16 +1196,16 @@ class TestPortfolioConfigEdgeCases:
         assert cfg.use_trailing_stop is True
         assert cfg.min_confidence == 0.6
 
-    def test_from_dict_strategy_string_split(self):
-        """enabled_strategies as comma-separated string is split correctly."""
+    def test_from_dict_strategy_string_normalized(self):
+        """The sole Gate-A strategy is normalized from explicit string input."""
         cfg = PortfolioConfig.from_dict(
             {
                 "id": "test",
                 "name": "T",
-                "enabled_strategies": "momentum, ml_enhanced , pairs",
+                "enabled_strategies": " BASELINE_SMA ",
             }
         )
-        assert cfg.enabled_strategies == ["momentum", "ml_enhanced", "pairs"]
+        assert cfg.enabled_strategies == ["baseline_sma"]
 
     def test_from_dict_extra_fields_ignored(self):
         """Unknown fields in dict don't cause errors."""

--- a/tests/test_pr1a_runner_event_time.py
+++ b/tests/test_pr1a_runner_event_time.py
@@ -568,6 +568,8 @@ def _runner_for_parallel(process_symbol) -> AsyncRunner:
 
 async def _configure_order_runtime(runner: AsyncRunner, executor_result=None) -> None:
     runner.portfolio_id = "default"
+    runner._baseline_entry_handle = object()
+    runner._baseline_entry_intent = object()
     accepted_at = datetime.now(timezone.utc)
     accepted_monotonic = 1000.0
     protective_clock = {
@@ -689,15 +691,29 @@ async def _configure_order_runtime(runner: AsyncRunner, executor_result=None) ->
     gateway._started = True
 
     @asynccontextmanager
-    async def serialize_entry(symbol=None):
+    async def serialize_entry(symbol=None, *, portfolio_id=None):
+        assert portfolio_id == "default"
         yield broker_quote if symbol == "AAPL" else None
 
     gateway.serialize_entry = serialize_entry
     gateway.submit_reduction = AsyncMock(
         return_value=runner.executor.place_order.return_value,
     )
+    gateway.submit_baseline_entry = MagicMock(
+        return_value=runner.executor.place_order.return_value,
+    )
+    gateway.issue_baseline_entry_intent = MagicMock(
+        return_value=runner._baseline_entry_intent,
+    )
     runner.paper_reduction_gateway = gateway
     runner.monitor = PerformanceMonitor()
+
+
+async def _place_order(runner: AsyncRunner, order: Order):
+    return await runner._place_order_with_circuit_breaker(
+        order,
+        _entry_intent=(runner._baseline_entry_intent if order.side == "BUY" else None),
+    )
 
 
 @pytest.mark.asyncio
@@ -719,19 +735,20 @@ async def test_dashboard_status_cannot_revoke_exact_live_protection(
     await _configure_order_runtime(runner)
     runner._protective_feed_status = {} if status is None else {"AAPL": status}
 
-    result = await runner._place_order_with_circuit_breaker(
+    result = await _place_order(
+        runner,
         Order(
             symbol="AAPL",
             quantity=1,
             side=side,
             price=100.0,
-            intent_source="baseline_sma" if side == "BUY" else "",
-        )
+        ),
     )
 
     assert result.ok is True
     if side == "BUY":
-        runner.executor.place_order.assert_called_once()
+        runner.paper_reduction_gateway.submit_baseline_entry.assert_called_once()
+        runner.executor.place_order.assert_not_called()
     else:
         runner.paper_reduction_gateway.submit_reduction.assert_awaited_once()
 
@@ -742,14 +759,14 @@ async def test_central_order_admission_accepts_exact_live_protection(side: str) 
     runner = AsyncRunner.__new__(AsyncRunner)
     await _configure_order_runtime(runner)
 
-    result = await runner._place_order_with_circuit_breaker(
+    result = await _place_order(
+        runner,
         Order(
             symbol="AAPL",
             quantity=1,
             side=side,
             price=100.0,
-            intent_source="baseline_sma" if side == "BUY" else "",
-        )
+        ),
     )
 
     assert result.ok is True
@@ -769,7 +786,8 @@ async def test_central_order_admission_accepts_exact_live_protection(side: str) 
         )
         runner.executor.place_order.assert_not_called()
     else:
-        runner.executor.place_order.assert_called_once()
+        runner.paper_reduction_gateway.submit_baseline_entry.assert_called_once()
+        runner.executor.place_order.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -789,14 +807,14 @@ async def test_order_admission_rechecks_monitor_owned_protective_freshness(
     else:
         runner._test_protective_clock["monotonic"] += 11
 
-    result = await runner._place_order_with_circuit_breaker(
+    result = await _place_order(
+        runner,
         Order(
             symbol="AAPL",
             quantity=1,
             side=side,
             price=100.0,
-            intent_source="baseline_sma" if side == "BUY" else "",
-        )
+        ),
     )
 
     assert runner._has_live_protective_feed("AAPL") is False
@@ -819,14 +837,14 @@ async def test_entry_quote_aging_during_equity_await_never_touches_executor() ->
 
     runner.portfolio.equity = AsyncMock(side_effect=age_quote_during_equity)
 
-    result = await runner._place_order_with_circuit_breaker(
+    result = await _place_order(
+        runner,
         Order(
             symbol="AAPL",
             quantity=1,
             side="BUY",
             price=100.0,
-            intent_source="baseline_sma",
-        )
+        ),
     )
 
     assert result.ok is False
@@ -1072,14 +1090,14 @@ async def test_transport_abort_drains_running_sibling_and_blocks_its_order() -> 
         sibling_started.set()
         while not runner._symbol_cycle_abort_event.is_set():
             await asyncio.sleep(0)
-        result = await runner._place_order_with_circuit_breaker(
+        result = await _place_order(
+            runner,
             Order(
                 symbol="MSFT",
                 quantity=1,
                 side="BUY",
                 price=100.0,
-                intent_source="baseline_sma",
-            )
+            ),
         )
         assert result.ok is False
         sibling_settled.set()
@@ -1163,14 +1181,14 @@ async def test_abort_before_order_admission_has_no_fill() -> None:
     abort_task = asyncio.create_task(runner._latch_symbol_cycle_abort())
     await asyncio.sleep(0)
     order_task = asyncio.create_task(
-        runner._place_order_with_circuit_breaker(
+        _place_order(
+            runner,
             Order(
                 symbol="AAPL",
                 quantity=1,
                 side="BUY",
                 price=100.0,
-                intent_source="baseline_sma",
-            )
+            ),
         )
     )
     runner._order_admission_lock.release()
@@ -1189,14 +1207,14 @@ async def test_queued_order_cannot_beat_abort_intent_to_admission_lock() -> None
 
     # Queue the order first so it is the lock's oldest waiter.
     order_task = asyncio.create_task(
-        runner._place_order_with_circuit_breaker(
+        _place_order(
+            runner,
             Order(
                 symbol="AAPL",
                 quantity=1,
                 side="BUY",
                 price=100.0,
-                intent_source="baseline_sma",
-            )
+            ),
         )
     )
     await asyncio.sleep(0)
@@ -1229,14 +1247,14 @@ async def test_fill_then_sibling_abort_drains_accounting() -> None:
         if symbol == "MSFT":
             await fill_happened.wait()
             raise SymbolCycleAbortError("poisoned generation")
-        result = await runner._place_order_with_circuit_breaker(
+        result = await _place_order(
+            runner,
             Order(
                 symbol="AAPL",
                 quantity=1,
                 side="BUY",
                 price=100.0,
-                intent_source="baseline_sma",
-            )
+            ),
         )
         assert result.ok
         assert runner._symbol_cycle_abort_event.is_set()
@@ -1249,11 +1267,14 @@ async def test_fill_then_sibling_abort_drains_accounting() -> None:
     runner.max_concurrent_symbols = 2
     await _configure_order_runtime(runner)
 
-    def fill(_order):
+    def fill(*, order, portfolio_id, intent):
+        assert order.symbol == "AAPL"
+        assert portfolio_id == "default"
+        assert intent is runner._baseline_entry_intent
         fill_happened.set()
         return SimpleNamespace(ok=True, fill_price=100.0, msg="filled", message="filled")
 
-    runner.executor.place_order.side_effect = fill
+    runner.paper_reduction_gateway.submit_baseline_entry.side_effect = fill
 
     async def hold_after_fill_until_abort():
         await runner._symbol_cycle_abort_event.wait()
@@ -1266,7 +1287,8 @@ async def test_fill_then_sibling_abort_drains_accounting() -> None:
     with pytest.raises(SymbolCycleAbortError, match="poisoned generation"):
         await cycle
 
-    runner.executor.place_order.assert_called_once()
+    runner.paper_reduction_gateway.submit_baseline_entry.assert_called_once()
+    runner.executor.place_order.assert_not_called()
     accounting.assert_awaited_once_with("AAPL", 100.0)
     runner.update_position_market_prices.assert_not_awaited()
 
@@ -1278,14 +1300,14 @@ async def test_parent_cancel_after_fill_waits_for_accounting() -> None:
     accounting_done = asyncio.Event()
 
     async def process(_symbol: str):
-        result = await runner._place_order_with_circuit_breaker(
+        result = await _place_order(
+            runner,
             Order(
                 symbol="AAPL",
                 quantity=1,
                 side="BUY",
                 price=100.0,
-                intent_source="baseline_sma",
-            )
+            ),
         )
         fill_happened.set()
         await release_accounting.wait()
@@ -1318,14 +1340,14 @@ async def test_parent_cancel_during_abort_drain_preserves_cancellation() -> None
         if symbol == "MSFT":
             await fill_happened.wait()
             raise SymbolCycleAbortError("originating transport poison")
-        result = await runner._place_order_with_circuit_breaker(
+        result = await _place_order(
+            runner,
             Order(
                 symbol="AAPL",
                 quantity=1,
                 side="BUY",
                 price=100.0,
-                intent_source="baseline_sma",
-            )
+            ),
         )
         fill_happened.set()
         await release_accounting.wait()
@@ -1689,18 +1711,18 @@ async def test_extended_hours_blocks_entry_sides_but_not_exit() -> None:
     await _configure_order_runtime(runner)
     with patch("robo_trader.runner_async.is_extended_hours", return_value=True):
         for side in ("BUY", "SELL_SHORT"):
-            result = await runner._place_order_with_circuit_breaker(
+            result = await _place_order(
+                runner,
                 Order(
                     symbol="AAPL",
                     quantity=1,
                     side=side,
                     price=100.0,
-                    intent_source="baseline_sma" if side == "BUY" else "",
-                )
+                ),
             )
             assert result.ok is False
-        exit_result = await runner._place_order_with_circuit_breaker(
-            Order(symbol="AAPL", quantity=1, side="SELL", price=100.0)
+        exit_result = await _place_order(
+            runner, Order(symbol="AAPL", quantity=1, side="SELL", price=100.0)
         )
     assert exit_result.ok is True
     runner.paper_reduction_gateway.submit_reduction.assert_awaited_once()
@@ -1742,7 +1764,8 @@ async def test_extended_hours_entry_requires_and_accepts_matching_exact_session(
     )
 
     @asynccontextmanager
-    async def serialize_entry(symbol=None):
+    async def serialize_entry(symbol=None, *, portfolio_id=None):
+        assert portfolio_id == "default"
         yield quote if symbol == "AAPL" else None
 
     runner.paper_reduction_gateway.serialize_entry = serialize_entry
@@ -1750,18 +1773,18 @@ async def test_extended_hours_entry_requires_and_accepts_matching_exact_session(
         patch("robo_trader.runner_async.is_extended_hours", return_value=True),
         patch("robo_trader.runner_async.get_market_session", return_value="pre-market"),
     ):
-        result = await runner._place_order_with_circuit_breaker(
+        result = await _place_order(
+            runner,
             Order(
                 symbol="AAPL",
                 quantity=1,
                 side="BUY",
                 price=Decimal("1"),
-                intent_source="baseline_sma",
-            )
+            ),
         )
 
     assert result.ok is True
-    submitted = runner.executor.place_order.call_args.args[0]
+    submitted = runner.paper_reduction_gateway.submit_baseline_entry.call_args.kwargs["order"]
     assert submitted.price == Decimal("100.0")
 
 
@@ -1785,14 +1808,14 @@ async def test_final_entry_admission_rejects_stale_canonical_bar_batch() -> None
     stale_frame = stale_batch.to_frame()
     runner._canonical_bar_batches["AAPL"] = (stale_batch, stale_frame)
 
-    result = await runner._place_order_with_circuit_breaker(
+    result = await _place_order(
+        runner,
         Order(
             symbol="AAPL",
             quantity=1,
             side="BUY",
             price=Decimal("100"),
-            intent_source="baseline_sma",
-        )
+        ),
     )
 
     assert result.ok is False
@@ -1805,14 +1828,15 @@ async def test_regular_hours_entry_reaches_executor() -> None:
     runner = AsyncRunner.__new__(AsyncRunner)
     await _configure_order_runtime(runner)
     with patch("robo_trader.runner_async.is_extended_hours", return_value=False):
-        result = await runner._place_order_with_circuit_breaker(
+        result = await _place_order(
+            runner,
             Order(
                 symbol="AAPL",
                 quantity=1,
                 side="BUY",
                 price=100.0,
-                intent_source="baseline_sma",
-            )
+            ),
         )
     assert result.ok is True
-    runner.executor.place_order.assert_called_once()
+    runner.paper_reduction_gateway.submit_baseline_entry.assert_called_once()
+    runner.executor.place_order.assert_not_called()

--- a/tests/test_pr1a_runner_event_time.py
+++ b/tests/test_pr1a_runner_event_time.py
@@ -701,7 +701,7 @@ async def _configure_order_runtime(runner: AsyncRunner, executor_result=None) ->
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("side", ["BUY", "SELL", "SELL_SHORT", "BUY_TO_COVER"])
+@pytest.mark.parametrize("side", ["BUY", "SELL", "BUY_TO_COVER"])
 @pytest.mark.parametrize(
     "status",
     [
@@ -720,24 +720,36 @@ async def test_dashboard_status_cannot_revoke_exact_live_protection(
     runner._protective_feed_status = {} if status is None else {"AAPL": status}
 
     result = await runner._place_order_with_circuit_breaker(
-        Order(symbol="AAPL", quantity=1, side=side, price=100.0)
+        Order(
+            symbol="AAPL",
+            quantity=1,
+            side=side,
+            price=100.0,
+            intent_source="baseline_sma" if side == "BUY" else "",
+        )
     )
 
     assert result.ok is True
-    if side in {"BUY", "SELL_SHORT"}:
+    if side == "BUY":
         runner.executor.place_order.assert_called_once()
     else:
         runner.paper_reduction_gateway.submit_reduction.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("side", ["BUY", "SELL", "SELL_SHORT", "BUY_TO_COVER"])
+@pytest.mark.parametrize("side", ["BUY", "SELL", "BUY_TO_COVER"])
 async def test_central_order_admission_accepts_exact_live_protection(side: str) -> None:
     runner = AsyncRunner.__new__(AsyncRunner)
     await _configure_order_runtime(runner)
 
     result = await runner._place_order_with_circuit_breaker(
-        Order(symbol="AAPL", quantity=1, side=side, price=100.0)
+        Order(
+            symbol="AAPL",
+            quantity=1,
+            side=side,
+            price=100.0,
+            intent_source="baseline_sma" if side == "BUY" else "",
+        )
     )
 
     assert result.ok is True
@@ -762,7 +774,7 @@ async def test_central_order_admission_accepts_exact_live_protection(side: str) 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("aged_clock", ["event", "receipt"])
-@pytest.mark.parametrize("side", ["BUY", "SELL_SHORT", "SELL", "BUY_TO_COVER"])
+@pytest.mark.parametrize("side", ["BUY", "SELL", "BUY_TO_COVER"])
 async def test_order_admission_rechecks_monitor_owned_protective_freshness(
     aged_clock: str,
     side: str,
@@ -778,7 +790,13 @@ async def test_order_admission_rechecks_monitor_owned_protective_freshness(
         runner._test_protective_clock["monotonic"] += 11
 
     result = await runner._place_order_with_circuit_breaker(
-        Order(symbol="AAPL", quantity=1, side=side, price=100.0)
+        Order(
+            symbol="AAPL",
+            quantity=1,
+            side=side,
+            price=100.0,
+            intent_source="baseline_sma" if side == "BUY" else "",
+        )
     )
 
     assert runner._has_live_protective_feed("AAPL") is False
@@ -802,7 +820,13 @@ async def test_entry_quote_aging_during_equity_await_never_touches_executor() ->
     runner.portfolio.equity = AsyncMock(side_effect=age_quote_during_equity)
 
     result = await runner._place_order_with_circuit_breaker(
-        Order(symbol="AAPL", quantity=1, side="BUY", price=100.0)
+        Order(
+            symbol="AAPL",
+            quantity=1,
+            side="BUY",
+            price=100.0,
+            intent_source="baseline_sma",
+        )
     )
 
     assert result.ok is False
@@ -1049,7 +1073,13 @@ async def test_transport_abort_drains_running_sibling_and_blocks_its_order() -> 
         while not runner._symbol_cycle_abort_event.is_set():
             await asyncio.sleep(0)
         result = await runner._place_order_with_circuit_breaker(
-            Order(symbol="MSFT", quantity=1, side="BUY", price=100.0)
+            Order(
+                symbol="MSFT",
+                quantity=1,
+                side="BUY",
+                price=100.0,
+                intent_source="baseline_sma",
+            )
         )
         assert result.ok is False
         sibling_settled.set()
@@ -1134,7 +1164,13 @@ async def test_abort_before_order_admission_has_no_fill() -> None:
     await asyncio.sleep(0)
     order_task = asyncio.create_task(
         runner._place_order_with_circuit_breaker(
-            Order(symbol="AAPL", quantity=1, side="BUY", price=100.0)
+            Order(
+                symbol="AAPL",
+                quantity=1,
+                side="BUY",
+                price=100.0,
+                intent_source="baseline_sma",
+            )
         )
     )
     runner._order_admission_lock.release()
@@ -1154,7 +1190,13 @@ async def test_queued_order_cannot_beat_abort_intent_to_admission_lock() -> None
     # Queue the order first so it is the lock's oldest waiter.
     order_task = asyncio.create_task(
         runner._place_order_with_circuit_breaker(
-            Order(symbol="AAPL", quantity=1, side="BUY", price=100.0)
+            Order(
+                symbol="AAPL",
+                quantity=1,
+                side="BUY",
+                price=100.0,
+                intent_source="baseline_sma",
+            )
         )
     )
     await asyncio.sleep(0)
@@ -1188,7 +1230,13 @@ async def test_fill_then_sibling_abort_drains_accounting() -> None:
             await fill_happened.wait()
             raise SymbolCycleAbortError("poisoned generation")
         result = await runner._place_order_with_circuit_breaker(
-            Order(symbol="AAPL", quantity=1, side="BUY", price=100.0)
+            Order(
+                symbol="AAPL",
+                quantity=1,
+                side="BUY",
+                price=100.0,
+                intent_source="baseline_sma",
+            )
         )
         assert result.ok
         assert runner._symbol_cycle_abort_event.is_set()
@@ -1231,7 +1279,13 @@ async def test_parent_cancel_after_fill_waits_for_accounting() -> None:
 
     async def process(_symbol: str):
         result = await runner._place_order_with_circuit_breaker(
-            Order(symbol="AAPL", quantity=1, side="BUY", price=100.0)
+            Order(
+                symbol="AAPL",
+                quantity=1,
+                side="BUY",
+                price=100.0,
+                intent_source="baseline_sma",
+            )
         )
         fill_happened.set()
         await release_accounting.wait()
@@ -1265,7 +1319,13 @@ async def test_parent_cancel_during_abort_drain_preserves_cancellation() -> None
             await fill_happened.wait()
             raise SymbolCycleAbortError("originating transport poison")
         result = await runner._place_order_with_circuit_breaker(
-            Order(symbol="AAPL", quantity=1, side="BUY", price=100.0)
+            Order(
+                symbol="AAPL",
+                quantity=1,
+                side="BUY",
+                price=100.0,
+                intent_source="baseline_sma",
+            )
         )
         fill_happened.set()
         await release_accounting.wait()
@@ -1630,7 +1690,13 @@ async def test_extended_hours_blocks_entry_sides_but_not_exit() -> None:
     with patch("robo_trader.runner_async.is_extended_hours", return_value=True):
         for side in ("BUY", "SELL_SHORT"):
             result = await runner._place_order_with_circuit_breaker(
-                Order(symbol="AAPL", quantity=1, side=side, price=100.0)
+                Order(
+                    symbol="AAPL",
+                    quantity=1,
+                    side=side,
+                    price=100.0,
+                    intent_source="baseline_sma" if side == "BUY" else "",
+                )
             )
             assert result.ok is False
         exit_result = await runner._place_order_with_circuit_breaker(
@@ -1685,7 +1751,13 @@ async def test_extended_hours_entry_requires_and_accepts_matching_exact_session(
         patch("robo_trader.runner_async.get_market_session", return_value="pre-market"),
     ):
         result = await runner._place_order_with_circuit_breaker(
-            Order(symbol="AAPL", quantity=1, side="BUY", price=Decimal("1"))
+            Order(
+                symbol="AAPL",
+                quantity=1,
+                side="BUY",
+                price=Decimal("1"),
+                intent_source="baseline_sma",
+            )
         )
 
     assert result.ok is True
@@ -1714,7 +1786,13 @@ async def test_final_entry_admission_rejects_stale_canonical_bar_batch() -> None
     runner._canonical_bar_batches["AAPL"] = (stale_batch, stale_frame)
 
     result = await runner._place_order_with_circuit_breaker(
-        Order(symbol="AAPL", quantity=1, side="BUY", price=Decimal("100"))
+        Order(
+            symbol="AAPL",
+            quantity=1,
+            side="BUY",
+            price=Decimal("100"),
+            intent_source="baseline_sma",
+        )
     )
 
     assert result.ok is False
@@ -1728,7 +1806,13 @@ async def test_regular_hours_entry_reaches_executor() -> None:
     await _configure_order_runtime(runner)
     with patch("robo_trader.runner_async.is_extended_hours", return_value=False):
         result = await runner._place_order_with_circuit_breaker(
-            Order(symbol="AAPL", quantity=1, side="BUY", price=100.0)
+            Order(
+                symbol="AAPL",
+                quantity=1,
+                side="BUY",
+                price=100.0,
+                intent_source="baseline_sma",
+            )
         )
     assert result.ok is True
     runner.executor.place_order.assert_called_once()

--- a/tests/test_pr2b2_paper_executor_decimal.py
+++ b/tests/test_pr2b2_paper_executor_decimal.py
@@ -18,6 +18,7 @@ def _order(*, side: str = "BUY", price: float | Decimal = Decimal("123.45")) -> 
         side=side,
         price=price,
         order_ref="decimal-paper-test",
+        intent_source="baseline_sma" if side == "BUY" else "",
     )
 
 
@@ -131,7 +132,7 @@ def test_decimal_nonfinite_or_nonpositive_fill_fails_closed(
 
 @pytest.mark.parametrize(
     ("side", "expected"),
-    [("BUY", 100.1), ("SELL", 99.9), ("BUY_TO_COVER", 100.1), ("SELL_SHORT", 99.9)],
+    [("BUY", 100.1), ("SELL", 99.9), ("BUY_TO_COVER", 100.1)],
 )
 def test_legacy_float_price_behavior_is_unchanged(side: str, expected: float) -> None:
     order = _order(side=side, price=100.0)
@@ -143,6 +144,16 @@ def test_legacy_float_price_behavior_is_unchanged(side: str, expected: float) ->
     assert result.fill_price == pytest.approx(expected)
     assert type(order.price) is float
     assert next(iter(executor.fills.values()))[1] is order
+
+
+def test_private_simple_sink_cannot_open_short_exposure() -> None:
+    executor = PaperExecutor(slippage_bps=10.0)
+
+    result = executor._place_simple_order(_order(side="SELL_SHORT", price=100.0))
+
+    assert result.ok is False
+    assert "blocks new short exposure" in result.message
+    assert executor.fills == {}
 
 
 def test_public_kill_switch_gate_blocks_while_private_sink_remains_narrowly_callable(

--- a/tests/test_pr2b2_paper_executor_decimal.py
+++ b/tests/test_pr2b2_paper_executor_decimal.py
@@ -9,10 +9,12 @@ import pytest
 
 import robo_trader.execution as execution_module
 from robo_trader.execution import ExecutionResult, Order, PaperExecutor
-from robo_trader.paper_execution_capability import _bind_paper_execution_authority
+from robo_trader.paper_execution_capability import (
+    _bind_paper_reduction_execution_authority,
+)
 
 
-def _order(*, side: str = "BUY", price: float | Decimal = Decimal("123.45")) -> Order:
+def _order(*, side: str = "BUY_TO_COVER", price: float | Decimal = Decimal("123.45")) -> Order:
     return Order(
         symbol="AAPL",
         quantity=3,
@@ -23,9 +25,7 @@ def _order(*, side: str = "BUY", price: float | Decimal = Decimal("123.45")) -> 
 
 
 def _submit(executor: PaperExecutor, order: Order) -> ExecutionResult:
-    authority = _bind_paper_execution_authority(executor, "test")
-    if order.side == "BUY":
-        return authority._submit_baseline_once(order)
+    authority = _bind_paper_reduction_execution_authority(executor, "test")
     if order.side == "SELL":
         return authority._submit_reduction_once(
             order,
@@ -128,10 +128,10 @@ def test_arbitrary_finite_slippage_is_normalized_before_float_compatibility_view
 @pytest.mark.parametrize(
     ("side", "slippage_bps"),
     [
-        ("BUY", float("nan")),
-        ("BUY", float("inf")),
+        ("BUY_TO_COVER", float("nan")),
+        ("BUY_TO_COVER", float("inf")),
         ("SELL", 20_000.0),
-        ("BUY", -20_000.0),
+        ("BUY_TO_COVER", -20_000.0),
     ],
 )
 def test_decimal_nonfinite_or_nonpositive_fill_fails_closed(
@@ -150,7 +150,7 @@ def test_decimal_nonfinite_or_nonpositive_fill_fails_closed(
 
 @pytest.mark.parametrize(
     ("side", "expected"),
-    [("BUY", 100.1), ("SELL", 99.9), ("BUY_TO_COVER", 100.1)],
+    [("SELL", 99.9), ("BUY_TO_COVER", 100.1)],
 )
 def test_legacy_float_price_behavior_is_unchanged(side: str, expected: float) -> None:
     order = _order(side=side, price=100.0)

--- a/tests/test_pr2b2_paper_executor_decimal.py
+++ b/tests/test_pr2b2_paper_executor_decimal.py
@@ -9,6 +9,7 @@ import pytest
 
 import robo_trader.execution as execution_module
 from robo_trader.execution import ExecutionResult, Order, PaperExecutor
+from robo_trader.paper_execution_capability import _bind_paper_execution_authority
 
 
 def _order(*, side: str = "BUY", price: float | Decimal = Decimal("123.45")) -> Order:
@@ -18,8 +19,24 @@ def _order(*, side: str = "BUY", price: float | Decimal = Decimal("123.45")) -> 
         side=side,
         price=price,
         order_ref="decimal-paper-test",
-        intent_source="baseline_sma" if side == "BUY" else "",
     )
+
+
+def _submit(executor: PaperExecutor, order: Order) -> ExecutionResult:
+    authority = _bind_paper_execution_authority(executor, "test")
+    if order.side == "BUY":
+        return authority._submit_baseline_once(order)
+    if order.side == "SELL":
+        return authority._submit_reduction_once(
+            order,
+            pre_position_quantity=Decimal(order.quantity),
+        )
+    if order.side == "BUY_TO_COVER":
+        return authority._submit_reduction_once(
+            order,
+            pre_position_quantity=Decimal(-order.quantity),
+        )
+    return executor._place_simple_order(order)
 
 
 def _patch_execution_path_exists(monkeypatch, exists) -> None:
@@ -37,7 +54,8 @@ def test_public_place_order_preserves_exact_decimal_into_simple_sink(monkeypatch
 
     _patch_execution_path_exists(monkeypatch, lambda _path: False)
 
-    def simple_sink(order: Order) -> ExecutionResult:
+    def simple_sink(order: Order, *, _capability: object) -> ExecutionResult:
+        assert _capability is not None
         captured.append(order)
         return ExecutionResult(True, "captured", fill_price=float(order.price))
 
@@ -45,7 +63,7 @@ def test_public_place_order_preserves_exact_decimal_into_simple_sink(monkeypatch
     exact_price = Decimal("123.4500")
     order = _order(price=exact_price)
 
-    result = executor.place_order(order)
+    result = _submit(executor, order)
 
     assert result.ok is True
     assert captured == [order]
@@ -64,8 +82,10 @@ def test_common_decimal_price_has_deterministic_finite_fill(slippage_bps: float)
         )
     )
 
-    first = PaperExecutor(slippage_bps=slippage_bps)._place_simple_order(_order(price=exact_price))
-    second = PaperExecutor(slippage_bps=slippage_bps)._place_simple_order(_order(price=exact_price))
+    first_executor = PaperExecutor(slippage_bps=slippage_bps)
+    second_executor = PaperExecutor(slippage_bps=slippage_bps)
+    first = _submit(first_executor, _order(price=exact_price))
+    second = _submit(second_executor, _order(price=exact_price))
 
     assert first.ok is True
     assert second.ok is True
@@ -88,9 +108,8 @@ def test_decimal_slippage_direction_for_reducing_sides(side: str, direction: int
         )
     )
 
-    result = PaperExecutor(slippage_bps=float(slippage_bps))._place_simple_order(
-        _order(side=side, price=price)
-    )
+    executor = PaperExecutor(slippage_bps=float(slippage_bps))
+    result = _submit(executor, _order(side=side, price=price))
 
     assert result.ok is True
     assert result.fill_price == expected
@@ -98,9 +117,8 @@ def test_decimal_slippage_direction_for_reducing_sides(side: str, direction: int
 
 
 def test_arbitrary_finite_slippage_is_normalized_before_float_compatibility_view() -> None:
-    result = PaperExecutor(slippage_bps=0.3333333333333333)._place_simple_order(
-        _order(side="SELL", price=Decimal("123.4567"))
-    )
+    executor = PaperExecutor(slippage_bps=0.3333333333333333)
+    result = _submit(executor, _order(side="SELL", price=Decimal("123.4567")))
 
     assert result.ok is True
     assert result.exact_fill_price == Decimal("123.4526")
@@ -122,7 +140,7 @@ def test_decimal_nonfinite_or_nonpositive_fill_fails_closed(
 ) -> None:
     executor = PaperExecutor(slippage_bps=slippage_bps)
 
-    result = executor._place_simple_order(_order(side=side))
+    result = _submit(executor, _order(side=side))
 
     assert result.ok is False
     assert result.fill_price is None
@@ -138,7 +156,7 @@ def test_legacy_float_price_behavior_is_unchanged(side: str, expected: float) ->
     order = _order(side=side, price=100.0)
     executor = PaperExecutor(slippage_bps=10.0)
 
-    result = executor._place_simple_order(order)
+    result = _submit(executor, order)
 
     assert result.ok is True
     assert result.fill_price == pytest.approx(expected)
@@ -178,7 +196,11 @@ def test_public_kill_switch_gate_blocks_while_private_sink_remains_narrowly_call
 
     private_result = executor._place_simple_order(order)
 
-    assert private_result.ok is True
-    assert private_result.fill_price == 123.45
-    assert len(executor.fills) == 1
+    assert private_result.ok is False
+    assert "submission capability" in private_result.message
+    assert executor.fills == {}
     assert probes == ["data/kill_switch.lock"]
+
+    authorized_result = _submit(executor, order)
+    assert authorized_result.ok is True
+    assert authorized_result.fill_price == 123.45

--- a/tests/test_pr2b2_paper_executor_decimal.py
+++ b/tests/test_pr2b2_paper_executor_decimal.py
@@ -9,9 +9,7 @@ import pytest
 
 import robo_trader.execution as execution_module
 from robo_trader.execution import ExecutionResult, Order, PaperExecutor
-from robo_trader.paper_execution_capability import (
-    _bind_paper_reduction_execution_authority,
-)
+from tests.paper_execution_test_support import bind_gateway_reduction_harness
 
 
 def _order(*, side: str = "BUY_TO_COVER", price: float | Decimal = Decimal("123.45")) -> Order:
@@ -25,14 +23,14 @@ def _order(*, side: str = "BUY_TO_COVER", price: float | Decimal = Decimal("123.
 
 
 def _submit(executor: PaperExecutor, order: Order) -> ExecutionResult:
-    authority = _bind_paper_reduction_execution_authority(executor, "test")
+    harness = bind_gateway_reduction_harness(executor, "test")
     if order.side == "SELL":
-        return authority._submit_reduction_once(
+        return harness.submit(
             order,
             pre_position_quantity=Decimal(order.quantity),
         )
     if order.side == "BUY_TO_COVER":
-        return authority._submit_reduction_once(
+        return harness.submit(
             order,
             pre_position_quantity=Decimal(-order.quantity),
         )

--- a/tests/test_pr2b2_paper_executor_decimal.py
+++ b/tests/test_pr2b2_paper_executor_decimal.py
@@ -46,28 +46,26 @@ def _patch_execution_path_exists(monkeypatch, exists) -> None:
     )
 
 
-def test_public_place_order_preserves_exact_decimal_into_simple_sink(monkeypatch) -> None:
+def test_authorized_sink_preserves_exact_decimal_without_mutable_executor_method(
+    monkeypatch,
+) -> None:
     executor = PaperExecutor(slippage_bps=0)
-    captured: list[Order] = []
-
-    _patch_execution_path_exists(monkeypatch, lambda _path: False)
-
-    def simple_sink(order: Order, *, _capability: object) -> ExecutionResult:
-        assert _capability is not None
-        captured.append(order)
-        return ExecutionResult(True, "captured", fill_price=float(order.price))
-
-    monkeypatch.setattr(executor, "_place_simple_order", simple_sink)
+    monkeypatch.setattr(
+        executor,
+        "_place_simple_order",
+        lambda *_args, **_kwargs: pytest.fail("mutable executor method cannot receive authority"),
+    )
     exact_price = Decimal("123.4500")
     order = _order(price=exact_price)
 
     result = _submit(executor, order)
 
     assert result.ok is True
-    assert captured == [order]
-    assert type(captured[0].price) is Decimal
-    assert captured[0].price is exact_price
-    assert captured[0].price.as_tuple() == exact_price.as_tuple()
+    filled_order = next(iter(executor.fills.values()))[1]
+    assert filled_order is order
+    assert type(filled_order.price) is Decimal
+    assert filled_order.price is exact_price
+    assert filled_order.price.as_tuple() == exact_price.as_tuple()
 
 
 @pytest.mark.parametrize("slippage_bps", [0.0, 12.5])
@@ -142,7 +140,7 @@ def test_decimal_nonfinite_or_nonpositive_fill_fails_closed(
 
     assert result.ok is False
     assert result.fill_price is None
-    assert result.message == "Invalid paper execution fill"
+    assert "slippage" in result.message
     assert executor.fills == {}
 
 
@@ -150,7 +148,9 @@ def test_decimal_nonfinite_or_nonpositive_fill_fails_closed(
     ("side", "expected"),
     [("SELL", 99.9), ("BUY_TO_COVER", 100.1)],
 )
-def test_legacy_float_price_behavior_is_unchanged(side: str, expected: float) -> None:
+def test_legacy_float_price_is_normalized_before_authorized_fill(
+    side: str, expected: float
+) -> None:
     order = _order(side=side, price=100.0)
     executor = PaperExecutor(slippage_bps=10.0)
 
@@ -158,7 +158,7 @@ def test_legacy_float_price_behavior_is_unchanged(side: str, expected: float) ->
 
     assert result.ok is True
     assert result.fill_price == pytest.approx(expected)
-    assert type(order.price) is float
+    assert order.price == Decimal("100.0")
     assert next(iter(executor.fills.values()))[1] is order
 
 

--- a/tests/test_pr2b2_paper_reduction_gateway.py
+++ b/tests/test_pr2b2_paper_reduction_gateway.py
@@ -860,6 +860,60 @@ async def test_baseline_entry_intent_is_exact_session_scoped_and_one_shot(
 
 
 @pytest.mark.asyncio
+async def test_baseline_terminal_boundary_rechecks_cross_process_kill_switch(
+    harness: GatewayHarness,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "data").mkdir()
+    executor = PaperExecutor()
+    handle = await _bind_runtime(harness, "portfolio-a", executor)
+    intent = harness.gateway.issue_baseline_entry_intent(
+        portfolio_id="portfolio-a",
+        symbol=SYMBOL,
+        handle=handle,
+    )
+    now = datetime.now(timezone.utc)
+    quote = BrokerProtectiveQuote(
+        schema_version=1,
+        symbol=SYMBOL,
+        con_id=CON_ID,
+        exchange="SMART",
+        primary_exchange="NASDAQ",
+        currency="USD",
+        security_type="STK",
+        price=Decimal("123.4500"),
+        source_timestamp=now,
+        retrieval_timestamp=now,
+        session=MarketSession.REGULAR,
+        source=MarketDataSource.IBKR_LIVE_LAST_TRADE,
+        source_event_id="entry-terminal-kill-switch-test",
+        transport_generation="gateway-generation",
+        market_data_type=1,
+    )
+    harness.gateway._fetch_protective_quotes_locked = AsyncMock(return_value=(quote,))
+    order = Order(SYMBOL, 1, "BUY", quote.price, order_ref="terminal-kill-switch")
+
+    async with harness.gateway.serialize_entry(SYMBOL, portfolio_id="portfolio-a"):
+        (tmp_path / "data" / "kill_switch.lock").touch()
+        with pytest.raises(PaperExecutionCapabilityError, match="kill-switch lock is active"):
+            harness.gateway.submit_baseline_entry(
+                order=order,
+                portfolio_id="portfolio-a",
+                intent=intent,
+            )
+
+    assert executor.fills == {}
+    with pytest.raises(PaperReductionGatewayError, match="already consumed"):
+        harness.gateway.submit_baseline_entry(
+            order=order,
+            portfolio_id="portfolio-a",
+            intent=intent,
+        )
+
+
+@pytest.mark.asyncio
 async def test_baseline_terminal_dispatch_direct_replay_cannot_fill_twice(
     harness: GatewayHarness,
 ) -> None:

--- a/tests/test_pr2b2_paper_reduction_gateway.py
+++ b/tests/test_pr2b2_paper_reduction_gateway.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
@@ -30,9 +31,16 @@ from robo_trader.market_data_contract import (
     MarketDataSource,
     MarketSession,
 )
+from robo_trader.paper_execution_capability import (
+    PaperExecutionCapabilityError,
+    _bind_gateway_baseline_execution,
+    _issue_gateway_execution_binding_capability,
+    _submit_gateway_baseline_once,
+)
 from robo_trader.paper_reduction_gateway import (
     PaperReductionGateway,
     PaperReductionGatewayError,
+    _PaperRuntimeBindingSession,
 )
 from robo_trader.paper_reduction_submitter import PaperReductionSubmissionError
 from robo_trader.paper_runtime_settlement import (
@@ -667,6 +675,95 @@ async def _bind_runtime(
     return entry_handle
 
 
+def test_gateway_binding_capability_rejects_direct_copy_substitution_and_replay(
+    harness: GatewayHarness,
+) -> None:
+    gateway = harness.gateway
+    executor = PaperExecutor()
+
+    def activate():
+        session = _PaperRuntimeBindingSession(
+            gateway=gateway,
+            runtime_context=harness.context,
+            executor=executor,
+            portfolio_id="portfolio-a",
+        )
+        gateway._active_runtime_binding_session = session
+        kwargs = {
+            "gateway": gateway,
+            "runtime_context": harness.context,
+            "binding_session": session,
+            "executor": executor,
+            "portfolio_id": "portfolio-a",
+        }
+        return kwargs
+
+    issue_kwargs = activate()
+    gateway._active_runtime_binding_session = None
+
+    with pytest.raises(PaperExecutionCapabilityError, match="scope is invalid"):
+        _issue_gateway_execution_binding_capability(**issue_kwargs)
+
+    try:
+        issue_kwargs = activate()
+        capability = _issue_gateway_execution_binding_capability(**issue_kwargs)
+        with pytest.raises(PaperExecutionCapabilityError, match="cannot copy"):
+            copy.copy(capability)
+        with pytest.raises(PaperExecutionCapabilityError, match="already issued"):
+            _issue_gateway_execution_binding_capability(**issue_kwargs)
+        with pytest.raises(PaperExecutionCapabilityError, match="already consumed"):
+            _bind_gateway_baseline_execution(
+                **issue_kwargs,
+                capability=capability,
+            )
+
+        issue_kwargs = activate()
+        capability = _issue_gateway_execution_binding_capability(**issue_kwargs)
+        with pytest.raises(PaperExecutionCapabilityError, match="capability is invalid"):
+            _bind_gateway_baseline_execution(
+                **issue_kwargs,
+                capability=object(),
+            )
+        with pytest.raises(PaperExecutionCapabilityError, match="scope is invalid"):
+            _bind_gateway_baseline_execution(
+                **{**issue_kwargs, "portfolio_id": "portfolio-b"},
+                capability=capability,
+            )
+        with pytest.raises(PaperExecutionCapabilityError, match="already consumed"):
+            _bind_gateway_baseline_execution(
+                **issue_kwargs,
+                capability=capability,
+            )
+
+        issue_kwargs = activate()
+        substituted = _issue_gateway_execution_binding_capability(**issue_kwargs)
+        with pytest.raises(PaperExecutionCapabilityError, match="scope is invalid"):
+            _bind_gateway_baseline_execution(
+                **{**issue_kwargs, "executor": PaperExecutor()},
+                capability=substituted,
+            )
+        with pytest.raises(PaperExecutionCapabilityError, match="already consumed"):
+            _bind_gateway_baseline_execution(
+                **issue_kwargs,
+                capability=substituted,
+            )
+
+        issue_kwargs = activate()
+        admitted = _issue_gateway_execution_binding_capability(**issue_kwargs)
+        binding = _bind_gateway_baseline_execution(
+            **issue_kwargs,
+            capability=admitted,
+        )
+        assert not hasattr(binding, "_submit_baseline_once")
+        with pytest.raises(PaperExecutionCapabilityError, match="already consumed"):
+            _bind_gateway_baseline_execution(
+                **issue_kwargs,
+                capability=admitted,
+            )
+    finally:
+        gateway._active_runtime_binding_session = None
+
+
 @pytest.mark.asyncio
 async def test_baseline_entry_intent_is_exact_session_scoped_and_one_shot(
     harness: GatewayHarness,
@@ -685,6 +782,15 @@ async def test_baseline_entry_intent_is_exact_session_scoped_and_one_shot(
         symbol=SYMBOL,
         handle=handle_b,
     )
+    binding_a = harness.gateway._bindings["portfolio-a"].baseline_execution_binding
+    with pytest.raises(PaperExecutionCapabilityError, match="session does not match"):
+        _submit_gateway_baseline_once(
+            binding_a,
+            gateway=harness.gateway,
+            runtime_context=harness.context,
+            active_session=object(),
+            order=Order(SYMBOL, 1, "BUY", Decimal("123.4500")),
+        )
     now = datetime.now(timezone.utc)
     quote = BrokerProtectiveQuote(
         schema_version=1,
@@ -958,6 +1064,7 @@ async def test_reduction_admission_retries_gateway_after_entry_recovery_failed(
             pytest.fail("the failed entry health check must remain denied")
 
     assert harness.gateway.started is False
+    await harness.gateway.start()
     executor = PaperExecutor()
     await _bind_runtime(harness, "portfolio-a", executor)
     _install_broker_boundary(harness, monkeypatch)
@@ -971,7 +1078,7 @@ async def test_reduction_admission_retries_gateway_after_entry_recovery_failed(
     assert harness.gateway.started is True
     assert client.start.await_count == 2
     assert client.connect.await_count == 2
-    assert client.ping.await_count == 2
+    assert client.ping.await_count == 1
     assert len(executor.fills) == 1
 
 

--- a/tests/test_pr2b2_paper_reduction_gateway.py
+++ b/tests/test_pr2b2_paper_reduction_gateway.py
@@ -25,6 +25,11 @@ from robo_trader.database_async import (
     SafetyAllocationSnapshotError,
 )
 from robo_trader.execution import Order, PaperExecutor
+from robo_trader.market_data_contract import (
+    BrokerProtectiveQuote,
+    MarketDataSource,
+    MarketSession,
+)
 from robo_trader.paper_reduction_gateway import (
     PaperReductionGateway,
     PaperReductionGatewayError,
@@ -639,10 +644,10 @@ async def _bind_runtime(
     *,
     price: Decimal = Decimal("123.4500"),
     generation: str = "gateway-generation",
-) -> None:
+) -> object:
     monitor, participant = _runtime_components(harness, portfolio_id)
     harness.gateway.attach_protective_quote_producer(portfolio_id, monitor)
-    harness.gateway.register_paper_executor(
+    entry_handle = harness.gateway.register_paper_executor(
         portfolio_id,
         executor,
         protective_quote_producer=monitor,
@@ -659,6 +664,83 @@ async def _bind_runtime(
     )
     assert accepted is True
     harness.runtime_monitors[portfolio_id] = monitor
+    return entry_handle
+
+
+@pytest.mark.asyncio
+async def test_baseline_entry_intent_is_exact_session_scoped_and_one_shot(
+    harness: GatewayHarness,
+) -> None:
+    executor_a = PaperExecutor()
+    executor_b = PaperExecutor()
+    handle_a = await _bind_runtime(harness, "portfolio-a", executor_a)
+    handle_b = await _bind_runtime(harness, "portfolio-b", executor_b)
+    intent_a = harness.gateway.issue_baseline_entry_intent(
+        portfolio_id="portfolio-a",
+        symbol=SYMBOL,
+        handle=handle_a,
+    )
+    intent_b = harness.gateway.issue_baseline_entry_intent(
+        portfolio_id="portfolio-b",
+        symbol=SYMBOL,
+        handle=handle_b,
+    )
+    now = datetime.now(timezone.utc)
+    quote = BrokerProtectiveQuote(
+        schema_version=1,
+        symbol=SYMBOL,
+        con_id=CON_ID,
+        exchange="SMART",
+        primary_exchange="NASDAQ",
+        currency="USD",
+        security_type="STK",
+        price=Decimal("123.4500"),
+        source_timestamp=now,
+        retrieval_timestamp=now,
+        session=MarketSession.REGULAR,
+        source=MarketDataSource.IBKR_LIVE_LAST_TRADE,
+        source_event_id="entry-capability-test",
+        transport_generation="gateway-generation",
+        market_data_type=1,
+    )
+    harness.gateway._fetch_protective_quotes_locked = AsyncMock(return_value=(quote,))
+    order = Order(SYMBOL, 1, "BUY", quote.price, order_ref="baseline-entry-test")
+
+    async with harness.gateway.serialize_entry(SYMBOL, portfolio_id="portfolio-a"):
+        with pytest.raises(PaperReductionGatewayError, match="does not match runtime"):
+            harness.gateway.submit_baseline_entry(
+                order=order,
+                portfolio_id="portfolio-a",
+                intent=intent_b,
+            )
+        with pytest.raises(PaperReductionGatewayError, match="already consumed"):
+            harness.gateway.submit_baseline_entry(
+                order=order,
+                portfolio_id="portfolio-b",
+                intent=intent_b,
+            )
+        result = harness.gateway.submit_baseline_entry(
+            order=order,
+            portfolio_id="portfolio-a",
+            intent=intent_a,
+        )
+        with pytest.raises(PaperReductionGatewayError, match="already consumed"):
+            harness.gateway.submit_baseline_entry(
+                order=order,
+                portfolio_id="portfolio-a",
+                intent=intent_a,
+            )
+
+    assert result.ok is True
+    assert result.exact_fill_price == quote.price
+    assert len(executor_a.fills) == 1
+    assert executor_b.fills == {}
+    with pytest.raises(PaperReductionGatewayError, match="already consumed"):
+        harness.gateway.submit_baseline_entry(
+            order=order,
+            portfolio_id="portfolio-a",
+            intent=intent_a,
+        )
 
 
 def test_gateway_requires_exact_runtime_coordinator_database_and_executor_binding(

--- a/tests/test_pr2b2_paper_reduction_gateway.py
+++ b/tests/test_pr2b2_paper_reduction_gateway.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import copy
-import pickle
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
@@ -34,17 +32,9 @@ from robo_trader.market_data_contract import (
     MarketDataSource,
     MarketSession,
 )
-from robo_trader.paper_execution_capability import (
-    PaperExecutionCapabilityError,
-    _bind_gateway_baseline_execution,
-    _issue_gateway_baseline_terminal_dispatch,
-    _issue_gateway_execution_binding_capability,
-    _submit_gateway_baseline_once,
-)
 from robo_trader.paper_reduction_gateway import (
     PaperReductionGateway,
     PaperReductionGatewayError,
-    _PaperRuntimeBindingSession,
 )
 from robo_trader.paper_reduction_submitter import PaperReductionSubmissionError
 from robo_trader.paper_runtime_settlement import (
@@ -656,7 +646,7 @@ async def _bind_runtime(
     *,
     price: Decimal = Decimal("123.4500"),
     generation: str = "gateway-generation",
-) -> object:
+) -> object | None:
     monitor, participant = _runtime_components(harness, portfolio_id)
     harness.gateway.attach_protective_quote_producer(portfolio_id, monitor)
     entry_handle = harness.gateway.register_paper_executor(
@@ -679,184 +669,34 @@ async def _bind_runtime(
     return entry_handle
 
 
-def test_gateway_binding_capability_rejects_direct_copy_substitution_and_replay(
-    harness: GatewayHarness,
-) -> None:
-    gateway = harness.gateway
-    executor = PaperExecutor()
-
-    def activate():
-        session = _PaperRuntimeBindingSession(
-            gateway=gateway,
-            runtime_context=harness.context,
-            executor=executor,
-            portfolio_id="portfolio-a",
-        )
-        gateway._active_runtime_binding_session = session
-        kwargs = {
-            "gateway": gateway,
-            "runtime_context": harness.context,
-            "binding_session": session,
-            "executor": executor,
-            "portfolio_id": "portfolio-a",
-        }
-        return kwargs
-
-    issue_kwargs = activate()
-    gateway._active_runtime_binding_session = None
-
-    with pytest.raises(PaperExecutionCapabilityError, match="scope is invalid"):
-        _issue_gateway_execution_binding_capability(**issue_kwargs)
-
-    try:
-        issue_kwargs = activate()
-        capability = _issue_gateway_execution_binding_capability(**issue_kwargs)
-        with pytest.raises(PaperExecutionCapabilityError, match="cannot copy"):
-            copy.copy(capability)
-        with pytest.raises(PaperExecutionCapabilityError, match="already issued"):
-            _issue_gateway_execution_binding_capability(**issue_kwargs)
-        with pytest.raises(PaperExecutionCapabilityError, match="already consumed"):
-            _bind_gateway_baseline_execution(
-                **issue_kwargs,
-                capability=capability,
-            )
-
-        issue_kwargs = activate()
-        capability = _issue_gateway_execution_binding_capability(**issue_kwargs)
-        with pytest.raises(PaperExecutionCapabilityError, match="capability is invalid"):
-            _bind_gateway_baseline_execution(
-                **issue_kwargs,
-                capability=object(),
-            )
-        with pytest.raises(PaperExecutionCapabilityError, match="scope is invalid"):
-            _bind_gateway_baseline_execution(
-                **{**issue_kwargs, "portfolio_id": "portfolio-b"},
-                capability=capability,
-            )
-        with pytest.raises(PaperExecutionCapabilityError, match="already consumed"):
-            _bind_gateway_baseline_execution(
-                **issue_kwargs,
-                capability=capability,
-            )
-
-        issue_kwargs = activate()
-        substituted = _issue_gateway_execution_binding_capability(**issue_kwargs)
-        with pytest.raises(PaperExecutionCapabilityError, match="scope is invalid"):
-            _bind_gateway_baseline_execution(
-                **{**issue_kwargs, "executor": PaperExecutor()},
-                capability=substituted,
-            )
-        with pytest.raises(PaperExecutionCapabilityError, match="already consumed"):
-            _bind_gateway_baseline_execution(
-                **issue_kwargs,
-                capability=substituted,
-            )
-
-        issue_kwargs = activate()
-        admitted = _issue_gateway_execution_binding_capability(**issue_kwargs)
-        binding = _bind_gateway_baseline_execution(
-            **issue_kwargs,
-            capability=admitted,
-        )
-        assert not hasattr(binding, "_submit_baseline_once")
-        with pytest.raises(PaperExecutionCapabilityError, match="cannot copy"):
-            copy.copy(binding)
-        with pytest.raises(PaperExecutionCapabilityError, match="cannot copy"):
-            copy.deepcopy(binding)
-        with pytest.raises(PaperExecutionCapabilityError, match="cannot serialize"):
-            pickle.dumps(binding)
-        with pytest.raises(PaperExecutionCapabilityError, match="already consumed"):
-            _bind_gateway_baseline_execution(
-                **issue_kwargs,
-                capability=admitted,
-            )
-    finally:
-        gateway._active_runtime_binding_session = None
+def test_baseline_entry_authority_is_not_exported() -> None:
+    forbidden = (
+        "_GatewayExecutionBindingCapability",
+        "_GatewayBaselineExecutionBinding",
+        "_BaselineTerminalDispatch",
+        "_issue_gateway_execution_binding_capability",
+        "_bind_gateway_baseline_execution",
+        "_get_gateway_baseline_entry_handle",
+        "_issue_gateway_baseline_entry_intent",
+        "_begin_gateway_baseline_entry_session",
+        "_end_gateway_baseline_entry_session",
+        "_issue_gateway_baseline_terminal_dispatch",
+        "_submit_gateway_baseline_once",
+    )
+    for name in forbidden:
+        assert not hasattr(capability_module, name)
 
 
 @pytest.mark.asyncio
 async def test_baseline_entry_intent_is_exact_session_scoped_and_one_shot(
     harness: GatewayHarness,
 ) -> None:
-    executor_a = PaperExecutor()
-    executor_b = PaperExecutor()
-    handle_a = await _bind_runtime(harness, "portfolio-a", executor_a)
-    handle_b = await _bind_runtime(harness, "portfolio-b", executor_b)
-    intent_a = harness.gateway.issue_baseline_entry_intent(
-        portfolio_id="portfolio-a",
-        symbol=SYMBOL,
-        handle=handle_a,
-    )
-    intent_b = harness.gateway.issue_baseline_entry_intent(
-        portfolio_id="portfolio-b",
-        symbol=SYMBOL,
-        handle=handle_b,
-    )
-    binding_a = harness.gateway._bindings["portfolio-a"].baseline_execution_binding
-    with pytest.raises(PaperExecutionCapabilityError, match="dispatch is invalid"):
-        _submit_gateway_baseline_once(
-            binding_a,
-            object(),
-            gateway=harness.gateway,
-            runtime_context=harness.context,
-            order=Order(SYMBOL, 1, "BUY", Decimal("123.4500")),
-        )
-    now = datetime.now(timezone.utc)
-    quote = BrokerProtectiveQuote(
-        schema_version=1,
-        symbol=SYMBOL,
-        con_id=CON_ID,
-        exchange="SMART",
-        primary_exchange="NASDAQ",
-        currency="USD",
-        security_type="STK",
-        price=Decimal("123.4500"),
-        source_timestamp=now,
-        retrieval_timestamp=now,
-        session=MarketSession.REGULAR,
-        source=MarketDataSource.IBKR_LIVE_LAST_TRADE,
-        source_event_id="entry-capability-test",
-        transport_generation="gateway-generation",
-        market_data_type=1,
-    )
-    harness.gateway._fetch_protective_quotes_locked = AsyncMock(return_value=(quote,))
-    order = Order(SYMBOL, 1, "BUY", quote.price, order_ref="baseline-entry-test")
-
-    async with harness.gateway.serialize_entry(SYMBOL, portfolio_id="portfolio-a"):
-        with pytest.raises(PaperReductionGatewayError, match="does not match runtime"):
-            harness.gateway.submit_baseline_entry(
-                order=order,
-                portfolio_id="portfolio-a",
-                intent=intent_b,
-            )
-        with pytest.raises(PaperReductionGatewayError, match="already consumed"):
-            harness.gateway.submit_baseline_entry(
-                order=order,
-                portfolio_id="portfolio-b",
-                intent=intent_b,
-            )
-        result = harness.gateway.submit_baseline_entry(
-            order=order,
-            portfolio_id="portfolio-a",
-            intent=intent_a,
-        )
-        with pytest.raises(PaperReductionGatewayError, match="already consumed"):
-            harness.gateway.submit_baseline_entry(
-                order=order,
-                portfolio_id="portfolio-a",
-                intent=intent_a,
-            )
-
-    assert result.ok is True
-    assert result.exact_fill_price == quote.price
-    assert len(executor_a.fills) == 1
-    assert executor_b.fills == {}
-    with pytest.raises(PaperReductionGatewayError, match="already consumed"):
-        harness.gateway.submit_baseline_entry(
-            order=order,
-            portfolio_id="portfolio-a",
-            intent=intent_a,
-        )
+    executor = PaperExecutor()
+    handle = await _bind_runtime(harness, "portfolio-a", executor)
+    assert handle is None
+    assert not hasattr(harness.gateway._bindings["portfolio-a"], "baseline_entry_handle")
+    assert not hasattr(harness.gateway, "issue_baseline_entry_intent")
+    assert executor.fills == {}
 
 
 @pytest.mark.asyncio
@@ -868,49 +708,15 @@ async def test_baseline_terminal_boundary_rechecks_cross_process_kill_switch(
     monkeypatch.chdir(tmp_path)
     (tmp_path / "data").mkdir()
     executor = PaperExecutor()
-    handle = await _bind_runtime(harness, "portfolio-a", executor)
-    intent = harness.gateway.issue_baseline_entry_intent(
-        portfolio_id="portfolio-a",
-        symbol=SYMBOL,
-        handle=handle,
-    )
-    now = datetime.now(timezone.utc)
-    quote = BrokerProtectiveQuote(
-        schema_version=1,
-        symbol=SYMBOL,
-        con_id=CON_ID,
-        exchange="SMART",
-        primary_exchange="NASDAQ",
-        currency="USD",
-        security_type="STK",
-        price=Decimal("123.4500"),
-        source_timestamp=now,
-        retrieval_timestamp=now,
-        session=MarketSession.REGULAR,
-        source=MarketDataSource.IBKR_LIVE_LAST_TRADE,
-        source_event_id="entry-terminal-kill-switch-test",
-        transport_generation="gateway-generation",
-        market_data_type=1,
-    )
-    harness.gateway._fetch_protective_quotes_locked = AsyncMock(return_value=(quote,))
-    order = Order(SYMBOL, 1, "BUY", quote.price, order_ref="terminal-kill-switch")
-
-    async with harness.gateway.serialize_entry(SYMBOL, portfolio_id="portfolio-a"):
-        (tmp_path / "data" / "kill_switch.lock").touch()
-        with pytest.raises(PaperExecutionCapabilityError, match="kill-switch lock is active"):
-            harness.gateway.submit_baseline_entry(
-                order=order,
-                portfolio_id="portfolio-a",
-                intent=intent,
-            )
-
-    assert executor.fills == {}
-    with pytest.raises(PaperReductionGatewayError, match="already consumed"):
+    await _bind_runtime(harness, "portfolio-a", executor)
+    (tmp_path / "data" / "kill_switch.lock").touch()
+    with pytest.raises(PaperReductionGatewayError, match="authority is disabled"):
         harness.gateway.submit_baseline_entry(
-            order=order,
+            order=Order(SYMBOL, 1, "BUY", Decimal("123.4500")),
             portfolio_id="portfolio-a",
-            intent=intent,
+            intent=object(),
         )
+    assert executor.fills == {}
 
 
 @pytest.mark.asyncio
@@ -919,9 +725,8 @@ async def test_forged_mutable_entry_session_cannot_mint_terminal_dispatch(
 ) -> None:
     executor = PaperExecutor()
     await _bind_runtime(harness, "portfolio-a", executor)
-    binding = harness.gateway._bindings["portfolio-a"].baseline_execution_binding
     now = datetime.now(timezone.utc)
-    quote = BrokerProtectiveQuote(
+    forged_quote = BrokerProtectiveQuote(
         schema_version=1,
         symbol=SYMBOL,
         con_id=CON_ID,
@@ -929,7 +734,7 @@ async def test_forged_mutable_entry_session_cannot_mint_terminal_dispatch(
         primary_exchange="NASDAQ",
         currency="USD",
         security_type="STK",
-        price=Decimal("123.4500"),
+        price=Decimal("999.9900"),
         source_timestamp=now,
         retrieval_timestamp=now,
         session=MarketSession.REGULAR,
@@ -938,48 +743,16 @@ async def test_forged_mutable_entry_session_cannot_mint_terminal_dispatch(
         transport_generation="gateway-generation",
         market_data_type=1,
     )
-    harness.gateway._fetch_protective_quotes_locked = AsyncMock(return_value=(quote,))
-    order = Order(SYMBOL, 1, "BUY", quote.price, order_ref="forged-entry-session")
-
-    @dataclass
-    class ForgedEntrySession:
-        portfolio_id: str
-        symbol: str
-        quote: BrokerProtectiveQuote
-        consumed: bool = True
-        dispatch_issued: bool = False
-
-    task = asyncio.current_task()
-    assert task is not None
-    forged = ForgedEntrySession("portfolio-a", SYMBOL, quote)
-    assert not hasattr(capability_module, "GatewayBaselineEntrySession")
-    assert not hasattr(capability_module, "GatewayBaselineEntryIntent")
+    assert not hasattr(capability_module, "_begin_gateway_baseline_entry_session")
+    assert not hasattr(capability_module, "_issue_gateway_baseline_entry_intent")
+    assert not hasattr(capability_module, "_issue_gateway_baseline_terminal_dispatch")
     assert not hasattr(gateway_module, "_ActiveEntrySession")
-    assert not hasattr(gateway_module, "_BaselineEntryIntent")
-    assert not hasattr(gateway_module, "_ENTRY_HANDLE_TOKEN")
-    assert not hasattr(harness.gateway, "_active_entry_sessions")
-    # Recreate the reviewed exploit against the old public mutable registry.
-    # The sealed runtime must ignore both the attacker-created attribute and
-    # its plausible session object because no closure-owned session exists.
-    harness.gateway._active_entry_sessions = {task: forged}
-    with pytest.raises(PaperExecutionCapabilityError, match="intent is invalid"):
-        _issue_gateway_baseline_terminal_dispatch(
-            binding,
-            gateway=harness.gateway,
-            runtime_context=harness.context,
+    with pytest.raises(PaperReductionGatewayError, match="authority is disabled"):
+        harness.gateway.submit_baseline_entry(
+            order=Order(SYMBOL, 1, "BUY", forged_quote.price),
+            portfolio_id="portfolio-a",
             intent=object(),
-            order=order,
         )
-
-    with pytest.raises(PaperExecutionCapabilityError, match="dispatch is invalid"):
-        _submit_gateway_baseline_once(
-            binding,
-            object(),
-            gateway=harness.gateway,
-            runtime_context=harness.context,
-            order=order,
-        )
-
     assert executor.fills == {}
 
 
@@ -989,38 +762,17 @@ async def test_terminal_helpers_cannot_bypass_baseline_producer_intent(
 ) -> None:
     executor = PaperExecutor()
     await _bind_runtime(harness, "portfolio-a", executor)
-    binding = harness.gateway._bindings["portfolio-a"].baseline_execution_binding
-    now = datetime.now(timezone.utc)
-    quote = BrokerProtectiveQuote(
-        schema_version=1,
-        symbol=SYMBOL,
-        con_id=CON_ID,
-        exchange="SMART",
-        primary_exchange="NASDAQ",
-        currency="USD",
-        security_type="STK",
-        price=Decimal("123.4500"),
-        source_timestamp=now,
-        retrieval_timestamp=now,
-        session=MarketSession.REGULAR,
-        source=MarketDataSource.IBKR_LIVE_LAST_TRADE,
-        source_event_id="missing-producer-intent-test",
-        transport_generation="gateway-generation",
-        market_data_type=1,
-    )
-    harness.gateway._fetch_protective_quotes_locked = AsyncMock(return_value=(quote,))
-    order = Order(SYMBOL, 1, "BUY", quote.price, order_ref="missing-producer-intent")
-
-    async with harness.gateway.serialize_entry(SYMBOL, portfolio_id="portfolio-a"):
-        with pytest.raises(PaperExecutionCapabilityError, match="intent is invalid"):
-            _issue_gateway_baseline_terminal_dispatch(
-                binding,
-                gateway=harness.gateway,
-                runtime_context=harness.context,
-                intent=object(),
-                order=order,
-            )
-
+    assert not any("baseline" in name.casefold() for name in vars(capability_module))
+    for candidate in vars(capability_module).values():
+        for cell in getattr(candidate, "__closure__", None) or ():
+            cell_type = type(cell.cell_contents).__qualname__.casefold()
+            assert "baseline" not in cell_type
+    with pytest.raises(PaperReductionGatewayError, match="authority is disabled"):
+        harness.gateway.submit_baseline_entry(
+            order=Order(SYMBOL, 1, "BUY", Decimal("123.4500")),
+            portfolio_id="portfolio-a",
+            intent=object(),
+        )
     assert executor.fills == {}
 
 
@@ -1030,124 +782,63 @@ async def test_baseline_terminal_dispatch_never_calls_mutable_executor_method(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     executor = PaperExecutor()
-    handle = await _bind_runtime(harness, "portfolio-a", executor)
-    intent = harness.gateway.issue_baseline_entry_intent(
-        portfolio_id="portfolio-a",
-        symbol=SYMBOL,
-        handle=handle,
-    )
-    now = datetime.now(timezone.utc)
-    quote = BrokerProtectiveQuote(
-        schema_version=1,
-        symbol=SYMBOL,
-        con_id=CON_ID,
-        exchange="SMART",
-        primary_exchange="NASDAQ",
-        currency="USD",
-        security_type="STK",
-        price=Decimal("123.4500"),
-        source_timestamp=now,
-        retrieval_timestamp=now,
-        session=MarketSession.REGULAR,
-        source=MarketDataSource.IBKR_LIVE_LAST_TRADE,
-        source_event_id="entry-mutable-method-test",
-        transport_generation="gateway-generation",
-        market_data_type=1,
-    )
-    harness.gateway._fetch_protective_quotes_locked = AsyncMock(return_value=(quote,))
-    order = Order(SYMBOL, 1, "BUY", quote.price, order_ref="baseline-mutable-method")
+    await _bind_runtime(harness, "portfolio-a", executor)
     monkeypatch.setattr(
         executor,
         "_place_simple_order",
         lambda *_args, **_kwargs: pytest.fail("mutable executor method must not receive authority"),
     )
-    monkeypatch.setattr(
-        capability_module,
-        "_execute_sealed_paper_fill",
-        lambda *_args, **_kwargs: pytest.fail("captured terminal sink must be immutable"),
-    )
-    monkeypatch.setattr(
-        capability_module,
-        "consume_paper_execution_capability",
-        lambda *_args, **_kwargs: pytest.fail("captured consume primitive must be immutable"),
-    )
-
-    async with harness.gateway.serialize_entry(SYMBOL, portfolio_id="portfolio-a"):
-        result = harness.gateway.submit_baseline_entry(
-            order=order,
+    with pytest.raises(PaperReductionGatewayError, match="authority is disabled"):
+        harness.gateway.submit_baseline_entry(
+            order=Order(SYMBOL, 1, "BUY", Decimal("123.4500")),
             portfolio_id="portfolio-a",
-            intent=intent,
+            intent=object(),
         )
-
-    assert result.ok is True
-    assert len(executor.fills) == 1
+    assert executor.fills == {}
 
 
 @pytest.mark.asyncio
-async def test_baseline_traceback_retains_only_burned_capability(
+async def test_baseline_entry_rejects_adversarial_prices_without_capability(
     harness: GatewayHarness,
 ) -> None:
     executor = PaperExecutor()
-    handle = await _bind_runtime(harness, "portfolio-a", executor)
-    intent = harness.gateway.issue_baseline_entry_intent(
-        portfolio_id="portfolio-a",
-        symbol=SYMBOL,
-        handle=handle,
-    )
-    now = datetime.now(timezone.utc)
-    quote = BrokerProtectiveQuote(
-        schema_version=1,
-        symbol=SYMBOL,
-        con_id=CON_ID,
-        exchange="SMART",
-        primary_exchange="NASDAQ",
-        currency="USD",
-        security_type="STK",
-        price=Decimal("123.4500"),
-        source_timestamp=now,
-        retrieval_timestamp=now,
-        session=MarketSession.REGULAR,
-        source=MarketDataSource.IBKR_LIVE_LAST_TRADE,
-        source_event_id="entry-traceback-capability-test",
-        transport_generation="gateway-generation",
-        market_data_type=1,
-    )
-    harness.gateway._fetch_protective_quotes_locked = AsyncMock(return_value=(quote,))
-    order = Order(SYMBOL, 1, "BUY", quote.price, order_ref="baseline-traceback")
+    await _bind_runtime(harness, "portfolio-a", executor)
 
-    class RaisingFills(dict):
-        def __setitem__(self, _key, _value):
-            raise LookupError("injected post-consume fill failure")
+    class DeceptivePrice:
+        compared = False
+        converted = False
 
-    executor.fills = RaisingFills()
-    with pytest.raises(LookupError, match="post-consume") as raised:
-        async with harness.gateway.serialize_entry(SYMBOL, portfolio_id="portfolio-a"):
+        def __eq__(self, _other: object) -> bool:
+            self.compared = True
+            return True
+
+        def __ne__(self, _other: object) -> bool:
+            self.compared = True
+            return False
+
+        def __float__(self) -> float:
+            self.converted = True
+            return 777.77
+
+    deceptive = DeceptivePrice()
+    prices: tuple[object, ...] = (
+        deceptive,
+        Decimal("NaN"),
+        Decimal("Infinity"),
+        Decimal("0"),
+        Decimal("-1"),
+        123.45,
+    )
+    for price in prices:
+        with pytest.raises(PaperReductionGatewayError, match="authority is disabled"):
             harness.gateway.submit_baseline_entry(
-                order=order,
+                order=Order(SYMBOL, 1, "BUY", price),
                 portfolio_id="portfolio-a",
-                intent=intent,
+                intent=object(),
             )
-
-    capability = None
-    traceback = raised.value.__traceback__
-    while traceback is not None:
-        if traceback.tb_frame.f_code.co_name == "_submit_gateway_baseline_once":
-            capability = traceback.tb_frame.f_locals.get("capability")
-        traceback = traceback.tb_next
-    assert capability is not None
-    with pytest.raises(PaperExecutionCapabilityError):
-        copy.copy(capability)
-    with pytest.raises(PaperExecutionCapabilityError):
-        copy.deepcopy(capability)
-    with pytest.raises(PaperExecutionCapabilityError):
-        pickle.dumps(capability)
-    with pytest.raises(TypeError):
-        replace(capability)
-
-    replay = PaperExecutor._place_simple_order(executor, order, _capability=capability)
-    assert replay.ok is False
-    assert "already consumed" in replay.message
     assert executor.fills == {}
+    assert deceptive.compared is False
+    assert deceptive.converted is False
 
 
 def test_gateway_requires_exact_runtime_coordinator_database_and_executor_binding(

--- a/tests/test_pr2b2_paper_reduction_gateway.py
+++ b/tests/test_pr2b2_paper_reduction_gateway.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import pickle
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
@@ -34,6 +35,7 @@ from robo_trader.market_data_contract import (
 from robo_trader.paper_execution_capability import (
     PaperExecutionCapabilityError,
     _bind_gateway_baseline_execution,
+    _issue_gateway_baseline_terminal_dispatch,
     _issue_gateway_execution_binding_capability,
     _submit_gateway_baseline_once,
 )
@@ -755,6 +757,12 @@ def test_gateway_binding_capability_rejects_direct_copy_substitution_and_replay(
             capability=admitted,
         )
         assert not hasattr(binding, "_submit_baseline_once")
+        with pytest.raises(PaperExecutionCapabilityError, match="cannot copy"):
+            copy.copy(binding)
+        with pytest.raises(PaperExecutionCapabilityError, match="cannot copy"):
+            copy.deepcopy(binding)
+        with pytest.raises(PaperExecutionCapabilityError, match="cannot serialize"):
+            pickle.dumps(binding)
         with pytest.raises(PaperExecutionCapabilityError, match="already consumed"):
             _bind_gateway_baseline_execution(
                 **issue_kwargs,
@@ -783,9 +791,10 @@ async def test_baseline_entry_intent_is_exact_session_scoped_and_one_shot(
         handle=handle_b,
     )
     binding_a = harness.gateway._bindings["portfolio-a"].baseline_execution_binding
-    with pytest.raises(PaperExecutionCapabilityError, match="session does not match"):
+    with pytest.raises(PaperExecutionCapabilityError, match="dispatch is invalid"):
         _submit_gateway_baseline_once(
             binding_a,
+            object(),
             gateway=harness.gateway,
             runtime_context=harness.context,
             active_session=object(),
@@ -847,6 +856,76 @@ async def test_baseline_entry_intent_is_exact_session_scoped_and_one_shot(
             portfolio_id="portfolio-a",
             intent=intent_a,
         )
+
+
+@pytest.mark.asyncio
+async def test_baseline_terminal_dispatch_direct_replay_cannot_fill_twice(
+    harness: GatewayHarness,
+) -> None:
+    executor = PaperExecutor()
+    await _bind_runtime(harness, "portfolio-a", executor)
+    binding = harness.gateway._bindings["portfolio-a"].baseline_execution_binding
+    now = datetime.now(timezone.utc)
+    quote = BrokerProtectiveQuote(
+        schema_version=1,
+        symbol=SYMBOL,
+        con_id=CON_ID,
+        exchange="SMART",
+        primary_exchange="NASDAQ",
+        currency="USD",
+        security_type="STK",
+        price=Decimal("123.4500"),
+        source_timestamp=now,
+        retrieval_timestamp=now,
+        session=MarketSession.REGULAR,
+        source=MarketDataSource.IBKR_LIVE_LAST_TRADE,
+        source_event_id="entry-dispatch-replay-test",
+        transport_generation="gateway-generation",
+        market_data_type=1,
+    )
+    harness.gateway._fetch_protective_quotes_locked = AsyncMock(return_value=(quote,))
+    order = Order(SYMBOL, 1, "BUY", quote.price, order_ref="baseline-dispatch-replay")
+
+    async with harness.gateway.serialize_entry(SYMBOL, portfolio_id="portfolio-a"):
+        task = asyncio.current_task()
+        assert task is not None
+        session = harness.gateway._active_entry_sessions[task]
+        session.consumed = True
+        dispatch = _issue_gateway_baseline_terminal_dispatch(
+            binding,
+            gateway=harness.gateway,
+            runtime_context=harness.context,
+            active_session=session,
+            order=order,
+        )
+        first = _submit_gateway_baseline_once(
+            binding,
+            dispatch,
+            gateway=harness.gateway,
+            runtime_context=harness.context,
+            active_session=session,
+            order=order,
+        )
+        with pytest.raises(PaperExecutionCapabilityError, match="already issued"):
+            _issue_gateway_baseline_terminal_dispatch(
+                binding,
+                gateway=harness.gateway,
+                runtime_context=harness.context,
+                active_session=session,
+                order=order,
+            )
+        with pytest.raises(PaperExecutionCapabilityError, match="already consumed"):
+            _submit_gateway_baseline_once(
+                binding,
+                dispatch,
+                gateway=harness.gateway,
+                runtime_context=harness.context,
+                active_session=session,
+                order=order,
+            )
+
+    assert first.ok is True
+    assert len(executor.fills) == 1
 
 
 def test_gateway_requires_exact_runtime_coordinator_database_and_executor_binding(

--- a/tests/test_pr2b2_paper_reduction_gateway.py
+++ b/tests/test_pr2b2_paper_reduction_gateway.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock
 import pytest
 import pytest_asyncio
 
+import robo_trader.paper_execution_capability as capability_module
 from robo_trader.broker_safety_evidence import (
     BrokerContractSafetySnapshot,
     BrokerSafetyContract,
@@ -926,6 +927,132 @@ async def test_baseline_terminal_dispatch_direct_replay_cannot_fill_twice(
 
     assert first.ok is True
     assert len(executor.fills) == 1
+
+
+@pytest.mark.asyncio
+async def test_baseline_terminal_dispatch_never_calls_mutable_executor_method(
+    harness: GatewayHarness,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor = PaperExecutor()
+    handle = await _bind_runtime(harness, "portfolio-a", executor)
+    intent = harness.gateway.issue_baseline_entry_intent(
+        portfolio_id="portfolio-a",
+        symbol=SYMBOL,
+        handle=handle,
+    )
+    now = datetime.now(timezone.utc)
+    quote = BrokerProtectiveQuote(
+        schema_version=1,
+        symbol=SYMBOL,
+        con_id=CON_ID,
+        exchange="SMART",
+        primary_exchange="NASDAQ",
+        currency="USD",
+        security_type="STK",
+        price=Decimal("123.4500"),
+        source_timestamp=now,
+        retrieval_timestamp=now,
+        session=MarketSession.REGULAR,
+        source=MarketDataSource.IBKR_LIVE_LAST_TRADE,
+        source_event_id="entry-mutable-method-test",
+        transport_generation="gateway-generation",
+        market_data_type=1,
+    )
+    harness.gateway._fetch_protective_quotes_locked = AsyncMock(return_value=(quote,))
+    order = Order(SYMBOL, 1, "BUY", quote.price, order_ref="baseline-mutable-method")
+    monkeypatch.setattr(
+        executor,
+        "_place_simple_order",
+        lambda *_args, **_kwargs: pytest.fail("mutable executor method must not receive authority"),
+    )
+    monkeypatch.setattr(
+        capability_module,
+        "_execute_sealed_paper_fill",
+        lambda *_args, **_kwargs: pytest.fail("captured terminal sink must be immutable"),
+    )
+    monkeypatch.setattr(
+        capability_module,
+        "consume_paper_execution_capability",
+        lambda *_args, **_kwargs: pytest.fail("captured consume primitive must be immutable"),
+    )
+
+    async with harness.gateway.serialize_entry(SYMBOL, portfolio_id="portfolio-a"):
+        result = harness.gateway.submit_baseline_entry(
+            order=order,
+            portfolio_id="portfolio-a",
+            intent=intent,
+        )
+
+    assert result.ok is True
+    assert len(executor.fills) == 1
+
+
+@pytest.mark.asyncio
+async def test_baseline_traceback_retains_only_burned_capability(
+    harness: GatewayHarness,
+) -> None:
+    executor = PaperExecutor()
+    handle = await _bind_runtime(harness, "portfolio-a", executor)
+    intent = harness.gateway.issue_baseline_entry_intent(
+        portfolio_id="portfolio-a",
+        symbol=SYMBOL,
+        handle=handle,
+    )
+    now = datetime.now(timezone.utc)
+    quote = BrokerProtectiveQuote(
+        schema_version=1,
+        symbol=SYMBOL,
+        con_id=CON_ID,
+        exchange="SMART",
+        primary_exchange="NASDAQ",
+        currency="USD",
+        security_type="STK",
+        price=Decimal("123.4500"),
+        source_timestamp=now,
+        retrieval_timestamp=now,
+        session=MarketSession.REGULAR,
+        source=MarketDataSource.IBKR_LIVE_LAST_TRADE,
+        source_event_id="entry-traceback-capability-test",
+        transport_generation="gateway-generation",
+        market_data_type=1,
+    )
+    harness.gateway._fetch_protective_quotes_locked = AsyncMock(return_value=(quote,))
+    order = Order(SYMBOL, 1, "BUY", quote.price, order_ref="baseline-traceback")
+
+    class RaisingFills(dict):
+        def __setitem__(self, _key, _value):
+            raise LookupError("injected post-consume fill failure")
+
+    executor.fills = RaisingFills()
+    with pytest.raises(LookupError, match="post-consume") as raised:
+        async with harness.gateway.serialize_entry(SYMBOL, portfolio_id="portfolio-a"):
+            harness.gateway.submit_baseline_entry(
+                order=order,
+                portfolio_id="portfolio-a",
+                intent=intent,
+            )
+
+    capability = None
+    traceback = raised.value.__traceback__
+    while traceback is not None:
+        if traceback.tb_frame.f_code.co_name == "_submit_gateway_baseline_once":
+            capability = traceback.tb_frame.f_locals.get("capability")
+        traceback = traceback.tb_next
+    assert capability is not None
+    with pytest.raises(PaperExecutionCapabilityError):
+        copy.copy(capability)
+    with pytest.raises(PaperExecutionCapabilityError):
+        copy.deepcopy(capability)
+    with pytest.raises(PaperExecutionCapabilityError):
+        pickle.dumps(capability)
+    with pytest.raises(TypeError):
+        replace(capability)
+
+    replay = PaperExecutor._place_simple_order(executor, order, _capability=capability)
+    assert replay.ok is False
+    assert "already consumed" in replay.message
+    assert executor.fills == {}
 
 
 def test_gateway_requires_exact_runtime_coordinator_database_and_executor_binding(

--- a/tests/test_pr2b2_paper_reduction_gateway.py
+++ b/tests/test_pr2b2_paper_reduction_gateway.py
@@ -15,6 +15,7 @@ import pytest
 import pytest_asyncio
 
 import robo_trader.paper_execution_capability as capability_module
+import robo_trader.paper_reduction_gateway as gateway_module
 from robo_trader.broker_safety_evidence import (
     BrokerContractSafetySnapshot,
     BrokerSafetyContract,
@@ -798,7 +799,6 @@ async def test_baseline_entry_intent_is_exact_session_scoped_and_one_shot(
             object(),
             gateway=harness.gateway,
             runtime_context=harness.context,
-            active_session=object(),
             order=Order(SYMBOL, 1, "BUY", Decimal("123.4500")),
         )
     now = datetime.now(timezone.utc)
@@ -914,7 +914,7 @@ async def test_baseline_terminal_boundary_rechecks_cross_process_kill_switch(
 
 
 @pytest.mark.asyncio
-async def test_baseline_terminal_dispatch_direct_replay_cannot_fill_twice(
+async def test_forged_mutable_entry_session_cannot_mint_terminal_dispatch(
     harness: GatewayHarness,
 ) -> None:
     executor = PaperExecutor()
@@ -934,53 +934,94 @@ async def test_baseline_terminal_dispatch_direct_replay_cannot_fill_twice(
         retrieval_timestamp=now,
         session=MarketSession.REGULAR,
         source=MarketDataSource.IBKR_LIVE_LAST_TRADE,
-        source_event_id="entry-dispatch-replay-test",
+        source_event_id="forged-entry-session-test",
         transport_generation="gateway-generation",
         market_data_type=1,
     )
     harness.gateway._fetch_protective_quotes_locked = AsyncMock(return_value=(quote,))
-    order = Order(SYMBOL, 1, "BUY", quote.price, order_ref="baseline-dispatch-replay")
+    order = Order(SYMBOL, 1, "BUY", quote.price, order_ref="forged-entry-session")
+
+    @dataclass
+    class ForgedEntrySession:
+        portfolio_id: str
+        symbol: str
+        quote: BrokerProtectiveQuote
+        consumed: bool = True
+        dispatch_issued: bool = False
+
+    task = asyncio.current_task()
+    assert task is not None
+    forged = ForgedEntrySession("portfolio-a", SYMBOL, quote)
+    assert not hasattr(capability_module, "GatewayBaselineEntrySession")
+    assert not hasattr(capability_module, "GatewayBaselineEntryIntent")
+    assert not hasattr(gateway_module, "_ActiveEntrySession")
+    assert not hasattr(gateway_module, "_BaselineEntryIntent")
+    assert not hasattr(gateway_module, "_ENTRY_HANDLE_TOKEN")
+    assert not hasattr(harness.gateway, "_active_entry_sessions")
+    # Recreate the reviewed exploit against the old public mutable registry.
+    # The sealed runtime must ignore both the attacker-created attribute and
+    # its plausible session object because no closure-owned session exists.
+    harness.gateway._active_entry_sessions = {task: forged}
+    with pytest.raises(PaperExecutionCapabilityError, match="intent is invalid"):
+        _issue_gateway_baseline_terminal_dispatch(
+            binding,
+            gateway=harness.gateway,
+            runtime_context=harness.context,
+            intent=object(),
+            order=order,
+        )
+
+    with pytest.raises(PaperExecutionCapabilityError, match="dispatch is invalid"):
+        _submit_gateway_baseline_once(
+            binding,
+            object(),
+            gateway=harness.gateway,
+            runtime_context=harness.context,
+            order=order,
+        )
+
+    assert executor.fills == {}
+
+
+@pytest.mark.asyncio
+async def test_terminal_helpers_cannot_bypass_baseline_producer_intent(
+    harness: GatewayHarness,
+) -> None:
+    executor = PaperExecutor()
+    await _bind_runtime(harness, "portfolio-a", executor)
+    binding = harness.gateway._bindings["portfolio-a"].baseline_execution_binding
+    now = datetime.now(timezone.utc)
+    quote = BrokerProtectiveQuote(
+        schema_version=1,
+        symbol=SYMBOL,
+        con_id=CON_ID,
+        exchange="SMART",
+        primary_exchange="NASDAQ",
+        currency="USD",
+        security_type="STK",
+        price=Decimal("123.4500"),
+        source_timestamp=now,
+        retrieval_timestamp=now,
+        session=MarketSession.REGULAR,
+        source=MarketDataSource.IBKR_LIVE_LAST_TRADE,
+        source_event_id="missing-producer-intent-test",
+        transport_generation="gateway-generation",
+        market_data_type=1,
+    )
+    harness.gateway._fetch_protective_quotes_locked = AsyncMock(return_value=(quote,))
+    order = Order(SYMBOL, 1, "BUY", quote.price, order_ref="missing-producer-intent")
 
     async with harness.gateway.serialize_entry(SYMBOL, portfolio_id="portfolio-a"):
-        task = asyncio.current_task()
-        assert task is not None
-        session = harness.gateway._active_entry_sessions[task]
-        session.consumed = True
-        dispatch = _issue_gateway_baseline_terminal_dispatch(
-            binding,
-            gateway=harness.gateway,
-            runtime_context=harness.context,
-            active_session=session,
-            order=order,
-        )
-        first = _submit_gateway_baseline_once(
-            binding,
-            dispatch,
-            gateway=harness.gateway,
-            runtime_context=harness.context,
-            active_session=session,
-            order=order,
-        )
-        with pytest.raises(PaperExecutionCapabilityError, match="already issued"):
+        with pytest.raises(PaperExecutionCapabilityError, match="intent is invalid"):
             _issue_gateway_baseline_terminal_dispatch(
                 binding,
                 gateway=harness.gateway,
                 runtime_context=harness.context,
-                active_session=session,
-                order=order,
-            )
-        with pytest.raises(PaperExecutionCapabilityError, match="already consumed"):
-            _submit_gateway_baseline_once(
-                binding,
-                dispatch,
-                gateway=harness.gateway,
-                runtime_context=harness.context,
-                active_session=session,
+                intent=object(),
                 order=order,
             )
 
-    assert first.ok is True
-    assert len(executor.fills) == 1
+    assert executor.fills == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_pr2b2_paper_reduction_submitter.py
+++ b/tests/test_pr2b2_paper_reduction_submitter.py
@@ -26,6 +26,7 @@ from robo_trader.paper_reduction_submitter import (
     PaperReductionSubmitter,
     _bind_paper_reduction_submitter,
     _exact_limit_price,
+    _terminal_outcome,
 )
 from robo_trader.safety.journal import SafetyJournal
 from robo_trader.safety.models import (
@@ -55,15 +56,6 @@ from tests.paper_execution_test_support import bind_gateway_reduction_authority
 ACCOUNT_SCOPE = "acct_v1_" + hashlib.sha256(b"paper-submit-account").hexdigest()
 OTHER_ACCOUNT_SCOPE = "acct_v1_" + hashlib.sha256(b"other-account").hexdigest()
 NOW = datetime(2026, 7, 25, 15, 0, tzinfo=timezone.utc)
-
-
-def _filled_result(price: Decimal = Decimal("187.25")) -> ExecutionResult:
-    return ExecutionResult(
-        True,
-        "accepted",
-        float(price),
-        exact_fill_price=price,
-    )
 
 
 @dataclass
@@ -308,7 +300,6 @@ def test_binding_is_private_sealed_and_exact(tmp_path: Path) -> None:
 )
 def test_exact_mapping_and_one_execution_call(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
     side: OrderSide,
     order_type: OrderType,
     limit_price: Decimal | None,
@@ -320,15 +311,9 @@ def test_exact_mapping_and_one_execution_call(
         order_type=order_type,
         limit_price=limit_price,
     )
-    received: list[Order] = []
-    expected = _filled_result()
-
-    def simple(order: Order, *, _capability: object) -> ExecutionResult:
-        assert _capability is not None
-        received.append(order)
-        return expected
-
-    monkeypatch.setattr(case.executor, "_place_simple_order", simple)
+    if expected_price is None:
+        case.executor._execution_cache["AAPL"] = 187.25
+        case.executor._execution_cache_ts["AAPL"] = datetime.utcnow()
     outcome = _submit(case, _envelope(case))
     assert type(outcome) is LocalPaperTerminalOutcome
     assert outcome.order_ref == "paper-submit-one"
@@ -336,40 +321,41 @@ def test_exact_mapping_and_one_execution_call(
     assert outcome.requested_quantity == Decimal("3")
     assert outcome.filled_quantity == Decimal("3")
     assert outcome.remaining_quantity == Decimal("0")
-    assert outcome.exact_fill_price == Decimal("187.25")
+    assert outcome.exact_fill_price == (expected_price or Decimal("187.25"))
     assert outcome.provenance is LocalPaperOutcomeProvenance.LOCAL_PAPER_EXECUTOR
     assert outcome.terminal is True
-    assert received == [
-        Order(
-            symbol="AAPL",
-            quantity=3,
-            side=side.value,
-            price=expected_price,
-            order_ref="paper-submit-one",
-        )
-    ]
+    assert len(case.executor.fills) == 1
+    filled_order = next(iter(case.executor.fills.values()))[1]
+    assert filled_order == Order(
+        symbol="AAPL",
+        quantity=3,
+        side=side.value,
+        price=expected_price,
+        order_ref="paper-submit-one",
+    )
 
 
 @pytest.mark.parametrize("outcome", ["success", "rejection", "exception"])
 def test_replay_rejects_after_every_execution_outcome(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
     outcome: str,
 ) -> None:
-    case = _make_case(tmp_path)
+    case = _make_case(
+        tmp_path,
+        order_type=OrderType.MARKET if outcome == "rejection" else OrderType.LIMIT,
+        limit_price=None if outcome == "rejection" else Decimal("187.25"),
+    )
     envelope = _envelope(case)
-    calls: list[Order] = []
 
-    def simple(order: Order, *, _capability: object) -> ExecutionResult:
-        assert _capability is not None
-        calls.append(order)
-        if outcome == "exception":
+    class RaisingFills(dict):
+        attempts = 0
+
+        def __setitem__(self, _key, _value):
+            self.attempts += 1
             raise LookupError("injected paper failure")
-        if outcome == "rejection":
-            return ExecutionResult(False, "rejected")
-        return _filled_result()
 
-    monkeypatch.setattr(case.executor, "_place_simple_order", simple)
+    if outcome == "exception":
+        case.executor.fills = RaisingFills()
     if outcome == "exception":
         with pytest.raises(LookupError, match="injected"):
             _submit(case, envelope)
@@ -377,25 +363,20 @@ def test_replay_rejects_after_every_execution_outcome(
         _submit(case, envelope)
     with pytest.raises(PaperReductionSubmissionError, match="claim failed"):
         _submit(case, envelope)
-    assert len(calls) == 1
+    if outcome == "success":
+        assert len(case.executor.fills) == 1
+    elif outcome == "rejection":
+        assert case.executor.fills == {}
+    else:
+        assert case.executor.fills.attempts == 1
 
 
 def test_concurrent_envelope_claim_allows_exactly_one_call(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     case = _make_case(tmp_path)
     envelope = _envelope(case)
     barrier = threading.Barrier(2)
-    call_lock = threading.Lock()
-    calls = 0
-
-    def simple(order: Order, *, _capability: object) -> ExecutionResult:
-        assert _capability is not None
-        nonlocal calls
-        with call_lock:
-            calls += 1
-        return _filled_result()
 
     def submit() -> object:
         barrier.wait()
@@ -404,13 +385,12 @@ def test_concurrent_envelope_claim_allows_exactly_one_call(
         except PaperReductionSubmissionError as exc:
             return exc
 
-    monkeypatch.setattr(case.executor, "_place_simple_order", simple)
     with ThreadPoolExecutor(max_workers=2) as pool:
         results = list(pool.map(lambda _: submit(), range(2)))
 
     assert sum(type(result) is LocalPaperTerminalOutcome for result in results) == 1
     assert sum(type(result) is PaperReductionSubmissionError for result in results) == 1
-    assert calls == 1
+    assert len(case.executor.fills) == 1
 
 
 def test_proof_and_envelope_copies_forgery_and_replay_reject(
@@ -497,20 +477,15 @@ def test_tampered_final_proof_rejects_before_permit_consumption(
 )
 def test_tampered_envelope_scope_identity_and_fingerprint_reject_before_fill(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
     field_name: str,
     value: object,
 ) -> None:
     case = _make_case(tmp_path)
     envelope = _envelope(case)
     object.__setattr__(envelope, field_name, value)
-    monkeypatch.setattr(
-        case.executor,
-        "_place_simple_order",
-        lambda order, **kwargs: pytest.fail("execution must not be reached"),
-    )
     with pytest.raises(PaperReductionSubmissionError, match="claim failed"):
         _submit(case, envelope)
+    assert case.executor.fills == {}
 
 
 def test_cross_account_coordinator_cannot_claim_envelope(tmp_path: Path) -> None:
@@ -686,21 +661,16 @@ def test_narrow_explicit_invalidation_rejects_copies_foreign_and_replay(
 @pytest.mark.parametrize("slippage", [float("nan"), float("inf"), -0.01, 10_000.0])
 def test_nonfinite_or_out_of_bounds_slippage_rejects_before_execution(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
     slippage: float,
 ) -> None:
     case = _make_case(tmp_path)
     envelope = _envelope(case)
     case.executor.slippage_bps = slippage
-    monkeypatch.setattr(
-        case.executor,
-        "_place_simple_order",
-        lambda order, **kwargs: pytest.fail("execution must not be reached"),
-    )
     with pytest.raises(PaperReductionSubmissionError, match="slippage"):
         _submit(case, envelope)
     with pytest.raises(PaperReductionSubmissionError, match="claim failed"):
         _submit(case, envelope)
+    assert case.executor.fills == {}
 
 
 @pytest.mark.parametrize(
@@ -780,27 +750,13 @@ def test_preterminal_failure_retires_traceback_retained_final_allocation(
         ExecutionResult(False, "", None),
     ],
 )
-def test_malformed_execution_result_fails_closed_after_one_call(
+def test_malformed_execution_result_fails_closed(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
     bad_result: object,
 ) -> None:
     case = _make_case(tmp_path)
-    envelope = _envelope(case)
-    calls = 0
-
-    def simple(order: Order, *, _capability: object) -> object:
-        assert _capability is not None
-        nonlocal calls
-        calls += 1
-        return bad_result
-
-    monkeypatch.setattr(case.executor, "_place_simple_order", simple)
     with pytest.raises(PaperReductionSubmissionError):
-        _submit(case, envelope)
-    with pytest.raises(PaperReductionSubmissionError, match="claim failed"):
-        _submit(case, envelope)
-    assert calls == 1
+        _terminal_outcome(bad_result, case.request)  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize(
@@ -828,21 +784,13 @@ def test_nonfinite_decimal_price_rejects(price: Decimal) -> None:
 
 def test_limit_price_reaches_executor_as_exact_decimal(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     case = _make_case(tmp_path, limit_price=Decimal("123.45"))
-    received: list[Order] = []
-
-    def simple(order: Order, *, _capability: object) -> ExecutionResult:
-        assert _capability is not None
-        received.append(order)
-        assert type(order.price) is Decimal
-        assert order.price == Decimal("123.45")
-        return _filled_result(Decimal("123.45"))
-
-    monkeypatch.setattr(case.executor, "_place_simple_order", simple)
     _submit(case, _envelope(case))
-    assert len(received) == 1
+    assert len(case.executor.fills) == 1
+    filled_order = next(iter(case.executor.fills.values()))[1]
+    assert type(filled_order.price) is Decimal
+    assert filled_order.price == Decimal("123.45")
 
 
 def test_legacy_soft_gate_is_bypassed_only_after_consumed_authority(
@@ -882,13 +830,11 @@ def test_arbitrary_finite_slippage_returns_one_normalized_exact_terminal_fill(
 
 def test_rejection_returns_exact_terminal_zero_fill_metadata(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    case = _make_case(tmp_path)
-    monkeypatch.setattr(
-        case.executor,
-        "_place_simple_order",
-        lambda order, **kwargs: ExecutionResult(False, "rejected"),
+    case = _make_case(
+        tmp_path,
+        order_type=OrderType.MARKET,
+        limit_price=None,
     )
 
     outcome = _submit(case, _envelope(case))
@@ -903,31 +849,19 @@ def test_rejection_returns_exact_terminal_zero_fill_metadata(
     assert outcome.terminal is True
 
 
-def test_exact_fill_mismatch_fails_closed_after_single_submission(
+def test_exact_fill_mismatch_fails_closed(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     case = _make_case(tmp_path)
-    envelope = _envelope(case)
-    calls = 0
+    mismatched = ExecutionResult(
+        True,
+        "accepted",
+        187.25,
+        exact_fill_price=Decimal("187.24"),
+    )
 
-    def mismatched(order: Order, *, _capability: object) -> ExecutionResult:
-        assert _capability is not None
-        nonlocal calls
-        calls += 1
-        return ExecutionResult(
-            True,
-            "accepted",
-            187.25,
-            exact_fill_price=Decimal("187.24"),
-        )
-
-    monkeypatch.setattr(case.executor, "_place_simple_order", mismatched)
     with pytest.raises(PaperReductionSubmissionError, match="matching exact Decimal"):
-        _submit(case, envelope)
-    with pytest.raises(PaperReductionSubmissionError, match="claim failed"):
-        _submit(case, envelope)
-    assert calls == 1
+        _terminal_outcome(mismatched, case.request)  # type: ignore[arg-type]
 
 
 def test_adapter_has_one_capability_call_and_no_forbidden_route() -> None:

--- a/tests/test_pr2b2_paper_reduction_submitter.py
+++ b/tests/test_pr2b2_paper_reduction_submitter.py
@@ -13,9 +13,6 @@ from pathlib import Path
 import pytest
 
 from robo_trader.execution import ExecutionResult, Order, PaperExecutor
-from robo_trader.paper_execution_capability import (
-    _bind_paper_reduction_execution_authority,
-)
 from robo_trader.paper_reduction_submitter import (
     LocalPaperOrderStatus,
     LocalPaperOutcomeProvenance,
@@ -48,6 +45,7 @@ from robo_trader.safety.runtime import (
     SafetyRuntimeCoordinator,
     _assemble_coherent_safety_snapshot,
 )
+from tests.paper_execution_test_support import bind_gateway_reduction_authority
 
 ACCOUNT_SCOPE = "acct_v1_" + hashlib.sha256(b"paper-submit-account").hexdigest()
 OTHER_ACCOUNT_SCOPE = "acct_v1_" + hashlib.sha256(b"other-account").hexdigest()
@@ -205,7 +203,11 @@ def _make_case(
         portfolio_quantity=starting_quantity,
     )
     executor = PaperExecutor()
-    authority = _bind_paper_reduction_execution_authority(executor, "portfolio-a")
+    authority, _ = bind_gateway_reduction_authority(
+        executor,
+        "portfolio-a",
+        coordinator=coordinator,
+    )
     submitter = _bind_paper_reduction_submitter(
         executor,
         coordinator,
@@ -516,7 +518,11 @@ def test_cross_account_coordinator_cannot_claim_envelope(tmp_path: Path) -> None
     foreign_submitter = _bind_paper_reduction_submitter(
         second.executor,
         second.coordinator,
-        _bind_paper_reduction_execution_authority(second.executor, "portfolio-a"),
+        bind_gateway_reduction_authority(
+            second.executor,
+            "portfolio-a",
+            coordinator=second.coordinator,
+        )[0],
         "portfolio-a",
     )
     with pytest.raises(PaperReductionSubmissionError, match="claim failed"):
@@ -863,7 +869,13 @@ def test_adapter_has_one_capability_call_and_no_forbidden_route() -> None:
         for node in ast.walk(tree)
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
     ]
-    assert sum(node.func.attr == "_submit_reduction_once" for node in calls) == 1
+    named_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    ]
+    assert sum(node.func.id == "_submit_gateway_reduction_once" for node in named_calls) == 1
+    assert not any(node.func.attr == "_submit_reduction_once" for node in calls)
     assert not any(node.func.attr == "_place_simple_order" for node in calls)
     forbidden = {
         "place_order",

--- a/tests/test_pr2b2_paper_reduction_submitter.py
+++ b/tests/test_pr2b2_paper_reduction_submitter.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 import robo_trader.paper_reduction_submitter as submitter_module
+import robo_trader.safety.runtime as runtime_module
 from robo_trader.execution import ExecutionResult, Order, PaperExecutor
 from robo_trader.paper_execution_capability import (
     PaperExecutionCapabilityError,
@@ -269,6 +270,26 @@ def test_submitter_rejects_caller_quantity_that_differs_from_final_allocation(
             pre_position_quantity=Decimal("11"),
         )
     assert case.executor.fills == {}
+
+
+def test_one_envelope_cannot_mint_two_allocations_or_fill_twice(tmp_path: Path) -> None:
+    case = _make_case(tmp_path)
+    envelope = _envelope(case)
+
+    assert not hasattr(runtime_module, "_issue_claimed_paper_submission_allocation")
+
+    first = case.submitter._submit_once(
+        envelope,
+        pre_position_quantity=Decimal("10"),
+    )
+    with pytest.raises(PaperReductionSubmissionError, match="envelope claim failed"):
+        case.submitter._submit_once(
+            envelope,
+            pre_position_quantity=Decimal("10"),
+        )
+
+    assert first.status is LocalPaperOrderStatus.FILLED
+    assert len(case.executor.fills) == 1
 
 
 def test_binding_is_private_sealed_and_exact(tmp_path: Path) -> None:

--- a/tests/test_pr2b2_paper_reduction_submitter.py
+++ b/tests/test_pr2b2_paper_reduction_submitter.py
@@ -256,6 +256,21 @@ def _submit(case: RuntimeCase, envelope):
     )
 
 
+def test_submitter_rejects_caller_quantity_that_differs_from_final_allocation(
+    tmp_path: Path,
+) -> None:
+    case = _make_case(tmp_path)
+    envelope = _envelope(case)
+
+    assert envelope.pre_position_quantity == Decimal("10")
+    with pytest.raises(PaperExecutionCapabilityError, match="exact final allocation"):
+        case.submitter._submit_once(
+            envelope,
+            pre_position_quantity=Decimal("11"),
+        )
+    assert case.executor.fills == {}
+
+
 def test_binding_is_private_sealed_and_exact(tmp_path: Path) -> None:
     case = _make_case(tmp_path)
     with pytest.raises(PaperReductionSubmissionError, match="private bind"):
@@ -443,6 +458,7 @@ def test_proof_and_envelope_copies_forgery_and_replay_reject(
         ("con_id", 999),
         ("descriptor_fingerprint", "0" * 64),
         ("final_evidence_fingerprint", "1" * 64),
+        ("pre_position_quantity", Decimal("11")),
     ],
 )
 def test_tampered_final_proof_rejects_before_permit_consumption(
@@ -473,6 +489,7 @@ def test_tampered_final_proof_rejects_before_permit_consumption(
         ("con_id", 999),
         ("descriptor_fingerprint", "0" * 64),
         ("final_evidence_fingerprint", "1" * 64),
+        ("pre_position_quantity", Decimal("11")),
     ],
 )
 def test_tampered_envelope_scope_identity_and_fingerprint_reject_before_fill(

--- a/tests/test_pr2b2_paper_reduction_submitter.py
+++ b/tests/test_pr2b2_paper_reduction_submitter.py
@@ -12,7 +12,12 @@ from pathlib import Path
 
 import pytest
 
+import robo_trader.paper_reduction_submitter as submitter_module
 from robo_trader.execution import ExecutionResult, Order, PaperExecutor
+from robo_trader.paper_execution_capability import (
+    PaperExecutionCapabilityError,
+    _issue_gateway_reduction_terminal_dispatch,
+)
 from robo_trader.paper_reduction_submitter import (
     LocalPaperOrderStatus,
     LocalPaperOutcomeProvenance,
@@ -696,6 +701,70 @@ def test_nonfinite_or_out_of_bounds_slippage_rejects_before_execution(
         _submit(case, envelope)
     with pytest.raises(PaperReductionSubmissionError, match="claim failed"):
         _submit(case, envelope)
+
+
+@pytest.mark.parametrize(
+    "failure_point",
+    ["descriptor_snapshot", "contract_snapshot", "nan_slippage", "order_map"],
+)
+def test_preterminal_failure_retires_traceback_retained_final_allocation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_point: str,
+) -> None:
+    case = _make_case(tmp_path, key_suffix=f"retire-{failure_point}")
+    envelope = _envelope(case)
+    original_map = submitter_module._map_order
+
+    if failure_point == "descriptor_snapshot":
+        monkeypatch.setattr(
+            submitter_module,
+            "_snapshot_descriptor",
+            lambda _descriptor: (_ for _ in ()).throw(RuntimeError("snapshot descriptor")),
+        )
+    elif failure_point == "contract_snapshot":
+        monkeypatch.setattr(
+            submitter_module,
+            "_snapshot_contract",
+            lambda _contract: (_ for _ in ()).throw(RuntimeError("snapshot contract")),
+        )
+    elif failure_point == "nan_slippage":
+        case.executor.slippage_bps = float("nan")
+    else:
+        monkeypatch.setattr(
+            submitter_module,
+            "_map_order",
+            lambda _descriptor, _contract: (_ for _ in ()).throw(RuntimeError("order map")),
+        )
+
+    with pytest.raises((PaperReductionSubmissionError, RuntimeError)) as raised:
+        _submit(case, envelope)
+
+    retained: dict[str, object] = {}
+    traceback = raised.value.__traceback__
+    while traceback is not None:
+        for name in ("final_allocation", "descriptor", "contract"):
+            if name in traceback.tb_frame.f_locals:
+                retained[name] = traceback.tb_frame.f_locals[name]
+        traceback = traceback.tb_next
+    assert set(retained) == {"final_allocation", "descriptor", "contract"}
+
+    order = original_map(retained["descriptor"], retained["contract"])
+    authority = getattr(case.submitter, "_PaperReductionSubmitter__authority")
+    with pytest.raises(PaperExecutionCapabilityError, match="final allocation"):
+        _issue_gateway_reduction_terminal_dispatch(
+            authority,
+            submitter=case.submitter,
+            executor=case.executor,
+            coordinator=case.coordinator,
+            final_allocation=retained["final_allocation"],
+            descriptor=retained["descriptor"],
+            contract=retained["contract"],
+            order=order,
+            pre_position_quantity=Decimal("10"),
+        )
+
+    assert case.executor.fills == {}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pr2b2_paper_reduction_submitter.py
+++ b/tests/test_pr2b2_paper_reduction_submitter.py
@@ -13,7 +13,9 @@ from pathlib import Path
 import pytest
 
 from robo_trader.execution import ExecutionResult, Order, PaperExecutor
-from robo_trader.paper_execution_capability import _bind_paper_execution_authority
+from robo_trader.paper_execution_capability import (
+    _bind_paper_reduction_execution_authority,
+)
 from robo_trader.paper_reduction_submitter import (
     LocalPaperOrderStatus,
     LocalPaperOutcomeProvenance,
@@ -203,7 +205,7 @@ def _make_case(
         portfolio_quantity=starting_quantity,
     )
     executor = PaperExecutor()
-    authority = _bind_paper_execution_authority(executor, "portfolio-a")
+    authority = _bind_paper_reduction_execution_authority(executor, "portfolio-a")
     submitter = _bind_paper_reduction_submitter(
         executor,
         coordinator,
@@ -514,7 +516,7 @@ def test_cross_account_coordinator_cannot_claim_envelope(tmp_path: Path) -> None
     foreign_submitter = _bind_paper_reduction_submitter(
         second.executor,
         second.coordinator,
-        _bind_paper_execution_authority(second.executor, "portfolio-a"),
+        _bind_paper_reduction_execution_authority(second.executor, "portfolio-a"),
         "portfolio-a",
     )
     with pytest.raises(PaperReductionSubmissionError, match="claim failed"):

--- a/tests/test_pr2b2_paper_reduction_submitter.py
+++ b/tests/test_pr2b2_paper_reduction_submitter.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from robo_trader.execution import ExecutionResult, Order, PaperExecutor
+from robo_trader.paper_execution_capability import _bind_paper_execution_authority
 from robo_trader.paper_reduction_submitter import (
     LocalPaperOrderStatus,
     LocalPaperOutcomeProvenance,
@@ -202,7 +203,13 @@ def _make_case(
         portfolio_quantity=starting_quantity,
     )
     executor = PaperExecutor()
-    submitter = _bind_paper_reduction_submitter(executor, coordinator)
+    authority = _bind_paper_execution_authority(executor, "portfolio-a")
+    submitter = _bind_paper_reduction_submitter(
+        executor,
+        coordinator,
+        authority,
+        "portfolio-a",
+    )
     return RuntimeCase(
         coordinator,
         executor,
@@ -240,18 +247,36 @@ def _envelope(
     )
 
 
+def _submit(case: RuntimeCase, envelope):
+    pre_position = Decimal("-10") if case.request.side is OrderSide.BUY_TO_COVER else Decimal("10")
+    return case.submitter._submit_once(
+        envelope,
+        pre_position_quantity=pre_position,
+    )
+
+
 def test_binding_is_private_sealed_and_exact(tmp_path: Path) -> None:
     case = _make_case(tmp_path)
     with pytest.raises(PaperReductionSubmissionError, match="private bind"):
-        PaperReductionSubmitter(case.executor, case.coordinator)
+        PaperReductionSubmitter(case.executor, case.coordinator, object(), "portfolio-a")
 
     class PaperExecutorSubclass(PaperExecutor):
         pass
 
     with pytest.raises(PaperReductionSubmissionError, match="exactly PaperExecutor"):
-        _bind_paper_reduction_submitter(PaperExecutorSubclass(), case.coordinator)
+        _bind_paper_reduction_submitter(
+            PaperExecutorSubclass(),
+            case.coordinator,
+            object(),
+            "portfolio-a",
+        )
     with pytest.raises(PaperReductionSubmissionError, match="exactly SafetyRuntime"):
-        _bind_paper_reduction_submitter(case.executor, object())  # type: ignore[arg-type]
+        _bind_paper_reduction_submitter(
+            case.executor,
+            object(),
+            object(),
+            "portfolio-a",
+        )  # type: ignore[arg-type]
 
     assert not hasattr(case.submitter, "executor")
     with pytest.raises(AttributeError, match="sealed"):
@@ -289,12 +314,13 @@ def test_exact_mapping_and_one_execution_call(
     received: list[Order] = []
     expected = _filled_result()
 
-    def simple(order: Order) -> ExecutionResult:
+    def simple(order: Order, *, _capability: object) -> ExecutionResult:
+        assert _capability is not None
         received.append(order)
         return expected
 
     monkeypatch.setattr(case.executor, "_place_simple_order", simple)
-    outcome = case.submitter._submit_once(_envelope(case))
+    outcome = _submit(case, _envelope(case))
     assert type(outcome) is LocalPaperTerminalOutcome
     assert outcome.order_ref == "paper-submit-one"
     assert outcome.status is LocalPaperOrderStatus.FILLED
@@ -325,7 +351,8 @@ def test_replay_rejects_after_every_execution_outcome(
     envelope = _envelope(case)
     calls: list[Order] = []
 
-    def simple(order: Order) -> ExecutionResult:
+    def simple(order: Order, *, _capability: object) -> ExecutionResult:
+        assert _capability is not None
         calls.append(order)
         if outcome == "exception":
             raise LookupError("injected paper failure")
@@ -336,11 +363,11 @@ def test_replay_rejects_after_every_execution_outcome(
     monkeypatch.setattr(case.executor, "_place_simple_order", simple)
     if outcome == "exception":
         with pytest.raises(LookupError, match="injected"):
-            case.submitter._submit_once(envelope)
+            _submit(case, envelope)
     else:
-        case.submitter._submit_once(envelope)
+        _submit(case, envelope)
     with pytest.raises(PaperReductionSubmissionError, match="claim failed"):
-        case.submitter._submit_once(envelope)
+        _submit(case, envelope)
     assert len(calls) == 1
 
 
@@ -354,7 +381,8 @@ def test_concurrent_envelope_claim_allows_exactly_one_call(
     call_lock = threading.Lock()
     calls = 0
 
-    def simple(order: Order) -> ExecutionResult:
+    def simple(order: Order, *, _capability: object) -> ExecutionResult:
+        assert _capability is not None
         nonlocal calls
         with call_lock:
             calls += 1
@@ -363,7 +391,7 @@ def test_concurrent_envelope_claim_allows_exactly_one_call(
     def submit() -> object:
         barrier.wait()
         try:
-            return case.submitter._submit_once(envelope)
+            return _submit(case, envelope)
         except PaperReductionSubmissionError as exc:
             return exc
 
@@ -408,7 +436,7 @@ def test_proof_and_envelope_copies_forgery_and_replay_reject(
         copy.copy(envelope)
     envelope_clone = replace(envelope)
     with pytest.raises(PaperReductionSubmissionError, match="claim failed"):
-        case.submitter._submit_once(envelope_clone)
+        _submit(case, envelope_clone)
 
     values = {
         definition.name: getattr(envelope, definition.name) for definition in fields(envelope)
@@ -470,10 +498,10 @@ def test_tampered_envelope_scope_identity_and_fingerprint_reject_before_fill(
     monkeypatch.setattr(
         case.executor,
         "_place_simple_order",
-        lambda order: pytest.fail("execution must not be reached"),
+        lambda order, **kwargs: pytest.fail("execution must not be reached"),
     )
     with pytest.raises(PaperReductionSubmissionError, match="claim failed"):
-        case.submitter._submit_once(envelope)
+        _submit(case, envelope)
 
 
 def test_cross_account_coordinator_cannot_claim_envelope(tmp_path: Path) -> None:
@@ -486,9 +514,14 @@ def test_cross_account_coordinator_cannot_claim_envelope(tmp_path: Path) -> None
     foreign_submitter = _bind_paper_reduction_submitter(
         second.executor,
         second.coordinator,
+        _bind_paper_execution_authority(second.executor, "portfolio-a"),
+        "portfolio-a",
     )
     with pytest.raises(PaperReductionSubmissionError, match="claim failed"):
-        foreign_submitter._submit_once(_envelope(first))
+        foreign_submitter._submit_once(
+            _envelope(first),
+            pre_position_quantity=Decimal("10"),
+        )
 
 
 def test_final_smaller_exposure_rejects_and_invalidates_authorization(
@@ -649,12 +682,12 @@ def test_nonfinite_or_out_of_bounds_slippage_rejects_before_execution(
     monkeypatch.setattr(
         case.executor,
         "_place_simple_order",
-        lambda order: pytest.fail("execution must not be reached"),
+        lambda order, **kwargs: pytest.fail("execution must not be reached"),
     )
     with pytest.raises(PaperReductionSubmissionError, match="slippage"):
-        case.submitter._submit_once(envelope)
+        _submit(case, envelope)
     with pytest.raises(PaperReductionSubmissionError, match="claim failed"):
-        case.submitter._submit_once(envelope)
+        _submit(case, envelope)
 
 
 @pytest.mark.parametrize(
@@ -679,16 +712,17 @@ def test_malformed_execution_result_fails_closed_after_one_call(
     envelope = _envelope(case)
     calls = 0
 
-    def simple(order: Order) -> object:
+    def simple(order: Order, *, _capability: object) -> object:
+        assert _capability is not None
         nonlocal calls
         calls += 1
         return bad_result
 
     monkeypatch.setattr(case.executor, "_place_simple_order", simple)
     with pytest.raises(PaperReductionSubmissionError):
-        case.submitter._submit_once(envelope)
+        _submit(case, envelope)
     with pytest.raises(PaperReductionSubmissionError, match="claim failed"):
-        case.submitter._submit_once(envelope)
+        _submit(case, envelope)
     assert calls == 1
 
 
@@ -706,7 +740,7 @@ def test_unsafe_decimal_price_rejects(
 ) -> None:
     case = _make_case(tmp_path, limit_price=price)
     with pytest.raises(PaperReductionSubmissionError, match=message):
-        case.submitter._submit_once(_envelope(case))
+        _submit(case, _envelope(case))
 
 
 @pytest.mark.parametrize("price", [Decimal("NaN"), Decimal("Infinity")])
@@ -722,14 +756,15 @@ def test_limit_price_reaches_executor_as_exact_decimal(
     case = _make_case(tmp_path, limit_price=Decimal("123.45"))
     received: list[Order] = []
 
-    def simple(order: Order) -> ExecutionResult:
+    def simple(order: Order, *, _capability: object) -> ExecutionResult:
+        assert _capability is not None
         received.append(order)
         assert type(order.price) is Decimal
         assert order.price == Decimal("123.45")
         return _filled_result(Decimal("123.45"))
 
     monkeypatch.setattr(case.executor, "_place_simple_order", simple)
-    case.submitter._submit_once(_envelope(case))
+    _submit(case, _envelope(case))
     assert len(received) == 1
 
 
@@ -747,7 +782,7 @@ def test_legacy_soft_gate_is_bypassed_only_after_consumed_authority(
     assert normal.ok is False
     assert case.executor.fills == {}
 
-    result = case.submitter._submit_once(_envelope(case))
+    result = _submit(case, _envelope(case))
     assert result.ok is True
     assert result.fill_price == 187.25
     assert len(case.executor.fills) == 1
@@ -759,7 +794,7 @@ def test_arbitrary_finite_slippage_returns_one_normalized_exact_terminal_fill(
     case = _make_case(tmp_path)
     case.executor.slippage_bps = 0.3333333333333333
 
-    outcome = case.submitter._submit_once(_envelope(case))
+    outcome = _submit(case, _envelope(case))
 
     assert outcome.ok is True
     assert outcome.exact_fill_price is not None
@@ -776,10 +811,10 @@ def test_rejection_returns_exact_terminal_zero_fill_metadata(
     monkeypatch.setattr(
         case.executor,
         "_place_simple_order",
-        lambda order: ExecutionResult(False, "rejected"),
+        lambda order, **kwargs: ExecutionResult(False, "rejected"),
     )
 
-    outcome = case.submitter._submit_once(_envelope(case))
+    outcome = _submit(case, _envelope(case))
 
     assert outcome.status is LocalPaperOrderStatus.REJECTED
     assert outcome.ok is False
@@ -799,7 +834,8 @@ def test_exact_fill_mismatch_fails_closed_after_single_submission(
     envelope = _envelope(case)
     calls = 0
 
-    def mismatched(order: Order) -> ExecutionResult:
+    def mismatched(order: Order, *, _capability: object) -> ExecutionResult:
+        assert _capability is not None
         nonlocal calls
         calls += 1
         return ExecutionResult(
@@ -811,13 +847,13 @@ def test_exact_fill_mismatch_fails_closed_after_single_submission(
 
     monkeypatch.setattr(case.executor, "_place_simple_order", mismatched)
     with pytest.raises(PaperReductionSubmissionError, match="matching exact Decimal"):
-        case.submitter._submit_once(envelope)
+        _submit(case, envelope)
     with pytest.raises(PaperReductionSubmissionError, match="claim failed"):
-        case.submitter._submit_once(envelope)
+        _submit(case, envelope)
     assert calls == 1
 
 
-def test_adapter_has_one_simple_call_and_no_forbidden_route() -> None:
+def test_adapter_has_one_capability_call_and_no_forbidden_route() -> None:
     module_path = Path(__file__).parents[1] / "robo_trader" / "paper_reduction_submitter.py"
     tree = ast.parse(module_path.read_text(encoding="utf-8"))
     calls = [
@@ -825,7 +861,8 @@ def test_adapter_has_one_simple_call_and_no_forbidden_route() -> None:
         for node in ast.walk(tree)
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
     ]
-    assert sum(node.func.attr == "_place_simple_order" for node in calls) == 1
+    assert sum(node.func.attr == "_submit_reduction_once" for node in calls) == 1
+    assert not any(node.func.attr == "_place_simple_order" for node in calls)
     forbidden = {
         "place_order",
         "place_order_async",

--- a/tests/test_pr2b2_runner_routing.py
+++ b/tests/test_pr2b2_runner_routing.py
@@ -515,6 +515,101 @@ async def test_entry_dispatch_occurs_inside_gateway_serialization(
 
 
 @pytest.mark.asyncio
+async def test_entry_terminal_gate_rechecks_lock_file_after_equity_await(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("robo_trader.runner_async.is_extended_hours", lambda: False)
+    (tmp_path / "data").mkdir()
+    gateway, probe = _exact_gateway()
+    runner = _runner(gateway)
+
+    async def equity_then_lock(_prices) -> Decimal:
+        (tmp_path / "data" / "kill_switch.lock").touch()
+        return Decimal("100000")
+
+    runner.portfolio.equity = AsyncMock(side_effect=equity_then_lock)
+
+    result = await _place(runner, _order("BUY"))
+
+    assert result.ok is False
+    assert "terminal safety gate" in result.message
+    assert "kill switch lock active" in result.message.lower()
+    assert probe.enter_count == 1
+    assert probe.exit_count == 1
+    gateway.submit_baseline_entry.assert_not_called()
+    runner.executor.place_order.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_entry_terminal_gate_rechecks_in_memory_kill_switch_after_equity_await(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("robo_trader.runner_async.is_extended_hours", lambda: False)
+    gateway, _ = _exact_gateway()
+    runner = _runner(gateway)
+
+    async def equity_then_trigger(_prices) -> Decimal:
+        runner.advanced_risk.kill_switch.triggered = True
+        runner.advanced_risk.kill_switch.trigger_reason = "Loss limit crossed"
+        return Decimal("100000")
+
+    runner.portfolio.equity = AsyncMock(side_effect=equity_then_trigger)
+
+    result = await _place(runner, _order("BUY"))
+
+    assert result.ok is False
+    assert "terminal safety gate" in result.message
+    assert "loss limit crossed" in result.message.lower()
+    gateway.submit_baseline_entry.assert_not_called()
+    runner.executor.place_order.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_entry_fails_closed_when_lock_file_state_is_unreadable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gateway, _ = _exact_gateway()
+    runner = _runner(gateway)
+
+    def unreadable_lock(_path: Path):
+        raise PermissionError("lock metadata denied")
+
+    monkeypatch.setattr(Path, "lstat", unreadable_lock)
+
+    result = await _place(runner, _order("BUY"))
+
+    assert result.ok is False
+    assert "lock state unavailable" in result.message.lower()
+    gateway.serialize_entry.assert_not_called()
+    gateway.submit_baseline_entry.assert_not_called()
+    runner.executor.place_order.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reduction_still_bypasses_entry_only_lock_file_gate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "data").mkdir()
+    (tmp_path / "data" / "kill_switch.lock").touch()
+    expected = ExecutionResult(True, "gateway reduction filled", 99.5)
+    gateway, _ = _exact_gateway(reduction_result=expected)
+    runner = _runner(gateway)
+
+    result = await _place(runner, _order("SELL"))
+
+    assert result is expected
+    gateway.submit_reduction.assert_awaited_once()
+    gateway.submit_baseline_entry.assert_not_called()
+    runner.executor.place_order.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_new_short_rejects_before_gateway_or_executor() -> None:
     gateway, _ = _exact_gateway()
     runner = _runner(gateway)

--- a/tests/test_pr2b2_runner_routing.py
+++ b/tests/test_pr2b2_runner_routing.py
@@ -248,6 +248,7 @@ def _order(side: str) -> Order:
         side=side,
         price=100.0,
         order_ref=f"routing-{side.lower()}",
+        intent_source="baseline_sma" if side == "BUY" else "",
     )
 
 
@@ -305,7 +306,7 @@ def test_runner_database_fallback_uses_validated_contract_path() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("side", ["BUY", "SELL_SHORT"])
+@pytest.mark.parametrize("side", ["BUY"])
 @pytest.mark.parametrize(
     ("blocker", "expected_message"),
     [
@@ -466,7 +467,7 @@ async def test_transport_abort_blocks_reduction_before_gateway(side: str) -> Non
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("side", ["BUY", "SELL_SHORT"])
+@pytest.mark.parametrize("side", ["BUY"])
 async def test_entry_dispatch_occurs_inside_gateway_serialization(
     side: str,
     monkeypatch,
@@ -494,7 +495,21 @@ async def test_entry_dispatch_occurs_inside_gateway_serialization(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("side", ["BUY", "SELL_SHORT"])
+async def test_new_short_rejects_before_gateway_or_executor() -> None:
+    gateway, _ = _exact_gateway()
+    runner = _runner(gateway)
+
+    result = await runner._place_order_with_circuit_breaker(_order("SELL_SHORT"))
+
+    assert result.ok is False
+    assert "blocks new short exposure" in result.message
+    gateway.submit_reduction.assert_not_awaited()
+    gateway.serialize_entry.assert_not_called()
+    runner.executor.place_order.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("side", ["BUY"])
 @pytest.mark.parametrize("gateway_kind", ["missing", "wrong_type", "stopped"])
 async def test_entries_require_exact_started_account_gateway(
     side: str,
@@ -524,7 +539,7 @@ async def test_entries_require_exact_started_account_gateway(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("side", ["BUY", "SELL_SHORT"])
+@pytest.mark.parametrize("side", ["BUY"])
 async def test_entries_reach_gateway_when_diagnostic_recovery_is_pending(
     side: str,
     monkeypatch,

--- a/tests/test_pr2b2_runner_routing.py
+++ b/tests/test_pr2b2_runner_routing.py
@@ -569,6 +569,62 @@ async def test_entry_terminal_gate_rechecks_in_memory_kill_switch_after_equity_a
 
 
 @pytest.mark.asyncio
+async def test_entry_terminal_gate_rechecks_lock_file_after_timer_enters(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("robo_trader.runner_async.is_extended_hours", lambda: False)
+    (tmp_path / "data").mkdir()
+    gateway, probe = _exact_gateway()
+    runner = _runner(gateway)
+
+    def start_timer_then_lock(*_args, **_kwargs) -> None:
+        (tmp_path / "data" / "kill_switch.lock").touch()
+
+    runner.monitor.start_timer.side_effect = start_timer_then_lock
+
+    result = await _place(runner, _order("BUY"))
+
+    assert result.ok is False
+    assert "terminal safety gate" in result.message
+    assert "kill switch lock active" in result.message.lower()
+    assert probe.enter_count == 1
+    assert probe.exit_count == 1
+    runner.monitor.start_timer.assert_called_once()
+    runner.monitor.end_timer.assert_called_once()
+    gateway.submit_baseline_entry.assert_not_called()
+    runner.executor.place_order.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_entry_terminal_gate_rechecks_in_memory_kill_switch_after_timer_enters(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("robo_trader.runner_async.is_extended_hours", lambda: False)
+    gateway, _ = _exact_gateway()
+    runner = _runner(gateway)
+
+    def start_timer_then_trigger(*_args, **_kwargs) -> None:
+        runner.advanced_risk.kill_switch.triggered = True
+        runner.advanced_risk.kill_switch.trigger_reason = "Loss limit crossed"
+
+    runner.monitor.start_timer.side_effect = start_timer_then_trigger
+
+    result = await _place(runner, _order("BUY"))
+
+    assert result.ok is False
+    assert "terminal safety gate" in result.message
+    assert "loss limit crossed" in result.message.lower()
+    runner.monitor.start_timer.assert_called_once()
+    runner.monitor.end_timer.assert_called_once()
+    gateway.submit_baseline_entry.assert_not_called()
+    runner.executor.place_order.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_entry_fails_closed_when_lock_file_state_is_unreadable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_pr2b2_runner_routing.py
+++ b/tests/test_pr2b2_runner_routing.py
@@ -71,6 +71,9 @@ def _exact_gateway(
     gateway.submit_reduction = AsyncMock(
         return_value=reduction_result or ExecutionResult(True, "gateway reduction filled", 100.0)
     )
+    gateway.submit_baseline_entry = MagicMock(
+        return_value=ExecutionResult(True, "entry filled", 100.0)
+    )
     now = datetime.now(timezone.utc)
     probe = _EntrySerializationProbe(
         BrokerProtectiveQuote(
@@ -106,6 +109,8 @@ def _runner(
 ) -> AsyncRunner:
     runner = AsyncRunner.__new__(AsyncRunner)
     runner.portfolio_id = "default"
+    runner._baseline_entry_handle = object()
+    runner._baseline_entry_intent = object()
     runner.paper_reduction_gateway = gateway
     runner._order_admission_lock = asyncio.Lock()
     runner._symbol_cycle_abort_event = asyncio.Event()
@@ -248,7 +253,13 @@ def _order(side: str) -> Order:
         side=side,
         price=100.0,
         order_ref=f"routing-{side.lower()}",
-        intent_source="baseline_sma" if side == "BUY" else "",
+    )
+
+
+async def _place(runner: AsyncRunner, order: Order):
+    return await runner._place_order_with_circuit_breaker(
+        order,
+        _entry_intent=(runner._baseline_entry_intent if order.side == "BUY" else None),
     )
 
 
@@ -330,7 +341,7 @@ async def test_entries_remain_blocked_before_gateway_or_executor(
         circuit_allows=blocker != "circuit",
     )
 
-    result = await runner._place_order_with_circuit_breaker(_order(side))
+    result = await _place(runner, _order(side))
 
     assert result.ok is False
     assert expected_message in result.message
@@ -355,7 +366,7 @@ async def test_reductions_bypass_entry_soft_blocks_through_gateway_once(
         circuit_allows=False,
     )
 
-    result = await runner._place_order_with_circuit_breaker(_order(side))
+    result = await _place(runner, _order(side))
 
     assert result is expected
     gateway.submit_reduction.assert_awaited_once_with(
@@ -387,7 +398,7 @@ async def test_reductions_require_exact_started_account_gateway(
         gateway, _ = _exact_gateway(started=False)
     runner = _runner(gateway)
 
-    result = await runner._place_order_with_circuit_breaker(_order(side))
+    result = await _place(runner, _order(side))
 
     assert result.ok is False
     assert "safety gateway unavailable" in result.message.lower()
@@ -408,7 +419,7 @@ async def test_reductions_reach_gateway_when_diagnostic_recovery_is_pending(side
     )
     runner = _runner(gateway)
 
-    result = await runner._place_order_with_circuit_breaker(_order(side))
+    result = await _place(runner, _order(side))
 
     assert result is expected
     gateway.submit_reduction.assert_awaited_once_with(
@@ -425,7 +436,7 @@ async def test_reductions_require_live_protective_feed(side: str) -> None:
     gateway, _ = _exact_gateway()
     runner = _runner(gateway, live_feed=False)
 
-    result = await runner._place_order_with_circuit_breaker(_order(side))
+    result = await _place(runner, _order(side))
 
     assert result.ok is False
     assert "live protective feed unavailable" in result.message.lower()
@@ -445,7 +456,7 @@ async def test_reduction_gateway_failure_fails_closed() -> None:
         PaperReductionGatewayError,
         match="final evidence no longer authorizes reduction",
     ):
-        await runner._place_order_with_circuit_breaker(_order("SELL"))
+        await _place(runner, _order("SELL"))
 
     gateway.submit_reduction.assert_awaited_once()
     runner.executor.place_order.assert_not_called()
@@ -458,7 +469,7 @@ async def test_transport_abort_blocks_reduction_before_gateway(side: str) -> Non
     runner = _runner(gateway)
     runner._symbol_cycle_abort_event.set()
 
-    result = await runner._place_order_with_circuit_breaker(_order(side))
+    result = await _place(runner, _order(side))
 
     assert result.ok is False
     assert "broker transport unavailable" in result.message.lower()
@@ -476,22 +487,31 @@ async def test_entry_dispatch_occurs_inside_gateway_serialization(
     gateway, probe = _exact_gateway()
     runner = _runner(gateway)
 
-    def place_order(order: Order) -> ExecutionResult:
-        assert order == _order(side)
+    def submit_baseline_entry(**kwargs) -> ExecutionResult:
         assert probe.active is True
+        assert kwargs["portfolio_id"] == "default"
+        assert kwargs["intent"] is runner._baseline_entry_intent
+        assert kwargs["order"] == Order(
+            symbol="AAPL",
+            quantity=2,
+            side="BUY",
+            price=Decimal("100.0"),
+            order_ref="routing-buy",
+        )
         return ExecutionResult(True, "entry filled", 100.0)
 
-    runner.executor.place_order.side_effect = place_order
+    gateway.submit_baseline_entry.side_effect = submit_baseline_entry
 
-    result = await runner._place_order_with_circuit_breaker(_order(side))
+    result = await _place(runner, _order(side))
 
     assert result.ok is True
     assert probe.active is False
     assert probe.enter_count == 1
     assert probe.exit_count == 1
-    gateway.serialize_entry.assert_called_once_with("AAPL")
+    gateway.serialize_entry.assert_called_once_with("AAPL", portfolio_id="default")
     gateway.submit_reduction.assert_not_awaited()
-    runner.executor.place_order.assert_called_once_with(_order(side))
+    gateway.submit_baseline_entry.assert_called_once()
+    runner.executor.place_order.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -499,7 +519,7 @@ async def test_new_short_rejects_before_gateway_or_executor() -> None:
     gateway, _ = _exact_gateway()
     runner = _runner(gateway)
 
-    result = await runner._place_order_with_circuit_breaker(_order("SELL_SHORT"))
+    result = await _place(runner, _order("SELL_SHORT"))
 
     assert result.ok is False
     assert "blocks new short exposure" in result.message
@@ -528,7 +548,7 @@ async def test_entries_require_exact_started_account_gateway(
         gateway, _ = _exact_gateway(started=False)
     runner = _runner(gateway)
 
-    result = await runner._place_order_with_circuit_breaker(_order(side))
+    result = await _place(runner, _order(side))
 
     assert result.ok is False
     assert "safety gateway unavailable" in result.message.lower()
@@ -548,13 +568,14 @@ async def test_entries_reach_gateway_when_diagnostic_recovery_is_pending(
     gateway, probe = _exact_gateway(started=False, recovery_required=True)
     runner = _runner(gateway)
 
-    result = await runner._place_order_with_circuit_breaker(_order(side))
+    result = await _place(runner, _order(side))
 
     assert result.ok is True
-    gateway.serialize_entry.assert_called_once_with("AAPL")
+    gateway.serialize_entry.assert_called_once_with("AAPL", portfolio_id="default")
     assert probe.enter_count == 1
     assert probe.exit_count == 1
-    runner.executor.place_order.assert_called_once_with(_order(side))
+    gateway.submit_baseline_entry.assert_called_once()
+    runner.executor.place_order.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -563,7 +584,7 @@ async def test_unsupported_sides_reject_before_any_dispatch(side: str) -> None:
     gateway, _ = _exact_gateway()
     runner = _runner(gateway)
 
-    result = await runner._place_order_with_circuit_breaker(_order(side))
+    result = await _place(runner, _order(side))
 
     assert result.ok is False
     assert result.message == "Unsupported order side"

--- a/tests/test_pr2b3_emergency_protection.py
+++ b/tests/test_pr2b3_emergency_protection.py
@@ -28,6 +28,8 @@ def _minimal_runner() -> AsyncRunner:
     runner.advanced_risk = None
     runner.running = True
     runner.stop_loss_monitor = None
+    runner._baseline_entry_handle = object()
+    runner._baseline_entry_intent = object()
     return runner
 
 
@@ -93,8 +95,8 @@ async def test_entry_waiting_at_final_admission_is_rejected_after_freeze():
                 quantity=1,
                 side="BUY",
                 price=100.0,
-                intent_source="baseline_sma",
-            )
+            ),
+            _entry_intent=runner._baseline_entry_intent,
         )
     )
     await asyncio.sleep(0)

--- a/tests/test_pr2b3_emergency_protection.py
+++ b/tests/test_pr2b3_emergency_protection.py
@@ -88,7 +88,13 @@ async def test_entry_waiting_at_final_admission_is_rejected_after_freeze():
     await runner._order_admission_lock.acquire()
     order_task = asyncio.create_task(
         runner._place_order_with_circuit_breaker(
-            Order(symbol="NVDA", quantity=1, side="BUY", price=100.0)
+            Order(
+                symbol="NVDA",
+                quantity=1,
+                side="BUY",
+                price=100.0,
+                intent_source="baseline_sma",
+            )
         )
     )
     await asyncio.sleep(0)

--- a/tests/test_pr2b3_gateway_failure_injection.py
+++ b/tests/test_pr2b3_gateway_failure_injection.py
@@ -15,7 +15,7 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 import pytest_asyncio
 
-from robo_trader.execution import ExecutionResult, PaperExecutor
+from robo_trader.execution import PaperExecutor
 from robo_trader.paper_reduction_gateway import (
     PaperReductionGateway,
     PaperReductionGatewayError,
@@ -426,13 +426,16 @@ async def test_terminal_rejection_releases_once_and_restart_cannot_retry(
     harness = failure_harness
     rejection_calls = 0
 
-    def reject(_executor, _order, *, _capability):
+    def reject(_submitter, _envelope, *, pre_position_quantity):
         nonlocal rejection_calls
-        assert _capability is not None
+        assert pre_position_quantity == Decimal("7")
         rejection_calls += 1
-        return ExecutionResult(False, "injected definitive rejection")
+        return _unfilled_terminal_outcome(
+            order_ref="terminal-rejection-survives-restart",
+            status=LocalPaperOrderStatus.REJECTED,
+        )
 
-    monkeypatch.setattr(PaperExecutor, "_place_simple_order", reject)
+    monkeypatch.setattr(PaperReductionSubmitter, "_submit_once", reject)
     first_executor = PaperExecutor()
     await _bind_runtime(harness, "portfolio-a", first_executor)
     _install_broker_boundary(harness, monkeypatch)

--- a/tests/test_pr2b3_gateway_failure_injection.py
+++ b/tests/test_pr2b3_gateway_failure_injection.py
@@ -210,8 +210,9 @@ async def test_partial_nonterminal_and_unknown_outcomes_are_quarantined(
     order_ref = f"unsafe-{status.value.lower()}"
     submit_calls = 0
 
-    def injected_submit(_submitter, _envelope):
+    def injected_submit(_submitter, _envelope, *, pre_position_quantity):
         nonlocal submit_calls
+        assert pre_position_quantity == Decimal("7")
         submit_calls += 1
         return _unsafe_outcome(order_ref=order_ref, status=status)
 
@@ -251,8 +252,9 @@ async def test_failure_after_durable_dispatch_before_executor_submit_blocks_rest
     _install_broker_boundary(harness, monkeypatch)
     submit_calls = 0
 
-    def fail_before_executor(_submitter, _envelope):
+    def fail_before_executor(_submitter, _envelope, *, pre_position_quantity):
         nonlocal submit_calls
+        assert pre_position_quantity == Decimal("7")
         submit_calls += 1
         raise RuntimeError("injected failure before executor submit")
 
@@ -424,8 +426,9 @@ async def test_terminal_rejection_releases_once_and_restart_cannot_retry(
     harness = failure_harness
     rejection_calls = 0
 
-    def reject(_executor, _order):
+    def reject(_executor, _order, *, _capability):
         nonlocal rejection_calls
+        assert _capability is not None
         rejection_calls += 1
         return ExecutionResult(False, "injected definitive rejection")
 
@@ -501,8 +504,9 @@ async def test_unfilled_terminal_status_releases_exactly_once(
     order_ref = f"terminal-{status.value.lower()}"
     submit_calls = 0
 
-    def terminal_without_fill(_submitter, _envelope):
+    def terminal_without_fill(_submitter, _envelope, *, pre_position_quantity):
         nonlocal submit_calls
+        assert pre_position_quantity == Decimal("7")
         submit_calls += 1
         return _unfilled_terminal_outcome(order_ref=order_ref, status=status)
 

--- a/tests/test_pr7_gatea_containment.py
+++ b/tests/test_pr7_gatea_containment.py
@@ -1,0 +1,188 @@
+"""Machine-enforced containment for the narrow Gate-A paper profile."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+import robo_trader.execution as execution_module
+from robo_trader.config import Config
+from robo_trader.core.engine import TradingEngine
+from robo_trader.execution import Order, PaperExecutor
+from robo_trader.gatea_containment import (
+    ALLOWED_STRATEGIES,
+    GateAContainmentError,
+    assert_gate_a_runner_options,
+    validate_gate_a_environment,
+    validate_gate_a_order,
+)
+from robo_trader.runner.signal_generator import SignalGenerator
+from robo_trader.runner.trade_executor import TradeExecutor
+
+
+@pytest.mark.parametrize(
+    "flag",
+    [
+        "AI_TRADING_ENABLED",
+        "EXECUTION_SHORT_SELLING",
+        "ML_ENHANCED_ENABLED",
+        "ML_SELECTOR_ENABLED",
+        "RISK_TAKE_PROFIT_ENABLED",
+        "SMART_EXECUTION_ENABLED",
+    ],
+)
+def test_gate_a_rejects_every_disabled_environment_capability(flag: str) -> None:
+    with pytest.raises(GateAContainmentError, match=flag):
+        validate_gate_a_environment({flag: "true"})
+
+
+@pytest.mark.parametrize(
+    "strategy_value",
+    ["pairs_trading", "stat_arbitrage", "mean_reversion", "baseline_sma,pairs_trading"],
+)
+def test_gate_a_rejects_nonbaseline_strategy_configuration(strategy_value: str) -> None:
+    with pytest.raises(GateAContainmentError, match="requires exactly baseline_sma"):
+        validate_gate_a_environment({"STRATEGY_ENABLED": strategy_value})
+
+
+def test_gate_a_rejects_contradictory_strategy_aliases() -> None:
+    with pytest.raises(GateAContainmentError, match="contradict"):
+        validate_gate_a_environment(
+            {
+                "STRATEGY_ENABLED": "baseline_sma",
+                "STRATEGY_ENABLED_STRATEGIES": "pairs_trading",
+            }
+        )
+
+
+def test_gate_a_safe_environment_has_one_strategy() -> None:
+    profile = validate_gate_a_environment({})
+
+    assert profile.enabled_strategies == ALLOWED_STRATEGIES
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"execution": {"enable_short_selling": True}},
+        {"execution": {"use_smart_execution": True}},
+        {"strategy": {"enabled_strategies": ["pairs_trading"]}},
+        {"strategy": {"enable_ai_discovery": True}},
+        {"strategy": {"enable_ml_selectors": True}},
+        {"risk": {"enable_take_profit": True}},
+    ],
+)
+def test_direct_config_contradictions_fail_closed(override: dict) -> None:
+    with pytest.raises(ValidationError, match="Gate-A containment contradiction"):
+        Config(**override)
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"use_ml_strategy": True, "use_ml_enhanced": False, "use_smart_execution": False},
+        {"use_ml_strategy": False, "use_ml_enhanced": True, "use_smart_execution": False},
+        {"use_ml_strategy": False, "use_ml_enhanced": False, "use_smart_execution": True},
+    ],
+)
+def test_runner_constructor_options_cannot_reenable_quarantined_paths(options: dict) -> None:
+    with pytest.raises(GateAContainmentError):
+        assert_gate_a_runner_options(env={}, **options)
+
+
+@pytest.mark.parametrize(
+    ("side", "source", "take_profit", "expected_fragment"),
+    [
+        ("BUY", "pairs_trading", None, "not the baseline"),
+        ("BUY", "stat_arbitrage", None, "not the baseline"),
+        ("BUY", "ai_discovery", None, "not the baseline"),
+        ("BUY", "ml_selector", None, "not the baseline"),
+        ("BUY", "", None, "not the baseline"),
+        ("SELL_SHORT", "baseline_sma", None, "blocks new short exposure"),
+        ("BUY", "baseline_sma", 110.0, "take-profit"),
+    ],
+)
+def test_disabled_paths_cannot_create_entry_intent(
+    side: str,
+    source: str,
+    take_profit: float | None,
+    expected_fragment: str,
+) -> None:
+    admitted, reason = validate_gate_a_order(
+        side=side,
+        intent_source=source,
+        take_profit=take_profit,
+    )
+
+    assert admitted is False
+    assert expected_fragment in reason
+
+
+@pytest.mark.parametrize("side", ["SELL", "BUY_TO_COVER"])
+def test_semantic_reductions_remain_admitted_without_entry_source(side: str) -> None:
+    admitted, reason = validate_gate_a_order(
+        side=side,
+        intent_source="",
+        take_profit=None,
+    )
+
+    assert admitted is True
+    assert reason == "Gate-A semantic reduction"
+
+
+def test_paper_executor_rechecks_containment_at_submission(monkeypatch) -> None:
+    monkeypatch.setattr(
+        execution_module,
+        "os",
+        SimpleNamespace(path=SimpleNamespace(exists=lambda _path: False)),
+    )
+    executor = PaperExecutor(slippage_bps=0)
+
+    rejected = executor.place_order(Order("AAPL", 1, "BUY", 100.0, intent_source="pairs_trading"))
+    short = executor.place_order(
+        Order("AAPL", 1, "SELL_SHORT", 100.0, intent_source="baseline_sma")
+    )
+    buy = executor.place_order(Order("AAPL", 1, "BUY", 100.0, intent_source="baseline_sma"))
+    sell = executor.place_order(Order("AAPL", 1, "SELL", 100.0))
+    cover = executor.place_order(Order("AAPL", 1, "BUY_TO_COVER", 100.0))
+
+    assert rejected.ok is False
+    assert short.ok is False
+    assert buy.ok is True
+    assert sell.ok is True
+    assert cover.ok is True
+    assert len(executor.fills) == 3
+
+
+@pytest.mark.asyncio
+async def test_smart_executor_cannot_be_constructed_or_reenabled() -> None:
+    with pytest.raises(ValueError, match="smart execution"):
+        PaperExecutor(use_smart_execution=True)
+    with pytest.raises(ValueError, match="smart execution"):
+        PaperExecutor(smart_executor=object())
+
+    executor = PaperExecutor()
+    executor.use_smart_execution = True
+    order = Order("AAPL", 1, "BUY", 100.0, intent_source="baseline_sma")
+
+    assert executor.place_order(order).ok is False
+    assert (await executor.place_order_async(order)).ok is False
+    assert executor._place_smart_order(order).ok is False
+    assert (await executor._execute_smart_order_async(order)).ok is False
+    assert (await executor.execute_order("AAPL", "BUY", 1, "market"))["executed_quantity"] == 0
+    assert executor.fills == {}
+
+
+@pytest.mark.parametrize(
+    ("component", "construct"),
+    [
+        ("TradingEngine", lambda: TradingEngine(Config())),
+        ("SignalGenerator", SignalGenerator),
+        ("TradeExecutor", lambda: TradeExecutor(None, None, None, {})),
+    ],
+)
+def test_alternate_entry_engines_are_quarantined(component: str, construct) -> None:
+    with pytest.raises(GateAContainmentError, match=component):
+        construct()

--- a/tests/test_pr7_gatea_containment.py
+++ b/tests/test_pr7_gatea_containment.py
@@ -12,6 +12,7 @@ import pytest
 from pydantic import ValidationError
 
 import robo_trader.execution as execution_module
+import robo_trader.paper_execution_capability as capability_module
 from robo_trader.config import Config
 from robo_trader.core.engine import TradingEngine
 from robo_trader.execution import Order, PaperExecutor
@@ -26,7 +27,7 @@ from robo_trader.multiuser.portfolio_config import PortfolioConfig, load_portfol
 from robo_trader.order_manager import OrderManager, OrderStatus
 from robo_trader.paper_execution_capability import (
     PaperExecutionCapabilityError,
-    _bind_paper_execution_authority,
+    _bind_paper_reduction_execution_authority,
 )
 from robo_trader.runner.signal_generator import SignalGenerator
 from robo_trader.runner.trade_executor import TradeExecutor
@@ -179,15 +180,25 @@ def test_baseline_intent_and_terminal_capability_have_single_runtime_call_sites(
     for path in package.rglob("*.py"):
         tree = ast.parse(path.read_text(encoding="utf-8"))
         for node in ast.walk(tree):
-            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            if not isinstance(node, ast.Call):
                 continue
-            if node.func.attr == "issue_baseline_entry_intent":
+            if isinstance(node.func, ast.Attribute) and node.func.attr == (
+                "issue_baseline_entry_intent"
+            ):
                 issue_calls.append(path)
-            elif node.func.attr == "_submit_baseline_once":
+            elif isinstance(node.func, ast.Name) and node.func.id == (
+                "_submit_gateway_baseline_once"
+            ):
                 terminal_calls.append(path)
 
     assert issue_calls == [package / "runner_async.py"]
     assert terminal_calls == [package / "paper_reduction_gateway.py"]
+
+
+def test_no_independently_bindable_baseline_authority_exists() -> None:
+    assert not hasattr(capability_module, "_bind_paper_execution_authority")
+    authority = _bind_paper_reduction_execution_authority(PaperExecutor(), "default")
+    assert not hasattr(authority, "_submit_baseline_once")
 
 
 def test_paper_executor_rejects_every_naked_submission(monkeypatch) -> None:
@@ -211,7 +222,7 @@ def test_paper_executor_rejects_every_naked_submission(monkeypatch) -> None:
 
 def test_bound_authority_preserves_exact_reductions() -> None:
     executor = PaperExecutor()
-    authority = _bind_paper_execution_authority(executor, "default")
+    authority = _bind_paper_reduction_execution_authority(executor, "default")
 
     sell = authority._submit_reduction_once(
         Order("AAPL", 1, "SELL", Decimal("100.0000")),
@@ -240,7 +251,7 @@ def test_reduction_capability_cannot_cross_zero(
     side: str, quantity: int, pre_position: Decimal
 ) -> None:
     executor = PaperExecutor()
-    authority = _bind_paper_execution_authority(executor, "default")
+    authority = _bind_paper_reduction_execution_authority(executor, "default")
 
     with pytest.raises(PaperExecutionCapabilityError, match="exposure"):
         authority._submit_reduction_once(
@@ -253,7 +264,7 @@ def test_reduction_capability_cannot_cross_zero(
 
 def test_capability_substitution_burns_authority(monkeypatch) -> None:
     executor = PaperExecutor()
-    authority = _bind_paper_execution_authority(executor, "default")
+    authority = _bind_paper_reduction_execution_authority(executor, "default")
     captured = []
 
     def capture(_order, *, _capability):
@@ -287,15 +298,36 @@ def test_capability_substitution_burns_authority(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_order_manager_cannot_bypass_terminal_capability() -> None:
+@pytest.mark.parametrize("side", ["BUY", "SELL", "BUY_TO_COVER"])
+async def test_order_manager_cannot_bypass_terminal_capability(side: str) -> None:
     executor = PaperExecutor()
     manager = OrderManager(max_retries=1)
 
-    result = await manager.place_order("AAPL", 1, "BUY", executor=executor)
+    result = await manager.place_order("AAPL", 1, side, executor=executor)
 
     assert result.status is OrderStatus.ERROR
     assert "submission capability" in (result.error_message or "")
     assert executor.fills == {}
+
+
+class _FakeOrderExecutor:
+    def place_order(self, _order):
+        return SimpleNamespace(ok=True, message="forged acceptance", order_id="fake")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("side", ["BUY", "SELL", "BUY_TO_COVER"])
+@pytest.mark.parametrize("executor", [None, object(), _FakeOrderExecutor()])
+async def test_order_manager_rejects_missing_or_alternate_executor(side, executor) -> None:
+    manager = OrderManager(max_retries=1)
+
+    result = await manager.place_order("AAPL", 1, side, executor=executor)
+
+    assert result.status is OrderStatus.ERROR
+    assert "exact contained PaperExecutor" in (result.error_message or "")
+    assert result.id not in manager.pending_orders
+    assert result.id not in manager.active_orders
+    assert result.id not in manager.monitoring_tasks
 
 
 @pytest.mark.asyncio

--- a/tests/test_pr7_gatea_containment.py
+++ b/tests/test_pr7_gatea_containment.py
@@ -185,7 +185,7 @@ def test_forgeable_intent_source_field_no_longer_exists() -> None:
         Order("AAPL", 1, "BUY", 100.0, intent_source="baseline_sma")
 
 
-def test_baseline_intent_and_terminal_capability_have_single_runtime_call_sites() -> None:
+def test_baseline_intent_and_terminal_capability_have_no_runtime_call_sites() -> None:
     package = Path(__file__).parents[1] / "robo_trader"
     issue_calls: list[Path] = []
     terminal_calls: list[Path] = []
@@ -203,8 +203,8 @@ def test_baseline_intent_and_terminal_capability_have_single_runtime_call_sites(
             ):
                 terminal_calls.append(path)
 
-    assert issue_calls == [package / "runner_async.py"]
-    assert terminal_calls == [package / "paper_reduction_gateway.py"]
+    assert issue_calls == []
+    assert terminal_calls == []
 
 
 def test_no_independently_bindable_baseline_authority_exists() -> None:

--- a/tests/test_pr7_gatea_containment.py
+++ b/tests/test_pr7_gatea_containment.py
@@ -329,6 +329,28 @@ def test_terminal_fill_direct_call_without_exact_authority_cannot_fill() -> None
     assert executor.fills == {}
 
 
+def test_terminal_authority_state_is_not_importable_or_directly_constructible() -> None:
+    for name in (
+        "_CAPABILITY_TOKEN",
+        "_CAPABILITIES",
+        "_CapabilityRecord",
+        "_REGISTRY_LOCK",
+        "_TERMINAL_DISPATCH_TOKEN",
+        "_REDUCTION_DISPATCHES",
+    ):
+        assert not hasattr(capability_module, name)
+
+    with pytest.raises(PaperExecutionCapabilityError, match="minted only"):
+        capability_module._PaperExecutionCapability()
+
+    executor = PaperExecutor()
+    order = Order("AAPL", 1, "SELL", Decimal("100.0000"))
+    unissued = object.__new__(capability_module._PaperExecutionCapability)
+    with pytest.raises(PaperExecutionCapabilityError, match="unknown|already consumed"):
+        capability_module._execute_sealed_paper_fill(executor, order, unissued)
+    assert executor.fills == {}
+
+
 def test_reduction_traceback_retains_only_burned_capability() -> None:
     executor = PaperExecutor()
     harness = bind_gateway_reduction_harness(executor, "default")
@@ -350,12 +372,20 @@ def test_reduction_traceback_retains_only_burned_capability() -> None:
         )
 
     capability = None
+    retained_records = []
     traceback = raised.value.__traceback__
     while traceback is not None:
         if traceback.tb_frame.f_code.co_name == "_submit_gateway_reduction_once":
             capability = traceback.tb_frame.f_locals.get("capability")
+        record = traceback.tb_frame.f_locals.get("record")
+        if record is not None and hasattr(record, "consumed"):
+            retained_records.append(record)
         traceback = traceback.tb_next
     assert capability is not None
+    for record in retained_records:
+        with pytest.raises(AttributeError):
+            record.consumed = False
+        replace(record, consumed=False)
     with pytest.raises(PaperExecutionCapabilityError):
         copy.copy(capability)
     with pytest.raises(PaperExecutionCapabilityError):
@@ -372,49 +402,28 @@ def test_reduction_traceback_retains_only_burned_capability() -> None:
     assert executor.fills == {}
 
 
-def test_reduction_consume_failure_cannot_promote_burned_capability(
+def test_reduction_consume_uses_closure_captured_fingerprint(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     executor = PaperExecutor()
     harness = bind_gateway_reduction_harness(executor, "default")
     original = Order("AAPL", 1, "SELL", Decimal("100.0000"))
     dispatch = harness.issue(original, pre_position_quantity=Decimal("1"))
-    original_fingerprint = capability_module._fingerprint_order
-    fingerprint_calls = 0
 
-    def fail_during_consume(order):
-        nonlocal fingerprint_calls
-        fingerprint_calls += 1
-        if fingerprint_calls == 2:
-            raise LookupError("injected consume validation failure")
-        return original_fingerprint(order)
+    def forged_fingerprint(_order):
+        pytest.fail("mutable module fingerprint must not replace the captured primitive")
 
-    monkeypatch.setattr(capability_module, "_fingerprint_order", fail_during_consume)
-    with pytest.raises(LookupError, match="consume validation") as raised:
-        _submit_gateway_reduction_once(
-            harness.authority,
-            dispatch,
-            submitter=harness.submitter_identity,
-            order=original,
-            pre_position_quantity=Decimal("1"),
-        )
+    monkeypatch.setattr(capability_module, "_fingerprint_order", forged_fingerprint)
+    result = _submit_gateway_reduction_once(
+        harness.authority,
+        dispatch,
+        submitter=harness.submitter_identity,
+        order=original,
+        pre_position_quantity=Decimal("1"),
+    )
 
-    capability = None
-    traceback = raised.value.__traceback__
-    while traceback is not None:
-        candidate = traceback.tb_frame.f_locals.get("capability")
-        if candidate is not None:
-            capability = candidate
-        traceback = traceback.tb_next
-    assert capability is not None
-
-    monkeypatch.setattr(capability_module, "_fingerprint_order", original_fingerprint)
-    replay = PaperExecutor._place_simple_order(executor, original, _capability=capability)
-    assert replay.ok is False
-    assert "already consumed" in replay.message
-    with pytest.raises(PaperExecutionCapabilityError, match="unconsumed|mismatched"):
-        capability_module._apply_consumed_paper_fill(executor, original, capability)
-    assert executor.fills == {}
+    assert result.ok is True
+    assert len(executor.fills) == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pr7_gatea_containment.py
+++ b/tests/test_pr7_gatea_containment.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import ast
+import copy
 import inspect
+import pickle
+from dataclasses import replace
 from decimal import Decimal
 from pathlib import Path
 from types import SimpleNamespace
@@ -277,38 +280,140 @@ def test_reduction_capability_cannot_cross_zero(
     assert executor.fills == {}
 
 
-def test_capability_substitution_burns_authority(monkeypatch) -> None:
+def test_reduction_terminal_dispatch_never_calls_mutable_executor_method(monkeypatch) -> None:
     executor = PaperExecutor()
     harness = bind_gateway_reduction_harness(executor, "default")
-    captured = []
-
-    def capture(_order, *, _capability):
-        captured.append(_capability)
-        return SimpleNamespace(ok=False)
-
-    monkeypatch.setattr(executor, "_place_simple_order", capture)
     original = Order("AAPL", 1, "SELL", Decimal("100.0000"))
-    harness.submit(
-        original,
+    dispatch = harness.issue(original, pre_position_quantity=Decimal("1"))
+    monkeypatch.setattr(
+        executor,
+        "_place_simple_order",
+        lambda *_args, **_kwargs: pytest.fail("mutable executor method must not receive authority"),
+    )
+    monkeypatch.setattr(
+        capability_module,
+        "_execute_sealed_paper_fill",
+        lambda *_args, **_kwargs: pytest.fail("captured terminal sink must be immutable"),
+    )
+    monkeypatch.setattr(
+        capability_module,
+        "consume_paper_execution_capability",
+        lambda *_args, **_kwargs: pytest.fail("captured consume primitive must be immutable"),
+    )
+
+    result = _submit_gateway_reduction_once(
+        harness.authority,
+        dispatch,
+        submitter=harness.submitter_identity,
+        order=original,
         pre_position_quantity=Decimal("1"),
     )
-    capability = captured[0]
 
-    substituted = PaperExecutor._place_simple_order(
-        executor,
-        Order("MSFT", 1, "SELL", Decimal("100.0000")),
-        _capability=capability,
-    )
-    replay = PaperExecutor._place_simple_order(
-        executor,
-        original,
-        _capability=capability,
-    )
+    assert result.ok is True
+    assert len(executor.fills) == 1
 
-    assert substituted.ok is False
-    assert "does not match" in substituted.message
+
+def test_terminal_fill_direct_call_without_exact_authority_cannot_fill() -> None:
+    executor = PaperExecutor()
+    order = Order("AAPL", 1, "SELL", Decimal("100.0000"))
+
+    with pytest.raises(PaperExecutionCapabilityError, match="exact submission capability"):
+        capability_module._execute_sealed_paper_fill(executor, order, None)
+    with pytest.raises(PaperExecutionCapabilityError, match="exact submission capability"):
+        capability_module._execute_sealed_paper_fill(executor, order, object())
+    with pytest.raises(PaperExecutionCapabilityError, match="exact consumed"):
+        capability_module._apply_consumed_paper_fill(executor, order, None)
+    with pytest.raises(PaperExecutionCapabilityError, match="exact consumed"):
+        capability_module._apply_consumed_paper_fill(executor, order, object())
+
+    assert executor.fills == {}
+
+
+def test_reduction_traceback_retains_only_burned_capability() -> None:
+    executor = PaperExecutor()
+    harness = bind_gateway_reduction_harness(executor, "default")
+    original = Order("AAPL", 1, "SELL", Decimal("100.0000"))
+    dispatch = harness.issue(original, pre_position_quantity=Decimal("1"))
+
+    class RaisingFills(dict):
+        def __setitem__(self, _key, _value):
+            raise LookupError("injected post-consume fill failure")
+
+    executor.fills = RaisingFills()
+    with pytest.raises(LookupError, match="post-consume") as raised:
+        _submit_gateway_reduction_once(
+            harness.authority,
+            dispatch,
+            submitter=harness.submitter_identity,
+            order=original,
+            pre_position_quantity=Decimal("1"),
+        )
+
+    capability = None
+    traceback = raised.value.__traceback__
+    while traceback is not None:
+        if traceback.tb_frame.f_code.co_name == "_submit_gateway_reduction_once":
+            capability = traceback.tb_frame.f_locals.get("capability")
+        traceback = traceback.tb_next
+    assert capability is not None
+    with pytest.raises(PaperExecutionCapabilityError):
+        copy.copy(capability)
+    with pytest.raises(PaperExecutionCapabilityError):
+        copy.deepcopy(capability)
+    with pytest.raises(PaperExecutionCapabilityError):
+        pickle.dumps(capability)
+    with pytest.raises(TypeError):
+        replace(capability)
+
+    replay = PaperExecutor._place_simple_order(executor, original, _capability=capability)
+
     assert replay.ok is False
     assert "already consumed" in replay.message
+    assert executor.fills == {}
+
+
+def test_reduction_consume_failure_cannot_promote_burned_capability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor = PaperExecutor()
+    harness = bind_gateway_reduction_harness(executor, "default")
+    original = Order("AAPL", 1, "SELL", Decimal("100.0000"))
+    dispatch = harness.issue(original, pre_position_quantity=Decimal("1"))
+    original_fingerprint = capability_module._fingerprint_order
+    fingerprint_calls = 0
+
+    def fail_during_consume(order):
+        nonlocal fingerprint_calls
+        fingerprint_calls += 1
+        if fingerprint_calls == 2:
+            raise LookupError("injected consume validation failure")
+        return original_fingerprint(order)
+
+    monkeypatch.setattr(capability_module, "_fingerprint_order", fail_during_consume)
+    with pytest.raises(LookupError, match="consume validation") as raised:
+        _submit_gateway_reduction_once(
+            harness.authority,
+            dispatch,
+            submitter=harness.submitter_identity,
+            order=original,
+            pre_position_quantity=Decimal("1"),
+        )
+
+    capability = None
+    traceback = raised.value.__traceback__
+    while traceback is not None:
+        candidate = traceback.tb_frame.f_locals.get("capability")
+        if candidate is not None:
+            capability = candidate
+        traceback = traceback.tb_next
+    assert capability is not None
+
+    monkeypatch.setattr(capability_module, "_fingerprint_order", original_fingerprint)
+    replay = PaperExecutor._place_simple_order(executor, original, _capability=capability)
+    assert replay.ok is False
+    assert "already consumed" in replay.message
+    with pytest.raises(PaperExecutionCapabilityError, match="unconsumed|mismatched"):
+        capability_module._apply_consumed_paper_fill(executor, original, capability)
     assert executor.fills == {}
 
 

--- a/tests/test_pr7_gatea_containment.py
+++ b/tests/test_pr7_gatea_containment.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import ast
+import inspect
+from decimal import Decimal
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -18,8 +22,15 @@ from robo_trader.gatea_containment import (
     validate_gate_a_environment,
     validate_gate_a_order,
 )
+from robo_trader.multiuser.portfolio_config import PortfolioConfig, load_portfolio_configs
+from robo_trader.order_manager import OrderManager, OrderStatus
+from robo_trader.paper_execution_capability import (
+    PaperExecutionCapabilityError,
+    _bind_paper_execution_authority,
+)
 from robo_trader.runner.signal_generator import SignalGenerator
 from robo_trader.runner.trade_executor import TradeExecutor
+from robo_trader.runner_async import run_continuous
 
 
 @pytest.mark.parametrize(
@@ -79,6 +90,40 @@ def test_direct_config_contradictions_fail_closed(override: dict) -> None:
         Config(**override)
 
 
+def test_direct_config_rejects_invalid_explicit_portfolio_strategy() -> None:
+    with pytest.raises(ValidationError, match="portfolio_configs.*baseline_sma"):
+        Config(portfolio_configs=[{"id": "aggressive", "enabled_strategies": ["pairs_trading"]}])
+
+
+def test_explicit_portfolio_strategy_never_falls_back(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "PORTFOLIOS",
+        '[{"id":"aggressive","enabled_strategies":"pairs_trading"}]',
+    )
+
+    with pytest.raises(GateAContainmentError, match="baseline_sma"):
+        load_portfolio_configs()
+
+    assert "using default" not in inspect.getsource(run_continuous)
+
+
+def test_empty_explicit_portfolios_never_falls_back(monkeypatch) -> None:
+    monkeypatch.setenv("PORTFOLIOS", "")
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        load_portfolio_configs()
+
+
+def test_portfolio_strategy_override_accepts_only_baseline() -> None:
+    portfolio = PortfolioConfig(
+        id="baseline",
+        name="Baseline",
+        enabled_strategies=["BASELINE_SMA"],
+    )
+
+    assert portfolio.enabled_strategies == ["baseline_sma"]
+
+
 @pytest.mark.parametrize(
     "options",
     [
@@ -93,26 +138,17 @@ def test_runner_constructor_options_cannot_reenable_quarantined_paths(options: d
 
 
 @pytest.mark.parametrize(
-    ("side", "source", "take_profit", "expected_fragment"),
+    ("side", "take_profit", "expected_fragment"),
     [
-        ("BUY", "pairs_trading", None, "not the baseline"),
-        ("BUY", "stat_arbitrage", None, "not the baseline"),
-        ("BUY", "ai_discovery", None, "not the baseline"),
-        ("BUY", "ml_selector", None, "not the baseline"),
-        ("BUY", "", None, "not the baseline"),
-        ("SELL_SHORT", "baseline_sma", None, "blocks new short exposure"),
-        ("BUY", "baseline_sma", 110.0, "take-profit"),
+        ("SELL_SHORT", None, "blocks new short exposure"),
+        ("BUY", 110.0, "take-profit"),
     ],
 )
-def test_disabled_paths_cannot_create_entry_intent(
-    side: str,
-    source: str,
-    take_profit: float | None,
-    expected_fragment: str,
+def test_disabled_order_shapes_fail_before_capability_admission(
+    side: str, take_profit: float | None, expected_fragment: str
 ) -> None:
     admitted, reason = validate_gate_a_order(
         side=side,
-        intent_source=source,
         take_profit=take_profit,
     )
 
@@ -121,10 +157,9 @@ def test_disabled_paths_cannot_create_entry_intent(
 
 
 @pytest.mark.parametrize("side", ["SELL", "BUY_TO_COVER"])
-def test_semantic_reductions_remain_admitted_without_entry_source(side: str) -> None:
+def test_semantic_reductions_remain_structurally_admitted(side: str) -> None:
     admitted, reason = validate_gate_a_order(
         side=side,
-        intent_source="",
         take_profit=None,
     )
 
@@ -132,7 +167,30 @@ def test_semantic_reductions_remain_admitted_without_entry_source(side: str) -> 
     assert reason == "Gate-A semantic reduction"
 
 
-def test_paper_executor_rechecks_containment_at_submission(monkeypatch) -> None:
+def test_forgeable_intent_source_field_no_longer_exists() -> None:
+    with pytest.raises(TypeError, match="intent_source"):
+        Order("AAPL", 1, "BUY", 100.0, intent_source="baseline_sma")
+
+
+def test_baseline_intent_and_terminal_capability_have_single_runtime_call_sites() -> None:
+    package = Path(__file__).parents[1] / "robo_trader"
+    issue_calls: list[Path] = []
+    terminal_calls: list[Path] = []
+    for path in package.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+                continue
+            if node.func.attr == "issue_baseline_entry_intent":
+                issue_calls.append(path)
+            elif node.func.attr == "_submit_baseline_once":
+                terminal_calls.append(path)
+
+    assert issue_calls == [package / "runner_async.py"]
+    assert terminal_calls == [package / "paper_reduction_gateway.py"]
+
+
+def test_paper_executor_rejects_every_naked_submission(monkeypatch) -> None:
     monkeypatch.setattr(
         execution_module,
         "os",
@@ -140,20 +198,104 @@ def test_paper_executor_rechecks_containment_at_submission(monkeypatch) -> None:
     )
     executor = PaperExecutor(slippage_bps=0)
 
-    rejected = executor.place_order(Order("AAPL", 1, "BUY", 100.0, intent_source="pairs_trading"))
-    short = executor.place_order(
-        Order("AAPL", 1, "SELL_SHORT", 100.0, intent_source="baseline_sma")
-    )
-    buy = executor.place_order(Order("AAPL", 1, "BUY", 100.0, intent_source="baseline_sma"))
+    buy = executor.place_order(Order("AAPL", 1, "BUY", 100.0))
     sell = executor.place_order(Order("AAPL", 1, "SELL", 100.0))
     cover = executor.place_order(Order("AAPL", 1, "BUY_TO_COVER", 100.0))
+    private = executor._place_simple_order(Order("AAPL", 1, "BUY", 100.0))
 
-    assert rejected.ok is False
-    assert short.ok is False
-    assert buy.ok is True
+    for result in (buy, sell, cover, private):
+        assert result.ok is False
+        assert "submission capability" in result.message
+    assert executor.fills == {}
+
+
+def test_bound_authority_preserves_exact_reductions() -> None:
+    executor = PaperExecutor()
+    authority = _bind_paper_execution_authority(executor, "default")
+
+    sell = authority._submit_reduction_once(
+        Order("AAPL", 1, "SELL", Decimal("100.0000")),
+        pre_position_quantity=Decimal("1"),
+    )
+    cover = authority._submit_reduction_once(
+        Order("MSFT", 2, "BUY_TO_COVER", Decimal("50.0000")),
+        pre_position_quantity=Decimal("-2"),
+    )
+
     assert sell.ok is True
     assert cover.ok is True
-    assert len(executor.fills) == 3
+    assert len(executor.fills) == 2
+
+
+@pytest.mark.parametrize(
+    ("side", "quantity", "pre_position"),
+    [
+        ("SELL", 2, Decimal("1")),
+        ("SELL", 1, Decimal("-1")),
+        ("BUY_TO_COVER", 2, Decimal("-1")),
+        ("BUY_TO_COVER", 1, Decimal("1")),
+    ],
+)
+def test_reduction_capability_cannot_cross_zero(
+    side: str, quantity: int, pre_position: Decimal
+) -> None:
+    executor = PaperExecutor()
+    authority = _bind_paper_execution_authority(executor, "default")
+
+    with pytest.raises(PaperExecutionCapabilityError, match="exposure"):
+        authority._submit_reduction_once(
+            Order("AAPL", quantity, side, Decimal("100.0000")),
+            pre_position_quantity=pre_position,
+        )
+
+    assert executor.fills == {}
+
+
+def test_capability_substitution_burns_authority(monkeypatch) -> None:
+    executor = PaperExecutor()
+    authority = _bind_paper_execution_authority(executor, "default")
+    captured = []
+
+    def capture(_order, *, _capability):
+        captured.append(_capability)
+        return SimpleNamespace(ok=False)
+
+    monkeypatch.setattr(executor, "_place_simple_order", capture)
+    original = Order("AAPL", 1, "SELL", Decimal("100.0000"))
+    authority._submit_reduction_once(
+        original,
+        pre_position_quantity=Decimal("1"),
+    )
+    capability = captured[0]
+
+    substituted = PaperExecutor._place_simple_order(
+        executor,
+        Order("MSFT", 1, "SELL", Decimal("100.0000")),
+        _capability=capability,
+    )
+    replay = PaperExecutor._place_simple_order(
+        executor,
+        original,
+        _capability=capability,
+    )
+
+    assert substituted.ok is False
+    assert "does not match" in substituted.message
+    assert replay.ok is False
+    assert "already consumed" in replay.message
+    assert executor.fills == {}
+
+
+@pytest.mark.asyncio
+async def test_order_manager_cannot_bypass_terminal_capability() -> None:
+    executor = PaperExecutor()
+    manager = OrderManager(max_retries=1)
+
+    result = await manager.place_order("AAPL", 1, "BUY", executor=executor)
+
+    assert result.status is OrderStatus.ERROR
+    assert "submission capability" in (result.error_message or "")
+    assert executor.fills == {}
 
 
 @pytest.mark.asyncio
@@ -165,7 +307,7 @@ async def test_smart_executor_cannot_be_constructed_or_reenabled() -> None:
 
     executor = PaperExecutor()
     executor.use_smart_execution = True
-    order = Order("AAPL", 1, "BUY", 100.0, intent_source="baseline_sma")
+    order = Order("AAPL", 1, "BUY", 100.0)
 
     assert executor.place_order(order).ok is False
     assert (await executor.place_order_async(order)).ok is False

--- a/tests/test_pr7_gatea_containment.py
+++ b/tests/test_pr7_gatea_containment.py
@@ -27,11 +27,13 @@ from robo_trader.multiuser.portfolio_config import PortfolioConfig, load_portfol
 from robo_trader.order_manager import OrderManager, OrderStatus
 from robo_trader.paper_execution_capability import (
     PaperExecutionCapabilityError,
-    _bind_paper_reduction_execution_authority,
+    _issue_gateway_reduction_terminal_dispatch,
+    _submit_gateway_reduction_once,
 )
 from robo_trader.runner.signal_generator import SignalGenerator
 from robo_trader.runner.trade_executor import TradeExecutor
 from robo_trader.runner_async import run_continuous
+from tests.paper_execution_test_support import bind_gateway_reduction_harness
 
 
 @pytest.mark.parametrize(
@@ -73,6 +75,13 @@ def test_gate_a_safe_environment_has_one_strategy() -> None:
     profile = validate_gate_a_environment({})
 
     assert profile.enabled_strategies == ALLOWED_STRATEGIES
+
+
+def test_example_environment_uses_the_only_admitted_strategy() -> None:
+    example = (Path(__file__).parents[1] / ".env.example").read_text(encoding="utf-8")
+
+    assignments = [line for line in example.splitlines() if line.startswith("STRATEGY_ENABLED=")]
+    assert assignments == ["STRATEGY_ENABLED=baseline_sma  # Gate-A permits exactly this strategy"]
 
 
 @pytest.mark.parametrize(
@@ -197,8 +206,13 @@ def test_baseline_intent_and_terminal_capability_have_single_runtime_call_sites(
 
 def test_no_independently_bindable_baseline_authority_exists() -> None:
     assert not hasattr(capability_module, "_bind_paper_execution_authority")
-    authority = _bind_paper_reduction_execution_authority(PaperExecutor(), "default")
+    assert not hasattr(capability_module, "_bind_paper_reduction_execution_authority")
+    authority = bind_gateway_reduction_harness(
+        PaperExecutor(),
+        "default",
+    ).authority
     assert not hasattr(authority, "_submit_baseline_once")
+    assert not hasattr(authority, "_submit_reduction_once")
 
 
 def test_paper_executor_rejects_every_naked_submission(monkeypatch) -> None:
@@ -222,13 +236,13 @@ def test_paper_executor_rejects_every_naked_submission(monkeypatch) -> None:
 
 def test_bound_authority_preserves_exact_reductions() -> None:
     executor = PaperExecutor()
-    authority = _bind_paper_reduction_execution_authority(executor, "default")
+    harness = bind_gateway_reduction_harness(executor, "default")
 
-    sell = authority._submit_reduction_once(
+    sell = harness.submit(
         Order("AAPL", 1, "SELL", Decimal("100.0000")),
         pre_position_quantity=Decimal("1"),
     )
-    cover = authority._submit_reduction_once(
+    cover = harness.submit(
         Order("MSFT", 2, "BUY_TO_COVER", Decimal("50.0000")),
         pre_position_quantity=Decimal("-2"),
     )
@@ -251,20 +265,21 @@ def test_reduction_capability_cannot_cross_zero(
     side: str, quantity: int, pre_position: Decimal
 ) -> None:
     executor = PaperExecutor()
-    authority = _bind_paper_reduction_execution_authority(executor, "default")
+    harness = bind_gateway_reduction_harness(executor, "default")
 
-    with pytest.raises(PaperExecutionCapabilityError, match="exposure"):
-        authority._submit_reduction_once(
-            Order("AAPL", quantity, side, Decimal("100.0000")),
-            pre_position_quantity=pre_position,
-        )
+    result = harness.submit(
+        Order("AAPL", quantity, side, Decimal("100.0000")),
+        pre_position_quantity=pre_position,
+    )
 
+    assert result.ok is False
+    assert "exposure" in result.message
     assert executor.fills == {}
 
 
 def test_capability_substitution_burns_authority(monkeypatch) -> None:
     executor = PaperExecutor()
-    authority = _bind_paper_reduction_execution_authority(executor, "default")
+    harness = bind_gateway_reduction_harness(executor, "default")
     captured = []
 
     def capture(_order, *, _capability):
@@ -273,7 +288,7 @@ def test_capability_substitution_burns_authority(monkeypatch) -> None:
 
     monkeypatch.setattr(executor, "_place_simple_order", capture)
     original = Order("AAPL", 1, "SELL", Decimal("100.0000"))
-    authority._submit_reduction_once(
+    harness.submit(
         original,
         pre_position_quantity=Decimal("1"),
     )
@@ -294,6 +309,70 @@ def test_capability_substitution_burns_authority(monkeypatch) -> None:
     assert "does not match" in substituted.message
     assert replay.ok is False
     assert "already consumed" in replay.message
+    assert executor.fills == {}
+
+
+@pytest.mark.parametrize(
+    ("side", "pre_position"),
+    [("SELL", Decimal("1")), ("BUY_TO_COVER", Decimal("-1"))],
+)
+def test_direct_reduction_helpers_reject_unregistered_authority(
+    side: str,
+    pre_position: Decimal,
+) -> None:
+    executor = PaperExecutor()
+    order = Order("AAPL", 1, side, Decimal("100.0000"))
+
+    with pytest.raises(PaperExecutionCapabilityError, match="final allocation"):
+        _issue_gateway_reduction_terminal_dispatch(
+            object(),
+            submitter=object(),
+            executor=executor,
+            coordinator=object(),
+            final_allocation=object(),
+            descriptor=object(),
+            contract=object(),
+            order=order,
+            pre_position_quantity=pre_position,
+        )
+    with pytest.raises(PaperExecutionCapabilityError, match="dispatch is invalid"):
+        _submit_gateway_reduction_once(
+            object(),
+            object(),
+            submitter=object(),
+            order=order,
+            pre_position_quantity=pre_position,
+        )
+
+    assert executor.fills == {}
+
+
+def test_reduction_terminal_dispatch_mismatch_burns_before_replay() -> None:
+    executor = PaperExecutor()
+    harness = bind_gateway_reduction_harness(executor, "default")
+    admitted = Order("AAPL", 1, "SELL", Decimal("100.0000"))
+    dispatch = harness.issue(
+        admitted,
+        pre_position_quantity=Decimal("1"),
+    )
+
+    with pytest.raises(PaperExecutionCapabilityError, match="does not match attempt"):
+        _submit_gateway_reduction_once(
+            harness.authority,
+            dispatch,
+            submitter=harness.submitter_identity,
+            order=Order("MSFT", 1, "SELL", Decimal("100.0000")),
+            pre_position_quantity=Decimal("1"),
+        )
+    with pytest.raises(PaperExecutionCapabilityError, match="already consumed"):
+        _submit_gateway_reduction_once(
+            harness.authority,
+            dispatch,
+            submitter=harness.submitter_identity,
+            order=admitted,
+            pre_position_quantity=Decimal("1"),
+        )
+
     assert executor.fills == {}
 
 


### PR DESCRIPTION
## Outcome

Constrains the active paper runtime to the admitted baseline-SMA strategy and seals terminal paper-execution admission. Gate A remains closed.

## Safety contract

- incomplete pairs, stat-arb, shorts, smart execution, AI/ML discovery, take-profit, and alternate engines are disabled/quarantined
- no caller-controlled provenance string can authorize a BUY
- only the actual baseline-SMA producer branch receives an immutable one-shot entry intent
- exact entry session consumes it and mints an executor/order-bound terminal capability
- mismatch, substitution, direct executor/order-manager calls, and replay reject
- reductions require the coordinator envelope plus exact final allocation evidence; naked, oversized, and cross-zero reductions reject at the sink
- every explicit portfolio must enable exactly baseline_sma; malformed/empty/contradictory explicit PORTFOLIOS fails closed without default fallback
- legitimate risk-reducing exits remain supported through the sealed gateway
- no live-order or startup authorization

## Verification

- 477 focused tests passed, 2 skipped
- 2,682 full tests passed, 5 skipped
- Black, isort, Flake8, compileall, and diff checks pass
- new capability module has no MyPy errors; existing touched-module MyPy debt remains baseline
- independent exact-head re-review is in progress

## Remediation scope

Relevant PR 7 / Gate A containment in `docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md`. Exact risk, filled-notional, reconciliation, and startup/order-path integration remain separate gates.

The trader remains stopped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core order admission, paper execution, and config enforcement on safety-critical trading paths; misconfiguration or capability bugs could block legitimate exits or leave entries incorrectly open.
> 
> **Overview**
> Introduces **Gate-A containment** so the paper runtime only admits **`baseline_sma`**, with env/config/docker defaults and validation that reject ML/AI, smart execution, shorts, take-profit, and contradictory strategy lists. **`AsyncRunner`** is the sole engine; alternate **`TradingEngine`**, **`SignalGenerator`**, and **`TradeExecutor`** paths fail at construction.
> 
> **New exposure stays closed:** no baseline entry handle is published, **`submit_baseline_entry`** always fails closed, and BUY orders are rejected without registered entry authority. **Semantic reductions** go through a new **one-shot paper execution capability** chain (gateway binding → terminal dispatch → sealed fill) tied to safety coordinator envelopes and **exact pre-position quantity** evidence; direct **`PaperExecutor`** / order-manager bypass and smart execution are removed or blocked.
> 
> Config load and portfolio overrides are **fail-closed** (including explicit **`PORTFOLIOS`**). Entry gating also checks the on-disk **kill-switch lock** independently of in-memory state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e070c80d88d59c34d4d3b66ed952b35e5b8855ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->