### PR TITLE
feat(accounting): add exact FIFO ledger foundation

### DIFF
--- a/docs/design/PR4A_FIFO_ACCOUNTING_FOUNDATION.md
+++ b/docs/design/PR4A_FIFO_ACCOUNTING_FOUNDATION.md
@@ -1,0 +1,80 @@
+# PR4A exact FIFO accounting foundation
+
+## Status and safety boundary
+
+This slice is dormant. It adds an exact append-only accounting contract and a
+deterministic projector, but does not connect either to the runner, settlement,
+broker, dashboard, startup script, or `trading_data.db`.
+
+The only migration entry point is named `migrate_fifo_fixture_database`. It
+accepts an in-memory database or a database whose filename ends in
+`.fifo-fixture.sqlite3`; an ordinary production-style filename is rejected.
+Production migration, backup/restore, legacy adoption, and runtime settlement
+belong to later PR4 slices and require separate review.
+
+In particular, PR4A cannot create or project a
+`LEGACY_AGGREGATE_OPENING_BALANCE` epoch. Establishing that prospective legacy
+cost-basis boundary requires an operator-reviewed candidate, verified backup,
+and explicit user authorization in PR4B.
+
+## Exact value convention
+
+- Quantities, prices, gross P&L, realized P&L, and open position cost are
+  canonical fixed-point decimal strings. Application inputs must be finite
+  `Decimal` values with at most 38 digits and 18 fractional places. Floats are
+  rejected.
+- Commissions are signed integer USD cents. Positive values are expenses;
+  negative values are rebates. Every cent is allocated exactly.
+- Times are canonical UTC strings with microseconds and a trailing `Z`.
+- Fill order is an explicit, gap-free epoch sequence. Event time cannot move
+  backwards. Equal timestamps remain deterministic because the sequence is the
+  primary ordering authority.
+
+## FIFO and commission rules
+
+Each BUY contributes positive quantity and each SELL contributes negative
+quantity. A fill first closes opposite-direction lots in opening order. Any
+remainder opens one new lot, so a single fill can cross through zero without
+losing provenance.
+
+The fill commission is allocated across match fragments and any new opening
+fragment by integer largest remainder, with FIFO segment order as the stable
+tie-breaker. An opening lot's commission is allocated cumulatively as it is
+matched; the final match receives the exact remainder. Therefore allocations
+are deterministic, replayable, and sum exactly to both the fill commission and
+the opening-lot commission, including partial fills and rebates.
+
+Realized P&L is:
+
+`directional gross P&L - allocated opening commission - allocated closing commission`
+
+No commission is embedded in a fill price, so costs are not counted twice.
+
+## Durable records and invariants
+
+The fixture schema contains append-only records for:
+
+- accounting epochs;
+- fills and one exact commission event per fill;
+- lot openings;
+- FIFO lot matches;
+- chained position snapshots; and
+- ordered migration evidence.
+
+Primary keys, scope-local sequence/idempotency/execution uniqueness, composite
+foreign keys, direction/state checks, and no-update/no-delete triggers are
+enforced by SQLite. `FifoLedger.verify_epoch_integrity()` recomputes fill
+fingerprints, sequence/time ordering, commission conservation, lot quantities,
+gross/net P&L, complete opening-commission allocation, and snapshot chains.
+
+One `record_fill` transaction appends the fill, commission, derived lots and
+matches, and snapshot atomically. Any exception rolls back the entire event.
+
+## Later PR4 slices
+
+1. PR4B: reviewed prospective legacy bootstrap using one explicitly marked
+   aggregate opening lot per current position. It must not fabricate historical
+   FIFO or commissions.
+2. PR4C: atomic runtime settlement integration and compatibility projections.
+3. PR4D: descriptor-bound WAL-safe migration, backup, restore, dry-run reports,
+   and fault-injection evidence.

--- a/docs/design/PR4A_FIFO_ACCOUNTING_FOUNDATION.md
+++ b/docs/design/PR4A_FIFO_ACCOUNTING_FOUNDATION.md
@@ -8,7 +8,8 @@ broker, dashboard, startup script, or `trading_data.db`.
 
 The only migration entry point is named `migrate_fifo_fixture_database`. It
 accepts an in-memory database or a database whose filename ends in
-`.fifo-fixture.sqlite3`; an ordinary production-style filename is rejected.
+`.fifo-fixture.sqlite3`; an ordinary production-style filename, symlink, or
+multiply linked file is rejected before migration or schema recovery.
 Production migration, backup/restore, legacy adoption, and runtime settlement
 belong to later PR4 slices and require separate review.
 
@@ -65,7 +66,8 @@ Primary keys, scope-local sequence/idempotency/execution uniqueness, composite
 foreign keys, direction/state checks, and no-update/no-delete triggers are
 enforced by SQLite. `FifoLedger.verify_epoch_integrity()` recomputes fill
 fingerprints, sequence/time ordering, commission conservation, lot quantities,
-gross/net P&L, complete opening-commission allocation, and snapshot chains.
+gross/net P&L, complete opening-commission allocation, source-fill participation,
+the exact FIFO lot/match projection, and snapshot chains.
 
 One `record_fill` transaction appends the fill, commission, derived lots and
 matches, and snapshot atomically. Any exception rolls back the entire event.

--- a/robo_trader/accounting/__init__.py
+++ b/robo_trader/accounting/__init__.py
@@ -1,0 +1,42 @@
+"""Dormant exact-accounting foundations.
+
+Nothing in this package is connected to the trading runtime.  PR4A exposes a
+fixture-only schema migration and a deterministic FIFO projector so the ledger
+contract can be reviewed before any operational database is eligible to use it.
+"""
+
+from .fifo import (
+    AccountingEpoch,
+    FifoAccountingConflict,
+    FifoAccountingError,
+    FifoAccountingOrderingError,
+    FifoAccountingValidationError,
+    FifoLedger,
+    FillEvent,
+    FillResult,
+    FillSide,
+    PositionSnapshot,
+)
+from .fifo_fixture_migration import (
+    FIFO_ACCOUNTING_COMPONENT,
+    FIFO_ACCOUNTING_SCHEMA_VERSION,
+    assert_fifo_accounting_schema,
+    migrate_fifo_fixture_database,
+)
+
+__all__ = [
+    "AccountingEpoch",
+    "FIFO_ACCOUNTING_COMPONENT",
+    "FIFO_ACCOUNTING_SCHEMA_VERSION",
+    "FillEvent",
+    "FillResult",
+    "FillSide",
+    "FifoAccountingConflict",
+    "FifoAccountingError",
+    "FifoAccountingOrderingError",
+    "FifoAccountingValidationError",
+    "FifoLedger",
+    "PositionSnapshot",
+    "assert_fifo_accounting_schema",
+    "migrate_fifo_fixture_database",
+]

--- a/robo_trader/accounting/fifo.py
+++ b/robo_trader/accounting/fifo.py
@@ -1,0 +1,1199 @@
+"""Deterministic, exact FIFO projection for the dormant PR4A ledger.
+
+The projector records one complete fill, its commission, derived lot openings
+and matches, and a chained position snapshot in one SQLite transaction.  It
+contains no runtime wiring and cannot migrate a production database.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation, localcontext
+from enum import Enum
+from typing import Optional, Sequence
+
+from .fifo_fixture_migration import assert_fifo_accounting_schema
+
+_ID_PATTERNS = {
+    "epoch_id": re.compile(r"^fepoch-[0-9a-f]{32}$"),
+    "fill_id": re.compile(r"^ffill-[0-9a-f]{32}$"),
+    "commission_id": re.compile(r"^fcomm-[0-9a-f]{32}$"),
+}
+_SCOPE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
+_SYMBOL = re.compile(r"^[A-Z][A-Z0-9._-]{0,31}$")
+_HASH = re.compile(r"^[0-9a-f]{64}$")
+_MAX_INPUT_DECIMAL_DIGITS = 38
+_MAX_INPUT_DECIMAL_SCALE = 18
+_MAX_DERIVED_DECIMAL_DIGITS = 76
+_MAX_DERIVED_DECIMAL_SCALE = 36
+_MAX_COMMISSION_MINOR = 1_000_000_000_000
+
+
+class FifoAccountingError(RuntimeError):
+    """Base class for exact FIFO accounting failures."""
+
+
+class FifoAccountingValidationError(FifoAccountingError):
+    """Input or persisted exact accounting data is malformed."""
+
+
+class FifoAccountingConflict(FifoAccountingError):
+    """An idempotency identity is bound to different fill data."""
+
+
+class FifoAccountingOrderingError(FifoAccountingError):
+    """A fill does not extend the epoch's deterministic event order."""
+
+
+class FillSide(str, Enum):
+    BUY = "BUY"
+    SELL = "SELL"
+
+
+def _text(value: object, field: str, pattern: re.Pattern[str] = _SCOPE) -> str:
+    if type(value) is not str or pattern.fullmatch(value) is None:
+        raise FifoAccountingValidationError(f"{field} is malformed")
+    return value
+
+
+def _identifier(value: object, field: str) -> str:
+    return _text(value, field, _ID_PATTERNS[field])
+
+
+def _utc(value: object, field: str) -> datetime:
+    if type(value) is not datetime:
+        raise FifoAccountingValidationError(f"{field} must be a datetime")
+    offset = value.utcoffset()
+    if value.tzinfo is None or offset is None:
+        raise FifoAccountingValidationError(f"{field} must be timezone-aware UTC")
+    if offset.total_seconds() != 0:
+        raise FifoAccountingValidationError(f"{field} must be UTC")
+    return value.astimezone(timezone.utc)
+
+
+def _utc_text(value: datetime) -> str:
+    return _utc(value, "timestamp").isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _parse_utc(value: object, field: str) -> datetime:
+    if type(value) is not str or not value.endswith("Z"):
+        raise FifoAccountingValidationError(f"{field} is not canonical UTC text")
+    try:
+        parsed = datetime.fromisoformat(value[:-1] + "+00:00")
+    except ValueError as exc:
+        raise FifoAccountingValidationError(f"{field} is not a UTC timestamp") from exc
+    if _utc_text(parsed) != value:
+        raise FifoAccountingValidationError(f"{field} is not canonical UTC text")
+    return parsed
+
+
+def _decimal(value: object, field: str, *, positive: bool = False) -> Decimal:
+    if type(value) is not Decimal or not value.is_finite():
+        raise FifoAccountingValidationError(f"{field} must be a finite Decimal")
+    sign, digits, decimal_exponent = value.as_tuple()
+    del sign
+    exponent = int(decimal_exponent)
+    if len(digits) > _MAX_DERIVED_DECIMAL_DIGITS or exponent < -_MAX_DERIVED_DECIMAL_SCALE:
+        raise FifoAccountingValidationError(f"{field} exceeds exact-ledger precision")
+    if positive and value <= 0:
+        raise FifoAccountingValidationError(f"{field} must be positive")
+    return value
+
+
+def _input_decimal(value: object, field: str, *, positive: bool = False) -> Decimal:
+    exact = _decimal(value, field, positive=positive)
+    _, digits, decimal_exponent = exact.as_tuple()
+    exponent = int(decimal_exponent)
+    if len(digits) > _MAX_INPUT_DECIMAL_DIGITS or exponent < -_MAX_INPUT_DECIMAL_SCALE:
+        raise FifoAccountingValidationError(f"{field} exceeds input precision")
+    return exact
+
+
+def _decimal_text(value: Decimal) -> str:
+    _decimal(value, "decimal")
+    rendered = format(value, "f")
+    if "." in rendered:
+        rendered = rendered.rstrip("0").rstrip(".")
+    return "0" if rendered in {"", "-0"} else rendered
+
+
+def _parse_decimal(value: object, field: str, *, positive: bool = False) -> Decimal:
+    if type(value) is not str or not value or "e" in value.lower() or value.startswith("+"):
+        raise FifoAccountingValidationError(f"{field} is not canonical decimal text")
+    if re.fullmatch(r"-?(?:0|[1-9]\d*)(?:\.\d+)?", value) is None:
+        raise FifoAccountingValidationError(f"{field} is not canonical decimal text")
+    try:
+        parsed = Decimal(value)
+    except InvalidOperation as exc:
+        raise FifoAccountingValidationError(f"{field} is not decimal text") from exc
+    _decimal(parsed, field, positive=positive)
+    if _decimal_text(parsed) != value:
+        raise FifoAccountingValidationError(f"{field} is not canonical decimal text")
+    return parsed
+
+
+def _add(left: Decimal, right: Decimal, field: str) -> Decimal:
+    with localcontext() as context:
+        context.prec = 96
+        result = left + right
+    return _decimal(result, field)
+
+
+def _subtract(left: Decimal, right: Decimal, field: str) -> Decimal:
+    return _add(left, right.copy_negate(), field)
+
+
+def _multiply(left: Decimal, right: Decimal, field: str) -> Decimal:
+    with localcontext() as context:
+        context.prec = 96
+        result = left * right
+    return _decimal(result, field)
+
+
+def _money_from_minor(value: int) -> Decimal:
+    if type(value) is not int or abs(value) > _MAX_COMMISSION_MINOR:
+        raise FifoAccountingValidationError("commission_minor is outside the allowed range")
+    return Decimal(value).scaleb(-2)
+
+
+def _fingerprint(payload: dict[str, object]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _derived_id(prefix: str, *parts: object) -> str:
+    value = "\x1f".join(str(part) for part in parts)
+    return f"{prefix}-{hashlib.sha256(value.encode('utf-8')).hexdigest()[:32]}"
+
+
+def _quantity_atoms(values: Sequence[Decimal]) -> list[int]:
+    if not values:
+        return []
+    scale = max(max(-int(value.as_tuple().exponent), 0) for value in values)
+    atoms: list[int] = []
+    with localcontext() as context:
+        context.prec = 96
+        factor = Decimal(10) ** scale
+        for value in values:
+            exact = value * factor
+            if exact != exact.to_integral_value():
+                raise FifoAccountingValidationError(
+                    "quantity could not be converted to exact atoms"
+                )
+            atoms.append(int(exact))
+    return atoms
+
+
+def _allocate_minor(total_minor: int, quantities: Sequence[Decimal]) -> list[int]:
+    """Allocate every minor unit exactly using deterministic largest remainder."""
+
+    _money_from_minor(total_minor)
+    if not quantities:
+        if total_minor != 0:
+            raise FifoAccountingValidationError("commission has no fill segment")
+        return []
+    for quantity in quantities:
+        _decimal(quantity, "allocation quantity", positive=True)
+    weights = _quantity_atoms(quantities)
+    total_weight = sum(weights)
+    magnitude = abs(total_minor)
+    quotients = [magnitude * weight // total_weight for weight in weights]
+    remainders = [magnitude * weight % total_weight for weight in weights]
+    residual = magnitude - sum(quotients)
+    order = sorted(range(len(weights)), key=lambda index: (-remainders[index], index))
+    for index in order[:residual]:
+        quotients[index] += 1
+    sign = -1 if total_minor < 0 else 1
+    allocations = [sign * value for value in quotients]
+    if sum(allocations) != total_minor:
+        raise AssertionError("commission allocation did not conserve minor units")
+    return allocations
+
+
+@dataclass(frozen=True, slots=True)
+class AccountingEpoch:
+    epoch_id: str
+    execution_domain_scope: str
+    account_scope: str
+    portfolio_id: str
+    source_fingerprint: str
+    effective_at: datetime
+    created_at: datetime
+    origin_kind: str = "EMPTY_LEDGER"
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        _identifier(self.epoch_id, "epoch_id")
+        _text(self.execution_domain_scope, "execution_domain_scope")
+        _text(self.account_scope, "account_scope")
+        _text(self.portfolio_id, "portfolio_id")
+        if self.origin_kind != "EMPTY_LEDGER":
+            raise FifoAccountingValidationError(
+                "PR4A can create only EMPTY_LEDGER epochs; legacy adoption belongs to PR4B"
+            )
+        if (
+            type(self.source_fingerprint) is not str
+            or _HASH.fullmatch(self.source_fingerprint) is None
+        ):
+            raise FifoAccountingValidationError("source_fingerprint is malformed")
+        _utc(self.effective_at, "effective_at")
+        _utc(self.created_at, "created_at")
+        if self.created_at < self.effective_at:
+            raise FifoAccountingValidationError("created_at precedes effective_at")
+        if self.schema_version != 1:
+            raise FifoAccountingValidationError("unsupported epoch schema version")
+
+    def payload(self) -> dict[str, object]:
+        return {
+            "account_scope": self.account_scope,
+            "created_at": _utc_text(self.created_at),
+            "effective_at": _utc_text(self.effective_at),
+            "epoch_id": self.epoch_id,
+            "execution_domain_scope": self.execution_domain_scope,
+            "origin_kind": self.origin_kind,
+            "portfolio_id": self.portfolio_id,
+            "schema_version": self.schema_version,
+            "source_fingerprint": self.source_fingerprint,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class FillEvent:
+    epoch_id: str
+    fill_id: str
+    commission_id: str
+    event_sequence: int
+    execution_id: str
+    idempotency_key: str
+    con_id: int
+    symbol: str
+    side: FillSide
+    quantity: Decimal
+    price: Decimal
+    commission_minor: int
+    occurred_at: datetime
+    recorded_at: datetime
+
+    def __post_init__(self) -> None:
+        _identifier(self.epoch_id, "epoch_id")
+        _identifier(self.fill_id, "fill_id")
+        _identifier(self.commission_id, "commission_id")
+        if type(self.event_sequence) is not int or self.event_sequence <= 0:
+            raise FifoAccountingValidationError("event_sequence must be a positive integer")
+        _text(self.execution_id, "execution_id")
+        _text(self.idempotency_key, "idempotency_key")
+        if type(self.con_id) is not int or self.con_id <= 0:
+            raise FifoAccountingValidationError("con_id must be a positive integer")
+        _text(self.symbol, "symbol", _SYMBOL)
+        if type(self.side) is not FillSide:
+            raise FifoAccountingValidationError("side must be FillSide")
+        _input_decimal(self.quantity, "quantity", positive=True)
+        _input_decimal(self.price, "price", positive=True)
+        _money_from_minor(self.commission_minor)
+        _utc(self.occurred_at, "occurred_at")
+        _utc(self.recorded_at, "recorded_at")
+        if self.recorded_at < self.occurred_at:
+            raise FifoAccountingValidationError("recorded_at precedes occurred_at")
+
+    def payload(self) -> dict[str, object]:
+        return {
+            "commission_id": self.commission_id,
+            "commission_minor": self.commission_minor,
+            "con_id": self.con_id,
+            "epoch_id": self.epoch_id,
+            "event_sequence": self.event_sequence,
+            "execution_id": self.execution_id,
+            "fill_id": self.fill_id,
+            "idempotency_key": self.idempotency_key,
+            "occurred_at": _utc_text(self.occurred_at),
+            "price": _decimal_text(self.price),
+            "quantity": _decimal_text(self.quantity),
+            "recorded_at": _utc_text(self.recorded_at),
+            "side": self.side.value,
+            "symbol": self.symbol,
+        }
+
+    def fingerprint(self) -> str:
+        return _fingerprint(self.payload())
+
+
+@dataclass(frozen=True, slots=True)
+class PositionSnapshot:
+    snapshot_id: str
+    epoch_id: str
+    source_fill_id: str
+    event_sequence: int
+    con_id: int
+    symbol: str
+    signed_quantity: Decimal
+    open_cost: Optional[Decimal]
+    open_lot_count: int
+    cumulative_realized_pnl: Decimal
+    cumulative_commission_minor: int
+    previous_snapshot_id: Optional[str]
+    previous_state_fingerprint: Optional[str]
+    state_fingerprint: str
+    created_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class FillResult:
+    fill_id: str
+    opened_lot_id: Optional[str]
+    match_ids: tuple[str, ...]
+    snapshot: PositionSnapshot
+    replayed: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _OpenLot:
+    lot_id: str
+    opened_sequence: int
+    direction: str
+    opened_quantity: Decimal
+    remaining_quantity: Decimal
+    open_price: Decimal
+    opening_commission_minor: int
+    allocated_opening_commission_minor: int
+
+
+class FifoLedger:
+    """Append exact fill events to a previously migrated fixture ledger."""
+
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        if type(connection) is not sqlite3.Connection:
+            raise TypeError("connection must be sqlite3.Connection")
+        assert_fifo_accounting_schema(connection)
+        self._connection = connection
+
+    def create_epoch(self, epoch: AccountingEpoch) -> AccountingEpoch:
+        if type(epoch) is not AccountingEpoch:
+            raise TypeError("epoch must be AccountingEpoch")
+        if self._connection.in_transaction:
+            raise FifoAccountingError("epoch creation requires an idle connection")
+        try:
+            self._connection.execute("BEGIN IMMEDIATE")
+            by_id = self._connection.execute(
+                "SELECT * FROM fifo_accounting_epochs WHERE epoch_id = ?",
+                (epoch.epoch_id,),
+            ).fetchone()
+            by_scope = self._connection.execute(
+                """
+                SELECT * FROM fifo_accounting_epochs
+                WHERE execution_domain_scope = ? AND account_scope = ? AND portfolio_id = ?
+                """,
+                (epoch.execution_domain_scope, epoch.account_scope, epoch.portfolio_id),
+            ).fetchone()
+            by_fingerprint = self._connection.execute(
+                "SELECT * FROM fifo_accounting_epochs WHERE source_fingerprint = ?",
+                (epoch.source_fingerprint,),
+            ).fetchone()
+            existing = [row for row in (by_id, by_scope, by_fingerprint) if row is not None]
+            if existing:
+                if any(tuple(row) != tuple(existing[0]) for row in existing[1:]):
+                    raise FifoAccountingConflict("epoch identities resolve to different records")
+                if self._epoch_payload_from_row(existing[0]) != epoch.payload():
+                    raise FifoAccountingConflict("epoch identity is bound to different data")
+                self._connection.rollback()
+                return epoch
+            self._connection.execute(
+                """
+                INSERT INTO fifo_accounting_epochs(
+                    epoch_id, schema_version, execution_domain_scope, account_scope,
+                    portfolio_id, origin_kind, source_fingerprint, effective_at, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    epoch.epoch_id,
+                    epoch.schema_version,
+                    epoch.execution_domain_scope,
+                    epoch.account_scope,
+                    epoch.portfolio_id,
+                    epoch.origin_kind,
+                    epoch.source_fingerprint,
+                    _utc_text(epoch.effective_at),
+                    _utc_text(epoch.created_at),
+                ),
+            )
+            self._connection.commit()
+        except BaseException:
+            if self._connection.in_transaction:
+                self._connection.rollback()
+            raise
+        return epoch
+
+    @staticmethod
+    def _epoch_payload_from_row(row: Sequence[object]) -> dict[str, object]:
+        return {
+            "account_scope": row[3],
+            "created_at": row[8],
+            "effective_at": row[7],
+            "epoch_id": row[0],
+            "execution_domain_scope": row[2],
+            "origin_kind": row[5],
+            "portfolio_id": row[4],
+            "schema_version": row[1],
+            "source_fingerprint": row[6],
+        }
+
+    def record_fill(self, event: FillEvent) -> FillResult:
+        if type(event) is not FillEvent:
+            raise TypeError("event must be FillEvent")
+        if self._connection.in_transaction:
+            raise FifoAccountingError("fill recording requires an idle connection")
+        try:
+            self._connection.execute("BEGIN IMMEDIATE")
+            self._require_epoch(event.epoch_id)
+            replay = self._existing_fill(event)
+            if replay is not None:
+                self._connection.rollback()
+                return replay
+            self._assert_next_event(event)
+            self._assert_instrument_identity(event)
+            self._connection.execute(
+                """
+                INSERT INTO fifo_fills(
+                    fill_id, epoch_id, event_sequence, execution_id, idempotency_key,
+                    con_id, symbol, side, quantity_text, price_text, occurred_at,
+                    recorded_at, payload_fingerprint
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event.fill_id,
+                    event.epoch_id,
+                    event.event_sequence,
+                    event.execution_id,
+                    event.idempotency_key,
+                    event.con_id,
+                    event.symbol,
+                    event.side.value,
+                    _decimal_text(event.quantity),
+                    _decimal_text(event.price),
+                    _utc_text(event.occurred_at),
+                    _utc_text(event.recorded_at),
+                    event.fingerprint(),
+                ),
+            )
+            self._connection.execute(
+                """
+                INSERT INTO fifo_commissions(
+                    commission_id, epoch_id, fill_id, amount_minor, currency,
+                    minor_unit_exponent, recorded_at
+                ) VALUES (?, ?, ?, ?, 'USD', 2, ?)
+                """,
+                (
+                    event.commission_id,
+                    event.epoch_id,
+                    event.fill_id,
+                    event.commission_minor,
+                    _utc_text(event.recorded_at),
+                ),
+            )
+            result = self._project_fill(event)
+            self._connection.commit()
+            return result
+        except BaseException:
+            if self._connection.in_transaction:
+                self._connection.rollback()
+            raise
+
+    def verify_epoch_integrity(self, epoch_id: str) -> None:
+        """Recompute immutable relationships and hash-chain evidence for an epoch."""
+
+        _identifier(epoch_id, "epoch_id")
+        self._require_epoch(epoch_id)
+        rows = self._connection.execute(
+            """
+            SELECT f.fill_id, c.commission_id, f.event_sequence, f.execution_id,
+                   f.idempotency_key, f.con_id, f.symbol, f.side, f.quantity_text,
+                   f.price_text, c.amount_minor, f.occurred_at, f.recorded_at,
+                   f.payload_fingerprint
+            FROM fifo_fills f
+            JOIN fifo_commissions c ON c.epoch_id = f.epoch_id AND c.fill_id = f.fill_id
+            WHERE f.epoch_id = ? ORDER BY f.event_sequence
+            """,
+            (epoch_id,),
+        ).fetchall()
+        prior_time: Optional[datetime] = None
+        last_event_by_asset: dict[tuple[int, str], FillEvent] = {}
+        for expected_sequence, row in enumerate(rows, start=1):
+            event = FillEvent(
+                epoch_id=epoch_id,
+                fill_id=str(row[0]),
+                commission_id=str(row[1]),
+                event_sequence=int(row[2]),
+                execution_id=str(row[3]),
+                idempotency_key=str(row[4]),
+                con_id=int(row[5]),
+                symbol=str(row[6]),
+                side=FillSide(str(row[7])),
+                quantity=_parse_decimal(row[8], "fill quantity", positive=True),
+                price=_parse_decimal(row[9], "fill price", positive=True),
+                commission_minor=int(row[10]),
+                occurred_at=_parse_utc(row[11], "fill occurred_at"),
+                recorded_at=_parse_utc(row[12], "fill recorded_at"),
+            )
+            if event.event_sequence != expected_sequence:
+                raise FifoAccountingValidationError("fill sequence is not contiguous")
+            if prior_time is not None and event.occurred_at < prior_time:
+                raise FifoAccountingValidationError("fill event time is not monotonic")
+            prior_time = event.occurred_at
+            last_event_by_asset[(event.con_id, event.symbol)] = event
+            if event.fingerprint() != row[13]:
+                raise FifoAccountingValidationError("fill payload fingerprint mismatch")
+            allocations = self._connection.execute(
+                """
+                SELECT match_ordinal, matched_quantity_text,
+                       closing_commission_minor, 0 AS is_opening
+                FROM fifo_lot_matches
+                WHERE epoch_id = ? AND closing_fill_id = ?
+                UNION ALL
+                SELECT 1000000000 + lot_ordinal, opened_quantity_text,
+                       opening_commission_minor, 1 AS is_opening
+                FROM fifo_lot_openings
+                WHERE epoch_id = ? AND opening_fill_id = ?
+                ORDER BY match_ordinal
+                """,
+                (epoch_id, event.fill_id, epoch_id, event.fill_id),
+            ).fetchall()
+            exact_allocations = _allocate_minor(
+                event.commission_minor,
+                [
+                    _parse_decimal(allocation[1], "commission segment", positive=True)
+                    for allocation in allocations
+                ],
+            )
+            allocated_quantity = Decimal("0")
+            for allocation in allocations:
+                allocated_quantity = _add(
+                    allocated_quantity,
+                    _parse_decimal(allocation[1], "commission segment", positive=True),
+                    "allocated fill quantity",
+                )
+            if allocated_quantity != event.quantity:
+                raise FifoAccountingValidationError("fill quantity allocation is incomplete")
+            if [int(allocation[2]) for allocation in allocations] != exact_allocations:
+                raise FifoAccountingValidationError(
+                    "fill commission allocation is not deterministic"
+                )
+            if sum(int(allocation[2]) for allocation in allocations) != event.commission_minor:
+                raise FifoAccountingValidationError("fill commission allocation is incomplete")
+
+        lot_rows = self._connection.execute(
+            """
+            SELECT lot_id, direction, opened_quantity_text, open_price_text,
+                   opening_commission_minor
+            FROM fifo_lot_openings WHERE epoch_id = ?
+            """,
+            (epoch_id,),
+        ).fetchall()
+        for lot_id, direction, opened_text, open_price_text, commission_minor in lot_rows:
+            opened = _parse_decimal(opened_text, "opened quantity", positive=True)
+            open_price = _parse_decimal(open_price_text, "open price", positive=True)
+            matches = self._connection.execute(
+                """
+                SELECT matched_quantity_text, opening_price_text, closing_price_text,
+                       opening_commission_minor, closing_commission_minor,
+                       gross_pnl_text, realized_pnl_text
+                FROM fifo_lot_matches m
+                JOIN fifo_fills f ON f.fill_id = m.closing_fill_id
+                WHERE m.epoch_id = ? AND m.opening_lot_id = ?
+                ORDER BY f.event_sequence, m.match_ordinal
+                """,
+                (epoch_id, lot_id),
+            ).fetchall()
+            matched = Decimal("0")
+            allocated_opening = 0
+            for match in matches:
+                quantity = _parse_decimal(match[0], "matched quantity", positive=True)
+                if _parse_decimal(match[1], "recorded open price", positive=True) != open_price:
+                    raise FifoAccountingValidationError("lot match open price diverges")
+                close_price = _parse_decimal(match[2], "closing price", positive=True)
+                opening_allocation = int(match[3])
+                closing_allocation = int(match[4])
+                lot_state = _OpenLot(
+                    lot_id=str(lot_id),
+                    opened_sequence=0,
+                    direction=str(direction),
+                    opened_quantity=opened,
+                    remaining_quantity=_subtract(opened, matched, "remaining lot quantity"),
+                    open_price=open_price,
+                    opening_commission_minor=int(commission_minor),
+                    allocated_opening_commission_minor=allocated_opening,
+                )
+                if self._opening_commission_for_match(lot_state, quantity) != opening_allocation:
+                    raise FifoAccountingValidationError(
+                        "opening commission allocation is not deterministic"
+                    )
+                per_share = (
+                    _subtract(close_price, open_price, "long P&L per share")
+                    if direction == "LONG"
+                    else _subtract(open_price, close_price, "short P&L per share")
+                )
+                gross = _multiply(per_share, quantity, "gross realized P&L")
+                realized = _subtract(
+                    _subtract(
+                        gross,
+                        _money_from_minor(opening_allocation),
+                        "realized P&L",
+                    ),
+                    _money_from_minor(closing_allocation),
+                    "realized P&L",
+                )
+                if gross != _parse_decimal(match[5], "gross P&L"):
+                    raise FifoAccountingValidationError("lot match gross P&L diverges")
+                if realized != _parse_decimal(match[6], "realized P&L"):
+                    raise FifoAccountingValidationError("lot match realized P&L diverges")
+                matched = _add(matched, quantity, "matched quantity")
+                allocated_opening += opening_allocation
+            if matched > opened:
+                raise FifoAccountingValidationError("lot is over-matched")
+            if matched == opened and allocated_opening != int(commission_minor):
+                raise FifoAccountingValidationError(
+                    "closed lot opening commission is not fully allocated"
+                )
+
+        previous_by_asset: dict[tuple[int, str], tuple[str, str]] = {}
+        latest_snapshot_by_asset: dict[tuple[int, str], Sequence[object]] = {}
+        snapshots = self._connection.execute(
+            """
+            SELECT snapshot_id, source_fill_id, event_sequence, con_id, symbol,
+                   signed_quantity_text, open_cost_text, open_lot_count,
+                   cumulative_realized_pnl_text, cumulative_commission_minor,
+                   previous_snapshot_id, previous_state_fingerprint, state_fingerprint
+            FROM fifo_position_snapshots WHERE epoch_id = ? ORDER BY event_sequence
+            """,
+            (epoch_id,),
+        ).fetchall()
+        if len(snapshots) != len(rows):
+            raise FifoAccountingValidationError("every fill must have exactly one snapshot")
+        for row in snapshots:
+            asset = (int(row[3]), str(row[4]))
+            previous = previous_by_asset.get(asset)
+            expected_previous_id = None if previous is None else previous[0]
+            expected_previous_hash = None if previous is None else previous[1]
+            if row[10] != expected_previous_id or row[11] != expected_previous_hash:
+                raise FifoAccountingValidationError("snapshot chain is discontinuous")
+            payload = {
+                "con_id": int(row[3]),
+                "cumulative_commission_minor": int(row[9]),
+                "cumulative_realized_pnl": _decimal_text(
+                    _parse_decimal(row[8], "cumulative realized P&L")
+                ),
+                "epoch_id": epoch_id,
+                "event_sequence": int(row[2]),
+                "open_cost": (
+                    None
+                    if row[6] is None
+                    else _decimal_text(_parse_decimal(row[6], "open cost", positive=True))
+                ),
+                "open_lot_count": int(row[7]),
+                "previous_snapshot_id": expected_previous_id,
+                "previous_state_fingerprint": expected_previous_hash,
+                "signed_quantity": _decimal_text(_parse_decimal(row[5], "signed quantity")),
+                "snapshot_id": str(row[0]),
+                "source_fill_id": str(row[1]),
+                "symbol": str(row[4]),
+            }
+            if _fingerprint(payload) != row[12]:
+                raise FifoAccountingValidationError("snapshot state fingerprint mismatch")
+            previous_by_asset[asset] = (str(row[0]), str(row[12]))
+            latest_snapshot_by_asset[asset] = row
+
+        for asset, event in last_event_by_asset.items():
+            lots = self._open_lots(event)
+            expected_quantity = Decimal("0")
+            expected_open_cost = Decimal("0")
+            for lot in lots:
+                sign = Decimal("1") if lot.direction == "LONG" else Decimal("-1")
+                expected_quantity = _add(
+                    expected_quantity,
+                    _multiply(sign, lot.remaining_quantity, "signed lot quantity"),
+                    "signed position quantity",
+                )
+                expected_open_cost = _add(
+                    expected_open_cost,
+                    _multiply(lot.open_price, lot.remaining_quantity, "open lot cost"),
+                    "open position cost",
+                )
+            realized_rows = self._connection.execute(
+                """
+                SELECT m.realized_pnl_text
+                FROM fifo_lot_matches m
+                JOIN fifo_fills f ON f.fill_id = m.closing_fill_id
+                WHERE m.epoch_id = ? AND f.con_id = ? AND f.symbol = ?
+                """,
+                (epoch_id, asset[0], asset[1]),
+            ).fetchall()
+            expected_realized = Decimal("0")
+            for realized_row in realized_rows:
+                expected_realized = _add(
+                    expected_realized,
+                    _parse_decimal(realized_row[0], "realized P&L"),
+                    "cumulative realized P&L",
+                )
+            commission_rows = self._connection.execute(
+                """
+                SELECT c.amount_minor
+                FROM fifo_commissions c JOIN fifo_fills f ON f.fill_id = c.fill_id
+                WHERE c.epoch_id = ? AND f.con_id = ? AND f.symbol = ?
+                """,
+                (epoch_id, asset[0], asset[1]),
+            ).fetchall()
+            expected_commission = sum(int(commission_row[0]) for commission_row in commission_rows)
+            latest = latest_snapshot_by_asset[asset]
+            expected_open_cost_text = (
+                None if expected_quantity == 0 else _decimal_text(expected_open_cost)
+            )
+            if (
+                _parse_decimal(latest[5], "snapshot signed quantity") != expected_quantity
+                or latest[6] != expected_open_cost_text
+                or int(str(latest[7])) != len(lots)
+                or _parse_decimal(latest[8], "snapshot realized P&L") != expected_realized
+                or int(str(latest[9])) != expected_commission
+            ):
+                raise FifoAccountingValidationError(
+                    "latest position snapshot diverges from immutable events"
+                )
+
+    def _require_epoch(self, epoch_id: str) -> None:
+        row = self._connection.execute(
+            "SELECT origin_kind FROM fifo_accounting_epochs WHERE epoch_id = ?", (epoch_id,)
+        ).fetchone()
+        if row is None:
+            raise FifoAccountingValidationError("unknown accounting epoch")
+        if row != ("EMPTY_LEDGER",):
+            raise FifoAccountingValidationError(
+                "PR4A cannot project an adopted legacy accounting epoch"
+            )
+
+    def _existing_fill(self, event: FillEvent) -> Optional[FillResult]:
+        rows = self._connection.execute(
+            """
+            SELECT DISTINCT fill_id FROM fifo_fills
+            WHERE epoch_id = ? AND (
+                fill_id = ? OR execution_id = ? OR idempotency_key = ? OR event_sequence = ?
+            )
+            """,
+            (
+                event.epoch_id,
+                event.fill_id,
+                event.execution_id,
+                event.idempotency_key,
+                event.event_sequence,
+            ),
+        ).fetchall()
+        commission_owner = self._connection.execute(
+            "SELECT fill_id FROM fifo_commissions WHERE commission_id = ?",
+            (event.commission_id,),
+        ).fetchone()
+        identities = {str(row[0]) for row in rows}
+        if commission_owner is not None:
+            identities.add(str(commission_owner[0]))
+        if not identities:
+            return None
+        if identities != {event.fill_id}:
+            raise FifoAccountingConflict("fill identities resolve to different records")
+        stored = self._connection.execute(
+            """
+            SELECT f.epoch_id, f.fill_id, c.commission_id, f.event_sequence,
+                   f.execution_id, f.idempotency_key, f.con_id, f.symbol, f.side,
+                   f.quantity_text, f.price_text, c.amount_minor, f.occurred_at,
+                   f.recorded_at, f.payload_fingerprint
+            FROM fifo_fills f JOIN fifo_commissions c ON c.fill_id = f.fill_id
+            WHERE f.fill_id = ?
+            """,
+            (event.fill_id,),
+        ).fetchone()
+        if stored is None:
+            raise FifoAccountingConflict("existing fill is incomplete")
+        expected = (
+            event.epoch_id,
+            event.fill_id,
+            event.commission_id,
+            event.event_sequence,
+            event.execution_id,
+            event.idempotency_key,
+            event.con_id,
+            event.symbol,
+            event.side.value,
+            _decimal_text(event.quantity),
+            _decimal_text(event.price),
+            event.commission_minor,
+            _utc_text(event.occurred_at),
+            _utc_text(event.recorded_at),
+            event.fingerprint(),
+        )
+        if tuple(stored) != expected:
+            raise FifoAccountingConflict("fill identity is bound to different data")
+        return self._load_result(event.fill_id, replayed=True)
+
+    def _assert_next_event(self, event: FillEvent) -> None:
+        row = self._connection.execute(
+            """
+            SELECT event_sequence, occurred_at FROM fifo_fills
+            WHERE epoch_id = ? ORDER BY event_sequence DESC LIMIT 1
+            """,
+            (event.epoch_id,),
+        ).fetchone()
+        expected = 1 if row is None else int(row[0]) + 1
+        if event.event_sequence != expected:
+            raise FifoAccountingOrderingError(f"event_sequence must extend the epoch at {expected}")
+        if row is not None and event.occurred_at < _parse_utc(row[1], "prior occurred_at"):
+            raise FifoAccountingOrderingError("fill event time precedes the prior sequence")
+
+    def _assert_instrument_identity(self, event: FillEvent) -> None:
+        rows = self._connection.execute(
+            """
+            SELECT DISTINCT con_id, symbol FROM fifo_fills
+            WHERE epoch_id = ? AND (con_id = ? OR symbol = ?)
+            """,
+            (event.epoch_id, event.con_id, event.symbol),
+        ).fetchall()
+        if any((int(row[0]), str(row[1])) != (event.con_id, event.symbol) for row in rows):
+            raise FifoAccountingConflict("contract identifier and symbol binding changed")
+
+    def _open_lots(self, event: FillEvent) -> list[_OpenLot]:
+        rows = self._connection.execute(
+            """
+            SELECT l.lot_id, l.opened_sequence, l.direction, l.opened_quantity_text,
+                   l.open_price_text, l.opening_commission_minor
+            FROM fifo_lot_openings l
+            WHERE l.epoch_id = ? AND l.con_id = ? AND l.symbol = ?
+            ORDER BY l.opened_sequence, l.lot_id
+            """,
+            (event.epoch_id, event.con_id, event.symbol),
+        ).fetchall()
+        result: list[_OpenLot] = []
+        for row in rows:
+            opened = _parse_decimal(row[3], "opened_quantity", positive=True)
+            # SQLite numeric aggregation would be inexact. Recompute from text.
+            matched_rows = self._connection.execute(
+                """
+                SELECT m.matched_quantity_text, m.opening_commission_minor
+                FROM fifo_lot_matches m
+                JOIN fifo_fills f ON f.fill_id = m.closing_fill_id
+                WHERE m.epoch_id = ? AND m.opening_lot_id = ?
+                ORDER BY f.event_sequence, m.match_ordinal
+                """,
+                (event.epoch_id, row[0]),
+            ).fetchall()
+            matched = Decimal("0")
+            allocated = 0
+            for matched_text, allocated_minor in matched_rows:
+                matched = _add(
+                    matched,
+                    _parse_decimal(matched_text, "matched_quantity", positive=True),
+                    "matched quantity",
+                )
+                allocated += int(allocated_minor)
+            remaining = _subtract(opened, matched, "remaining lot quantity")
+            if remaining < 0:
+                raise FifoAccountingValidationError("persisted lot is over-matched")
+            if remaining == 0:
+                if allocated != int(row[5]):
+                    raise FifoAccountingValidationError(
+                        "closed lot did not allocate its complete opening commission"
+                    )
+                continue
+            result.append(
+                _OpenLot(
+                    lot_id=str(row[0]),
+                    opened_sequence=int(row[1]),
+                    direction=str(row[2]),
+                    opened_quantity=opened,
+                    remaining_quantity=remaining,
+                    open_price=_parse_decimal(row[4], "open_price", positive=True),
+                    opening_commission_minor=int(row[5]),
+                    allocated_opening_commission_minor=allocated,
+                )
+            )
+        directions = {lot.direction for lot in result}
+        if len(directions) > 1:
+            raise FifoAccountingValidationError("persisted open lots cross zero")
+        return result
+
+    @staticmethod
+    def _opening_commission_for_match(lot: _OpenLot, quantity: Decimal) -> int:
+        if quantity == lot.remaining_quantity:
+            return lot.opening_commission_minor - lot.allocated_opening_commission_minor
+        consumed_before = _subtract(
+            lot.opened_quantity,
+            lot.remaining_quantity,
+            "consumed opening quantity",
+        )
+        consumed_after = _add(consumed_before, quantity, "consumed opening quantity")
+        before_atoms, after_atoms, total_atoms = _quantity_atoms(
+            [consumed_before, consumed_after, lot.opened_quantity]
+        )
+        magnitude = abs(lot.opening_commission_minor)
+        sign = -1 if lot.opening_commission_minor < 0 else 1
+        target_before = sign * (magnitude * before_atoms // total_atoms)
+        target_after = sign * (magnitude * after_atoms // total_atoms)
+        allocation = target_after - target_before
+        if lot.allocated_opening_commission_minor != target_before:
+            raise FifoAccountingValidationError(
+                "persisted opening commission allocation is not deterministic"
+            )
+        return allocation
+
+    def _project_fill(self, event: FillEvent) -> FillResult:
+        lots = self._open_lots(event)
+        fill_direction = "LONG" if event.side is FillSide.BUY else "SHORT"
+        opposite = "SHORT" if fill_direction == "LONG" else "LONG"
+        remaining = event.quantity
+        match_specs: list[tuple[_OpenLot, Decimal]] = []
+        if lots and lots[0].direction == opposite:
+            for lot in lots:
+                if remaining == 0:
+                    break
+                quantity = min(remaining, lot.remaining_quantity)
+                match_specs.append((lot, quantity))
+                remaining = _subtract(remaining, quantity, "unmatched fill quantity")
+        segment_quantities = [quantity for _, quantity in match_specs]
+        if remaining > 0:
+            segment_quantities.append(remaining)
+        commission_allocations = _allocate_minor(event.commission_minor, segment_quantities)
+
+        match_ids: list[str] = []
+        realized_delta = Decimal("0")
+        for ordinal, ((lot, quantity), closing_commission) in enumerate(
+            zip(match_specs, commission_allocations)
+        ):
+            opening_commission = self._opening_commission_for_match(lot, quantity)
+            per_share = (
+                _subtract(event.price, lot.open_price, "long P&L per share")
+                if lot.direction == "LONG"
+                else _subtract(lot.open_price, event.price, "short P&L per share")
+            )
+            gross = _multiply(per_share, quantity, "gross realized P&L")
+            realized = _subtract(
+                _subtract(
+                    gross,
+                    _money_from_minor(opening_commission),
+                    "net realized P&L",
+                ),
+                _money_from_minor(closing_commission),
+                "net realized P&L",
+            )
+            match_id = _derived_id("fmatch", event.epoch_id, event.fill_id, ordinal)
+            self._connection.execute(
+                """
+                INSERT INTO fifo_lot_matches(
+                    match_id, epoch_id, closing_fill_id, opening_lot_id,
+                    match_ordinal, matched_quantity_text, opening_price_text,
+                    closing_price_text, opening_commission_minor,
+                    closing_commission_minor, gross_pnl_text, realized_pnl_text,
+                    matched_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    match_id,
+                    event.epoch_id,
+                    event.fill_id,
+                    lot.lot_id,
+                    ordinal,
+                    _decimal_text(quantity),
+                    _decimal_text(lot.open_price),
+                    _decimal_text(event.price),
+                    opening_commission,
+                    closing_commission,
+                    _decimal_text(gross),
+                    _decimal_text(realized),
+                    _utc_text(event.occurred_at),
+                ),
+            )
+            match_ids.append(match_id)
+            realized_delta = _add(realized_delta, realized, "fill realized P&L")
+
+        opened_lot_id: Optional[str] = None
+        if remaining > 0:
+            opening_commission = commission_allocations[-1]
+            opened_lot_id = _derived_id("flot", event.epoch_id, event.fill_id, 0)
+            self._connection.execute(
+                """
+                INSERT INTO fifo_lot_openings(
+                    lot_id, epoch_id, opening_fill_id, lot_ordinal, con_id, symbol,
+                    direction, opened_quantity_text, open_price_text,
+                    opening_commission_minor, opened_sequence, opened_at
+                ) VALUES (?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    opened_lot_id,
+                    event.epoch_id,
+                    event.fill_id,
+                    event.con_id,
+                    event.symbol,
+                    fill_direction,
+                    _decimal_text(remaining),
+                    _decimal_text(event.price),
+                    opening_commission,
+                    event.event_sequence,
+                    _utc_text(event.occurred_at),
+                ),
+            )
+        snapshot = self._append_snapshot(event, realized_delta)
+        return FillResult(
+            fill_id=event.fill_id,
+            opened_lot_id=opened_lot_id,
+            match_ids=tuple(match_ids),
+            snapshot=snapshot,
+            replayed=False,
+        )
+
+    def _append_snapshot(self, event: FillEvent, realized_delta: Decimal) -> PositionSnapshot:
+        lots = self._open_lots(event)
+        signed_quantity = Decimal("0")
+        open_cost = Decimal("0")
+        for lot in lots:
+            sign = Decimal("1") if lot.direction == "LONG" else Decimal("-1")
+            signed_quantity = _add(
+                signed_quantity,
+                _multiply(sign, lot.remaining_quantity, "signed lot quantity"),
+                "signed position quantity",
+            )
+            open_cost = _add(
+                open_cost,
+                _multiply(lot.open_price, lot.remaining_quantity, "open lot cost"),
+                "open position cost",
+            )
+        exact_open_cost = None if signed_quantity == 0 else open_cost
+
+        previous = self._connection.execute(
+            """
+            SELECT snapshot_id, cumulative_realized_pnl_text,
+                   cumulative_commission_minor, state_fingerprint
+            FROM fifo_position_snapshots
+            WHERE epoch_id = ? AND con_id = ? AND symbol = ?
+            ORDER BY event_sequence DESC LIMIT 1
+            """,
+            (event.epoch_id, event.con_id, event.symbol),
+        ).fetchone()
+        previous_id = None if previous is None else str(previous[0])
+        previous_realized = (
+            Decimal("0")
+            if previous is None
+            else _parse_decimal(previous[1], "cumulative realized P&L")
+        )
+        cumulative_realized = _add(previous_realized, realized_delta, "cumulative realized P&L")
+        previous_commission = 0 if previous is None else int(previous[2])
+        cumulative_commission = previous_commission + event.commission_minor
+        previous_fingerprint = None if previous is None else str(previous[3])
+        snapshot_id = _derived_id("fsnap", event.epoch_id, event.fill_id)
+        payload = {
+            "con_id": event.con_id,
+            "cumulative_commission_minor": cumulative_commission,
+            "cumulative_realized_pnl": _decimal_text(cumulative_realized),
+            "epoch_id": event.epoch_id,
+            "event_sequence": event.event_sequence,
+            "open_cost": None if exact_open_cost is None else _decimal_text(exact_open_cost),
+            "open_lot_count": len(lots),
+            "previous_snapshot_id": previous_id,
+            "previous_state_fingerprint": previous_fingerprint,
+            "signed_quantity": _decimal_text(signed_quantity),
+            "snapshot_id": snapshot_id,
+            "source_fill_id": event.fill_id,
+            "symbol": event.symbol,
+        }
+        state_fingerprint = _fingerprint(payload)
+        self._connection.execute(
+            """
+            INSERT INTO fifo_position_snapshots(
+                snapshot_id, epoch_id, source_fill_id, event_sequence, con_id,
+                symbol, signed_quantity_text, open_cost_text,
+                open_lot_count, cumulative_realized_pnl_text,
+                cumulative_commission_minor, previous_snapshot_id,
+                previous_state_fingerprint, state_fingerprint, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                snapshot_id,
+                event.epoch_id,
+                event.fill_id,
+                event.event_sequence,
+                event.con_id,
+                event.symbol,
+                _decimal_text(signed_quantity),
+                None if exact_open_cost is None else _decimal_text(exact_open_cost),
+                len(lots),
+                _decimal_text(cumulative_realized),
+                cumulative_commission,
+                previous_id,
+                previous_fingerprint,
+                state_fingerprint,
+                _utc_text(event.recorded_at),
+            ),
+        )
+        return PositionSnapshot(
+            snapshot_id=snapshot_id,
+            epoch_id=event.epoch_id,
+            source_fill_id=event.fill_id,
+            event_sequence=event.event_sequence,
+            con_id=event.con_id,
+            symbol=event.symbol,
+            signed_quantity=signed_quantity,
+            open_cost=exact_open_cost,
+            open_lot_count=len(lots),
+            cumulative_realized_pnl=cumulative_realized,
+            cumulative_commission_minor=cumulative_commission,
+            previous_snapshot_id=previous_id,
+            previous_state_fingerprint=previous_fingerprint,
+            state_fingerprint=state_fingerprint,
+            created_at=event.recorded_at,
+        )
+
+    def _load_result(self, fill_id: str, *, replayed: bool) -> FillResult:
+        opening = self._connection.execute(
+            "SELECT lot_id FROM fifo_lot_openings WHERE opening_fill_id = ?", (fill_id,)
+        ).fetchone()
+        matches = self._connection.execute(
+            """
+            SELECT match_id FROM fifo_lot_matches
+            WHERE closing_fill_id = ? ORDER BY match_ordinal
+            """,
+            (fill_id,),
+        ).fetchall()
+        row = self._connection.execute(
+            """
+            SELECT snapshot_id, epoch_id, source_fill_id, event_sequence, con_id,
+                   symbol, signed_quantity_text, open_cost_text, open_lot_count,
+                   cumulative_realized_pnl_text, cumulative_commission_minor,
+                   previous_snapshot_id, previous_state_fingerprint,
+                   state_fingerprint, created_at
+            FROM fifo_position_snapshots WHERE source_fill_id = ?
+            """,
+            (fill_id,),
+        ).fetchone()
+        if row is None:
+            raise FifoAccountingConflict("existing fill has no derived snapshot")
+        snapshot = PositionSnapshot(
+            snapshot_id=str(row[0]),
+            epoch_id=str(row[1]),
+            source_fill_id=str(row[2]),
+            event_sequence=int(row[3]),
+            con_id=int(row[4]),
+            symbol=str(row[5]),
+            signed_quantity=_parse_decimal(row[6], "signed quantity"),
+            open_cost=(
+                None if row[7] is None else _parse_decimal(row[7], "open cost basis", positive=True)
+            ),
+            open_lot_count=int(row[8]),
+            cumulative_realized_pnl=_parse_decimal(row[9], "cumulative realized P&L"),
+            cumulative_commission_minor=int(row[10]),
+            previous_snapshot_id=None if row[11] is None else str(row[11]),
+            previous_state_fingerprint=None if row[12] is None else str(row[12]),
+            state_fingerprint=str(row[13]),
+            created_at=_parse_utc(row[14], "snapshot created_at"),
+        )
+        return FillResult(
+            fill_id=fill_id,
+            opened_lot_id=None if opening is None else str(opening[0]),
+            match_ids=tuple(str(match[0]) for match in matches),
+            snapshot=snapshot,
+            replayed=replayed,
+        )

--- a/robo_trader/accounting/fifo.py
+++ b/robo_trader/accounting/fifo.py
@@ -362,6 +362,14 @@ class _OpenLot:
     allocated_opening_commission_minor: int
 
 
+@dataclass(slots=True)
+class _ProjectionLot:
+    lot_id: str
+    direction: str
+    remaining_quantity: Decimal
+    open_price: Decimal
+
+
 class FifoLedger:
     """Append exact fill events to a previously migrated fixture ledger."""
 
@@ -448,7 +456,9 @@ class FifoLedger:
             raise FifoAccountingError("fill recording requires an idle connection")
         try:
             self._connection.execute("BEGIN IMMEDIATE")
-            self._require_epoch(event.epoch_id)
+            effective_at = self._require_epoch(event.epoch_id)
+            if event.occurred_at < effective_at:
+                raise FifoAccountingOrderingError("fill event time precedes epoch effective_at")
             replay = self._existing_fill(event)
             if replay is not None:
                 self._connection.rollback()
@@ -506,21 +516,35 @@ class FifoLedger:
         """Recompute immutable relationships and hash-chain evidence for an epoch."""
 
         _identifier(epoch_id, "epoch_id")
-        self._require_epoch(epoch_id)
+        effective_at = self._require_epoch(epoch_id)
+        fill_count, commission_count, snapshot_count = self._connection.execute(
+            """
+            SELECT
+                (SELECT COUNT(*) FROM fifo_fills WHERE epoch_id = ?),
+                (SELECT COUNT(*) FROM fifo_commissions WHERE epoch_id = ?),
+                (SELECT COUNT(*) FROM fifo_position_snapshots WHERE epoch_id = ?)
+            """,
+            (epoch_id, epoch_id, epoch_id),
+        ).fetchone()
+        if not (int(fill_count) == int(commission_count) == int(snapshot_count)):
+            raise FifoAccountingValidationError(
+                "every fill must have exactly one commission and one snapshot"
+            )
         rows = self._connection.execute(
             """
             SELECT f.fill_id, c.commission_id, f.event_sequence, f.execution_id,
                    f.idempotency_key, f.con_id, f.symbol, f.side, f.quantity_text,
                    f.price_text, c.amount_minor, f.occurred_at, f.recorded_at,
-                   f.payload_fingerprint
+                   f.payload_fingerprint, c.recorded_at
             FROM fifo_fills f
             JOIN fifo_commissions c ON c.epoch_id = f.epoch_id AND c.fill_id = f.fill_id
             WHERE f.epoch_id = ? ORDER BY f.event_sequence
             """,
             (epoch_id,),
         ).fetchall()
-        prior_time: Optional[datetime] = None
+        prior_time: Optional[datetime] = effective_at
         last_event_by_asset: dict[tuple[int, str], FillEvent] = {}
+        events: list[FillEvent] = []
         for expected_sequence, row in enumerate(rows, start=1):
             event = FillEvent(
                 epoch_id=epoch_id,
@@ -543,9 +567,12 @@ class FifoLedger:
             if prior_time is not None and event.occurred_at < prior_time:
                 raise FifoAccountingValidationError("fill event time is not monotonic")
             prior_time = event.occurred_at
+            events.append(event)
             last_event_by_asset[(event.con_id, event.symbol)] = event
             if event.fingerprint() != row[13]:
                 raise FifoAccountingValidationError("fill payload fingerprint mismatch")
+            if _parse_utc(row[14], "commission recorded_at") != event.recorded_at:
+                raise FifoAccountingValidationError("commission does not match its source fill")
             allocations = self._connection.execute(
                 """
                 SELECT match_ordinal, matched_quantity_text,
@@ -583,6 +610,8 @@ class FifoLedger:
                 )
             if sum(int(allocation[2]) for allocation in allocations) != event.commission_minor:
                 raise FifoAccountingValidationError("fill commission allocation is incomplete")
+
+        self._verify_fifo_projection_structure(events)
 
         lot_rows = self._connection.execute(
             """
@@ -665,14 +694,29 @@ class FifoLedger:
             SELECT snapshot_id, source_fill_id, event_sequence, con_id, symbol,
                    signed_quantity_text, open_cost_text, open_lot_count,
                    cumulative_realized_pnl_text, cumulative_commission_minor,
-                   previous_snapshot_id, previous_state_fingerprint, state_fingerprint
+                   previous_snapshot_id, previous_state_fingerprint, state_fingerprint,
+                   created_at
             FROM fifo_position_snapshots WHERE epoch_id = ? ORDER BY event_sequence
             """,
             (epoch_id,),
         ).fetchall()
         if len(snapshots) != len(rows):
             raise FifoAccountingValidationError("every fill must have exactly one snapshot")
+        events_by_fill = {event.fill_id: event for event in events}
         for row in snapshots:
+            source_event = events_by_fill.get(str(row[1]))
+            if source_event is None or (
+                int(row[2]),
+                int(row[3]),
+                str(row[4]),
+                _parse_utc(row[13], "snapshot created_at"),
+            ) != (
+                source_event.event_sequence,
+                source_event.con_id,
+                source_event.symbol,
+                source_event.recorded_at,
+            ):
+                raise FifoAccountingValidationError("snapshot does not match its source fill")
             asset = (int(row[3]), str(row[4]))
             previous = previous_by_asset.get(asset)
             expected_previous_id = None if previous is None else previous[0]
@@ -761,16 +805,103 @@ class FifoLedger:
                     "latest position snapshot diverges from immutable events"
                 )
 
-    def _require_epoch(self, epoch_id: str) -> None:
+    def _verify_fifo_projection_structure(self, events: Sequence[FillEvent]) -> None:
+        active_by_asset: dict[tuple[int, str], list[_ProjectionLot]] = {}
+        for event in events:
+            asset = (event.con_id, event.symbol)
+            active = active_by_asset.setdefault(asset, [])
+            fill_direction = "LONG" if event.side is FillSide.BUY else "SHORT"
+            opposite = "SHORT" if fill_direction == "LONG" else "LONG"
+            remaining = event.quantity
+            expected_matches: list[tuple[_ProjectionLot, Decimal]] = []
+            if active and active[0].direction == opposite:
+                for lot in active:
+                    if remaining == 0:
+                        break
+                    quantity = min(remaining, lot.remaining_quantity)
+                    expected_matches.append((lot, quantity))
+                    remaining = _subtract(remaining, quantity, "verified unmatched fill quantity")
+
+            matches = self._connection.execute(
+                """
+                SELECT match_id, opening_lot_id, match_ordinal, matched_quantity_text,
+                       opening_price_text, closing_price_text, matched_at
+                FROM fifo_lot_matches
+                WHERE epoch_id = ? AND closing_fill_id = ?
+                ORDER BY match_ordinal
+                """,
+                (event.epoch_id, event.fill_id),
+            ).fetchall()
+            if len(matches) != len(expected_matches):
+                raise FifoAccountingValidationError("FIFO projection structure diverges")
+            for ordinal, (row, (lot, quantity)) in enumerate(zip(matches, expected_matches)):
+                expected = (
+                    _derived_id("fmatch", event.epoch_id, event.fill_id, ordinal),
+                    lot.lot_id,
+                    ordinal,
+                    _decimal_text(quantity),
+                    _decimal_text(lot.open_price),
+                    _decimal_text(event.price),
+                    _utc_text(event.occurred_at),
+                )
+                if tuple(row) != expected:
+                    raise FifoAccountingValidationError("FIFO projection structure diverges")
+                lot.remaining_quantity = _subtract(
+                    lot.remaining_quantity,
+                    quantity,
+                    "verified remaining lot quantity",
+                )
+            active[:] = [lot for lot in active if lot.remaining_quantity > 0]
+
+            openings = self._connection.execute(
+                """
+                SELECT lot_id, lot_ordinal, con_id, symbol, direction,
+                       opened_quantity_text, open_price_text, opened_sequence, opened_at
+                FROM fifo_lot_openings
+                WHERE epoch_id = ? AND opening_fill_id = ?
+                ORDER BY lot_ordinal
+                """,
+                (event.epoch_id, event.fill_id),
+            ).fetchall()
+            if remaining == 0:
+                if openings:
+                    raise FifoAccountingValidationError("FIFO projection structure diverges")
+                continue
+            expected_lot_id = _derived_id("flot", event.epoch_id, event.fill_id, 0)
+            expected_opening = (
+                expected_lot_id,
+                0,
+                event.con_id,
+                event.symbol,
+                fill_direction,
+                _decimal_text(remaining),
+                _decimal_text(event.price),
+                event.event_sequence,
+                _utc_text(event.occurred_at),
+            )
+            if len(openings) != 1 or tuple(openings[0]) != expected_opening:
+                raise FifoAccountingValidationError("FIFO projection structure diverges")
+            active.append(
+                _ProjectionLot(
+                    lot_id=expected_lot_id,
+                    direction=fill_direction,
+                    remaining_quantity=remaining,
+                    open_price=event.price,
+                )
+            )
+
+    def _require_epoch(self, epoch_id: str) -> datetime:
         row = self._connection.execute(
-            "SELECT origin_kind FROM fifo_accounting_epochs WHERE epoch_id = ?", (epoch_id,)
+            "SELECT origin_kind, effective_at FROM fifo_accounting_epochs WHERE epoch_id = ?",
+            (epoch_id,),
         ).fetchone()
         if row is None:
             raise FifoAccountingValidationError("unknown accounting epoch")
-        if row != ("EMPTY_LEDGER",):
+        if row[0] != "EMPTY_LEDGER":
             raise FifoAccountingValidationError(
                 "PR4A cannot project an adopted legacy accounting epoch"
             )
+        return _parse_utc(row[1], "epoch effective_at")
 
     def _existing_fill(self, event: FillEvent) -> Optional[FillResult]:
         rows = self._connection.execute(

--- a/robo_trader/accounting/fifo.py
+++ b/robo_trader/accounting/fifo.py
@@ -543,7 +543,6 @@ class FifoLedger:
             (epoch_id,),
         ).fetchall()
         prior_time: Optional[datetime] = effective_at
-        last_event_by_asset: dict[tuple[int, str], FillEvent] = {}
         events: list[FillEvent] = []
         for expected_sequence, row in enumerate(rows, start=1):
             event = FillEvent(
@@ -568,7 +567,6 @@ class FifoLedger:
                 raise FifoAccountingValidationError("fill event time is not monotonic")
             prior_time = event.occurred_at
             events.append(event)
-            last_event_by_asset[(event.con_id, event.symbol)] = event
             if event.fingerprint() != row[13]:
                 raise FifoAccountingValidationError("fill payload fingerprint mismatch")
             if _parse_utc(row[14], "commission recorded_at") != event.recorded_at:
@@ -688,7 +686,7 @@ class FifoLedger:
                 )
 
         previous_by_asset: dict[tuple[int, str], tuple[str, str]] = {}
-        latest_snapshot_by_asset: dict[tuple[int, str], Sequence[object]] = {}
+        snapshot_by_fill: dict[str, Sequence[object]] = {}
         snapshots = self._connection.execute(
             """
             SELECT snapshot_id, source_fill_id, event_sequence, con_id, symbol,
@@ -747,10 +745,11 @@ class FifoLedger:
             if _fingerprint(payload) != row[12]:
                 raise FifoAccountingValidationError("snapshot state fingerprint mismatch")
             previous_by_asset[asset] = (str(row[0]), str(row[12]))
-            latest_snapshot_by_asset[asset] = row
+            snapshot_by_fill[str(row[1])] = row
 
-        for asset, event in last_event_by_asset.items():
-            lots = self._open_lots(event)
+        for event in events:
+            asset = (event.con_id, event.symbol)
+            lots = self._open_lots(event, through_sequence=event.event_sequence)
             expected_quantity = Decimal("0")
             expected_open_cost = Decimal("0")
             for lot in lots:
@@ -771,8 +770,9 @@ class FifoLedger:
                 FROM fifo_lot_matches m
                 JOIN fifo_fills f ON f.fill_id = m.closing_fill_id
                 WHERE m.epoch_id = ? AND f.con_id = ? AND f.symbol = ?
+                  AND f.event_sequence <= ?
                 """,
-                (epoch_id, asset[0], asset[1]),
+                (epoch_id, asset[0], asset[1], event.event_sequence),
             ).fetchall()
             expected_realized = Decimal("0")
             for realized_row in realized_rows:
@@ -786,23 +786,24 @@ class FifoLedger:
                 SELECT c.amount_minor
                 FROM fifo_commissions c JOIN fifo_fills f ON f.fill_id = c.fill_id
                 WHERE c.epoch_id = ? AND f.con_id = ? AND f.symbol = ?
+                  AND f.event_sequence <= ?
                 """,
-                (epoch_id, asset[0], asset[1]),
+                (epoch_id, asset[0], asset[1], event.event_sequence),
             ).fetchall()
             expected_commission = sum(int(commission_row[0]) for commission_row in commission_rows)
-            latest = latest_snapshot_by_asset[asset]
+            snapshot = snapshot_by_fill[event.fill_id]
             expected_open_cost_text = (
                 None if expected_quantity == 0 else _decimal_text(expected_open_cost)
             )
             if (
-                _parse_decimal(latest[5], "snapshot signed quantity") != expected_quantity
-                or latest[6] != expected_open_cost_text
-                or int(str(latest[7])) != len(lots)
-                or _parse_decimal(latest[8], "snapshot realized P&L") != expected_realized
-                or int(str(latest[9])) != expected_commission
+                _parse_decimal(snapshot[5], "snapshot signed quantity") != expected_quantity
+                or snapshot[6] != expected_open_cost_text
+                or int(str(snapshot[7])) != len(lots)
+                or _parse_decimal(snapshot[8], "snapshot realized P&L") != expected_realized
+                or int(str(snapshot[9])) != expected_commission
             ):
                 raise FifoAccountingValidationError(
-                    "latest position snapshot diverges from immutable events"
+                    "position snapshot diverges from immutable events"
                 )
 
     def _verify_fifo_projection_structure(self, events: Sequence[FillEvent]) -> None:
@@ -989,16 +990,28 @@ class FifoLedger:
         if any((int(row[0]), str(row[1])) != (event.con_id, event.symbol) for row in rows):
             raise FifoAccountingConflict("contract identifier and symbol binding changed")
 
-    def _open_lots(self, event: FillEvent) -> list[_OpenLot]:
+    def _open_lots(
+        self,
+        event: FillEvent,
+        *,
+        through_sequence: Optional[int] = None,
+    ) -> list[_OpenLot]:
         rows = self._connection.execute(
             """
             SELECT l.lot_id, l.opened_sequence, l.direction, l.opened_quantity_text,
                    l.open_price_text, l.opening_commission_minor
             FROM fifo_lot_openings l
             WHERE l.epoch_id = ? AND l.con_id = ? AND l.symbol = ?
+              AND (? IS NULL OR l.opened_sequence <= ?)
             ORDER BY l.opened_sequence, l.lot_id
             """,
-            (event.epoch_id, event.con_id, event.symbol),
+            (
+                event.epoch_id,
+                event.con_id,
+                event.symbol,
+                through_sequence,
+                through_sequence,
+            ),
         ).fetchall()
         result: list[_OpenLot] = []
         for row in rows:
@@ -1010,9 +1023,10 @@ class FifoLedger:
                 FROM fifo_lot_matches m
                 JOIN fifo_fills f ON f.fill_id = m.closing_fill_id
                 WHERE m.epoch_id = ? AND m.opening_lot_id = ?
+                  AND (? IS NULL OR f.event_sequence <= ?)
                 ORDER BY f.event_sequence, m.match_ordinal
                 """,
-                (event.epoch_id, row[0]),
+                (event.epoch_id, row[0], through_sequence, through_sequence),
             ).fetchall()
             matched = Decimal("0")
             allocated = 0

--- a/robo_trader/accounting/fifo.py
+++ b/robo_trader/accounting/fifo.py
@@ -17,7 +17,7 @@ from decimal import Decimal, InvalidOperation, localcontext
 from enum import Enum
 from typing import Optional, Sequence
 
-from .fifo_fixture_migration import assert_fifo_accounting_schema
+from .fifo_fixture_migration import _assert_no_temp_fifo_objects, assert_fifo_accounting_schema
 
 _ID_PATTERNS = {
     "epoch_id": re.compile(r"^fepoch-[0-9a-f]{32}$"),
@@ -107,9 +107,16 @@ def _decimal(value: object, field: str, *, positive: bool = False) -> Decimal:
 
 def _input_decimal(value: object, field: str, *, positive: bool = False) -> Decimal:
     exact = _decimal(value, field, positive=positive)
-    _, digits, decimal_exponent = exact.as_tuple()
+    _, coefficient, decimal_exponent = exact.as_tuple()
     exponent = int(decimal_exponent)
-    if len(digits) > _MAX_INPUT_DECIMAL_DIGITS or exponent < -_MAX_INPUT_DECIMAL_SCALE:
+    significant_digits = list(coefficient)
+    while len(significant_digits) > 1 and significant_digits[-1] == 0:
+        significant_digits.pop()
+        exponent += 1
+    integer_digits = max(len(significant_digits) + exponent, 0)
+    fractional_digits = max(-exponent, 0)
+    expanded_digits = integer_digits + fractional_digits
+    if expanded_digits > _MAX_INPUT_DECIMAL_DIGITS or exponent < -_MAX_INPUT_DECIMAL_SCALE:
         raise FifoAccountingValidationError(f"{field} exceeds input precision")
     return exact
 
@@ -158,7 +165,16 @@ def _multiply(left: Decimal, right: Decimal, field: str) -> Decimal:
 def _money_from_minor(value: int) -> Decimal:
     if type(value) is not int or abs(value) > _MAX_COMMISSION_MINOR:
         raise FifoAccountingValidationError("commission_minor is outside the allowed range")
-    return Decimal(value).scaleb(-2)
+    magnitude = str(abs(value))
+    return Decimal((1 if value < 0 else 0, tuple(int(digit) for digit in magnitude), -2))
+
+
+def _stored_int(value: object, field: str) -> int:
+    """Read an SQLite INTEGER without silently truncating REAL or TEXT storage."""
+
+    if type(value) is not int:
+        raise FifoAccountingValidationError(f"{field} is not stored as an exact integer")
+    return value
 
 
 def _fingerprint(payload: dict[str, object]) -> str:
@@ -380,6 +396,7 @@ class FifoLedger:
         self._connection = connection
 
     def create_epoch(self, epoch: AccountingEpoch) -> AccountingEpoch:
+        _assert_no_temp_fifo_objects(self._connection)
         if type(epoch) is not AccountingEpoch:
             raise TypeError("epoch must be AccountingEpoch")
         if self._connection.in_transaction:
@@ -450,6 +467,7 @@ class FifoLedger:
         }
 
     def record_fill(self, event: FillEvent) -> FillResult:
+        _assert_no_temp_fifo_objects(self._connection)
         if type(event) is not FillEvent:
             raise TypeError("event must be FillEvent")
         if self._connection.in_transaction:
@@ -515,6 +533,7 @@ class FifoLedger:
     def verify_epoch_integrity(self, epoch_id: str) -> None:
         """Recompute immutable relationships and hash-chain evidence for an epoch."""
 
+        _assert_no_temp_fifo_objects(self._connection)
         _identifier(epoch_id, "epoch_id")
         effective_at = self._require_epoch(epoch_id)
         fill_count, commission_count, snapshot_count = self._connection.execute(
@@ -526,7 +545,11 @@ class FifoLedger:
             """,
             (epoch_id, epoch_id, epoch_id),
         ).fetchone()
-        if not (int(fill_count) == int(commission_count) == int(snapshot_count)):
+        if not (
+            _stored_int(fill_count, "fill count")
+            == _stored_int(commission_count, "commission count")
+            == _stored_int(snapshot_count, "snapshot count")
+        ):
             raise FifoAccountingValidationError(
                 "every fill must have exactly one commission and one snapshot"
             )
@@ -549,15 +572,15 @@ class FifoLedger:
                 epoch_id=epoch_id,
                 fill_id=str(row[0]),
                 commission_id=str(row[1]),
-                event_sequence=int(row[2]),
+                event_sequence=_stored_int(row[2], "fill event_sequence"),
                 execution_id=str(row[3]),
                 idempotency_key=str(row[4]),
-                con_id=int(row[5]),
+                con_id=_stored_int(row[5], "fill con_id"),
                 symbol=str(row[6]),
                 side=FillSide(str(row[7])),
                 quantity=_parse_decimal(row[8], "fill quantity", positive=True),
                 price=_parse_decimal(row[9], "fill price", positive=True),
-                commission_minor=int(row[10]),
+                commission_minor=_stored_int(row[10], "commission amount_minor"),
                 occurred_at=_parse_utc(row[11], "fill occurred_at"),
                 recorded_at=_parse_utc(row[12], "fill recorded_at"),
             )
@@ -602,11 +625,14 @@ class FifoLedger:
                 )
             if allocated_quantity != event.quantity:
                 raise FifoAccountingValidationError("fill quantity allocation is incomplete")
-            if [int(allocation[2]) for allocation in allocations] != exact_allocations:
+            stored_allocations = [
+                _stored_int(allocation[2], "commission allocation") for allocation in allocations
+            ]
+            if stored_allocations != exact_allocations:
                 raise FifoAccountingValidationError(
                     "fill commission allocation is not deterministic"
                 )
-            if sum(int(allocation[2]) for allocation in allocations) != event.commission_minor:
+            if sum(stored_allocations) != event.commission_minor:
                 raise FifoAccountingValidationError("fill commission allocation is incomplete")
 
         self._verify_fifo_projection_structure(events)
@@ -641,8 +667,8 @@ class FifoLedger:
                 if _parse_decimal(match[1], "recorded open price", positive=True) != open_price:
                     raise FifoAccountingValidationError("lot match open price diverges")
                 close_price = _parse_decimal(match[2], "closing price", positive=True)
-                opening_allocation = int(match[3])
-                closing_allocation = int(match[4])
+                opening_allocation = _stored_int(match[3], "opening commission allocation")
+                closing_allocation = _stored_int(match[4], "closing commission allocation")
                 lot_state = _OpenLot(
                     lot_id=str(lot_id),
                     opened_sequence=0,
@@ -650,7 +676,9 @@ class FifoLedger:
                     opened_quantity=opened,
                     remaining_quantity=_subtract(opened, matched, "remaining lot quantity"),
                     open_price=open_price,
-                    opening_commission_minor=int(commission_minor),
+                    opening_commission_minor=_stored_int(
+                        commission_minor, "lot opening commission"
+                    ),
                     allocated_opening_commission_minor=allocated_opening,
                 )
                 if self._opening_commission_for_match(lot_state, quantity) != opening_allocation:
@@ -680,7 +708,9 @@ class FifoLedger:
                 allocated_opening += opening_allocation
             if matched > opened:
                 raise FifoAccountingValidationError("lot is over-matched")
-            if matched == opened and allocated_opening != int(commission_minor):
+            if matched == opened and allocated_opening != _stored_int(
+                commission_minor, "lot opening commission"
+            ):
                 raise FifoAccountingValidationError(
                     "closed lot opening commission is not fully allocated"
                 )
@@ -704,8 +734,8 @@ class FifoLedger:
         for row in snapshots:
             source_event = events_by_fill.get(str(row[1]))
             if source_event is None or (
-                int(row[2]),
-                int(row[3]),
+                _stored_int(row[2], "snapshot event_sequence"),
+                _stored_int(row[3], "snapshot con_id"),
                 str(row[4]),
                 _parse_utc(row[13], "snapshot created_at"),
             ) != (
@@ -715,26 +745,28 @@ class FifoLedger:
                 source_event.recorded_at,
             ):
                 raise FifoAccountingValidationError("snapshot does not match its source fill")
-            asset = (int(row[3]), str(row[4]))
+            asset = (_stored_int(row[3], "snapshot con_id"), str(row[4]))
             previous = previous_by_asset.get(asset)
             expected_previous_id = None if previous is None else previous[0]
             expected_previous_hash = None if previous is None else previous[1]
             if row[10] != expected_previous_id or row[11] != expected_previous_hash:
                 raise FifoAccountingValidationError("snapshot chain is discontinuous")
             payload = {
-                "con_id": int(row[3]),
-                "cumulative_commission_minor": int(row[9]),
+                "con_id": _stored_int(row[3], "snapshot con_id"),
+                "cumulative_commission_minor": _stored_int(
+                    row[9], "snapshot cumulative commission"
+                ),
                 "cumulative_realized_pnl": _decimal_text(
                     _parse_decimal(row[8], "cumulative realized P&L")
                 ),
                 "epoch_id": epoch_id,
-                "event_sequence": int(row[2]),
+                "event_sequence": _stored_int(row[2], "snapshot event_sequence"),
                 "open_cost": (
                     None
                     if row[6] is None
                     else _decimal_text(_parse_decimal(row[6], "open cost", positive=True))
                 ),
-                "open_lot_count": int(row[7]),
+                "open_lot_count": _stored_int(row[7], "snapshot open_lot_count"),
                 "previous_snapshot_id": expected_previous_id,
                 "previous_state_fingerprint": expected_previous_hash,
                 "signed_quantity": _decimal_text(_parse_decimal(row[5], "signed quantity")),
@@ -790,7 +822,10 @@ class FifoLedger:
                 """,
                 (epoch_id, asset[0], asset[1], event.event_sequence),
             ).fetchall()
-            expected_commission = sum(int(commission_row[0]) for commission_row in commission_rows)
+            expected_commission = sum(
+                _stored_int(commission_row[0], "commission amount_minor")
+                for commission_row in commission_rows
+            )
             snapshot = snapshot_by_fill[event.fill_id]
             expected_open_cost_text = (
                 None if expected_quantity == 0 else _decimal_text(expected_open_cost)
@@ -798,9 +833,9 @@ class FifoLedger:
             if (
                 _parse_decimal(snapshot[5], "snapshot signed quantity") != expected_quantity
                 or snapshot[6] != expected_open_cost_text
-                or int(str(snapshot[7])) != len(lots)
+                or _stored_int(snapshot[7], "snapshot open_lot_count") != len(lots)
                 or _parse_decimal(snapshot[8], "snapshot realized P&L") != expected_realized
-                or int(str(snapshot[9])) != expected_commission
+                or _stored_int(snapshot[9], "snapshot cumulative commission") != expected_commission
             ):
                 raise FifoAccountingValidationError(
                     "position snapshot diverges from immutable events"
@@ -973,7 +1008,7 @@ class FifoLedger:
             """,
             (event.epoch_id,),
         ).fetchone()
-        expected = 1 if row is None else int(row[0]) + 1
+        expected = 1 if row is None else _stored_int(row[0], "fill event_sequence") + 1
         if event.event_sequence != expected:
             raise FifoAccountingOrderingError(f"event_sequence must extend the epoch at {expected}")
         if row is not None and event.occurred_at < _parse_utc(row[1], "prior occurred_at"):
@@ -987,7 +1022,10 @@ class FifoLedger:
             """,
             (event.epoch_id, event.con_id, event.symbol),
         ).fetchall()
-        if any((int(row[0]), str(row[1])) != (event.con_id, event.symbol) for row in rows):
+        if any(
+            (_stored_int(row[0], "fill con_id"), str(row[1])) != (event.con_id, event.symbol)
+            for row in rows
+        ):
             raise FifoAccountingConflict("contract identifier and symbol binding changed")
 
     def _open_lots(
@@ -1036,12 +1074,12 @@ class FifoLedger:
                     _parse_decimal(matched_text, "matched_quantity", positive=True),
                     "matched quantity",
                 )
-                allocated += int(allocated_minor)
+                allocated += _stored_int(allocated_minor, "opening commission allocation")
             remaining = _subtract(opened, matched, "remaining lot quantity")
             if remaining < 0:
                 raise FifoAccountingValidationError("persisted lot is over-matched")
             if remaining == 0:
-                if allocated != int(row[5]):
+                if allocated != _stored_int(row[5], "lot opening commission"):
                     raise FifoAccountingValidationError(
                         "closed lot did not allocate its complete opening commission"
                     )
@@ -1049,12 +1087,12 @@ class FifoLedger:
             result.append(
                 _OpenLot(
                     lot_id=str(row[0]),
-                    opened_sequence=int(row[1]),
+                    opened_sequence=_stored_int(row[1], "lot opened_sequence"),
                     direction=str(row[2]),
                     opened_quantity=opened,
                     remaining_quantity=remaining,
                     open_price=_parse_decimal(row[4], "open_price", positive=True),
-                    opening_commission_minor=int(row[5]),
+                    opening_commission_minor=_stored_int(row[5], "lot opening commission"),
                     allocated_opening_commission_minor=allocated,
                 )
             )
@@ -1320,16 +1358,16 @@ class FifoLedger:
             snapshot_id=str(row[0]),
             epoch_id=str(row[1]),
             source_fill_id=str(row[2]),
-            event_sequence=int(row[3]),
-            con_id=int(row[4]),
+            event_sequence=_stored_int(row[3], "snapshot event_sequence"),
+            con_id=_stored_int(row[4], "snapshot con_id"),
             symbol=str(row[5]),
             signed_quantity=_parse_decimal(row[6], "signed quantity"),
             open_cost=(
                 None if row[7] is None else _parse_decimal(row[7], "open cost basis", positive=True)
             ),
-            open_lot_count=int(row[8]),
+            open_lot_count=_stored_int(row[8], "snapshot open_lot_count"),
             cumulative_realized_pnl=_parse_decimal(row[9], "cumulative realized P&L"),
-            cumulative_commission_minor=int(row[10]),
+            cumulative_commission_minor=_stored_int(row[10], "snapshot cumulative commission"),
             previous_snapshot_id=None if row[11] is None else str(row[11]),
             previous_state_fingerprint=None if row[12] is None else str(row[12]),
             state_fingerprint=str(row[13]),

--- a/robo_trader/accounting/fifo_fixture_migration.py
+++ b/robo_trader/accounting/fifo_fixture_migration.py
@@ -48,7 +48,7 @@ _TABLE_SQL = {
     "fifo_schema_migrations": """
         CREATE TABLE fifo_schema_migrations (
             component TEXT NOT NULL,
-            version INTEGER NOT NULL CHECK (version > 0),
+            version INTEGER NOT NULL CHECK (typeof(version) = 'integer' AND version > 0),
             description TEXT NOT NULL CHECK (length(trim(description)) > 0),
             applied_at TEXT NOT NULL CHECK (applied_at LIKE '%Z'),
             PRIMARY KEY(component, version)
@@ -60,7 +60,9 @@ _TABLE_SQL = {
                 length(epoch_id) = 39 AND substr(epoch_id, 1, 7) = 'fepoch-'
                 AND substr(epoch_id, 8) NOT GLOB '*[^0-9a-f]*'
             ),
-            schema_version INTEGER NOT NULL CHECK (schema_version = 1),
+            schema_version INTEGER NOT NULL CHECK (
+                typeof(schema_version) = 'integer' AND schema_version = 1
+            ),
             execution_domain_scope TEXT NOT NULL CHECK (length(trim(execution_domain_scope)) > 0),
             account_scope TEXT NOT NULL CHECK (length(trim(account_scope)) > 0),
             portfolio_id TEXT NOT NULL CHECK (length(trim(portfolio_id)) > 0),
@@ -83,10 +85,12 @@ _TABLE_SQL = {
                 AND substr(fill_id, 7) NOT GLOB '*[^0-9a-f]*'
             ),
             epoch_id TEXT NOT NULL,
-            event_sequence INTEGER NOT NULL CHECK (event_sequence > 0),
+            event_sequence INTEGER NOT NULL CHECK (
+                typeof(event_sequence) = 'integer' AND event_sequence > 0
+            ),
             execution_id TEXT NOT NULL CHECK (length(trim(execution_id)) > 0),
             idempotency_key TEXT NOT NULL CHECK (length(trim(idempotency_key)) > 0),
-            con_id INTEGER NOT NULL CHECK (con_id > 0),
+            con_id INTEGER NOT NULL CHECK (typeof(con_id) = 'integer' AND con_id > 0),
             symbol TEXT NOT NULL CHECK (length(symbol) BETWEEN 1 AND 32),
             side TEXT NOT NULL CHECK (side IN ('BUY', 'SELL')),
             quantity_text TEXT NOT NULL CHECK (
@@ -119,10 +123,13 @@ _TABLE_SQL = {
             epoch_id TEXT NOT NULL,
             fill_id TEXT NOT NULL UNIQUE,
             amount_minor INTEGER NOT NULL CHECK (
-                amount_minor BETWEEN -1000000000000 AND 1000000000000
+                typeof(amount_minor) = 'integer'
+                AND amount_minor BETWEEN -1000000000000 AND 1000000000000
             ),
             currency TEXT NOT NULL CHECK (currency = 'USD'),
-            minor_unit_exponent INTEGER NOT NULL CHECK (minor_unit_exponent = 2),
+            minor_unit_exponent INTEGER NOT NULL CHECK (
+                typeof(minor_unit_exponent) = 'integer' AND minor_unit_exponent = 2
+            ),
             recorded_at TEXT NOT NULL CHECK (recorded_at LIKE '%Z'),
             UNIQUE(epoch_id, commission_id),
             FOREIGN KEY(epoch_id, fill_id) REFERENCES fifo_fills(epoch_id, fill_id)
@@ -136,8 +143,10 @@ _TABLE_SQL = {
             ),
             epoch_id TEXT NOT NULL,
             opening_fill_id TEXT NOT NULL,
-            lot_ordinal INTEGER NOT NULL CHECK (lot_ordinal >= 0),
-            con_id INTEGER NOT NULL CHECK (con_id > 0),
+            lot_ordinal INTEGER NOT NULL CHECK (
+                typeof(lot_ordinal) = 'integer' AND lot_ordinal >= 0
+            ),
+            con_id INTEGER NOT NULL CHECK (typeof(con_id) = 'integer' AND con_id > 0),
             symbol TEXT NOT NULL CHECK (length(symbol) BETWEEN 1 AND 32),
             direction TEXT NOT NULL CHECK (direction IN ('LONG', 'SHORT')),
             opened_quantity_text TEXT NOT NULL CHECK (
@@ -149,9 +158,12 @@ _TABLE_SQL = {
                 AND ({_positive_decimal_check('open_price_text')})
             ),
             opening_commission_minor INTEGER NOT NULL CHECK (
-                opening_commission_minor BETWEEN -1000000000000 AND 1000000000000
+                typeof(opening_commission_minor) = 'integer'
+                AND opening_commission_minor BETWEEN -1000000000000 AND 1000000000000
             ),
-            opened_sequence INTEGER NOT NULL CHECK (opened_sequence > 0),
+            opened_sequence INTEGER NOT NULL CHECK (
+                typeof(opened_sequence) = 'integer' AND opened_sequence > 0
+            ),
             opened_at TEXT NOT NULL CHECK (opened_at LIKE '%Z'),
             UNIQUE(epoch_id, lot_id),
             UNIQUE(epoch_id, opening_fill_id, lot_ordinal),
@@ -168,7 +180,9 @@ _TABLE_SQL = {
             epoch_id TEXT NOT NULL,
             closing_fill_id TEXT NOT NULL,
             opening_lot_id TEXT NOT NULL,
-            match_ordinal INTEGER NOT NULL CHECK (match_ordinal >= 0),
+            match_ordinal INTEGER NOT NULL CHECK (
+                typeof(match_ordinal) = 'integer' AND match_ordinal >= 0
+            ),
             matched_quantity_text TEXT NOT NULL CHECK (
                 length(matched_quantity_text) BETWEEN 1 AND 64
                 AND ({_positive_decimal_check('matched_quantity_text')})
@@ -182,10 +196,12 @@ _TABLE_SQL = {
                 AND ({_positive_decimal_check('closing_price_text')})
             ),
             opening_commission_minor INTEGER NOT NULL CHECK (
-                opening_commission_minor BETWEEN -1000000000000 AND 1000000000000
+                typeof(opening_commission_minor) = 'integer'
+                AND opening_commission_minor BETWEEN -1000000000000 AND 1000000000000
             ),
             closing_commission_minor INTEGER NOT NULL CHECK (
-                closing_commission_minor BETWEEN -1000000000000 AND 1000000000000
+                typeof(closing_commission_minor) = 'integer'
+                AND closing_commission_minor BETWEEN -1000000000000 AND 1000000000000
             ),
             gross_pnl_text TEXT NOT NULL CHECK (
                 length(gross_pnl_text) BETWEEN 1 AND 96
@@ -212,8 +228,10 @@ _TABLE_SQL = {
             ),
             epoch_id TEXT NOT NULL,
             source_fill_id TEXT NOT NULL UNIQUE,
-            event_sequence INTEGER NOT NULL CHECK (event_sequence > 0),
-            con_id INTEGER NOT NULL CHECK (con_id > 0),
+            event_sequence INTEGER NOT NULL CHECK (
+                typeof(event_sequence) = 'integer' AND event_sequence > 0
+            ),
+            con_id INTEGER NOT NULL CHECK (typeof(con_id) = 'integer' AND con_id > 0),
             symbol TEXT NOT NULL CHECK (length(symbol) BETWEEN 1 AND 32),
             signed_quantity_text TEXT NOT NULL CHECK (
                 length(signed_quantity_text) BETWEEN 1 AND 64
@@ -225,13 +243,16 @@ _TABLE_SQL = {
                     AND ({_positive_decimal_check('open_cost_text')})
                 )
             ),
-            open_lot_count INTEGER NOT NULL CHECK (open_lot_count >= 0),
+            open_lot_count INTEGER NOT NULL CHECK (
+                typeof(open_lot_count) = 'integer' AND open_lot_count >= 0
+            ),
             cumulative_realized_pnl_text TEXT NOT NULL CHECK (
                 length(cumulative_realized_pnl_text) BETWEEN 1 AND 96
                 AND ({_signed_decimal_check('cumulative_realized_pnl_text')})
             ),
             cumulative_commission_minor INTEGER NOT NULL CHECK (
-                cumulative_commission_minor BETWEEN -1000000000000000 AND 1000000000000000
+                typeof(cumulative_commission_minor) = 'integer'
+                AND cumulative_commission_minor BETWEEN -1000000000000000 AND 1000000000000000
             ),
             previous_snapshot_id TEXT,
             previous_state_fingerprint TEXT,
@@ -268,11 +289,71 @@ def _trigger_sql(table: str, operation: str) -> str:
     """
 
 
+_INSERT_CONFLICT_PREDICATES = {
+    "fifo_schema_migrations": "component = NEW.component AND version = NEW.version",
+    "fifo_accounting_epochs": """
+        epoch_id = NEW.epoch_id
+        OR source_fingerprint = NEW.source_fingerprint
+        OR (
+            execution_domain_scope = NEW.execution_domain_scope
+            AND account_scope = NEW.account_scope
+            AND portfolio_id = NEW.portfolio_id
+        )
+    """,
+    "fifo_fills": """
+        fill_id = NEW.fill_id
+        OR (epoch_id = NEW.epoch_id AND event_sequence = NEW.event_sequence)
+        OR (epoch_id = NEW.epoch_id AND execution_id = NEW.execution_id)
+        OR (epoch_id = NEW.epoch_id AND idempotency_key = NEW.idempotency_key)
+    """,
+    "fifo_commissions": "commission_id = NEW.commission_id OR fill_id = NEW.fill_id",
+    "fifo_lot_openings": """
+        lot_id = NEW.lot_id
+        OR (
+            epoch_id = NEW.epoch_id
+            AND opening_fill_id = NEW.opening_fill_id
+            AND lot_ordinal = NEW.lot_ordinal
+        )
+    """,
+    "fifo_lot_matches": """
+        match_id = NEW.match_id
+        OR (
+            epoch_id = NEW.epoch_id
+            AND closing_fill_id = NEW.closing_fill_id
+            AND match_ordinal = NEW.match_ordinal
+        )
+    """,
+    "fifo_position_snapshots": """
+        snapshot_id = NEW.snapshot_id
+        OR source_fill_id = NEW.source_fill_id
+        OR (epoch_id = NEW.epoch_id AND event_sequence = NEW.event_sequence)
+    """,
+}
+
+
+def _insert_conflict_guard_sql(table: str) -> str:
+    # Every interpolated identifier and predicate comes from the closed constants above.
+    return f"""
+        CREATE TRIGGER {table}_no_replace
+        BEFORE INSERT ON {table}
+        WHEN EXISTS (
+            SELECT 1 FROM {table}
+            WHERE {_INSERT_CONFLICT_PREDICATES[table]}
+        )
+        BEGIN
+            SELECT RAISE(ABORT, '{table} identity is append-only');
+        END
+    """
+
+
 _TRIGGER_SQL = {
     f"{table}_no_{operation.lower()}": _trigger_sql(table, operation)
     for table in _APPEND_ONLY_TABLES
     for operation in ("UPDATE", "DELETE")
 }
+_TRIGGER_SQL.update(
+    {f"{table}_no_replace": _insert_conflict_guard_sql(table) for table in _APPEND_ONLY_TABLES}
+)
 
 
 def _normalize_sql(value: object) -> str:
@@ -313,20 +394,31 @@ def _assert_fixture_target(
         raise FifoFixtureMigrationError("fixture database must not have hard link aliases")
 
 
+def _assert_no_temp_fifo_objects(connection: sqlite3.Connection) -> None:
+    shadows = connection.execute(
+        "SELECT type, name FROM temp.sqlite_master WHERE name LIKE 'fifo_%' ORDER BY type, name"
+    ).fetchall()
+    if shadows:
+        raise FifoFixtureMigrationError("temporary FIFO objects cannot shadow durable main state")
+
+
 def assert_fifo_accounting_schema(connection: sqlite3.Connection) -> None:
     """Fail closed unless the complete PR4A fixture schema is exact."""
 
+    _assert_no_temp_fifo_objects(connection)
     if connection.execute("PRAGMA foreign_keys").fetchone() != (1,):
         raise FifoFixtureMigrationError("FIFO accounting requires foreign-key enforcement")
 
-    rows = connection.execute("SELECT name, sql FROM sqlite_master WHERE type = 'table'").fetchall()
+    rows = connection.execute(
+        "SELECT name, sql FROM main.sqlite_master WHERE type = 'table'"
+    ).fetchall()
     actual_tables = {str(name): _normalize_sql(sql) for name, sql in rows}
     for name, statement in _TABLE_SQL.items():
         if actual_tables.get(name) != _normalize_sql(statement):
             raise FifoFixtureMigrationError(f"FIFO accounting table {name} is malformed")
 
     rows = connection.execute(
-        "SELECT name, sql FROM sqlite_master WHERE type = 'trigger'"
+        "SELECT name, sql FROM main.sqlite_master WHERE type = 'trigger'"
     ).fetchall()
     actual_triggers = {str(name): _normalize_sql(sql) for name, sql in rows}
     for name, statement in _TRIGGER_SQL.items():
@@ -334,12 +426,12 @@ def assert_fifo_accounting_schema(connection: sqlite3.Connection) -> None:
             raise FifoFixtureMigrationError(f"FIFO accounting trigger {name} is malformed")
 
     versions = connection.execute(
-        "SELECT version FROM fifo_schema_migrations WHERE component = ? ORDER BY version",
+        "SELECT version FROM main.fifo_schema_migrations WHERE component = ? ORDER BY version",
         (FIFO_ACCOUNTING_COMPONENT,),
     ).fetchall()
     if versions != [(FIFO_ACCOUNTING_SCHEMA_VERSION,)]:
         raise FifoFixtureMigrationError("FIFO accounting migration evidence is incomplete")
-    if connection.execute("PRAGMA foreign_key_check").fetchone() is not None:
+    if connection.execute("PRAGMA main.foreign_key_check").fetchone() is not None:
         raise FifoFixtureMigrationError("FIFO accounting schema has foreign-key violations")
 
 
@@ -355,6 +447,7 @@ def migrate_fifo_fixture_database(
     """
 
     _assert_fixture_target(connection, expected_path)
+    _assert_no_temp_fifo_objects(connection)
     if connection.in_transaction:
         raise FifoFixtureMigrationError("fixture migration requires an idle connection")
     connection.execute("PRAGMA foreign_keys = ON")
@@ -362,7 +455,8 @@ def migrate_fifo_fixture_database(
         raise FifoFixtureMigrationError("could not enable fixture foreign keys")
 
     existing = connection.execute(
-        "SELECT name FROM sqlite_master WHERE type IN ('table','trigger') " "AND name LIKE 'fifo_%'"
+        "SELECT name FROM main.sqlite_master WHERE type IN ('table','trigger') "
+        "AND name LIKE 'fifo_%'"
     ).fetchall()
     if existing:
         assert_fifo_accounting_schema(connection)
@@ -374,7 +468,7 @@ def migrate_fifo_fixture_database(
             connection.execute(statement)
         connection.execute(
             """
-            INSERT INTO fifo_schema_migrations(component, version, description, applied_at)
+            INSERT INTO main.fifo_schema_migrations(component, version, description, applied_at)
             VALUES (?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
             """,
             (

--- a/robo_trader/accounting/fifo_fixture_migration.py
+++ b/robo_trader/accounting/fifo_fixture_migration.py
@@ -309,6 +309,8 @@ def _assert_fixture_target(
     resolved = expected.resolve(strict=True)
     if actual_path != resolved:
         raise FifoFixtureMigrationError("fixture connection does not match expected_path")
+    if resolved.stat().st_nlink != 1:
+        raise FifoFixtureMigrationError("fixture database must not have hard link aliases")
 
 
 def assert_fifo_accounting_schema(connection: sqlite3.Connection) -> None:

--- a/robo_trader/accounting/fifo_fixture_migration.py
+++ b/robo_trader/accounting/fifo_fixture_migration.py
@@ -333,17 +333,20 @@ _INSERT_CONFLICT_PREDICATES = {
 
 def _insert_conflict_guard_sql(table: str) -> str:
     # Every interpolated identifier and predicate comes from the closed constants above.
-    return f"""
-        CREATE TRIGGER {table}_no_replace
-        BEFORE INSERT ON {table}
-        WHEN EXISTS (
-            SELECT 1 FROM {table}
-            WHERE {_INSERT_CONFLICT_PREDICATES[table]}
+    predicate = _INSERT_CONFLICT_PREDICATES[table]
+    return "\n".join(
+        (
+            f"CREATE TRIGGER {table}_no_replace",
+            f"BEFORE INSERT ON {table}",
+            "WHEN EXISTS (",
+            f"SELECT 1 FROM {table}",  # nosec B608
+            f"WHERE {predicate}",
+            ")",
+            "BEGIN",
+            f"SELECT RAISE(ABORT, '{table} identity is append-only');",
+            "END",
         )
-        BEGIN
-            SELECT RAISE(ABORT, '{table} identity is append-only');
-        END
-    """
+    )
 
 
 _TRIGGER_SQL = {

--- a/robo_trader/accounting/fifo_fixture_migration.py
+++ b/robo_trader/accounting/fifo_fixture_migration.py
@@ -1,0 +1,390 @@
+"""Fixture-only migration for the dormant PR4A FIFO accounting schema.
+
+The deliberately narrow entry point refuses ordinary database filenames and
+is not imported by any runtime database module.  A later PR must provide a
+separately reviewed, backup-bound production migration before this schema can
+be applied to an operational ledger.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+FIFO_ACCOUNTING_COMPONENT = "fifo_accounting"
+FIFO_ACCOUNTING_SCHEMA_VERSION = 1
+FIXTURE_DATABASE_SUFFIX = ".fifo-fixture.sqlite3"
+
+
+class FifoFixtureMigrationError(RuntimeError):
+    """A fixture database cannot safely accept the FIFO schema."""
+
+
+def _positive_decimal_check(column: str) -> str:
+    return f"""
+        {column} NOT GLOB '*[^0-9.]*'
+        AND length({column}) - length(replace({column}, '.', '')) <= 1
+        AND {column} NOT LIKE '.%'
+        AND {column} NOT LIKE '%.'
+        AND {column} <> '0'
+        AND ({column} NOT LIKE '0%' OR {column} LIKE '0.%')
+        AND (instr({column}, '.') = 0 OR substr({column}, -1) <> '0')
+    """
+
+
+def _signed_decimal_check(column: str) -> str:
+    positive = _positive_decimal_check(column)
+    negative = _positive_decimal_check(f"substr({column}, 2)")
+    return f"""
+        {column} = '0'
+        OR ({positive})
+        OR (substr({column}, 1, 1) = '-' AND ({negative}))
+    """
+
+
+_TABLE_SQL = {
+    "fifo_schema_migrations": """
+        CREATE TABLE fifo_schema_migrations (
+            component TEXT NOT NULL,
+            version INTEGER NOT NULL CHECK (version > 0),
+            description TEXT NOT NULL CHECK (length(trim(description)) > 0),
+            applied_at TEXT NOT NULL CHECK (applied_at LIKE '%Z'),
+            PRIMARY KEY(component, version)
+        )
+    """,
+    "fifo_accounting_epochs": """
+        CREATE TABLE fifo_accounting_epochs (
+            epoch_id TEXT PRIMARY KEY CHECK (
+                length(epoch_id) = 39 AND substr(epoch_id, 1, 7) = 'fepoch-'
+                AND substr(epoch_id, 8) NOT GLOB '*[^0-9a-f]*'
+            ),
+            schema_version INTEGER NOT NULL CHECK (schema_version = 1),
+            execution_domain_scope TEXT NOT NULL CHECK (length(trim(execution_domain_scope)) > 0),
+            account_scope TEXT NOT NULL CHECK (length(trim(account_scope)) > 0),
+            portfolio_id TEXT NOT NULL CHECK (length(trim(portfolio_id)) > 0),
+            origin_kind TEXT NOT NULL CHECK (
+                origin_kind IN ('EMPTY_LEDGER', 'LEGACY_AGGREGATE_OPENING_BALANCE')
+            ),
+            source_fingerprint TEXT NOT NULL UNIQUE CHECK (
+                length(source_fingerprint) = 64 AND source_fingerprint = lower(source_fingerprint)
+                AND source_fingerprint NOT GLOB '*[^0-9a-f]*'
+            ),
+            effective_at TEXT NOT NULL CHECK (effective_at LIKE '%Z'),
+            created_at TEXT NOT NULL CHECK (created_at LIKE '%Z'),
+            UNIQUE(execution_domain_scope, account_scope, portfolio_id)
+        )
+    """,
+    "fifo_fills": f"""
+        CREATE TABLE fifo_fills (
+            fill_id TEXT PRIMARY KEY CHECK (
+                length(fill_id) = 38 AND substr(fill_id, 1, 6) = 'ffill-'
+                AND substr(fill_id, 7) NOT GLOB '*[^0-9a-f]*'
+            ),
+            epoch_id TEXT NOT NULL,
+            event_sequence INTEGER NOT NULL CHECK (event_sequence > 0),
+            execution_id TEXT NOT NULL CHECK (length(trim(execution_id)) > 0),
+            idempotency_key TEXT NOT NULL CHECK (length(trim(idempotency_key)) > 0),
+            con_id INTEGER NOT NULL CHECK (con_id > 0),
+            symbol TEXT NOT NULL CHECK (length(symbol) BETWEEN 1 AND 32),
+            side TEXT NOT NULL CHECK (side IN ('BUY', 'SELL')),
+            quantity_text TEXT NOT NULL CHECK (
+                length(quantity_text) BETWEEN 1 AND 64
+                AND ({_positive_decimal_check('quantity_text')})
+            ),
+            price_text TEXT NOT NULL CHECK (
+                length(price_text) BETWEEN 1 AND 64
+                AND ({_positive_decimal_check('price_text')})
+            ),
+            occurred_at TEXT NOT NULL CHECK (occurred_at LIKE '%Z'),
+            recorded_at TEXT NOT NULL CHECK (recorded_at LIKE '%Z'),
+            payload_fingerprint TEXT NOT NULL CHECK (
+                length(payload_fingerprint) = 64 AND payload_fingerprint = lower(payload_fingerprint)
+                AND payload_fingerprint NOT GLOB '*[^0-9a-f]*'
+            ),
+            UNIQUE(epoch_id, event_sequence),
+            UNIQUE(epoch_id, execution_id),
+            UNIQUE(epoch_id, idempotency_key),
+            UNIQUE(epoch_id, fill_id),
+            FOREIGN KEY(epoch_id) REFERENCES fifo_accounting_epochs(epoch_id)
+        )
+    """,
+    "fifo_commissions": """
+        CREATE TABLE fifo_commissions (
+            commission_id TEXT PRIMARY KEY CHECK (
+                length(commission_id) = 38 AND substr(commission_id, 1, 6) = 'fcomm-'
+                AND substr(commission_id, 7) NOT GLOB '*[^0-9a-f]*'
+            ),
+            epoch_id TEXT NOT NULL,
+            fill_id TEXT NOT NULL UNIQUE,
+            amount_minor INTEGER NOT NULL CHECK (
+                amount_minor BETWEEN -1000000000000 AND 1000000000000
+            ),
+            currency TEXT NOT NULL CHECK (currency = 'USD'),
+            minor_unit_exponent INTEGER NOT NULL CHECK (minor_unit_exponent = 2),
+            recorded_at TEXT NOT NULL CHECK (recorded_at LIKE '%Z'),
+            UNIQUE(epoch_id, commission_id),
+            FOREIGN KEY(epoch_id, fill_id) REFERENCES fifo_fills(epoch_id, fill_id)
+        )
+    """,
+    "fifo_lot_openings": f"""
+        CREATE TABLE fifo_lot_openings (
+            lot_id TEXT PRIMARY KEY CHECK (
+                length(lot_id) = 37 AND substr(lot_id, 1, 5) = 'flot-'
+                AND substr(lot_id, 6) NOT GLOB '*[^0-9a-f]*'
+            ),
+            epoch_id TEXT NOT NULL,
+            opening_fill_id TEXT NOT NULL,
+            lot_ordinal INTEGER NOT NULL CHECK (lot_ordinal >= 0),
+            con_id INTEGER NOT NULL CHECK (con_id > 0),
+            symbol TEXT NOT NULL CHECK (length(symbol) BETWEEN 1 AND 32),
+            direction TEXT NOT NULL CHECK (direction IN ('LONG', 'SHORT')),
+            opened_quantity_text TEXT NOT NULL CHECK (
+                length(opened_quantity_text) BETWEEN 1 AND 64
+                AND ({_positive_decimal_check('opened_quantity_text')})
+            ),
+            open_price_text TEXT NOT NULL CHECK (
+                length(open_price_text) BETWEEN 1 AND 64
+                AND ({_positive_decimal_check('open_price_text')})
+            ),
+            opening_commission_minor INTEGER NOT NULL CHECK (
+                opening_commission_minor BETWEEN -1000000000000 AND 1000000000000
+            ),
+            opened_sequence INTEGER NOT NULL CHECK (opened_sequence > 0),
+            opened_at TEXT NOT NULL CHECK (opened_at LIKE '%Z'),
+            UNIQUE(epoch_id, lot_id),
+            UNIQUE(epoch_id, opening_fill_id, lot_ordinal),
+            FOREIGN KEY(epoch_id, opening_fill_id)
+                REFERENCES fifo_fills(epoch_id, fill_id)
+        )
+    """,
+    "fifo_lot_matches": f"""
+        CREATE TABLE fifo_lot_matches (
+            match_id TEXT PRIMARY KEY CHECK (
+                length(match_id) = 39 AND substr(match_id, 1, 7) = 'fmatch-'
+                AND substr(match_id, 8) NOT GLOB '*[^0-9a-f]*'
+            ),
+            epoch_id TEXT NOT NULL,
+            closing_fill_id TEXT NOT NULL,
+            opening_lot_id TEXT NOT NULL,
+            match_ordinal INTEGER NOT NULL CHECK (match_ordinal >= 0),
+            matched_quantity_text TEXT NOT NULL CHECK (
+                length(matched_quantity_text) BETWEEN 1 AND 64
+                AND ({_positive_decimal_check('matched_quantity_text')})
+            ),
+            opening_price_text TEXT NOT NULL CHECK (
+                length(opening_price_text) BETWEEN 1 AND 64
+                AND ({_positive_decimal_check('opening_price_text')})
+            ),
+            closing_price_text TEXT NOT NULL CHECK (
+                length(closing_price_text) BETWEEN 1 AND 64
+                AND ({_positive_decimal_check('closing_price_text')})
+            ),
+            opening_commission_minor INTEGER NOT NULL CHECK (
+                opening_commission_minor BETWEEN -1000000000000 AND 1000000000000
+            ),
+            closing_commission_minor INTEGER NOT NULL CHECK (
+                closing_commission_minor BETWEEN -1000000000000 AND 1000000000000
+            ),
+            gross_pnl_text TEXT NOT NULL CHECK (
+                length(gross_pnl_text) BETWEEN 1 AND 96
+                AND ({_signed_decimal_check('gross_pnl_text')})
+            ),
+            realized_pnl_text TEXT NOT NULL CHECK (
+                length(realized_pnl_text) BETWEEN 1 AND 96
+                AND ({_signed_decimal_check('realized_pnl_text')})
+            ),
+            matched_at TEXT NOT NULL CHECK (matched_at LIKE '%Z'),
+            UNIQUE(epoch_id, closing_fill_id, match_ordinal),
+            UNIQUE(epoch_id, match_id),
+            FOREIGN KEY(epoch_id, closing_fill_id)
+                REFERENCES fifo_fills(epoch_id, fill_id),
+            FOREIGN KEY(epoch_id, opening_lot_id)
+                REFERENCES fifo_lot_openings(epoch_id, lot_id)
+        )
+    """,
+    "fifo_position_snapshots": f"""
+        CREATE TABLE fifo_position_snapshots (
+            snapshot_id TEXT PRIMARY KEY CHECK (
+                length(snapshot_id) = 38 AND substr(snapshot_id, 1, 6) = 'fsnap-'
+                AND substr(snapshot_id, 7) NOT GLOB '*[^0-9a-f]*'
+            ),
+            epoch_id TEXT NOT NULL,
+            source_fill_id TEXT NOT NULL UNIQUE,
+            event_sequence INTEGER NOT NULL CHECK (event_sequence > 0),
+            con_id INTEGER NOT NULL CHECK (con_id > 0),
+            symbol TEXT NOT NULL CHECK (length(symbol) BETWEEN 1 AND 32),
+            signed_quantity_text TEXT NOT NULL CHECK (
+                length(signed_quantity_text) BETWEEN 1 AND 64
+                AND ({_signed_decimal_check('signed_quantity_text')})
+            ),
+            open_cost_text TEXT CHECK (
+                open_cost_text IS NULL OR (
+                    length(open_cost_text) BETWEEN 1 AND 96
+                    AND ({_positive_decimal_check('open_cost_text')})
+                )
+            ),
+            open_lot_count INTEGER NOT NULL CHECK (open_lot_count >= 0),
+            cumulative_realized_pnl_text TEXT NOT NULL CHECK (
+                length(cumulative_realized_pnl_text) BETWEEN 1 AND 96
+                AND ({_signed_decimal_check('cumulative_realized_pnl_text')})
+            ),
+            cumulative_commission_minor INTEGER NOT NULL CHECK (
+                cumulative_commission_minor BETWEEN -1000000000000000 AND 1000000000000000
+            ),
+            previous_snapshot_id TEXT,
+            previous_state_fingerprint TEXT,
+            state_fingerprint TEXT NOT NULL CHECK (
+                length(state_fingerprint) = 64 AND state_fingerprint = lower(state_fingerprint)
+                AND state_fingerprint NOT GLOB '*[^0-9a-f]*'
+            ),
+            created_at TEXT NOT NULL CHECK (created_at LIKE '%Z'),
+            UNIQUE(epoch_id, event_sequence),
+            UNIQUE(epoch_id, snapshot_id),
+            FOREIGN KEY(epoch_id, source_fill_id)
+                REFERENCES fifo_fills(epoch_id, fill_id),
+            FOREIGN KEY(epoch_id, previous_snapshot_id)
+                REFERENCES fifo_position_snapshots(epoch_id, snapshot_id),
+            CHECK (
+                (previous_snapshot_id IS NULL AND previous_state_fingerprint IS NULL)
+                OR
+                (previous_snapshot_id IS NOT NULL AND previous_state_fingerprint IS NOT NULL)
+            )
+        )
+    """,
+}
+
+_APPEND_ONLY_TABLES = tuple(_TABLE_SQL)
+
+
+def _trigger_sql(table: str, operation: str) -> str:
+    return f"""
+        CREATE TRIGGER {table}_no_{operation.lower()}
+        BEFORE {operation} ON {table}
+        BEGIN
+            SELECT RAISE(ABORT, '{table} is append-only');
+        END
+    """
+
+
+_TRIGGER_SQL = {
+    f"{table}_no_{operation.lower()}": _trigger_sql(table, operation)
+    for table in _APPEND_ONLY_TABLES
+    for operation in ("UPDATE", "DELETE")
+}
+
+
+def _normalize_sql(value: object) -> str:
+    if not isinstance(value, str):
+        return ""
+    return re.sub(r"\s+", " ", value.strip().lower())
+
+
+def _database_path(connection: sqlite3.Connection) -> Optional[Path]:
+    rows = connection.execute("PRAGMA database_list").fetchall()
+    main_rows = [row for row in rows if row[1] == "main"]
+    if len(main_rows) != 1:
+        raise FifoFixtureMigrationError("fixture connection has ambiguous main database")
+    raw_path = str(main_rows[0][2])
+    return None if raw_path == "" else Path(raw_path).resolve(strict=True)
+
+
+def _assert_fixture_target(
+    connection: sqlite3.Connection,
+    expected_path: Optional[Path],
+) -> None:
+    actual_path = _database_path(connection)
+    if expected_path is None:
+        if actual_path is not None:
+            raise FifoFixtureMigrationError("only an in-memory database may omit expected_path")
+        return
+    expected = Path(expected_path)
+    if expected.name.endswith(FIXTURE_DATABASE_SUFFIX) is False:
+        raise FifoFixtureMigrationError(
+            f"fixture database name must end with {FIXTURE_DATABASE_SUFFIX}"
+        )
+    if expected.is_symlink():
+        raise FifoFixtureMigrationError("fixture database path must not be a symlink")
+    resolved = expected.resolve(strict=True)
+    if actual_path != resolved:
+        raise FifoFixtureMigrationError("fixture connection does not match expected_path")
+
+
+def assert_fifo_accounting_schema(connection: sqlite3.Connection) -> None:
+    """Fail closed unless the complete PR4A fixture schema is exact."""
+
+    if connection.execute("PRAGMA foreign_keys").fetchone() != (1,):
+        raise FifoFixtureMigrationError("FIFO accounting requires foreign-key enforcement")
+
+    rows = connection.execute("SELECT name, sql FROM sqlite_master WHERE type = 'table'").fetchall()
+    actual_tables = {str(name): _normalize_sql(sql) for name, sql in rows}
+    for name, statement in _TABLE_SQL.items():
+        if actual_tables.get(name) != _normalize_sql(statement):
+            raise FifoFixtureMigrationError(f"FIFO accounting table {name} is malformed")
+
+    rows = connection.execute(
+        "SELECT name, sql FROM sqlite_master WHERE type = 'trigger'"
+    ).fetchall()
+    actual_triggers = {str(name): _normalize_sql(sql) for name, sql in rows}
+    for name, statement in _TRIGGER_SQL.items():
+        if actual_triggers.get(name) != _normalize_sql(statement):
+            raise FifoFixtureMigrationError(f"FIFO accounting trigger {name} is malformed")
+
+    versions = connection.execute(
+        "SELECT version FROM fifo_schema_migrations WHERE component = ? ORDER BY version",
+        (FIFO_ACCOUNTING_COMPONENT,),
+    ).fetchall()
+    if versions != [(FIFO_ACCOUNTING_SCHEMA_VERSION,)]:
+        raise FifoFixtureMigrationError("FIFO accounting migration evidence is incomplete")
+    if connection.execute("PRAGMA foreign_key_check").fetchone() is not None:
+        raise FifoFixtureMigrationError("FIFO accounting schema has foreign-key violations")
+
+
+def migrate_fifo_fixture_database(
+    connection: sqlite3.Connection,
+    *,
+    expected_path: Optional[Path],
+) -> None:
+    """Apply the sole PR4A migration to an explicitly identified fixture DB.
+
+    This function intentionally rejects normal database filenames.  It is not a
+    production migration and must never be pointed at ``trading_data.db``.
+    """
+
+    _assert_fixture_target(connection, expected_path)
+    if connection.in_transaction:
+        raise FifoFixtureMigrationError("fixture migration requires an idle connection")
+    connection.execute("PRAGMA foreign_keys = ON")
+    if connection.execute("PRAGMA foreign_keys").fetchone() != (1,):
+        raise FifoFixtureMigrationError("could not enable fixture foreign keys")
+
+    existing = connection.execute(
+        "SELECT name FROM sqlite_master WHERE type IN ('table','trigger') " "AND name LIKE 'fifo_%'"
+    ).fetchall()
+    if existing:
+        assert_fifo_accounting_schema(connection)
+        return
+
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        for statement in _TABLE_SQL.values():
+            connection.execute(statement)
+        connection.execute(
+            """
+            INSERT INTO fifo_schema_migrations(component, version, description, applied_at)
+            VALUES (?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+            """,
+            (
+                FIFO_ACCOUNTING_COMPONENT,
+                FIFO_ACCOUNTING_SCHEMA_VERSION,
+                "dormant exact append-only FIFO accounting foundation",
+            ),
+        )
+        for statement in _TRIGGER_SQL.values():
+            connection.execute(statement)
+        connection.commit()
+    except BaseException:
+        connection.rollback()
+        raise
+    assert_fifo_accounting_schema(connection)

--- a/robo_trader/accounting/fifo_fixture_migration.py
+++ b/robo_trader/accounting/fifo_fixture_migration.py
@@ -405,17 +405,33 @@ def _assert_no_temp_fifo_objects(connection: sqlite3.Connection) -> None:
         raise FifoFixtureMigrationError("temporary FIFO objects cannot shadow durable main state")
 
 
+def _pragma_foreign_keys_enabled(connection: sqlite3.Connection) -> bool:
+    row = connection.execute("PRAGMA foreign_keys").fetchone()
+    return row is not None and type(row[0]) is int and row[0] == 1
+
+
 def assert_fifo_accounting_schema(connection: sqlite3.Connection) -> None:
     """Fail closed unless the complete PR4A fixture schema is exact."""
 
     _assert_no_temp_fifo_objects(connection)
-    if connection.execute("PRAGMA foreign_keys").fetchone() != (1,):
+    if not _pragma_foreign_keys_enabled(connection):
         raise FifoFixtureMigrationError("FIFO accounting requires foreign-key enforcement")
 
     rows = connection.execute(
-        "SELECT name, sql FROM main.sqlite_master WHERE type = 'table'"
+        "SELECT name, sql FROM main.sqlite_master "
+        "WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
     ).fetchall()
     actual_tables = {str(name): _normalize_sql(sql) for name, sql in rows}
+    missing_tables = set(_TABLE_SQL).difference(actual_tables)
+    unexpected_tables = set(actual_tables).difference(_TABLE_SQL)
+    if missing_tables:
+        raise FifoFixtureMigrationError(
+            f"FIFO accounting table {sorted(missing_tables)[0]} is missing"
+        )
+    if unexpected_tables:
+        raise FifoFixtureMigrationError(
+            f"FIFO fixture contains unexpected table {sorted(unexpected_tables)[0]}"
+        )
     for name, statement in _TABLE_SQL.items():
         if actual_tables.get(name) != _normalize_sql(statement):
             raise FifoFixtureMigrationError(f"FIFO accounting table {name} is malformed")
@@ -424,15 +440,35 @@ def assert_fifo_accounting_schema(connection: sqlite3.Connection) -> None:
         "SELECT name, sql FROM main.sqlite_master WHERE type = 'trigger'"
     ).fetchall()
     actual_triggers = {str(name): _normalize_sql(sql) for name, sql in rows}
+    missing_triggers = set(_TRIGGER_SQL).difference(actual_triggers)
+    unexpected_triggers = set(actual_triggers).difference(_TRIGGER_SQL)
+    if missing_triggers:
+        raise FifoFixtureMigrationError(
+            f"FIFO accounting trigger {sorted(missing_triggers)[0]} is missing"
+        )
+    if unexpected_triggers:
+        raise FifoFixtureMigrationError(
+            f"FIFO fixture contains unexpected trigger {sorted(unexpected_triggers)[0]}"
+        )
     for name, statement in _TRIGGER_SQL.items():
         if actual_triggers.get(name) != _normalize_sql(statement):
             raise FifoFixtureMigrationError(f"FIFO accounting trigger {name} is malformed")
 
-    versions = connection.execute(
+    unexpected_schema = connection.execute(
+        "SELECT type, name FROM main.sqlite_master "
+        "WHERE type IN ('view','index') AND name NOT LIKE 'sqlite_%'"
+    ).fetchall()
+    if unexpected_schema:
+        raise FifoFixtureMigrationError("FIFO fixture contains unexpected schema objects")
+
+    version_rows = connection.execute(
         "SELECT version FROM main.fifo_schema_migrations WHERE component = ? ORDER BY version",
         (FIFO_ACCOUNTING_COMPONENT,),
     ).fetchall()
-    if versions != [(FIFO_ACCOUNTING_SCHEMA_VERSION,)]:
+    versions = [row[0] for row in version_rows]
+    if versions != [FIFO_ACCOUNTING_SCHEMA_VERSION] or any(
+        type(version) is not int for version in versions
+    ):
         raise FifoFixtureMigrationError("FIFO accounting migration evidence is incomplete")
     if connection.execute("PRAGMA main.foreign_key_check").fetchone() is not None:
         raise FifoFixtureMigrationError("FIFO accounting schema has foreign-key violations")
@@ -454,19 +490,24 @@ def migrate_fifo_fixture_database(
     if connection.in_transaction:
         raise FifoFixtureMigrationError("fixture migration requires an idle connection")
     connection.execute("PRAGMA foreign_keys = ON")
-    if connection.execute("PRAGMA foreign_keys").fetchone() != (1,):
+    if not _pragma_foreign_keys_enabled(connection):
         raise FifoFixtureMigrationError("could not enable fixture foreign keys")
-
-    existing = connection.execute(
-        "SELECT name FROM main.sqlite_master WHERE type IN ('table','trigger') "
-        "AND name LIKE 'fifo_%'"
-    ).fetchall()
-    if existing:
-        assert_fifo_accounting_schema(connection)
-        return
 
     try:
         connection.execute("BEGIN IMMEDIATE")
+        schema_objects = connection.execute(
+            "SELECT type, name FROM main.sqlite_master "
+            "WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name"
+        ).fetchall()
+        fifo_objects = [row for row in schema_objects if str(row[1]).startswith("fifo_")]
+        if fifo_objects:
+            assert_fifo_accounting_schema(connection)
+            connection.commit()
+            return
+        if schema_objects:
+            raise FifoFixtureMigrationError(
+                "fixture migration requires an empty database or an exact FIFO fixture"
+            )
         for statement in _TABLE_SQL.values():
             connection.execute(statement)
         connection.execute(

--- a/tests/accounting/test_fifo_accounting.py
+++ b/tests/accounting/test_fifo_accounting.py
@@ -535,6 +535,75 @@ def test_snapshot_chain_is_per_asset_and_globally_sequenced(connection, ledger):
     ledger.verify_epoch_integrity(EPOCH_ID)
 
 
+def test_integrity_verifier_replays_every_intermediate_snapshot(connection, ledger):
+    first = ledger.record_fill(_fill(1, FillSide.BUY, "1", "10"))
+    second = ledger.record_fill(_fill(2, FillSide.BUY, "1", "20"))
+
+    first_payload = {
+        "con_id": first.snapshot.con_id,
+        "cumulative_commission_minor": 0,
+        "cumulative_realized_pnl": "0",
+        "epoch_id": EPOCH_ID,
+        "event_sequence": 1,
+        "open_cost": "90",
+        "open_lot_count": 1,
+        "previous_snapshot_id": None,
+        "previous_state_fingerprint": None,
+        "signed_quantity": "9",
+        "snapshot_id": first.snapshot.snapshot_id,
+        "source_fill_id": first.fill_id,
+        "symbol": first.snapshot.symbol,
+    }
+    bad_first_fingerprint = _snapshot_fingerprint(first_payload)
+    second_payload = {
+        "con_id": second.snapshot.con_id,
+        "cumulative_commission_minor": 0,
+        "cumulative_realized_pnl": "0",
+        "epoch_id": EPOCH_ID,
+        "event_sequence": 2,
+        "open_cost": "30",
+        "open_lot_count": 2,
+        "previous_snapshot_id": first.snapshot.snapshot_id,
+        "previous_state_fingerprint": bad_first_fingerprint,
+        "signed_quantity": "2",
+        "snapshot_id": second.snapshot.snapshot_id,
+        "source_fill_id": second.fill_id,
+        "symbol": second.snapshot.symbol,
+    }
+    connection.execute("DROP TRIGGER fifo_position_snapshots_no_update")
+    connection.execute(
+        """
+        UPDATE fifo_position_snapshots
+        SET signed_quantity_text='9', open_cost_text='90', state_fingerprint=?
+        WHERE snapshot_id=?
+        """,
+        (bad_first_fingerprint, first.snapshot.snapshot_id),
+    )
+    connection.execute(
+        """
+        UPDATE fifo_position_snapshots
+        SET previous_state_fingerprint=?, state_fingerprint=?
+        WHERE snapshot_id=?
+        """,
+        (
+            bad_first_fingerprint,
+            _snapshot_fingerprint(second_payload),
+            second.snapshot.snapshot_id,
+        ),
+    )
+    connection.execute("""
+        CREATE TRIGGER fifo_position_snapshots_no_update
+        BEFORE UPDATE ON fifo_position_snapshots
+        BEGIN
+            SELECT RAISE(ABORT, 'fifo_position_snapshots is append-only');
+        END
+        """)
+    connection.commit()
+
+    with pytest.raises(FifoAccountingValidationError, match="snapshot diverges"):
+        ledger.verify_epoch_integrity(EPOCH_ID)
+
+
 def test_integrity_verifier_rejects_fill_without_commission_and_snapshot(connection, ledger):
     _insert_fill_row(connection, _fill(1, FillSide.BUY, "2", "10"))
     connection.commit()

--- a/tests/accounting/test_fifo_accounting.py
+++ b/tests/accounting/test_fifo_accounting.py
@@ -1,0 +1,500 @@
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+from robo_trader.accounting import (
+    AccountingEpoch,
+    FifoAccountingConflict,
+    FifoAccountingOrderingError,
+    FifoAccountingValidationError,
+    FifoLedger,
+    FillEvent,
+    FillSide,
+    assert_fifo_accounting_schema,
+    migrate_fifo_fixture_database,
+)
+from robo_trader.accounting.fifo_fixture_migration import FifoFixtureMigrationError
+
+NOW = datetime(2026, 7, 28, 16, 0, tzinfo=timezone.utc)
+EPOCH_ID = "fepoch-" + "1" * 32
+
+
+def _digest(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _identifier(prefix: str, number: int) -> str:
+    return f"{prefix}-{number:032x}"
+
+
+@pytest.fixture
+def connection(tmp_path):
+    path = tmp_path / "accounting.fifo-fixture.sqlite3"
+    connection = sqlite3.connect(path)
+    migrate_fifo_fixture_database(connection, expected_path=path)
+    yield connection
+    connection.close()
+
+
+@pytest.fixture
+def ledger(connection):
+    ledger = FifoLedger(connection)
+    ledger.create_epoch(
+        AccountingEpoch(
+            epoch_id=EPOCH_ID,
+            execution_domain_scope="paper-simulator-v1",
+            account_scope="acct_v1_test_fixture",
+            portfolio_id="default",
+            source_fingerprint=_digest("empty fixture epoch"),
+            effective_at=NOW,
+            created_at=NOW,
+        )
+    )
+    return ledger
+
+
+def _fill(
+    sequence: int,
+    side: FillSide,
+    quantity: str,
+    price: str,
+    commission_minor: int = 0,
+    *,
+    con_id: int = 265598,
+    symbol: str = "AAPL",
+) -> FillEvent:
+    return FillEvent(
+        epoch_id=EPOCH_ID,
+        fill_id=_identifier("ffill", sequence),
+        commission_id=_identifier("fcomm", sequence),
+        event_sequence=sequence,
+        execution_id=f"execution-{sequence}",
+        idempotency_key=f"idempotency-{sequence}",
+        con_id=con_id,
+        symbol=symbol,
+        side=side,
+        quantity=Decimal(quantity),
+        price=Decimal(price),
+        commission_minor=commission_minor,
+        occurred_at=NOW + timedelta(seconds=sequence),
+        recorded_at=NOW + timedelta(seconds=sequence),
+    )
+
+
+def _table_count(connection, table: str) -> int:
+    return int(connection.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+
+
+def test_fixture_migration_is_exact_idempotent_and_foreign_keys_are_on(connection):
+    assert_fifo_accounting_schema(connection)
+    migrate_fifo_fixture_database(
+        connection,
+        expected_path=connection.execute("PRAGMA database_list").fetchone()[2],
+    )
+    assert connection.execute("PRAGMA foreign_keys").fetchone() == (1,)
+    assert connection.execute(
+        "SELECT version FROM fifo_schema_migrations WHERE component='fifo_accounting'"
+    ).fetchall() == [(1,)]
+
+
+def test_fixture_migration_rejects_production_style_filename(tmp_path):
+    path = tmp_path / "trading_data.db"
+    connection = sqlite3.connect(path)
+    with pytest.raises(FifoFixtureMigrationError, match="must end with"):
+        migrate_fifo_fixture_database(connection, expected_path=path)
+    assert connection.execute(
+        "SELECT COUNT(*) FROM sqlite_master WHERE name LIKE 'fifo_%'"
+    ).fetchone() == (0,)
+    connection.close()
+
+
+def test_fixture_migration_rejects_mismatched_connection(tmp_path):
+    actual = tmp_path / "actual.fifo-fixture.sqlite3"
+    expected = tmp_path / "expected.fifo-fixture.sqlite3"
+    expected.touch()
+    connection = sqlite3.connect(actual)
+    with pytest.raises(FifoFixtureMigrationError, match="does not match"):
+        migrate_fifo_fixture_database(connection, expected_path=expected)
+    connection.close()
+
+
+def test_interrupted_fixture_migration_rolls_back_all_schema_objects(tmp_path):
+    path = tmp_path / "interrupted.fifo-fixture.sqlite3"
+    connection = sqlite3.connect(path)
+
+    def reject_triggers(action, _arg1, _arg2, _database, _source):
+        return sqlite3.SQLITE_DENY if action == sqlite3.SQLITE_CREATE_TRIGGER else sqlite3.SQLITE_OK
+
+    connection.set_authorizer(reject_triggers)
+    with pytest.raises(sqlite3.DatabaseError):
+        migrate_fifo_fixture_database(connection, expected_path=path)
+    connection.set_authorizer(None)
+    assert connection.in_transaction is False
+    assert connection.execute(
+        "SELECT COUNT(*) FROM sqlite_master WHERE name LIKE 'fifo_%'"
+    ).fetchone() == (0,)
+
+    migrate_fifo_fixture_database(connection, expected_path=path)
+    assert_fifo_accounting_schema(connection)
+    connection.close()
+
+
+def test_financial_tables_are_append_only(connection, ledger):
+    ledger.record_fill(_fill(1, FillSide.BUY, "1", "10", 1))
+    ledger.record_fill(_fill(2, FillSide.SELL, "1", "11", 1))
+    for table in (
+        "fifo_schema_migrations",
+        "fifo_accounting_epochs",
+        "fifo_fills",
+        "fifo_commissions",
+        "fifo_lot_openings",
+        "fifo_lot_matches",
+        "fifo_position_snapshots",
+    ):
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            connection.execute(f"DELETE FROM {table}")
+        connection.rollback()
+    with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        connection.execute("UPDATE fifo_fills SET quantity_text='2'")
+    connection.rollback()
+
+
+def test_schema_constraints_reject_bad_ids_and_orphan_fills(connection):
+    with pytest.raises(sqlite3.IntegrityError):
+        connection.execute(
+            """
+            INSERT INTO fifo_accounting_epochs VALUES(
+                'fepoch-a', 1, 'paper', 'account', 'portfolio', 'EMPTY_LEDGER',
+                ?, '2026-07-28T16:00:00.000000Z', '2026-07-28T16:00:00.000000Z'
+            )
+            """,
+            (_digest("bad"),),
+        )
+    with pytest.raises(sqlite3.IntegrityError):
+        connection.execute(
+            """
+            INSERT INTO fifo_accounting_epochs VALUES(
+                ?, 1, 'paper', 'account', 'portfolio', 'EMPTY_LEDGER',
+                ?, '2026-07-28T16:00:00.000000Z', '2026-07-28T16:00:00.000000Z'
+            )
+            """,
+            ("fepoch-" + "z" * 32, _digest("bad hex")),
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="FOREIGN KEY"):
+        connection.execute(
+            """
+            INSERT INTO fifo_fills VALUES(
+                ?, ?, 1, 'execution', 'idempotency', 1, 'AAPL', 'BUY', '1', '1',
+                '2026-07-28T16:00:00.000000Z', '2026-07-28T16:00:00.000000Z', ?
+            )
+            """,
+            (_identifier("ffill", 1), _identifier("fepoch", 2), _digest("payload")),
+        )
+
+
+@pytest.mark.parametrize("bad_decimal", ["abc", "01", "1.0", "0", "-1", "1e2", ".5", "5."])
+def test_schema_rejects_noncanonical_or_nonpositive_fill_decimals(connection, ledger, bad_decimal):
+    with pytest.raises(sqlite3.IntegrityError, match="CHECK constraint"):
+        connection.execute(
+            """
+            INSERT INTO fifo_fills(
+                fill_id, epoch_id, event_sequence, execution_id, idempotency_key,
+                con_id, symbol, side, quantity_text, price_text, occurred_at,
+                recorded_at, payload_fingerprint
+            ) VALUES (?, ?, 1, 'execution', 'idempotency', 1, 'AAPL', 'BUY', ?, '1',
+                      '2026-07-28T16:00:00.000000Z',
+                      '2026-07-28T16:00:00.000000Z', ?)
+            """,
+            (_identifier("ffill", 1), EPOCH_ID, bad_decimal, _digest("payload")),
+        )
+    connection.rollback()
+
+
+def test_epoch_replay_is_idempotent_and_conflict_fails(connection):
+    ledger = FifoLedger(connection)
+    epoch = AccountingEpoch(
+        epoch_id=EPOCH_ID,
+        execution_domain_scope="paper-simulator-v1",
+        account_scope="acct_v1_test_fixture",
+        portfolio_id="default",
+        source_fingerprint=_digest("empty fixture epoch"),
+        effective_at=NOW,
+        created_at=NOW,
+    )
+    assert ledger.create_epoch(epoch) == epoch
+    assert ledger.create_epoch(epoch) == epoch
+    with pytest.raises(FifoAccountingConflict, match="different data"):
+        ledger.create_epoch(replace(epoch, created_at=NOW + timedelta(seconds=1)))
+    assert _table_count(connection, "fifo_accounting_epochs") == 1
+
+
+def test_legacy_epoch_cannot_be_created_or_projected(connection):
+    with pytest.raises(FifoAccountingValidationError, match="PR4B"):
+        AccountingEpoch(
+            epoch_id=EPOCH_ID,
+            execution_domain_scope="paper-simulator-v1",
+            account_scope="acct_v1_test_fixture",
+            portfolio_id="default",
+            source_fingerprint=_digest("legacy"),
+            effective_at=NOW,
+            created_at=NOW,
+            origin_kind="LEGACY_AGGREGATE_OPENING_BALANCE",
+        )
+
+
+def test_fill_replay_returns_same_projection_without_new_rows(connection, ledger):
+    event = _fill(1, FillSide.BUY, "2.5", "10.125", 3)
+    first = ledger.record_fill(event)
+    before = {
+        table: _table_count(connection, table)
+        for table in (
+            "fifo_fills",
+            "fifo_commissions",
+            "fifo_lot_openings",
+            "fifo_lot_matches",
+            "fifo_position_snapshots",
+        )
+    }
+    replay = ledger.record_fill(event)
+    assert replay.replayed is True
+    assert replay.snapshot == first.snapshot
+    assert replay.opened_lot_id == first.opened_lot_id
+    assert {table: _table_count(connection, table) for table in before} == before
+
+
+@pytest.mark.parametrize(
+    "replacement",
+    [
+        {"price": Decimal("11")},
+        {"execution_id": "different-execution"},
+        {"idempotency_key": "different-idempotency"},
+        {"commission_minor": 99},
+    ],
+)
+def test_fill_identity_conflicts_roll_back(connection, ledger, replacement):
+    event = _fill(1, FillSide.BUY, "2", "10", 1)
+    ledger.record_fill(event)
+    with pytest.raises(FifoAccountingConflict):
+        ledger.record_fill(replace(event, **replacement))
+    assert _table_count(connection, "fifo_fills") == 1
+    assert _table_count(connection, "fifo_commissions") == 1
+
+
+def test_fill_sequence_and_event_time_are_strict(connection, ledger):
+    ledger.record_fill(_fill(1, FillSide.BUY, "1", "10"))
+    with pytest.raises(FifoAccountingOrderingError, match="extend"):
+        ledger.record_fill(_fill(3, FillSide.BUY, "1", "11"))
+    early = replace(
+        _fill(2, FillSide.BUY, "1", "11"),
+        occurred_at=NOW,
+        recorded_at=NOW + timedelta(seconds=2),
+    )
+    with pytest.raises(FifoAccountingOrderingError, match="precedes"):
+        ledger.record_fill(early)
+    assert _table_count(connection, "fifo_fills") == 1
+
+
+@pytest.mark.parametrize(
+    "second",
+    [
+        _fill(2, FillSide.BUY, "1", "11", con_id=265598, symbol="MSFT"),
+        _fill(2, FillSide.BUY, "1", "11", con_id=272093, symbol="AAPL"),
+    ],
+)
+def test_contract_identifier_and_symbol_binding_cannot_drift(connection, ledger, second):
+    ledger.record_fill(_fill(1, FillSide.BUY, "1", "10"))
+    with pytest.raises(FifoAccountingConflict, match="binding changed"):
+        ledger.record_fill(second)
+    assert _table_count(connection, "fifo_fills") == 1
+
+
+def test_long_fifo_partial_fills_match_oldest_lot(connection, ledger):
+    ledger.record_fill(_fill(1, FillSide.BUY, "3", "10"))
+    ledger.record_fill(_fill(2, FillSide.BUY, "2", "20"))
+    result = ledger.record_fill(_fill(3, FillSide.SELL, "4", "30"))
+    rows = connection.execute(
+        """
+        SELECT matched_quantity_text, opening_price_text, gross_pnl_text
+        FROM fifo_lot_matches WHERE closing_fill_id = ? ORDER BY match_ordinal
+        """,
+        (result.fill_id,),
+    ).fetchall()
+    assert rows == [("3", "10", "60"), ("1", "20", "10")]
+    assert result.snapshot.signed_quantity == Decimal("1")
+    assert result.snapshot.open_cost == Decimal("20")
+    assert result.snapshot.cumulative_realized_pnl == Decimal("70")
+    ledger.verify_epoch_integrity(EPOCH_ID)
+
+
+def test_short_fifo_partial_cover_and_profit(connection, ledger):
+    ledger.record_fill(_fill(1, FillSide.SELL, "2", "50"))
+    ledger.record_fill(_fill(2, FillSide.SELL, "1", "40"))
+    result = ledger.record_fill(_fill(3, FillSide.BUY, "2.5", "30"))
+    rows = connection.execute(
+        """
+        SELECT matched_quantity_text, opening_price_text, gross_pnl_text
+        FROM fifo_lot_matches WHERE closing_fill_id = ? ORDER BY match_ordinal
+        """,
+        (result.fill_id,),
+    ).fetchall()
+    assert rows == [("2", "50", "40"), ("0.5", "40", "5")]
+    assert result.snapshot.signed_quantity == Decimal("-0.5")
+    assert result.snapshot.open_cost == Decimal("20.0")
+    assert result.snapshot.cumulative_realized_pnl == Decimal("45")
+    ledger.verify_epoch_integrity(EPOCH_ID)
+
+
+def test_zero_crossing_fill_closes_then_opens_opposite_lot(connection, ledger):
+    ledger.record_fill(_fill(1, FillSide.BUY, "2", "10", 2))
+    result = ledger.record_fill(_fill(2, FillSide.SELL, "5", "12", 5))
+    assert len(result.match_ids) == 1
+    assert result.opened_lot_id is not None
+    assert result.snapshot.signed_quantity == Decimal("-3")
+    assert result.snapshot.open_cost == Decimal("36")
+    allocations = connection.execute(
+        """
+        SELECT closing_commission_minor FROM fifo_lot_matches WHERE closing_fill_id = ?
+        UNION ALL
+        SELECT opening_commission_minor FROM fifo_lot_openings WHERE opening_fill_id = ?
+        """,
+        (result.fill_id, result.fill_id),
+    ).fetchall()
+    assert sorted(value[0] for value in allocations) == [2, 3]
+    ledger.verify_epoch_integrity(EPOCH_ID)
+
+
+def test_commission_allocation_conserves_every_cent_across_fifo_segments(connection, ledger):
+    ledger.record_fill(_fill(1, FillSide.BUY, "1", "10", 1))
+    ledger.record_fill(_fill(2, FillSide.BUY, "1", "11", 1))
+    ledger.record_fill(_fill(3, FillSide.BUY, "1", "12", 1))
+    result = ledger.record_fill(_fill(4, FillSide.SELL, "3", "20", 2))
+    rows = connection.execute(
+        """
+        SELECT opening_commission_minor, closing_commission_minor, realized_pnl_text
+        FROM fifo_lot_matches WHERE closing_fill_id = ? ORDER BY match_ordinal
+        """,
+        (result.fill_id,),
+    ).fetchall()
+    assert rows == [(1, 1, "9.98"), (1, 1, "8.98"), (1, 0, "7.99")]
+    assert sum(row[1] for row in rows) == 2
+    assert result.snapshot.cumulative_realized_pnl == Decimal("26.95")
+    ledger.verify_epoch_integrity(EPOCH_ID)
+
+
+def test_partial_closes_allocate_opening_commission_cumulatively(connection, ledger):
+    ledger.record_fill(_fill(1, FillSide.BUY, "3", "10", 2))
+    ledger.record_fill(_fill(2, FillSide.SELL, "1", "11"))
+    ledger.record_fill(_fill(3, FillSide.SELL, "1", "11"))
+    ledger.record_fill(_fill(4, FillSide.SELL, "1", "11"))
+    allocations = connection.execute("""
+        SELECT m.opening_commission_minor
+        FROM fifo_lot_matches m JOIN fifo_fills f ON f.fill_id=m.closing_fill_id
+        ORDER BY f.event_sequence
+        """).fetchall()
+    assert allocations == [(0,), (1,), (1,)]
+    assert sum(value[0] for value in allocations) == 2
+    assert ledger.record_fill(_fill(4, FillSide.SELL, "1", "11")).replayed is True
+    ledger.verify_epoch_integrity(EPOCH_ID)
+
+
+def test_negative_commission_rebate_is_allocated_exactly(connection, ledger):
+    ledger.record_fill(_fill(1, FillSide.SELL, "2", "10", -1))
+    result = ledger.record_fill(_fill(2, FillSide.BUY, "2", "8", -1))
+    row = connection.execute(
+        """
+        SELECT opening_commission_minor, closing_commission_minor, realized_pnl_text
+        FROM fifo_lot_matches WHERE closing_fill_id = ?
+        """,
+        (result.fill_id,),
+    ).fetchone()
+    assert row == (-1, -1, "4.02")
+    assert result.snapshot.cumulative_commission_minor == -2
+    ledger.verify_epoch_integrity(EPOCH_ID)
+
+
+def test_fractional_quantities_and_subpenny_prices_remain_exact(connection, ledger):
+    ledger.record_fill(_fill(1, FillSide.BUY, "0.125", "10.000001", 0))
+    result = ledger.record_fill(_fill(2, FillSide.SELL, "0.125", "10.000009", 0))
+    assert result.snapshot.signed_quantity == Decimal("0")
+    assert result.snapshot.open_cost is None
+    assert result.snapshot.cumulative_realized_pnl == Decimal("0.000001000")
+    row = connection.execute(
+        "SELECT gross_pnl_text FROM fifo_lot_matches WHERE closing_fill_id = ?",
+        (result.fill_id,),
+    ).fetchone()
+    assert row == ("0.000001",)
+    ledger.verify_epoch_integrity(EPOCH_ID)
+
+
+def test_maximum_input_scales_multiply_without_context_rounding(connection, ledger):
+    ledger.record_fill(_fill(1, FillSide.BUY, "0.000000000000000001", "0.000000000000000001"))
+    result = ledger.record_fill(
+        _fill(2, FillSide.SELL, "0.000000000000000001", "0.000000000000000002")
+    )
+    assert result.snapshot.cumulative_realized_pnl == Decimal(
+        "0.000000000000000000000000000000000001"
+    )
+    assert connection.execute(
+        "SELECT gross_pnl_text FROM fifo_lot_matches WHERE closing_fill_id = ?",
+        (result.fill_id,),
+    ).fetchone() == ("0.000000000000000000000000000000000001",)
+    ledger.verify_epoch_integrity(EPOCH_ID)
+
+
+def test_snapshot_chain_is_per_asset_and_globally_sequenced(connection, ledger):
+    first = ledger.record_fill(_fill(1, FillSide.BUY, "1", "10"))
+    second = ledger.record_fill(_fill(2, FillSide.BUY, "2", "20", con_id=272093, symbol="MSFT"))
+    third = ledger.record_fill(_fill(3, FillSide.SELL, "1", "11"))
+    assert first.snapshot.previous_snapshot_id is None
+    assert second.snapshot.previous_snapshot_id is None
+    assert third.snapshot.previous_snapshot_id == first.snapshot.snapshot_id
+    assert third.snapshot.previous_state_fingerprint == first.snapshot.state_fingerprint
+    assert [
+        row[0]
+        for row in connection.execute(
+            "SELECT event_sequence FROM fifo_position_snapshots ORDER BY event_sequence"
+        )
+    ] == [1, 2, 3]
+    ledger.verify_epoch_integrity(EPOCH_ID)
+
+
+def test_failed_snapshot_insert_rolls_back_fill_commission_matches_and_lots(connection, ledger):
+    connection.execute("""
+        CREATE TRIGGER fixture_reject_snapshot
+        BEFORE INSERT ON fifo_position_snapshots
+        BEGIN
+            SELECT RAISE(ABORT, 'injected snapshot failure');
+        END
+        """)
+    with pytest.raises(sqlite3.IntegrityError, match="injected snapshot failure"):
+        ledger.record_fill(_fill(1, FillSide.BUY, "1", "10", 1))
+    for table in (
+        "fifo_fills",
+        "fifo_commissions",
+        "fifo_lot_openings",
+        "fifo_lot_matches",
+        "fifo_position_snapshots",
+    ):
+        assert _table_count(connection, table) == 0
+
+
+def test_validation_rejects_float_non_utc_and_nonpositive_values():
+    base = _fill(1, FillSide.BUY, "1", "10")
+    with pytest.raises(FifoAccountingValidationError, match="finite Decimal"):
+        replace(base, price=10.0)
+    with pytest.raises(FifoAccountingValidationError, match="positive"):
+        replace(base, quantity=Decimal("0"))
+    with pytest.raises(FifoAccountingValidationError, match="UTC"):
+        replace(base, occurred_at=datetime(2026, 7, 28, 16, 0))
+
+
+def test_schema_drift_is_rejected_before_ledger_use(connection):
+    connection.execute("DROP TRIGGER fifo_fills_no_delete")
+    with pytest.raises(FifoFixtureMigrationError, match="trigger fifo_fills_no_delete"):
+        FifoLedger(connection)

--- a/tests/accounting/test_fifo_accounting.py
+++ b/tests/accounting/test_fifo_accounting.py
@@ -185,6 +185,52 @@ def test_fixture_migration_rejects_hard_link_alias_before_mutation(tmp_path):
     production.close()
 
 
+def test_fixture_migration_rejects_copied_or_renamed_nonfixture_schema(tmp_path):
+    path = tmp_path / "renamed-production.fifo-fixture.sqlite3"
+    connection = sqlite3.connect(path)
+    connection.execute("CREATE TABLE sentinel(value TEXT NOT NULL)")
+    connection.execute("INSERT INTO sentinel VALUES ('preserve')")
+    connection.commit()
+
+    with pytest.raises(FifoFixtureMigrationError, match="requires an empty database"):
+        migrate_fifo_fixture_database(connection, expected_path=path)
+
+    assert connection.execute("SELECT value FROM sentinel").fetchone() == ("preserve",)
+    assert connection.execute(
+        "SELECT COUNT(*) FROM sqlite_master WHERE name LIKE 'fifo_%'"
+    ).fetchone() == (0,)
+    connection.close()
+
+
+def test_fixture_migration_handles_sqlite_row_factory_exactly(tmp_path):
+    path = tmp_path / "row-factory.fifo-fixture.sqlite3"
+    connection = sqlite3.connect(path)
+    connection.row_factory = sqlite3.Row
+
+    migrate_fifo_fixture_database(connection, expected_path=path)
+    assert_fifo_accounting_schema(connection)
+    migrate_fifo_fixture_database(connection, expected_path=path)
+    assert_fifo_accounting_schema(connection)
+    connection.close()
+
+
+def test_exact_fifo_schema_plus_unrelated_table_is_not_a_fixture(tmp_path):
+    path = tmp_path / "mixed-schema.fifo-fixture.sqlite3"
+    connection = sqlite3.connect(path)
+    migrate_fifo_fixture_database(connection, expected_path=path)
+    connection.execute("CREATE TABLE sentinel(value TEXT NOT NULL)")
+    connection.execute("INSERT INTO sentinel VALUES ('preserve')")
+    connection.commit()
+
+    with pytest.raises(FifoFixtureMigrationError, match="unexpected table sentinel"):
+        assert_fifo_accounting_schema(connection)
+    with pytest.raises(FifoFixtureMigrationError, match="unexpected table sentinel"):
+        migrate_fifo_fixture_database(connection, expected_path=path)
+
+    assert connection.execute("SELECT value FROM sentinel").fetchone() == ("preserve",)
+    connection.close()
+
+
 def test_interrupted_fixture_migration_rolls_back_all_schema_objects(tmp_path):
     path = tmp_path / "interrupted.fifo-fixture.sqlite3"
     connection = sqlite3.connect(path)

--- a/tests/accounting/test_fifo_accounting.py
+++ b/tests/accounting/test_fifo_accounting.py
@@ -6,7 +6,7 @@ import os
 import sqlite3
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
-from decimal import Decimal
+from decimal import Decimal, localcontext
 
 import pytest
 
@@ -226,6 +226,52 @@ def test_financial_tables_are_append_only(connection, ledger):
     connection.rollback()
 
 
+def test_insert_or_replace_cannot_rewrite_any_append_only_identity(connection, ledger):
+    ledger.record_fill(_fill(1, FillSide.BUY, "2", "10", 1))
+    ledger.record_fill(_fill(2, FillSide.SELL, "1", "11", 1))
+    for table in (
+        "fifo_schema_migrations",
+        "fifo_accounting_epochs",
+        "fifo_fills",
+        "fifo_commissions",
+        "fifo_lot_openings",
+        "fifo_lot_matches",
+        "fifo_position_snapshots",
+    ):
+        with pytest.raises(sqlite3.IntegrityError, match="identity is append-only"):
+            connection.execute(f"INSERT OR REPLACE INTO {table} SELECT * FROM {table} LIMIT 1")
+        connection.rollback()
+
+    alternate_identity_rows = {
+        "fifo_accounting_epochs": "fepoch-" + "2" * 32,
+        "fifo_fills": _identifier("ffill", 99),
+        "fifo_commissions": _identifier("fcomm", 99),
+        "fifo_lot_openings": _identifier("flot", 99),
+        "fifo_lot_matches": _identifier("fmatch", 99),
+        "fifo_position_snapshots": _identifier("fsnap", 99),
+    }
+    for table, replacement_primary_key in alternate_identity_rows.items():
+        row = list(connection.execute(f"SELECT * FROM {table} LIMIT 1").fetchone())
+        row[0] = replacement_primary_key
+        placeholders = ",".join("?" for _ in row)
+        with pytest.raises(sqlite3.IntegrityError, match="identity is append-only"):
+            connection.execute(
+                f"INSERT OR REPLACE INTO {table} VALUES ({placeholders})",
+                row,
+            )
+        connection.rollback()
+
+    with pytest.raises(sqlite3.IntegrityError, match="identity is append-only"):
+        connection.execute("""
+            INSERT INTO fifo_schema_migrations(component, version, description, applied_at)
+            SELECT component, version, 'forged', applied_at FROM fifo_schema_migrations
+            WHERE true
+            ON CONFLICT(component, version) DO UPDATE SET description='forged'
+            """)
+    connection.rollback()
+    ledger.verify_epoch_integrity(EPOCH_ID)
+
+
 def test_schema_constraints_reject_bad_ids_and_orphan_fills(connection):
     with pytest.raises(sqlite3.IntegrityError):
         connection.execute(
@@ -257,6 +303,76 @@ def test_schema_constraints_reject_bad_ids_and_orphan_fills(connection):
             """,
             (_identifier("ffill", 1), _identifier("fepoch", 2), _digest("payload")),
         )
+
+
+def test_integer_minor_units_reject_fractional_real_storage(connection, ledger):
+    event = _fill(1, FillSide.BUY, "1", "10")
+    _insert_fill_row(connection, event)
+    connection.commit()
+
+    with pytest.raises(sqlite3.IntegrityError):
+        connection.execute(
+            "INSERT INTO fifo_commissions VALUES (?, ?, ?, 1.5, 'USD', 2, ?)",
+            (event.commission_id, event.epoch_id, event.fill_id, _utc_text(event.recorded_at)),
+        )
+    connection.rollback()
+    with pytest.raises(sqlite3.IntegrityError):
+        connection.execute(
+            """
+            INSERT INTO fifo_lot_openings VALUES(
+                ?, ?, ?, 0, ?, ?, 'LONG', '1', '10', 1.5, 1, ?
+            )
+            """,
+            (
+                _identifier("flot", 1),
+                event.epoch_id,
+                event.fill_id,
+                event.con_id,
+                event.symbol,
+                _utc_text(event.occurred_at),
+            ),
+        )
+    connection.rollback()
+
+
+def test_temp_fifo_shadows_created_after_ledger_init_fail_every_operation(connection, ledger):
+    tables = (
+        "fifo_schema_migrations",
+        "fifo_accounting_epochs",
+        "fifo_fills",
+        "fifo_commissions",
+        "fifo_lot_openings",
+        "fifo_lot_matches",
+        "fifo_position_snapshots",
+    )
+    before = {
+        table: connection.execute(f"SELECT COUNT(*) FROM main.{table}").fetchone()[0]
+        for table in tables
+    }
+    for table in tables:
+        connection.execute(f"CREATE TEMP TABLE {table} AS SELECT * FROM main.{table}")
+
+    with pytest.raises(FifoFixtureMigrationError, match="temporary FIFO"):
+        ledger.record_fill(_fill(1, FillSide.BUY, "1", "10"))
+    with pytest.raises(FifoFixtureMigrationError, match="temporary FIFO"):
+        ledger.verify_epoch_integrity(EPOCH_ID)
+    with pytest.raises(FifoFixtureMigrationError, match="temporary FIFO"):
+        ledger.create_epoch(
+            AccountingEpoch(
+                epoch_id="fepoch-" + "2" * 32,
+                execution_domain_scope="paper-simulator-v2",
+                account_scope="acct_v1_test_fixture",
+                portfolio_id="other",
+                source_fingerprint=_digest("shadowed epoch"),
+                effective_at=NOW,
+                created_at=NOW,
+            )
+        )
+
+    assert {
+        table: connection.execute(f"SELECT COUNT(*) FROM main.{table}").fetchone()[0]
+        for table in tables
+    } == before
 
 
 @pytest.mark.parametrize("bad_decimal", ["abc", "01", "1.0", "0", "-1", "1e2", ".5", "5."])
@@ -767,6 +883,28 @@ def test_validation_rejects_float_non_utc_and_nonpositive_values():
         replace(base, quantity=Decimal("0"))
     with pytest.raises(FifoAccountingValidationError, match="UTC"):
         replace(base, occurred_at=datetime(2026, 7, 28, 16, 0))
+
+
+def test_input_precision_counts_expanded_integer_digits():
+    base = _fill(1, FillSide.BUY, "1", "10")
+    assert replace(base, quantity=Decimal("1E+37")).quantity == Decimal("1E+37")
+    for field in ("quantity", "price"):
+        with pytest.raises(FifoAccountingValidationError, match="input precision"):
+            replace(base, **{field: Decimal("1E+38")})
+        with pytest.raises(FifoAccountingValidationError, match="input precision"):
+            replace(base, **{field: Decimal("1E+100")})
+        with pytest.raises(FifoAccountingValidationError, match="input precision"):
+            replace(base, **{field: Decimal("1E+100000000")})
+
+
+def test_minor_unit_conversion_is_exact_under_low_ambient_decimal_precision(ledger):
+    with localcontext() as context:
+        context.prec = 2
+        ledger.record_fill(_fill(1, FillSide.BUY, "1", "10", 1_000_000_000_000))
+        result = ledger.record_fill(_fill(2, FillSide.SELL, "1", "11", -999_999_999_999))
+        assert result.snapshot.cumulative_realized_pnl == Decimal("0.99")
+        assert result.snapshot.cumulative_commission_minor == 1
+        ledger.verify_epoch_integrity(EPOCH_ID)
 
 
 def test_schema_drift_is_rejected_before_ledger_use(connection):

--- a/tests/accounting/test_fifo_accounting.py
+++ b/tests/accounting/test_fifo_accounting.py
@@ -195,7 +195,7 @@ def test_interrupted_fixture_migration_rolls_back_all_schema_objects(tmp_path):
     connection.set_authorizer(reject_triggers)
     with pytest.raises(sqlite3.DatabaseError):
         migrate_fifo_fixture_database(connection, expected_path=path)
-    connection.set_authorizer(None)
+    connection.set_authorizer(lambda *_args: sqlite3.SQLITE_OK)
     assert connection.in_transaction is False
     assert connection.execute(
         "SELECT COUNT(*) FROM sqlite_master WHERE name LIKE 'fifo_%'"

--- a/tests/accounting/test_fifo_accounting.py
+++ b/tests/accounting/test_fifo_accounting.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import hashlib
+import json
+import os
 import sqlite3
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
@@ -91,6 +93,42 @@ def _table_count(connection, table: str) -> int:
     return int(connection.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
 
 
+def _utc_text(value: datetime) -> str:
+    return value.isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _insert_fill_row(connection: sqlite3.Connection, event: FillEvent) -> None:
+    connection.execute(
+        """
+        INSERT INTO fifo_fills(
+            fill_id, epoch_id, event_sequence, execution_id, idempotency_key,
+            con_id, symbol, side, quantity_text, price_text, occurred_at,
+            recorded_at, payload_fingerprint
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            event.fill_id,
+            event.epoch_id,
+            event.event_sequence,
+            event.execution_id,
+            event.idempotency_key,
+            event.con_id,
+            event.symbol,
+            event.side.value,
+            format(event.quantity, "f"),
+            format(event.price, "f"),
+            _utc_text(event.occurred_at),
+            _utc_text(event.recorded_at),
+            event.fingerprint(),
+        ),
+    )
+
+
+def _snapshot_fingerprint(payload: dict[str, object]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
 def test_fixture_migration_is_exact_idempotent_and_foreign_keys_are_on(connection):
     assert_fifo_accounting_schema(connection)
     migrate_fifo_fixture_database(
@@ -122,6 +160,29 @@ def test_fixture_migration_rejects_mismatched_connection(tmp_path):
     with pytest.raises(FifoFixtureMigrationError, match="does not match"):
         migrate_fifo_fixture_database(connection, expected_path=expected)
     connection.close()
+
+
+def test_fixture_migration_rejects_hard_link_alias_before_mutation(tmp_path):
+    production_path = tmp_path / "trading_data.db"
+    production = sqlite3.connect(production_path)
+    production.execute("CREATE TABLE sentinel(value TEXT NOT NULL)")
+    production.execute("INSERT INTO sentinel VALUES ('preserve')")
+    production.commit()
+    production.close()
+
+    alias_path = tmp_path / "alias.fifo-fixture.sqlite3"
+    os.link(production_path, alias_path)
+    connection = sqlite3.connect(alias_path)
+    with pytest.raises(FifoFixtureMigrationError, match="hard link"):
+        migrate_fifo_fixture_database(connection, expected_path=alias_path)
+    connection.close()
+
+    production = sqlite3.connect(production_path)
+    assert production.execute("SELECT value FROM sentinel").fetchone() == ("preserve",)
+    assert production.execute(
+        "SELECT COUNT(*) FROM sqlite_master WHERE name LIKE 'fifo_%'"
+    ).fetchone() == (0,)
+    production.close()
 
 
 def test_interrupted_fixture_migration_rolls_back_all_schema_objects(tmp_path):
@@ -300,6 +361,16 @@ def test_fill_sequence_and_event_time_are_strict(connection, ledger):
     assert _table_count(connection, "fifo_fills") == 1
 
 
+def test_fill_cannot_precede_epoch_effective_time(connection, ledger):
+    event = replace(
+        _fill(1, FillSide.BUY, "1", "10"),
+        occurred_at=NOW - timedelta(microseconds=1),
+    )
+    with pytest.raises(FifoAccountingOrderingError, match="epoch effective_at"):
+        ledger.record_fill(event)
+    assert _table_count(connection, "fifo_fills") == 0
+
+
 @pytest.mark.parametrize(
     "second",
     [
@@ -462,6 +533,141 @@ def test_snapshot_chain_is_per_asset_and_globally_sequenced(connection, ledger):
         )
     ] == [1, 2, 3]
     ledger.verify_epoch_integrity(EPOCH_ID)
+
+
+def test_integrity_verifier_rejects_fill_without_commission_and_snapshot(connection, ledger):
+    _insert_fill_row(connection, _fill(1, FillSide.BUY, "2", "10"))
+    connection.commit()
+
+    with pytest.raises(FifoAccountingValidationError, match="commission and one snapshot"):
+        ledger.verify_epoch_integrity(EPOCH_ID)
+
+
+def test_integrity_verifier_binds_opening_direction_to_source_fill(connection, ledger):
+    event = _fill(1, FillSide.BUY, "2", "10")
+    _insert_fill_row(connection, event)
+    connection.execute(
+        "INSERT INTO fifo_commissions VALUES (?, ?, ?, 0, 'USD', 2, ?)",
+        (event.commission_id, event.epoch_id, event.fill_id, _utc_text(event.recorded_at)),
+    )
+    lot_id = _identifier("flot", 1)
+    connection.execute(
+        """
+        INSERT INTO fifo_lot_openings VALUES(
+            ?, ?, ?, 0, ?, ?, 'SHORT', '2', '10', 0, 1, ?
+        )
+        """,
+        (
+            lot_id,
+            event.epoch_id,
+            event.fill_id,
+            event.con_id,
+            event.symbol,
+            _utc_text(event.occurred_at),
+        ),
+    )
+    snapshot_id = _identifier("fsnap", 1)
+    payload = {
+        "con_id": event.con_id,
+        "cumulative_commission_minor": 0,
+        "cumulative_realized_pnl": "0",
+        "epoch_id": event.epoch_id,
+        "event_sequence": 1,
+        "open_cost": "20",
+        "open_lot_count": 1,
+        "previous_snapshot_id": None,
+        "previous_state_fingerprint": None,
+        "signed_quantity": "-2",
+        "snapshot_id": snapshot_id,
+        "source_fill_id": event.fill_id,
+        "symbol": event.symbol,
+    }
+    connection.execute(
+        """
+        INSERT INTO fifo_position_snapshots VALUES(
+            ?, ?, ?, 1, ?, ?, '-2', '20', 1, '0', 0, NULL, NULL, ?, ?
+        )
+        """,
+        (
+            snapshot_id,
+            event.epoch_id,
+            event.fill_id,
+            event.con_id,
+            event.symbol,
+            _snapshot_fingerprint(payload),
+            _utc_text(event.recorded_at),
+        ),
+    )
+    connection.commit()
+
+    with pytest.raises(FifoAccountingValidationError, match="FIFO projection structure"):
+        ledger.verify_epoch_integrity(EPOCH_ID)
+
+
+def test_integrity_verifier_rejects_non_fifo_match_structure(connection, ledger):
+    first = ledger.record_fill(_fill(1, FillSide.BUY, "1", "10"))
+    second = ledger.record_fill(_fill(2, FillSide.BUY, "1", "20"))
+    assert first.opened_lot_id is not None
+    assert second.opened_lot_id is not None
+
+    event = _fill(3, FillSide.SELL, "1", "30")
+    _insert_fill_row(connection, event)
+    connection.execute(
+        "INSERT INTO fifo_commissions VALUES (?, ?, ?, 0, 'USD', 2, ?)",
+        (event.commission_id, event.epoch_id, event.fill_id, _utc_text(event.recorded_at)),
+    )
+    connection.execute(
+        """
+        INSERT INTO fifo_lot_matches VALUES(
+            ?, ?, ?, ?, 0, '1', '20', '30', 0, 0, '10', '10', ?
+        )
+        """,
+        (
+            _identifier("fmatch", 3),
+            event.epoch_id,
+            event.fill_id,
+            second.opened_lot_id,
+            _utc_text(event.occurred_at),
+        ),
+    )
+    snapshot_id = _identifier("fsnap", 3)
+    payload = {
+        "con_id": event.con_id,
+        "cumulative_commission_minor": 0,
+        "cumulative_realized_pnl": "10",
+        "epoch_id": event.epoch_id,
+        "event_sequence": 3,
+        "open_cost": "10",
+        "open_lot_count": 1,
+        "previous_snapshot_id": second.snapshot.snapshot_id,
+        "previous_state_fingerprint": second.snapshot.state_fingerprint,
+        "signed_quantity": "1",
+        "snapshot_id": snapshot_id,
+        "source_fill_id": event.fill_id,
+        "symbol": event.symbol,
+    }
+    connection.execute(
+        """
+        INSERT INTO fifo_position_snapshots VALUES(
+            ?, ?, ?, 3, ?, ?, '1', '10', 1, '10', 0, ?, ?, ?, ?
+        )
+        """,
+        (
+            snapshot_id,
+            event.epoch_id,
+            event.fill_id,
+            event.con_id,
+            event.symbol,
+            second.snapshot.snapshot_id,
+            second.snapshot.state_fingerprint,
+            _snapshot_fingerprint(payload),
+            _utc_text(event.recorded_at),
+        ),
+    )
+    connection.commit()
+
+    with pytest.raises(FifoAccountingValidationError, match="FIFO projection structure"):
+        ledger.verify_epoch_integrity(EPOCH_ID)
 
 
 def test_failed_snapshot_insert_rolls_back_fill_commission_matches_and_lots(connection, ledger):


### PR DESCRIPTION
Implements remediation PR4A as a dormant fixture-only accounting foundation. Adds append-only epochs, fills, commissions, lot openings, FIFO matches, snapshots, exact Decimal semantics, deterministic long and short FIFO with partial fills and reversals, replay and ordering constraints, and a fixture migration that explicitly rejects production-style database filenames. This PR does not integrate runtime settlement, bootstrap the legacy ledger, migrate trading_data.db, start the trader, or grant order authority. Real-ledger adoption remains PR4B and requires explicit typed operator authorization. Evidence before push: 36 focused tests and 2,760 full-suite tests passed; scoped Black, isort, Flake8, MyPy, Bandit, compilation, and diff checks passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New isolated package and tests only; migration explicitly blocks production DB paths and the module is not imported by the trading runtime.
> 
> **Overview**
> Adds a **dormant, fixture-only** exact FIFO accounting stack under `robo_trader/accounting` with design doc `docs/design/PR4A_FIFO_ACCOUNTING_FOUNDATION.md`. Nothing in this PR wires into the runner, settlement, broker, or `trading_data.db`.
> 
> **Fixture migration** (`migrate_fifo_fixture_database`) applies an append-only SQLite schema only to in-memory DBs or files ending in `.fifo-fixture.sqlite3`, rejecting production-style names, symlinks, hard links, and non-empty/non-exact schemas. Tables cover epochs, fills, commissions, lot openings, FIFO matches, and hash-chained position snapshots, with FK checks, append-only triggers, and identity conflict guards.
> 
> **`FifoLedger`** records fills in one transaction: deterministic FIFO (long/short, partials, zero-crossing), commission split by largest-remainder on integer USD cents, `Decimal`-only inputs, strict event ordering and idempotent replay, and `verify_epoch_integrity()` for full replay validation. PR4A allows only `EMPTY_LEDGER` epochs (no legacy bootstrap).
> 
> **Tests** (`tests/accounting/test_fifo_accounting.py`) cover migration safety, append-only behavior, FIFO/commission edge cases, and integrity verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 101beb94921c884c050580973a084e8a8380be8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->