### PR TITLE
test(ci): isolate recovery backoff sleep

### DIFF
--- a/tests/test_recover_connection.py
+++ b/tests/test_recover_connection.py
@@ -142,9 +142,19 @@ async def test_returns_false_after_exhausted_attempts():
 async def test_backoff_schedule_is_15_30_60_120_300():
     runner = make_runner_for_recovery(initialize_succeeds_on=999)
     sleeps = []
+    test_task = asyncio.current_task()
+    real_sleep = asyncio.sleep
 
     async def record_sleep(seconds):
-        sleeps.append(seconds)
+        # Patching runner_async.asyncio.sleep replaces the attribute on the
+        # shared asyncio module.  A reconciliation task left alive by an
+        # earlier test may therefore call this side effect while this test is
+        # running.  Record only the recovery coroutine under test and preserve
+        # real scheduling for unrelated tasks.
+        if asyncio.current_task() is test_task:
+            sleeps.append(seconds)
+            return
+        await real_sleep(seconds)
 
     with patch(
         "robo_trader.runner_async.restart_gateway_for_zombies_async",


### PR DESCRIPTION
## Root cause

`patch("robo_trader.runner_async.asyncio.sleep")` replaces the attribute on Python's shared `asyncio` module. A reconciliation task left alive by an earlier test can therefore invoke the backoff test's side effect. Python 3.11 CI recorded three unrelated 5-second sleeps and failed `[15, 30, 60, 120, 300]` as `[15, 30, 5, 60, 5, 120, 5, 300]`.

## Fix

The test now records sleeps only from its own recovery task and delegates unrelated tasks to the captured real `asyncio.sleep`. Production recovery behavior is unchanged.

## Verification

- 112 focused recovery + reconciliation runtime tests passed
- Black, isort, and `git diff --check` passed
- Full local suite is running; evidence will be added when complete
- No runtime, broker, credentials, or user trading data accessed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production or runtime behavior modified.
> 
> **Overview**
> Fixes a flaky CI failure in **`test_backoff_schedule_is_15_30_60_120_300`** where patching `robo_trader.runner_async.asyncio.sleep` replaced sleep on the shared **`asyncio`** module, so background tasks (e.g. reconciliation) could append extra values—Python 3.11 saw spurious **5**s sleeps mixed into the expected **`[15, 30, 60, 120, 300]`** schedule.
> 
> The test now captures the current task and real `asyncio.sleep`, records delays only when **`asyncio.current_task()`** is the recovery test coroutine, and forwards all other callers to the real sleep. **Production recovery backoff is unchanged**—test-only hardening.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72bc2c34c4151c3697f79904319553b88496a00d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->