### PR TITLE
feat(database): add descriptor-bound backup and restore tooling

### DIFF
--- a/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
+++ b/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
@@ -51,7 +51,7 @@ Final full repository regression:
 
 ```text
 python3 -m pytest tests/ -q --tb=short
-3110 passed, 5 skipped, 20 known warnings in 85.92s
+3110 passed, 5 skipped, 20 known warnings in 82.67s
 ```
 
 After PR 4C merged to `main`, that exact head was merge-integrated into this
@@ -164,7 +164,10 @@ claiming isolation that an in-process filesystem library cannot provide:
   internal ALTER TABLE helper calls are reserved from plan SQL. The deadline is
   checked after every VM opcode and after each statement. Separate main and
   temporary page ceilings limit synthetic growth to 64 MiB each by default,
-  and plan-controlled TEMP DDL is denied.
+  and plan-controlled TEMP DDL is denied. Deadline rollback has a distinct
+  `migration_deadline_exceeded` result, so its regression proves the interrupt
+  without relying on CI filesystem speed; a ten-second outer ceiling still
+  catches a lost interrupt or hang.
 - Migration plans are not arbitrary SQL. Full-match validation permits only a
   small documented grammar of basic DDL plus parameter-only INSERT and
   predicate-required UPDATE/DELETE. Functions, expressions, comments,

--- a/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
+++ b/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
@@ -86,7 +86,7 @@ type debt.
 
 ## 2026-07-30 exact-review follow-up
 
-Six additional exact-head P1 findings and the Python 3.10 CI failures were
+Ten additional exact-head P1 findings and the Python 3.10 CI failures were
 remediated without touching authoritative data or runtime services:
 
 - SQLite now operates only in memory. It never opens the requested output path,
@@ -98,6 +98,18 @@ remediated without touching authoritative data or runtime services:
 - A planted staging-name symlink cannot redirect SQLite into an attacker-owned
   directory because no filesystem target connection exists. Exclusive file
   creation refuses the symlink and preserves planted `database.db-wal` bytes.
+- The staged file is born with mode `000`; only the already-held guardian
+  descriptor can write the serialized image. A concurrent writable open is
+  denied before the inode is sealed and digested.
+- Publication fsyncs the bound parent-directory descriptor and revalidates both
+  the lexical parent and published target afterward. Parent replacement causes
+  a failed operation rather than a false successful manifest.
+- Migration dry runs capture before/after logical evidence through bound,
+  WAL-aware read snapshots, so a normally active RoboTrader WAL source is
+  accepted without relaxing source-change detection.
+- A normal WAL checkpoint may change physical main-file bytes while SQLite's
+  held read snapshot remains consistent. Online backup now relies on that bound
+  logical snapshot instead of incorrectly rejecting checkpointed bytes.
 - A public `-wal`, `-shm`, or `-journal` substitution while SQLite is active is
   preserved byte-for-byte and causes publication to fail closed. This closes
   the Linux behavior where SQLite itself could unlink a replacement before a
@@ -116,8 +128,8 @@ remediated without touching authoritative data or runtime services:
 Current verification:
 
 ```text
-focused maintenance + multiuser + DB isolation: 198 passed
-full repository: 3037 passed, 5 skipped, 20 known warnings
+focused maintenance + multiuser + DB isolation: 202 passed
+full repository: 3054 passed, 5 skipped, 20 known warnings
 Python 3.10 direct authorizer commit/rollback probe: passed
 Black, isort, flake8, Bandit, mypy, and git diff checks on changed scope: passed
 ```

--- a/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
+++ b/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
@@ -1,0 +1,84 @@
+# PR 4D local review evidence
+
+Date: 2026-07-28
+
+Base: `101beb94921c884c050580973a084e8a8380be8d`
+
+Branch: `codex/pr4d-backup-restore`
+
+## Scope and safety result
+
+- Added dormant, descriptor-bound SQLite backup, verification, clean-room
+  restore, and synthetic migration dry-run tooling.
+- Every output uses an exclusive new path. No operation deletes, renames over,
+  restores over, or automatically replaces an authoritative database.
+- Manifests contain no paths, row values, environment values, credentials, or
+  broker/account configuration and always report
+  `authorizes_startup=false`.
+- Removed the callable raw-copy, overwrite-restore, foreign-key-disabled, and
+  account-row-collapsing legacy multiuser implementation. Read-only inspection,
+  missing-database no-op, and already-applied no-op behavior remain.
+- Repository call-graph search found no non-test caller of
+  `MultiuserMigration`; no sanctioned startup path was changed.
+- All backup, corruption, restore, migration, WAL, alias, and interruption
+  exercises used pytest temporary databases. No authoritative/user database,
+  broker, runtime process, listener, or service was accessed or modified.
+- This work does not authorize startup and does not advance Gate A.
+
+## Verification
+
+Focused maintenance, legacy migration, and database-isolation matrix:
+
+```text
+python -m pytest tests/maintenance/test_sqlite_service.py \
+  tests/test_multiuser.py tests/security/test_db_isolation.py -q --tb=short
+188 passed
+```
+
+The new PR 4D maintenance module has 21 direct tests covering active WAL state,
+multiportfolio preservation, backup/restore manifests, clean-room equivalence,
+corruption, preexisting targets, symlinks, hardlinks, companion files,
+substitution races, backup/restore interruption, migration rollback, callback
+containment, CLI output, and legacy quarantine.
+
+Final full repository regression:
+
+```text
+python -m pytest tests/ -q --tb=short
+2854 passed, 5 skipped, 20 known warnings in 189.19s
+```
+
+Static checks:
+
+```text
+python -m black --check <changed Python paths>
+python -m isort --check-only <changed Python paths>
+python -m flake8 <changed Python paths>
+python -m bandit -q -r robo_trader/maintenance \
+  scripts/database_maintenance.py robo_trader/multiuser/migration.py
+python -m mypy --follow-imports=skip --ignore-missing-imports \
+  robo_trader/maintenance/models.py \
+  robo_trader/maintenance/sqlite_service.py \
+  scripts/database_maintenance.py robo_trader/multiuser/migration.py
+git diff --check
+```
+
+All listed static checks passed. The focused mypy invocation intentionally
+isolates changed modules because the repository retains unrelated, documented
+type debt.
+
+## Review notes
+
+- The service reuses the reviewed SQLite-owned-descriptor proof from
+  `robo_trader.safety.sqlite_identity` and independently holds an
+  `O_NOFOLLOW` guardian.
+- Main database and `-wal`/`-shm`/`-journal` identities are checked throughout
+  online copy progress. Backup and restore artifacts are integrity-checked,
+  foreign-key-checked, logically hashed, raw-file hashed, fsynced, and sealed
+  read-only.
+- Failed or interrupted outputs are retained read-only for forensic inspection
+  and have no successful manifest. They are never promoted or reused.
+- Migration callbacks run only against the new synthetic copy in a
+  service-owned transaction. Transaction control, `ATTACH`, `DETACH`, and
+  dangerous path/schema pragmas are denied; failures roll back and return a
+  secret-free report.

--- a/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
+++ b/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
@@ -76,9 +76,9 @@ type debt.
   online copy progress. Backup and restore artifacts are integrity-checked,
   foreign-key-checked, logically hashed, raw-file hashed, fsynced, and sealed
   read-only.
-- Failed or interrupted staged outputs are retained read-only inside their
-  private staging directory for forensic inspection and have no successful
-  manifest. They are never promoted or reused.
+- Failed or interrupted staged outputs are retained as randomly named,
+  read-only files for forensic inspection and have no successful manifest.
+  They are never promoted or reused.
 - Declarative migration plans run only against the new synthetic copy in a
   service-owned transaction. Transaction control, `ATTACH`, `DETACH`, and
   dangerous path/schema pragmas are denied; failures roll back and return a
@@ -86,13 +86,18 @@ type debt.
 
 ## 2026-07-30 exact-review follow-up
 
-Five additional exact-head P1 findings and the Python 3.10 CI failures were
+Six additional exact-head P1 findings and the Python 3.10 CI failures were
 remediated without touching authoritative data or runtime services:
 
-- SQLite now operates only in a fresh, unpredictable, owner-only staging
-  directory. It never opens the requested output path or any public sidecar
-  pathname. After close, the sealed main inode is published with an atomic
-  no-replace rename; the service performs no pathname unlink.
+- SQLite now operates only in memory. It never opens the requested output path,
+  a staging-directory path, or any public sidecar pathname. The exact finished
+  image is serialized into an exclusive file created with `openat` under a
+  bound parent-directory descriptor. The sealed inode is published with a
+  descriptor-relative atomic no-replace rename; the service performs no
+  pathname unlink.
+- A planted staging-name symlink cannot redirect SQLite into an attacker-owned
+  directory because no filesystem target connection exists. Exclusive file
+  creation refuses the symlink and preserves planted `database.db-wal` bytes.
 - A public `-wal`, `-shm`, or `-journal` substitution while SQLite is active is
   preserved byte-for-byte and causes publication to fail closed. This closes
   the Linux behavior where SQLite itself could unlink a replacement before a
@@ -111,8 +116,8 @@ remediated without touching authoritative data or runtime services:
 Current verification:
 
 ```text
-focused maintenance + multiuser + DB isolation: 197 passed
-full repository: 3036 passed, 5 skipped, 20 known warnings
+focused maintenance + multiuser + DB isolation: 198 passed
+full repository: 3037 passed, 5 skipped, 20 known warnings
 Python 3.10 direct authorizer commit/rollback probe: passed
 Black, isort, flake8, Bandit, mypy, and git diff checks on changed scope: passed
 ```

--- a/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
+++ b/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
@@ -32,22 +32,23 @@ Focused maintenance, legacy migration, and database-isolation matrix:
 ```text
 python3 -m pytest tests/maintenance/test_sqlite_service.py \
   tests/test_multiuser.py tests/security/test_db_isolation.py -q --tb=short
-222 passed
+224 passed
 ```
 
-The PR 4D maintenance module has 55 direct tests covering active WAL state,
+The PR 4D maintenance module has 57 direct tests covering active WAL state,
 multiportfolio preservation, backup/restore manifests, clean-room equivalence,
 corruption, preexisting targets, symlinks, hardlinks, companion files,
 substitution races, backup/restore interruption, migration rollback,
 declarative-plan containment, hidden-rowid source-change detection,
 planner-statistics evidence, bounded migration execution, `WITHOUT ROWID` and
-shadowed-rowid compatibility, CLI output, and legacy quarantine.
+shadowed-rowid compatibility, native-pointer and virtual-table denial,
+schema-cookie protection, CLI output, and legacy quarantine.
 
 Final full repository regression:
 
 ```text
 python3 -m pytest tests/ -q --tb=short
-3100 passed, 5 skipped, 20 known warnings in 82.61s
+3102 passed, 5 skipped, 20 known warnings in 79.38s
 ```
 
 After PR 4C merged to `main`, that exact head was merge-integrated into this
@@ -164,8 +165,8 @@ claiming isolation that an in-process filesystem library cannot provide:
 Current verification:
 
 ```text
-focused maintenance + multiuser + DB isolation: 222 passed
-full repository: 3100 passed, 5 skipped, 20 known warnings
+focused maintenance + multiuser + DB isolation: 224 passed
+full repository: 3102 passed, 5 skipped, 20 known warnings
 PR 4C settlement integration file: 30 passed
 Python 3.10 direct authorizer commit/rollback probe: passed
 Black, isort, flake8, Bandit, mypy, and git diff checks on changed scope: passed

--- a/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
+++ b/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
@@ -108,9 +108,16 @@ claiming isolation that an in-process filesystem library cannot provide:
   that guarantee impossible for an in-process library. The reviewed operating
   boundary now requires an exclusive maintenance window; stronger adversarial
   isolation requires a dedicated OS identity, container, or sandbox.
-- A cleanly closed database that retains `journal_mode=WAL` but has no sidecars
-  is opened immutably. The service therefore does not create `-wal`/`-shm`
-  companions and then reject its own identity check.
+- A cleanly closed database that retains `journal_mode=WAL` is opened with
+  normal SQLite locking. Safe companions created while establishing the bound
+  connection are adopted and monitored, preventing both self-rejection and the
+  torn snapshots caused by incorrectly inferring immutability from absent
+  sidecars. Only manifest-verified sealed restore input uses immutable mode.
+- The exact descriptor bytes are read back and deserialized before publication.
+  Their integrity, foreign-key, schema, row-count, and table-hash evidence must
+  match the in-memory copy, and the manifest digest must match the same byte
+  snapshot. A valid alternate database injected through a retained writable
+  descriptor therefore fails before publication.
 - Publication fsyncs the bound parent-directory descriptor and revalidates both
   the lexical parent and published target afterward. Parent replacement causes
   a failed operation rather than a false successful manifest.
@@ -138,8 +145,8 @@ claiming isolation that an in-process filesystem library cannot provide:
 Current verification:
 
 ```text
-focused maintenance + multiuser + DB isolation: 203 passed
-full repository: 3055 passed, 5 skipped, 20 known warnings
+focused maintenance + multiuser + DB isolation: 205 passed
+full repository: 3057 passed, 5 skipped, 20 known warnings
 Python 3.10 direct authorizer commit/rollback probe: passed
 Black, isort, flake8, Bandit, mypy, and git diff checks on changed scope: passed
 ```

--- a/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
+++ b/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
@@ -76,9 +76,9 @@ type debt.
   online copy progress. Backup and restore artifacts are integrity-checked,
   foreign-key-checked, logically hashed, raw-file hashed, fsynced, and sealed
   read-only.
-- Failed or interrupted staged outputs are retained as randomly named,
-  read-only files for forensic inspection and have no successful manifest.
-  They are never promoted or reused.
+- Failed or interrupted anonymous outputs disappear when their held descriptor
+  closes and have no successful manifest or requested target path. They are
+  never promoted or reused.
 - Declarative migration plans run only against the new synthetic copy in a
   service-owned transaction. Transaction control, `ATTACH`, `DETACH`, and
   dangerous path/schema pragmas are denied; failures roll back and return a
@@ -86,21 +86,21 @@ type debt.
 
 ## 2026-07-30 exact-review follow-up
 
-Ten additional exact-head P1 findings and the Python 3.10 CI failures were
+Eleven additional exact-head P1 findings and the Python 3.10 CI failures were
 remediated without touching authoritative data or runtime services:
 
 - SQLite now operates only in memory. It never opens the requested output path,
   a staging-directory path, or any public sidecar pathname. The exact finished
-  image is serialized into an exclusive file created with `openat` under a
-  bound parent-directory descriptor. The sealed inode is published with a
-  descriptor-relative atomic no-replace rename; the service performs no
-  pathname unlink.
+  image is serialized into an unlinked inode on the target filesystem. Linux
+  publishes its `O_TMPFILE` inode with `linkat(AT_EMPTY_PATH)`; macOS publishes
+  from an unlinked descriptor with `fclonefileat`. Unsupported topology fails
+  closed, and the service performs no pathname unlink.
 - A planted staging-name symlink cannot redirect SQLite into an attacker-owned
   directory because no filesystem target connection exists. Exclusive file
   creation refuses the symlink and preserves planted `database.db-wal` bytes.
-- The staged file is born with mode `000`; only the already-held guardian
-  descriptor can write the serialized image. A concurrent writable open is
-  denied before the inode is sealed and digested.
+- The staged inode has no pathname or directory entry (`st_nlink == 0`) before
+  publication. A same-user process therefore has no staging name to chmod,
+  open, hard-link, rename, or retain for post-digest mutation.
 - Publication fsyncs the bound parent-directory descriptor and revalidates both
   the lexical parent and published target afterward. Parent replacement causes
   a failed operation rather than a false successful manifest.

--- a/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
+++ b/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
@@ -86,8 +86,10 @@ type debt.
 
 ## 2026-07-30 exact-review follow-up
 
-Eleven additional exact-head P1 findings and the Python 3.10 CI failures were
-remediated without touching authoritative data or runtime services:
+The exact-head P1 findings and Python 3.10 CI failures were addressed without
+touching authoritative data or runtime services. The latest same-UID attacker
+reports were handled by correcting the documented trust boundary rather than
+claiming isolation that an in-process filesystem library cannot provide:
 
 - SQLite now operates only in memory. It never opens the requested output path,
   a staging-directory path, or any public sidecar pathname. The exact finished
@@ -98,9 +100,17 @@ remediated without touching authoritative data or runtime services:
 - A planted staging-name symlink cannot redirect SQLite into an attacker-owned
   directory because no filesystem target connection exists. Exclusive file
   creation refuses the symlink and preserves planted `database.db-wal` bytes.
-- The staged inode has no pathname or directory entry (`st_nlink == 0`) before
-  publication. A same-user process therefore has no staging name to chmod,
-  open, hard-link, rename, or retain for post-digest mutation.
+- The staged inode has no persistent directory entry (`st_nlink == 0`) before
+  publication, which removes the prior pathname substitution and hard-link
+  races. This is not claimed to isolate the service from actively hostile code
+  running under the same OS user: Linux `/proc` descriptor access, macOS's
+  temporary-file creation window, and post-publication directory access make
+  that guarantee impossible for an in-process library. The reviewed operating
+  boundary now requires an exclusive maintenance window; stronger adversarial
+  isolation requires a dedicated OS identity, container, or sandbox.
+- A cleanly closed database that retains `journal_mode=WAL` but has no sidecars
+  is opened immutably. The service therefore does not create `-wal`/`-shm`
+  companions and then reject its own identity check.
 - Publication fsyncs the bound parent-directory descriptor and revalidates both
   the lexical parent and published target afterward. Parent replacement causes
   a failed operation rather than a false successful manifest.
@@ -128,8 +138,8 @@ remediated without touching authoritative data or runtime services:
 Current verification:
 
 ```text
-focused maintenance + multiuser + DB isolation: 202 passed
-full repository: 3054 passed, 5 skipped, 20 known warnings
+focused maintenance + multiuser + DB isolation: 203 passed
+full repository: 3055 passed, 5 skipped, 20 known warnings
 Python 3.10 direct authorizer commit/rollback probe: passed
 Black, isort, flake8, Bandit, mypy, and git diff checks on changed scope: passed
 ```

--- a/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
+++ b/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
@@ -32,22 +32,22 @@ Focused maintenance, legacy migration, and database-isolation matrix:
 ```text
 python3 -m pytest tests/maintenance/test_sqlite_service.py \
   tests/test_multiuser.py tests/security/test_db_isolation.py -q --tb=short
-220 passed
+222 passed
 ```
 
-The PR 4D maintenance module has 53 direct tests covering active WAL state,
+The PR 4D maintenance module has 55 direct tests covering active WAL state,
 multiportfolio preservation, backup/restore manifests, clean-room equivalence,
 corruption, preexisting targets, symlinks, hardlinks, companion files,
 substitution races, backup/restore interruption, migration rollback,
 declarative-plan containment, hidden-rowid source-change detection,
-`WITHOUT ROWID` and shadowed-rowid compatibility, CLI output, and legacy
-quarantine.
+planner-statistics evidence, bounded migration execution, `WITHOUT ROWID` and
+shadowed-rowid compatibility, CLI output, and legacy quarantine.
 
 Final full repository regression:
 
 ```text
 python3 -m pytest tests/ -q --tb=short
-3098 passed, 5 skipped, 20 known warnings in 83.40s
+3100 passed, 5 skipped, 20 known warnings in 82.61s
 ```
 
 After PR 4C merged to `main`, that exact head was merge-integrated into this
@@ -164,8 +164,8 @@ claiming isolation that an in-process filesystem library cannot provide:
 Current verification:
 
 ```text
-focused maintenance + multiuser + DB isolation: 220 passed
-full repository: 3098 passed, 5 skipped, 20 known warnings
+focused maintenance + multiuser + DB isolation: 222 passed
+full repository: 3100 passed, 5 skipped, 20 known warnings
 PR 4C settlement integration file: 30 passed
 Python 3.10 direct authorizer commit/rollback probe: passed
 Black, isort, flake8, Bandit, mypy, and git diff checks on changed scope: passed

--- a/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
+++ b/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
@@ -47,8 +47,14 @@ Final full repository regression:
 
 ```text
 python3 -m pytest tests/ -q --tb=short
-3072 passed, 5 skipped, 20 known warnings in 78.67s
+3098 passed, 5 skipped, 20 known warnings in 83.40s
 ```
+
+After PR 4C merged to `main`, that exact head was merge-integrated into this
+branch. Its two settlement compatibility tests now install a synthetic copy of
+the historical multiuser-v1 result directly under `tests/`; they do not invoke
+or re-enable the quarantined in-place migrator. The complete settlement file
+passes 30 tests on the combined tree.
 
 Static checks:
 
@@ -159,7 +165,8 @@ Current verification:
 
 ```text
 focused maintenance + multiuser + DB isolation: 220 passed
-full repository: 3072 passed, 5 skipped, 20 known warnings
+full repository: 3098 passed, 5 skipped, 20 known warnings
+PR 4C settlement integration file: 30 passed
 Python 3.10 direct authorizer commit/rollback probe: passed
 Black, isort, flake8, Bandit, mypy, and git diff checks on changed scope: passed
 ```

--- a/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
+++ b/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
@@ -35,7 +35,7 @@ python -m pytest tests/maintenance/test_sqlite_service.py \
 188 passed
 ```
 
-The new PR 4D maintenance module has 21 direct tests covering active WAL state,
+The PR 4D maintenance module has 30 direct tests covering active WAL state,
 multiportfolio preservation, backup/restore manifests, clean-room equivalence,
 corruption, preexisting targets, symlinks, hardlinks, companion files,
 substitution races, backup/restore interruption, migration rollback, callback
@@ -78,7 +78,40 @@ type debt.
   read-only.
 - Failed or interrupted outputs are retained read-only for forensic inspection
   and have no successful manifest. They are never promoted or reused.
-- Migration callbacks run only against the new synthetic copy in a
+- Declarative migration plans run only against the new synthetic copy in a
   service-owned transaction. Transaction control, `ATTACH`, `DETACH`, and
   dangerous path/schema pragmas are denied; failures roll back and return a
   secret-free report.
+
+## 2026-07-30 exact-review follow-up
+
+Three additional exact-head P1 findings and the Python 3.10 CI failures were
+remediated without touching authoritative data or runtime services:
+
+- Sidecar release now distinguishes a reservation SQLite consumed itself by
+  checking the still-open descriptor's zero link count. Remaining reservations
+  are atomically moved with the platform's no-replace rename into an exclusive
+  sibling quarantine directory. The service performs no pathname unlink and
+  leaves zero-byte tombstones in place.
+- A substitution between pathname inspection and the atomic claim is preserved,
+  restored to its original name when that can be done without replacement, and
+  causes the operation to fail closed.
+- A migration plan runs on the same descriptor-bound target connection used by
+  the online copy. The synthetic database is never reopened writable between
+  copy verification and migration.
+- Service-owned commit and rollback replace the restrictive plan authorizer
+  with a completion-only policy. This avoids Python 3.10's unsupported
+  `set_authorizer(None)` behavior without allowing plan-supplied transaction
+  control.
+
+Current verification:
+
+```text
+focused maintenance + multiuser + DB isolation: 197 passed
+full repository: 3036 passed, 5 skipped, 20 known warnings
+Python 3.10 direct authorizer commit/rollback probe: passed
+Black, isort, flake8, Bandit, mypy, and git diff checks on changed scope: passed
+```
+
+Repository-wide Black and flake8 remain red only for pre-existing files outside
+this PR's changed scope; those unrelated files were not modified.

--- a/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
+++ b/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
@@ -32,10 +32,10 @@ Focused maintenance, legacy migration, and database-isolation matrix:
 ```text
 python3 -m pytest tests/maintenance/test_sqlite_service.py \
   tests/test_multiuser.py tests/security/test_db_isolation.py -q --tb=short
-232 passed
+234 passed
 ```
 
-The PR 4D maintenance module has 65 direct tests covering active WAL state,
+The PR 4D maintenance module has 67 direct tests covering active WAL state,
 multiportfolio preservation, backup/restore manifests, clean-room equivalence,
 corruption, preexisting targets, symlinks, hardlinks, companion files,
 substitution races, backup/restore interruption, migration rollback,
@@ -46,12 +46,14 @@ schema-cookie protection and tracking, native-function denial, bounded
 synthetic database growth, pre-publication final-evidence failure, CLI output,
 embedded-schema-function rejection, per-opcode deadline enforcement, TEMP
 storage containment, narrow migration-grammar rejection, and legacy quarantine.
+Block and line comments between a copied-schema function name and its opening
+parenthesis are normalized before screening and covered by integration tests.
 
 Final full repository regression:
 
 ```text
 python3 -m pytest tests/ -q --tb=short
-3110 passed, 5 skipped, 20 known warnings in 82.67s
+3112 passed, 5 skipped, 20 known warnings in 80.35s
 ```
 
 After PR 4C merged to `main`, that exact head was merge-integrated into this

--- a/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
+++ b/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
@@ -30,12 +30,12 @@ Branch: `codex/pr4d-backup-restore`
 Focused maintenance, legacy migration, and database-isolation matrix:
 
 ```text
-python -m pytest tests/maintenance/test_sqlite_service.py \
+python3 -m pytest tests/maintenance/test_sqlite_service.py \
   tests/test_multiuser.py tests/security/test_db_isolation.py -q --tb=short
-188 passed
+215 passed
 ```
 
-The PR 4D maintenance module has 30 direct tests covering active WAL state,
+The PR 4D maintenance module has 48 direct tests covering active WAL state,
 multiportfolio preservation, backup/restore manifests, clean-room equivalence,
 corruption, preexisting targets, symlinks, hardlinks, companion files,
 substitution races, backup/restore interruption, migration rollback,
@@ -44,19 +44,19 @@ declarative-plan containment, CLI output, and legacy quarantine.
 Final full repository regression:
 
 ```text
-python -m pytest tests/ -q --tb=short
-2854 passed, 5 skipped, 20 known warnings in 189.19s
+python3 -m pytest tests/ -q --tb=short
+3067 passed, 5 skipped, 20 known warnings in 80.90s
 ```
 
 Static checks:
 
 ```text
-python -m black --check <changed Python paths>
-python -m isort --check-only <changed Python paths>
-python -m flake8 <changed Python paths>
-python -m bandit -q -r robo_trader/maintenance \
+python3 -m black --check <changed Python paths>
+python3 -m isort --check-only <changed Python paths>
+python3 -m flake8 <changed Python paths>
+python3 -m bandit -q -r robo_trader/maintenance \
   scripts/database_maintenance.py robo_trader/multiuser/migration.py
-python -m mypy --follow-imports=skip --ignore-missing-imports \
+python3 -m mypy --follow-imports=skip --ignore-missing-imports \
   robo_trader/maintenance/models.py \
   robo_trader/maintenance/sqlite_service.py \
   scripts/database_maintenance.py robo_trader/multiuser/migration.py
@@ -141,12 +141,22 @@ claiming isolation that an in-process filesystem library cannot provide:
   with a completion-only policy. This avoids Python 3.10's unsupported
   `set_authorizer(None)` behavior without allowing plan-supplied transaction
   control.
+- Migration plans cannot change SQLite's process-global hard or soft heap
+  limits. Oversized integer binding failures are converted into the same
+  rollback-only, secret-free failure report as rejected SQL.
+- Every CLI report path is checked against the full main/`-wal`/`-shm`/
+  `-journal` family of each source, backup, and target database. Backup and
+  restore manifest paths are exclusively reserved and descriptor-bound before
+  database publication, so an existing or unwritable report path cannot leave
+  a new orphan database artifact.
+- All documented Python invocations use the project-required `python3`
+  executable name.
 
 Current verification:
 
 ```text
-focused maintenance + multiuser + DB isolation: 205 passed
-full repository: 3057 passed, 5 skipped, 20 known warnings
+focused maintenance + multiuser + DB isolation: 215 passed
+full repository: 3067 passed, 5 skipped, 20 known warnings
 Python 3.10 direct authorizer commit/rollback probe: passed
 Black, isort, flake8, Bandit, mypy, and git diff checks on changed scope: passed
 ```

--- a/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
+++ b/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
@@ -38,8 +38,8 @@ python -m pytest tests/maintenance/test_sqlite_service.py \
 The PR 4D maintenance module has 30 direct tests covering active WAL state,
 multiportfolio preservation, backup/restore manifests, clean-room equivalence,
 corruption, preexisting targets, symlinks, hardlinks, companion files,
-substitution races, backup/restore interruption, migration rollback, callback
-containment, CLI output, and legacy quarantine.
+substitution races, backup/restore interruption, migration rollback,
+declarative-plan containment, CLI output, and legacy quarantine.
 
 Final full repository regression:
 
@@ -76,8 +76,9 @@ type debt.
   online copy progress. Backup and restore artifacts are integrity-checked,
   foreign-key-checked, logically hashed, raw-file hashed, fsynced, and sealed
   read-only.
-- Failed or interrupted outputs are retained read-only for forensic inspection
-  and have no successful manifest. They are never promoted or reused.
+- Failed or interrupted staged outputs are retained read-only inside their
+  private staging directory for forensic inspection and have no successful
+  manifest. They are never promoted or reused.
 - Declarative migration plans run only against the new synthetic copy in a
   service-owned transaction. Transaction control, `ATTACH`, `DETACH`, and
   dangerous path/schema pragmas are denied; failures roll back and return a
@@ -85,20 +86,23 @@ type debt.
 
 ## 2026-07-30 exact-review follow-up
 
-Three additional exact-head P1 findings and the Python 3.10 CI failures were
+Five additional exact-head P1 findings and the Python 3.10 CI failures were
 remediated without touching authoritative data or runtime services:
 
-- Sidecar release now distinguishes a reservation SQLite consumed itself by
-  checking the still-open descriptor's zero link count. Remaining reservations
-  are atomically moved with the platform's no-replace rename into an exclusive
-  sibling quarantine directory. The service performs no pathname unlink and
-  leaves zero-byte tombstones in place.
-- A substitution between pathname inspection and the atomic claim is preserved,
-  restored to its original name when that can be done without replacement, and
-  causes the operation to fail closed.
+- SQLite now operates only in a fresh, unpredictable, owner-only staging
+  directory. It never opens the requested output path or any public sidecar
+  pathname. After close, the sealed main inode is published with an atomic
+  no-replace rename; the service performs no pathname unlink.
+- A public `-wal`, `-shm`, or `-journal` substitution while SQLite is active is
+  preserved byte-for-byte and causes publication to fail closed. This closes
+  the Linux behavior where SQLite itself could unlink a replacement before a
+  later reservation check.
 - A migration plan runs on the same descriptor-bound target connection used by
   the online copy. The synthetic database is never reopened writable between
   copy verification and migration.
+- Migration report evidence and artifact hash come directly from the final
+  descriptor-bound copy manifest. The published target is not reopened, so a
+  later path substitution cannot change what artifact the report describes.
 - Service-owned commit and rollback replace the restrictive plan authorizer
   with a completion-only policy. This avoids Python 3.10's unsupported
   `set_authorizer(None)` behavior without allowing plan-supplied transaction

--- a/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
+++ b/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
@@ -32,10 +32,10 @@ Focused maintenance, legacy migration, and database-isolation matrix:
 ```text
 python3 -m pytest tests/maintenance/test_sqlite_service.py \
   tests/test_multiuser.py tests/security/test_db_isolation.py -q --tb=short
-234 passed
+235 passed
 ```
 
-The PR 4D maintenance module has 67 direct tests covering active WAL state,
+The PR 4D maintenance module has 68 direct tests covering active WAL state,
 multiportfolio preservation, backup/restore manifests, clean-room equivalence,
 corruption, preexisting targets, symlinks, hardlinks, companion files,
 substitution races, backup/restore interruption, migration rollback,
@@ -48,12 +48,14 @@ embedded-schema-function rejection, per-opcode deadline enforcement, TEMP
 storage containment, narrow migration-grammar rejection, and legacy quarantine.
 Block and line comments between a copied-schema function name and its opening
 parenthesis are normalized before screening and covered by integration tests.
+Line comments follow SQLite's lexer and continue through a bare carriage return
+until line-feed; an apply-success regression prevents conservative false alarms.
 
 Final full repository regression:
 
 ```text
 python3 -m pytest tests/ -q --tb=short
-3112 passed, 5 skipped, 20 known warnings in 80.35s
+3113 passed, 5 skipped, 20 known warnings in 92.14s
 ```
 
 After PR 4C merged to `main`, that exact head was merge-integrated into this

--- a/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
+++ b/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
@@ -32,10 +32,10 @@ Focused maintenance, legacy migration, and database-isolation matrix:
 ```text
 python3 -m pytest tests/maintenance/test_sqlite_service.py \
   tests/test_multiuser.py tests/security/test_db_isolation.py -q --tb=short
-236 passed
+242 passed
 ```
 
-The PR 4D maintenance module has 69 direct tests covering active WAL state,
+The PR 4D maintenance module has 75 direct tests covering active WAL state,
 multiportfolio preservation, backup/restore manifests, clean-room equivalence,
 corruption, preexisting targets, symlinks, hardlinks, companion files,
 substitution races, backup/restore interruption, migration rollback,
@@ -46,20 +46,26 @@ schema-cookie protection and tracking, native-function denial, bounded
 synthetic database growth, pre-publication final-evidence failure, CLI output,
 embedded-schema-function rejection, per-opcode deadline enforcement, TEMP
 storage containment, narrow migration-grammar rejection, and legacy quarantine.
-Block and line comments between a copied-schema function name and its opening
-parenthesis are normalized before screening and covered by integration tests.
+Block and line comments before a copied-schema function name, and between that
+name and its opening parenthesis, are normalized before screening and covered
+by integration tests.
 Line comments follow SQLite's lexer and continue through a bare carriage return
 until line-feed; an apply-success regression prevents conservative false alarms.
-Write-capable plans screen the bound source schema before row evidence. VIRTUAL
-generated values are excluded from row hashes because schema plus stored base
-columns fully determine them; ordinary and STORED generated values remain
-covered. A tracked-order regression covers a native allocating expression.
+Write-capable plans screen the bound source schema before quick/integrity
+checks, row evidence, or target staging. VIRTUAL generated values are excluded
+from row hashes because schema plus stored base columns fully determine them;
+ordinary and STORED generated values remain covered. A tracked-order
+regression covers a native allocating expression. A subprocess-bounded
+deadline regression identifies VM progress-handler interruption, and a
+source-size regression proves oversized copy input is rejected before target
+materialization or copy progress.
 
 Final full repository regression:
 
 ```text
-python3 -m pytest tests/ -q --tb=short
-3114 passed, 5 skipped, 20 known warnings in 123.99s
+python3 -m pytest -q --tb=short -o faulthandler_timeout=120 \
+  -o faulthandler_exit_on_timeout=true
+3120 passed, 5 skipped, 20 known warnings in 89.78s
 ```
 
 After PR 4C merged to `main`, that exact head was merge-integrated into this
@@ -173,9 +179,12 @@ claiming isolation that an in-process filesystem library cannot provide:
   checked after every VM opcode and after each statement. Separate main and
   temporary page ceilings limit synthetic growth to 64 MiB each by default,
   and plan-controlled TEMP DDL is denied. Deadline rollback has a distinct
-  `migration_deadline_exceeded` result, so its regression proves the interrupt
-  without relying on CI filesystem speed; a ten-second outer ceiling still
-  catches a lost interrupt or hang.
+  `migration_progress_deadline_exceeded` result for a VM-handler interrupt;
+  its subprocess regression has a ten-second parent timeout that catches a
+  lost interrupt or hang.
+- Copy inputs have an explicit 256 MiB default source-file/logical-page-image
+  limit (configurable from 1 MiB to 1 GiB). The service checks it before
+  materializing an in-memory target, so an oversized input publishes nothing.
 - Migration plans are not arbitrary SQL. Full-match validation permits only a
   small documented grammar of basic DDL plus parameter-only INSERT and
   predicate-required UPDATE/DELETE. Functions, expressions, comments,
@@ -184,8 +193,8 @@ claiming isolation that an in-process filesystem library cannot provide:
   controls are defense in depth rather than a claimed complete SQL sandbox.
 - Functions embedded in persistent source schema can execute without an
   authorizer callback. The service now detects registered function names in
-  copied schema SQL before plan execution and returns a rollback-only failure
-  report rather than evaluating the schema expression.
+  copied schema SQL and fails before quick/integrity checks, row evidence,
+  target staging, or plan execution rather than evaluating the expression.
 - Final live-source evidence is captured after the descriptor-bound synthetic
   artifact is verified but before publication. A failed final evidence read
   closes the still-anonymous artifact and leaves no target path.

--- a/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
+++ b/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
@@ -32,10 +32,10 @@ Focused maintenance, legacy migration, and database-isolation matrix:
 ```text
 python3 -m pytest tests/maintenance/test_sqlite_service.py \
   tests/test_multiuser.py tests/security/test_db_isolation.py -q --tb=short
-215 passed
+218 passed
 ```
 
-The PR 4D maintenance module has 48 direct tests covering active WAL state,
+The PR 4D maintenance module has 51 direct tests covering active WAL state,
 multiportfolio preservation, backup/restore manifests, clean-room equivalence,
 corruption, preexisting targets, symlinks, hardlinks, companion files,
 substitution races, backup/restore interruption, migration rollback,
@@ -45,7 +45,7 @@ Final full repository regression:
 
 ```text
 python3 -m pytest tests/ -q --tb=short
-3067 passed, 5 skipped, 20 known warnings in 80.90s
+3070 passed, 5 skipped, 20 known warnings in 95.79s
 ```
 
 Static checks:
@@ -146,17 +146,18 @@ claiming isolation that an in-process filesystem library cannot provide:
   rollback-only, secret-free failure report as rejected SQL.
 - Every CLI report path is checked against the full main/`-wal`/`-shm`/
   `-journal` family of each source, backup, and target database. Backup and
-  restore manifest paths are exclusively reserved and descriptor-bound before
-  database publication, so an existing or unwritable report path cannot leave
-  a new orphan database artifact.
+  restore manifest paths are exclusively reserved, fully written, fsynced,
+  sealed read-only, and descriptor-checked before database publication. An
+  existing, unwritable, or failed report path therefore cannot leave a new
+  orphan database artifact.
 - All documented Python invocations use the project-required `python3`
   executable name.
 
 Current verification:
 
 ```text
-focused maintenance + multiuser + DB isolation: 215 passed
-full repository: 3067 passed, 5 skipped, 20 known warnings
+focused maintenance + multiuser + DB isolation: 218 passed
+full repository: 3070 passed, 5 skipped, 20 known warnings
 Python 3.10 direct authorizer commit/rollback probe: passed
 Black, isort, flake8, Bandit, mypy, and git diff checks on changed scope: passed
 ```

--- a/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
+++ b/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
@@ -32,10 +32,10 @@ Focused maintenance, legacy migration, and database-isolation matrix:
 ```text
 python3 -m pytest tests/maintenance/test_sqlite_service.py \
   tests/test_multiuser.py tests/security/test_db_isolation.py -q --tb=short
-228 passed
+232 passed
 ```
 
-The PR 4D maintenance module has 61 direct tests covering active WAL state,
+The PR 4D maintenance module has 65 direct tests covering active WAL state,
 multiportfolio preservation, backup/restore manifests, clean-room equivalence,
 corruption, preexisting targets, symlinks, hardlinks, companion files,
 substitution races, backup/restore interruption, migration rollback,
@@ -44,13 +44,14 @@ planner-statistics evidence, bounded migration execution, `WITHOUT ROWID` and
 shadowed-rowid compatibility, native-pointer and virtual-table denial,
 schema-cookie protection and tracking, native-function denial, bounded
 synthetic database growth, pre-publication final-evidence failure, CLI output,
-and legacy quarantine.
+embedded-schema-function rejection, per-opcode deadline enforcement, TEMP
+storage containment, narrow migration-grammar rejection, and legacy quarantine.
 
 Final full repository regression:
 
 ```text
 python3 -m pytest tests/ -q --tb=short
-3106 passed, 5 skipped, 20 known warnings in 178.63s
+3110 passed, 5 skipped, 20 known warnings in 85.92s
 ```
 
 After PR 4C merged to `main`, that exact head was merge-integrated into this
@@ -161,8 +162,19 @@ claiming isolation that an in-process filesystem library cannot provide:
 - Plan-invoked SQL functions are denied, including native functions that can
   allocate or execute without reaching the VM progress callback. SQLite's
   internal ALTER TABLE helper calls are reserved from plan SQL. The deadline is
-  rechecked after each statement, and a per-database page ceiling limits
-  synthetic growth to 64 MiB by default.
+  checked after every VM opcode and after each statement. Separate main and
+  temporary page ceilings limit synthetic growth to 64 MiB each by default,
+  and plan-controlled TEMP DDL is denied.
+- Migration plans are not arbitrary SQL. Full-match validation permits only a
+  small documented grammar of basic DDL plus parameter-only INSERT and
+  predicate-required UPDATE/DELETE. Functions, expressions, comments,
+  subqueries, PRAGMAs, TEMP objects, transaction control, and quoted
+  identifiers fail before source/target access. The authorizer and resource
+  controls are defense in depth rather than a claimed complete SQL sandbox.
+- Functions embedded in persistent source schema can execute without an
+  authorizer callback. The service now detects registered function names in
+  copied schema SQL before plan execution and returns a rollback-only failure
+  report rather than evaluating the schema expression.
 - Final live-source evidence is captured after the descriptor-bound synthetic
   artifact is verified but before publication. A failed final evidence read
   closes the still-anonymous artifact and leaves no target path.
@@ -178,8 +190,8 @@ claiming isolation that an in-process filesystem library cannot provide:
 Current verification:
 
 ```text
-focused maintenance + multiuser + DB isolation: 228 passed
-full repository: 3106 passed, 5 skipped, 20 known warnings
+focused maintenance + multiuser + DB isolation: 232 passed
+full repository: 3110 passed, 5 skipped, 20 known warnings
 PR 4C settlement integration file: 30 passed
 Python 3.10 direct authorizer commit/rollback probe: passed
 Black, isort, flake8, Bandit, mypy, and git diff checks on changed scope: passed

--- a/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
+++ b/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
@@ -32,20 +32,22 @@ Focused maintenance, legacy migration, and database-isolation matrix:
 ```text
 python3 -m pytest tests/maintenance/test_sqlite_service.py \
   tests/test_multiuser.py tests/security/test_db_isolation.py -q --tb=short
-218 passed
+220 passed
 ```
 
-The PR 4D maintenance module has 51 direct tests covering active WAL state,
+The PR 4D maintenance module has 53 direct tests covering active WAL state,
 multiportfolio preservation, backup/restore manifests, clean-room equivalence,
 corruption, preexisting targets, symlinks, hardlinks, companion files,
 substitution races, backup/restore interruption, migration rollback,
-declarative-plan containment, CLI output, and legacy quarantine.
+declarative-plan containment, hidden-rowid source-change detection,
+`WITHOUT ROWID` and shadowed-rowid compatibility, CLI output, and legacy
+quarantine.
 
 Final full repository regression:
 
 ```text
 python3 -m pytest tests/ -q --tb=short
-3070 passed, 5 skipped, 20 known warnings in 95.79s
+3072 passed, 5 skipped, 20 known warnings in 78.67s
 ```
 
 Static checks:
@@ -156,8 +158,8 @@ claiming isolation that an in-process filesystem library cannot provide:
 Current verification:
 
 ```text
-focused maintenance + multiuser + DB isolation: 218 passed
-full repository: 3070 passed, 5 skipped, 20 known warnings
+focused maintenance + multiuser + DB isolation: 220 passed
+full repository: 3072 passed, 5 skipped, 20 known warnings
 Python 3.10 direct authorizer commit/rollback probe: passed
 Black, isort, flake8, Bandit, mypy, and git diff checks on changed scope: passed
 ```

--- a/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
+++ b/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
@@ -32,10 +32,10 @@ Focused maintenance, legacy migration, and database-isolation matrix:
 ```text
 python3 -m pytest tests/maintenance/test_sqlite_service.py \
   tests/test_multiuser.py tests/security/test_db_isolation.py -q --tb=short
-235 passed
+236 passed
 ```
 
-The PR 4D maintenance module has 68 direct tests covering active WAL state,
+The PR 4D maintenance module has 69 direct tests covering active WAL state,
 multiportfolio preservation, backup/restore manifests, clean-room equivalence,
 corruption, preexisting targets, symlinks, hardlinks, companion files,
 substitution races, backup/restore interruption, migration rollback,
@@ -50,12 +50,16 @@ Block and line comments between a copied-schema function name and its opening
 parenthesis are normalized before screening and covered by integration tests.
 Line comments follow SQLite's lexer and continue through a bare carriage return
 until line-feed; an apply-success regression prevents conservative false alarms.
+Write-capable plans screen the bound source schema before row evidence. VIRTUAL
+generated values are excluded from row hashes because schema plus stored base
+columns fully determine them; ordinary and STORED generated values remain
+covered. A tracked-order regression covers a native allocating expression.
 
 Final full repository regression:
 
 ```text
 python3 -m pytest tests/ -q --tb=short
-3113 passed, 5 skipped, 20 known warnings in 92.14s
+3114 passed, 5 skipped, 20 known warnings in 123.99s
 ```
 
 After PR 4C merged to `main`, that exact head was merge-integrated into this

--- a/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
+++ b/docs/reviews/PR4D_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
@@ -32,23 +32,25 @@ Focused maintenance, legacy migration, and database-isolation matrix:
 ```text
 python3 -m pytest tests/maintenance/test_sqlite_service.py \
   tests/test_multiuser.py tests/security/test_db_isolation.py -q --tb=short
-224 passed
+228 passed
 ```
 
-The PR 4D maintenance module has 57 direct tests covering active WAL state,
+The PR 4D maintenance module has 61 direct tests covering active WAL state,
 multiportfolio preservation, backup/restore manifests, clean-room equivalence,
 corruption, preexisting targets, symlinks, hardlinks, companion files,
 substitution races, backup/restore interruption, migration rollback,
 declarative-plan containment, hidden-rowid source-change detection,
 planner-statistics evidence, bounded migration execution, `WITHOUT ROWID` and
 shadowed-rowid compatibility, native-pointer and virtual-table denial,
-schema-cookie protection, CLI output, and legacy quarantine.
+schema-cookie protection and tracking, native-function denial, bounded
+synthetic database growth, pre-publication final-evidence failure, CLI output,
+and legacy quarantine.
 
 Final full repository regression:
 
 ```text
 python3 -m pytest tests/ -q --tb=short
-3102 passed, 5 skipped, 20 known warnings in 79.38s
+3106 passed, 5 skipped, 20 known warnings in 178.63s
 ```
 
 After PR 4C merged to `main`, that exact head was merge-integrated into this
@@ -153,6 +155,17 @@ claiming isolation that an in-process filesystem library cannot provide:
 - Migration plans cannot change SQLite's process-global hard or soft heap
   limits. Oversized integer binding failures are converted into the same
   rollback-only, secret-free failure report as rejected SQL.
+- Database evidence includes SQLite's schema cookie, so transient create/drop
+  sequences cannot hide a schema-generation change behind identical final DDL.
+  The bound source cookie is preserved across SQLite's in-memory backup reset.
+- Plan-invoked SQL functions are denied, including native functions that can
+  allocate or execute without reaching the VM progress callback. SQLite's
+  internal ALTER TABLE helper calls are reserved from plan SQL. The deadline is
+  rechecked after each statement, and a per-database page ceiling limits
+  synthetic growth to 64 MiB by default.
+- Final live-source evidence is captured after the descriptor-bound synthetic
+  artifact is verified but before publication. A failed final evidence read
+  closes the still-anonymous artifact and leaves no target path.
 - Every CLI report path is checked against the full main/`-wal`/`-shm`/
   `-journal` family of each source, backup, and target database. Backup and
   restore manifest paths are exclusively reserved, fully written, fsynced,
@@ -165,8 +178,8 @@ claiming isolation that an in-process filesystem library cannot provide:
 Current verification:
 
 ```text
-focused maintenance + multiuser + DB isolation: 224 passed
-full repository: 3102 passed, 5 skipped, 20 known warnings
+focused maintenance + multiuser + DB isolation: 228 passed
+full repository: 3106 passed, 5 skipped, 20 known warnings
 PR 4C settlement integration file: 30 passed
 Python 3.10 direct authorizer commit/rollback probe: passed
 Black, isort, flake8, Bandit, mypy, and git diff checks on changed scope: passed

--- a/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
+++ b/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
@@ -8,13 +8,14 @@ over another path, or rolls back by replacing an authoritative ledger. Every
 output path must be absolute, canonical, and nonexistent. Existing files,
 symlink leaves, hard-linked databases, and path substitution fail closed.
 SQLite `-wal`, `-shm`, and `-journal` companions are checked for safe type,
-link count, and stable identity while a snapshot is running. The output family
-is reserved before SQLite opens the target. SQLite-consumed empty reservations
-are recognized through their still-open descriptors; remaining reservations
-are atomically moved, without replacement or unlinking, into a sibling
-`.TARGET.robo-trader-reservations/` directory as zero-byte safety tombstones.
-The maintenance service intentionally never deletes that directory or its
-tombstones.
+link count, and stable identity while a snapshot is running. SQLite never opens
+the requested output path. It operates only inside a fresh, unpredictable,
+owner-only `.TARGET.robo-trader-stage-RANDOM/` directory. After SQLite closes,
+the service verifies that the staged family has no companions, seals the main
+file, and publishes that inode with an atomic no-replace rename. A public
+`-wal`, `-shm`, or `-journal` path is therefore never touched or deleted by the
+service or its SQLite connection. Staging directories are intentionally retained
+rather than removed through a pathname race.
 
 The supported operations are:
 
@@ -34,8 +35,10 @@ credentials, account identifiers, or broker configuration. They always state
 `authorizes_startup=false`.
 
 If backup, restore, or verification is interrupted, the source remains
-untouched. Any already-reserved output is retained read-only for forensic
-inspection; it has no successful manifest and cannot be reused as a target.
+untouched. Any interrupted staged database is retained read-only in its private
+staging directory for forensic inspection; the requested output path remains
+absent, there is no successful manifest, and the partial file cannot be reused
+as a target.
 
 ## Commands
 
@@ -72,7 +75,9 @@ service-owned transaction on the same descriptor-bound connection used to
 create and verify the copy; there is no writable reopen gap. Plan-supplied
 transaction control, `ATTACH`, and `DETACH` are denied. Success and rollback
 reports include before/after schema, row counts, content hashes, integrity
-state, and a source-unchanged result.
+state, and a source-unchanged result. Final report evidence and the artifact
+digest come directly from the descriptor-bound manifest captured before atomic
+publication; the report never reopens the published target.
 
 ## Legacy multiuser migration quarantine
 

--- a/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
+++ b/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
@@ -52,8 +52,10 @@ credentials, account identifiers, or broker configuration. They always state
 `authorizes_startup=false`. A report path must be distinct from every database
 main path and its `-wal`, `-shm`, and `-journal` resource family. Backup and
 restore commands exclusively reserve their output-manifest path before the
-database artifact can be published, so an existing or unwritable report target
-cannot leave an orphan database artifact.
+database artifact can be published. The complete JSON is then written, fsynced,
+sealed read-only, and identity-checked through that reservation before the
+database descriptor is published, so an existing, unwritable, or failed report
+target cannot leave an orphan database artifact.
 
 If backup, restore, or verification is interrupted, the authoritative main-file
 bytes and committed logical state are not modified. A normal read connection to
@@ -65,7 +67,9 @@ mistaken for a usable artifact. The command-line tool leaves its exclusively
 created, owner-only manifest reservation in place as a failure marker. It may
 be empty or contain incomplete JSON, but the command returns nonzero and
 `load_manifest` rejects it. Operators must inspect that marker and choose a new
-output path; this service never deletes or reuses it.
+output path; this service never deletes or reuses it. If database publication
+itself fails after the manifest is complete, the valid manifest remains but its
+referenced database path is absent and verification fails closed.
 
 ## Commands
 

--- a/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
+++ b/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
@@ -1,0 +1,89 @@
+# PR 4D SQLite backup and clean-room restore
+
+## Safety boundary
+
+This tooling is dormant maintenance infrastructure. It never connects to IBKR,
+starts RoboTrader, authorizes startup, deletes a database, renames a database
+over another path, or rolls back by replacing an authoritative ledger. Every
+output path must be absolute, canonical, and nonexistent. Existing files,
+symlink leaves, hard-linked databases, and path substitution fail closed.
+SQLite `-wal`, `-shm`, and `-journal` companions are checked for safe type,
+link count, and stable identity while a snapshot is running.
+
+The supported operations are:
+
+- a SQLite online backup, including committed WAL state, into an exclusively
+  created owner-only file;
+- integrity, foreign-key, schema, row-count, and deterministic table-hash
+  verification;
+- restoration of a manifest-verified backup into a different, exclusively
+  created clean-room path;
+- library-level migration dry runs on synthetic copies. No production
+  migration is registered with the command-line tool; a reviewed callback is
+  required so arbitrary code cannot be selected from command-line input.
+
+Reports and manifests contain no paths, row values, environment values,
+credentials, account identifiers, or broker configuration. They always state
+`contains_secrets=false`, `mutated_authoritative_state=false`, and
+`authorizes_startup=false`.
+
+If backup, restore, or verification is interrupted, the source remains
+untouched. Any already-reserved output is retained read-only for forensic
+inspection; it has no successful manifest and cannot be reused as a target.
+
+## Commands
+
+Use only explicit synthetic or operator-approved paths. These examples are
+illustrative and must not be pointed at an authoritative database without the
+separate review and authorization required by `AGENTS.md`.
+
+```bash
+python3 scripts/database_maintenance.py backup \
+  --source /absolute/path/to/source.db \
+  --target /absolute/path/to/new-backup.db \
+  --manifest /absolute/path/to/new-backup-manifest.json
+
+python3 scripts/database_maintenance.py verify \
+  --database /absolute/path/to/new-backup.db \
+  --manifest /absolute/path/to/new-backup-manifest.json
+
+python3 scripts/database_maintenance.py restore-clean-room \
+  --backup /absolute/path/to/new-backup.db \
+  --backup-manifest /absolute/path/to/new-backup-manifest.json \
+  --target /absolute/path/to/new-clean-room.db \
+  --restore-manifest /absolute/path/to/new-restore-manifest.json
+```
+
+A restored clean-room database is evidence only. It is never promoted or
+swapped into runtime by this service, and its manifest does not authorize
+startup.
+
+## Migration dry runs
+
+`SQLiteMaintenanceService.dry_run_migration(...)` first creates a SQLite online
+snapshot at a new synthetic path. The reviewed callback runs within a service-
+owned transaction against that copy only. Transaction control, `ATTACH`, and
+`DETACH` are denied. Success and rollback reports include before/after schema,
+row counts, content hashes, integrity state, and a source-unchanged result.
+
+## Legacy multiuser migration quarantine
+
+`robo_trader.multiuser.migration.MultiuserMigration` is not called by any
+sanctioned startup path in the reviewed PR 4D baseline. Its read-only version
+inspection remains available and a database already at migration version 1 is
+still a no-op. Missing databases remain a no-op for `migrate()`.
+
+Mutation is disabled for an unmigrated database because the legacy path:
+
+- copied only the main file instead of using SQLite's WAL-aware backup API;
+- disabled foreign-key enforcement during table replacement;
+- selected one account row while rebuilding the account table, which could
+  collapse multi-row state;
+- attempted rollback by copying a backup over the authoritative path.
+
+The legacy backup, restore, and apply methods now raise
+`LegacyMultiuserMigrationDisabled`. The unsafe table-rewrite SQL has been
+removed rather than left as a callable dormant path. A future production
+migration needs its own reviewed adapter, descriptor-bound backup manifest,
+synthetic dry-run report, explicit operator approval, and post-operation
+reconciliation.

--- a/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
+++ b/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
@@ -175,8 +175,13 @@ other resource or execution failures return `migration_plan_failed`.
 
 SQLite does not consistently send authorizer callbacks for functions embedded
 in copied CHECK constraints, generated columns, defaults, expression indexes,
-views, or triggers. Before any plan write, the service compares persistent
-schema SQL with the isolated connection's registered function list. SQLite
+views, or triggers. Before any row evidence for a write-capable plan, the
+service compares the bound source's persistent schema SQL with the isolated
+connection's registered function list. VIRTUAL generated values are derived
+from that schema plus stored base columns and are excluded from row hashing, so
+evidence cannot evaluate their native functions; ordinary columns and STORED
+generated values remain included. The copied target is screened again before
+any plan write. SQLite
 block and line comments outside quoted tokens are normalized to whitespace
 before matching, so comments between a function name and `(` cannot bypass the
 screen. Matching follows SQLite's line-comment rule: a bare carriage return

--- a/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
+++ b/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
@@ -8,7 +8,13 @@ over another path, or rolls back by replacing an authoritative ledger. Every
 output path must be absolute, canonical, and nonexistent. Existing files,
 symlink leaves, hard-linked databases, and path substitution fail closed.
 SQLite `-wal`, `-shm`, and `-journal` companions are checked for safe type,
-link count, and stable identity while a snapshot is running.
+link count, and stable identity while a snapshot is running. The output family
+is reserved before SQLite opens the target. SQLite-consumed empty reservations
+are recognized through their still-open descriptors; remaining reservations
+are atomically moved, without replacement or unlinking, into a sibling
+`.TARGET.robo-trader-reservations/` directory as zero-byte safety tombstones.
+The maintenance service intentionally never deletes that directory or its
+tombstones.
 
 The supported operations are:
 
@@ -18,9 +24,9 @@ The supported operations are:
   verification;
 - restoration of a manifest-verified backup into a different, exclusively
   created clean-room path;
-- library-level migration dry runs on synthetic copies. No production
-  migration is registered with the command-line tool; a reviewed callback is
-  required so arbitrary code cannot be selected from command-line input.
+- library-level migration dry runs on synthetic copies through a bounded,
+  declarative `MigrationPlan`. No production migration is registered with the
+  command-line tool, and callers never receive the SQLite connection.
 
 Reports and manifests contain no paths, row values, environment values,
 credentials, account identifiers, or broker configuration. They always state
@@ -61,10 +67,12 @@ startup.
 ## Migration dry runs
 
 `SQLiteMaintenanceService.dry_run_migration(...)` first creates a SQLite online
-snapshot at a new synthetic path. The reviewed callback runs within a service-
-owned transaction against that copy only. Transaction control, `ATTACH`, and
-`DETACH` are denied. Success and rollback reports include before/after schema,
-row counts, content hashes, integrity state, and a source-unchanged result.
+snapshot at a new synthetic path. The declarative plan runs within a
+service-owned transaction on the same descriptor-bound connection used to
+create and verify the copy; there is no writable reopen gap. Plan-supplied
+transaction control, `ATTACH`, and `DETACH` are denied. Success and rollback
+reports include before/after schema, row counts, content hashes, integrity
+state, and a source-unchanged result.
 
 ## Legacy multiuser migration quarantine
 

--- a/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
+++ b/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
@@ -120,13 +120,35 @@ capture. Final report evidence and the artifact digest come directly from the
 descriptor-bound manifest captured before atomic publication; the report never
 reopens the published target.
 
+`MigrationStep` is not an arbitrary-SQL sandbox. Before opening the source or
+creating a synthetic target, the service requires every statement to match one
+of these exact, full-string templates:
+
+- `SELECT 1` for a no-op probe;
+- simple-identifier `CREATE TABLE`, `DROP TABLE`, or `ALTER TABLE ... ADD
+  COLUMN`, with columns limited to SQLite's five basic storage classes and
+  literal-only basic constraints;
+- parameter-only `INSERT ... (columns) VALUES (...)`;
+- single-column parameterized `UPDATE` or `DELETE` with one or more required
+  equality predicates in `WHERE`.
+
+Identifiers are unquoted ASCII names. DML values must be `?` parameters.
+Comments, schema expressions, functions, subqueries, compound statements,
+TEMP objects, PRAGMAs, transaction control, and every other SQL shape are
+rejected before the copy begins. Parameters are limited to 4 MiB individually
+and 16 MiB across a plan. The SQLite authorizer, per-opcode deadline, and page
+limits remain defense in depth; they are not claimed as a complete SQL
+sandbox. A migration outside this grammar needs a separately reviewed typed
+adapter.
+
 Table evidence includes an exposed SQLite rowid where one exists and persistent
 `sqlite_stat*` planner-statistics tables. Delete/reinsert changes that preserve
 visible values and changes produced by `ANALYZE` therefore cannot evade the
 before/after or source-unchanged comparison.
 
-Migration authorization permits only the read/evidence PRAGMAs the service
-requires plus the evidence-tracked `application_id` and `user_version` values.
+Defense-in-depth migration authorization permits only the read/evidence
+PRAGMAs the service requires plus the evidence-tracked `application_id` and
+`user_version` values.
 `schema_version` is readable for evidence but caller writes are denied. All
 other PRAGMAs, including path, journaling, checkpoint, schema-trust, and
 process-global allocator controls, are denied. Plan-invoked SQL functions,
@@ -142,10 +164,22 @@ report as SQL execution failures.
 Migration execution also has a SQLite progress-handler deadline (30 seconds by
 default, configurable on the service), checked again after each statement and
 before commit. Statements that exceed the deadline roll back even if a native
-SQLite operation returns without invoking the VM progress handler. The
-synthetic database can grow by at most 64 MiB by default (configurable from
-1 MiB to 1 GiB) through SQLite's per-database page limit. Exceeding either bound
+SQLite operation returns without invoking the VM progress handler. The handler
+runs after every VM opcode so repeated concatenations and similar low-opcode
+allocation chains cannot accumulate between checks. The main and temporary
+synthetic databases can each grow by at most 64 MiB by default (configurable
+from 1 MiB to 1 GiB) through separate SQLite page limits. Plan-controlled TEMP
+DDL is denied as an additional boundary. Exceeding either time or storage bound
 returns `migration_plan_failed`.
+
+SQLite does not consistently send authorizer callbacks for functions embedded
+in copied CHECK constraints, generated columns, defaults, expression indexes,
+views, or triggers. Before any plan write, the service compares persistent
+schema SQL with the isolated connection's registered function list. A named
+schema function makes the dry run return `migration_plan_failed` without
+executing the plan. This conservative fail-closed policy can reject a harmless
+schema expression; such a migration needs a separately reviewed adapter rather
+than a bypass.
 
 The final bound live-source evidence check runs after the synthetic bytes and
 manifest have been verified but before the anonymous target is published. If

--- a/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
+++ b/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
@@ -49,15 +49,23 @@ The supported operations are:
 Reports and manifests contain no paths, row values, environment values,
 credentials, account identifiers, or broker configuration. They always state
 `contains_secrets=false`, `mutated_authoritative_state=false`, and
-`authorizes_startup=false`.
+`authorizes_startup=false`. A report path must be distinct from every database
+main path and its `-wal`, `-shm`, and `-journal` resource family. Backup and
+restore commands exclusively reserve their output-manifest path before the
+database artifact can be published, so an existing or unwritable report target
+cannot leave an orphan database artifact.
 
 If backup, restore, or verification is interrupted, the authoritative main-file
 bytes and committed logical state are not modified. A normal read connection to
 a WAL-mode source may create SQLite-managed `-wal`/`-shm` companions; the
 service validates and preserves them and never deletes them. The unlinked
 partial output inode disappears when its held descriptor is closed; the
-requested output path remains absent, there is no successful manifest, and no
-partial file can be mistaken for a usable artifact.
+requested database output path remains absent and no partial database can be
+mistaken for a usable artifact. The command-line tool leaves its exclusively
+created, owner-only manifest reservation in place as a failure marker. It may
+be empty or contain incomplete JSON, but the command returns nonzero and
+`load_manifest` rejects it. Operators must inspect that marker and choose a new
+output path; this service never deletes or reuses it.
 
 ## Commands
 
@@ -98,6 +106,12 @@ reports include before/after schema, row counts, content hashes, integrity
 state, and a source-unchanged result. Final report evidence and the artifact
 digest come directly from the descriptor-bound manifest captured before atomic
 publication; the report never reopens the published target.
+
+Migration authorization also denies SQLite pragmas that can affect paths,
+journaling, schema trust, checkpoints, or process-global allocator limits,
+including `hard_heap_limit` and `soft_heap_limit`. Parameter binding failures,
+including integers outside SQLite's signed 64-bit range, roll back and produce
+the same secret-free `migration_plan_failed` report as SQL execution failures.
 
 Active WAL sources are supported. Initial and final source evidence is captured
 from bound SQLite read snapshots rather than by requiring a companion-free main

--- a/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
+++ b/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
@@ -12,8 +12,12 @@ link count, and stable identity while a snapshot is running. SQLite never opens
 the requested output path or any other filesystem target. Online backup and
 migration run in an in-memory SQLite database. The service serializes the exact
 finished image into an `O_EXCL|O_NOFOLLOW` file created with `openat` beneath a
-bound `O_DIRECTORY|O_NOFOLLOW` parent descriptor, then publishes that inode
-with descriptor-relative atomic no-replace rename. A public `-wal`, `-shm`, or
+bound `O_DIRECTORY|O_NOFOLLOW` parent descriptor. The named staged inode starts
+with mode `000`, so another process cannot retain a writable descriptor before
+it is sealed read-only. The service then publishes that inode with
+descriptor-relative atomic no-replace rename and fsyncs the already-bound
+parent descriptor. The published descriptor is digested again and its lexical
+parent and target identities are revalidated before success. A public `-wal`, `-shm`, or
 `-journal` path is therefore never touched or deleted by the service or its
 SQLite connection. There is no staging directory that a concurrent process
 can replace with a symlink.
@@ -80,6 +84,12 @@ reports include before/after schema, row counts, content hashes, integrity
 state, and a source-unchanged result. Final report evidence and the artifact
 digest come directly from the descriptor-bound manifest captured before atomic
 publication; the report never reopens the published target.
+
+Active WAL sources are supported. Initial and final source evidence is captured
+from bound SQLite read snapshots rather than by requiring a companion-free main
+file. Normal checkpoints may change the physical main-file bytes while the held
+read snapshot remains logically consistent; backup therefore does not treat a
+checkpoint as authoritative data mutation.
 
 ## Legacy multiuser migration quarantine
 

--- a/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
+++ b/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
@@ -22,6 +22,18 @@ identities are revalidated before success. A public `-wal`, `-shm`, or
 SQLite connection. There is no staging directory that a concurrent process
 can replace with a symlink.
 
+This is a filesystem pathname-integrity boundary, not isolation from actively
+hostile code running as the same operating-system user. On Linux, such a process
+may be able to inspect another process's file descriptors through `/proc`; on
+macOS, creation of the temporary file used to obtain an unlinked descriptor can
+be observed before unlinking. A hostile same-user process can also modify a
+published artifact or its destination directory. Backup and restore therefore
+require an exclusive maintenance window with no untrusted process running as
+the maintenance user. Environments that need protection from hostile local
+code must run this tooling under a dedicated OS identity, container, or sandbox
+whose output directory is inaccessible to the trader and other user processes.
+The in-process library cannot honestly provide that stronger isolation.
+
 The supported operations are:
 
 - a SQLite online backup, including committed WAL state, into an exclusively
@@ -40,7 +52,7 @@ credentials, account identifiers, or broker configuration. They always state
 `authorizes_startup=false`.
 
 If backup, restore, or verification is interrupted, the source remains
-untouched. The anonymous partial inode disappears when its held descriptor is
+untouched. The unlinked partial inode disappears when its held descriptor is
 closed; the requested output path remains absent, there is no successful
 manifest, and no partial file can be mistaken for a usable artifact.
 

--- a/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
+++ b/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
@@ -9,13 +9,14 @@ output path must be absolute, canonical, and nonexistent. Existing files,
 symlink leaves, hard-linked databases, and path substitution fail closed.
 SQLite `-wal`, `-shm`, and `-journal` companions are checked for safe type,
 link count, and stable identity while a snapshot is running. SQLite never opens
-the requested output path. It operates only inside a fresh, unpredictable,
-owner-only `.TARGET.robo-trader-stage-RANDOM/` directory. After SQLite closes,
-the service verifies that the staged family has no companions, seals the main
-file, and publishes that inode with an atomic no-replace rename. A public
-`-wal`, `-shm`, or `-journal` path is therefore never touched or deleted by the
-service or its SQLite connection. Staging directories are intentionally retained
-rather than removed through a pathname race.
+the requested output path or any other filesystem target. Online backup and
+migration run in an in-memory SQLite database. The service serializes the exact
+finished image into an `O_EXCL|O_NOFOLLOW` file created with `openat` beneath a
+bound `O_DIRECTORY|O_NOFOLLOW` parent descriptor, then publishes that inode
+with descriptor-relative atomic no-replace rename. A public `-wal`, `-shm`, or
+`-journal` path is therefore never touched or deleted by the service or its
+SQLite connection. There is no staging directory that a concurrent process
+can replace with a symlink.
 
 The supported operations are:
 
@@ -36,7 +37,7 @@ credentials, account identifiers, or broker configuration. They always state
 
 If backup, restore, or verification is interrupted, the source remains
 untouched. Any interrupted staged database is retained read-only in its private
-staging directory for forensic inspection; the requested output path remains
+randomly named file for forensic inspection; the requested output path remains
 absent, there is no successful manifest, and the partial file cannot be reused
 as a target.
 
@@ -71,8 +72,9 @@ startup.
 
 `SQLiteMaintenanceService.dry_run_migration(...)` first creates a SQLite online
 snapshot at a new synthetic path. The declarative plan runs within a
-service-owned transaction on the same descriptor-bound connection used to
-create and verify the copy; there is no writable reopen gap. Plan-supplied
+service-owned transaction on the same in-memory connection used to create and
+verify the copy; there is no writable reopen gap or filesystem SQLite target.
+Plan-supplied
 transaction control, `ATTACH`, and `DETACH` are denied. Success and rollback
 reports include before/after schema, row counts, content hashes, integrity
 state, and a source-unchanged result. Final report evidence and the artifact

--- a/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
+++ b/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
@@ -176,11 +176,13 @@ other resource or execution failures return `migration_plan_failed`.
 SQLite does not consistently send authorizer callbacks for functions embedded
 in copied CHECK constraints, generated columns, defaults, expression indexes,
 views, or triggers. Before any plan write, the service compares persistent
-schema SQL with the isolated connection's registered function list. A named
-schema function makes the dry run return `migration_plan_failed` without
-executing the plan. This conservative fail-closed policy can reject a harmless
-schema expression; such a migration needs a separately reviewed adapter rather
-than a bypass.
+schema SQL with the isolated connection's registered function list. SQLite
+block and line comments outside quoted tokens are normalized to whitespace
+before matching, so comments between a function name and `(` cannot bypass the
+screen. A named schema function makes the dry run return
+`migration_plan_failed` without executing the plan. This conservative
+fail-closed policy can reject a harmless schema expression; such a migration
+needs a separately reviewed adapter rather than a bypass.
 
 The final bound live-source evidence check runs after the synthetic bytes and
 manifest have been verified but before the anonymous target is published. If

--- a/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
+++ b/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
@@ -179,7 +179,9 @@ views, or triggers. Before any plan write, the service compares persistent
 schema SQL with the isolated connection's registered function list. SQLite
 block and line comments outside quoted tokens are normalized to whitespace
 before matching, so comments between a function name and `(` cannot bypass the
-screen. A named schema function makes the dry run return
+screen. Matching follows SQLite's line-comment rule: a bare carriage return
+does not end a `--` comment; line-feed or end-of-input does. A named schema
+function makes the dry run return
 `migration_plan_failed` without executing the plan. This conservative
 fail-closed policy can reject a harmless schema expression; such a migration
 needs a separately reviewed adapter rather than a bypass.

--- a/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
+++ b/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
@@ -112,10 +112,13 @@ service-owned transaction on the same in-memory connection used to create and
 verify the copy; there is no writable reopen gap or filesystem SQLite target.
 Plan-supplied
 transaction control, `ATTACH`, and `DETACH` are denied. Success and rollback
-reports include before/after schema, row counts, content hashes, integrity
-state, and a source-unchanged result. Final report evidence and the artifact
-digest come directly from the descriptor-bound manifest captured before atomic
-publication; the report never reopens the published target.
+reports include before/after schema, SQLite schema cookie, row counts, content
+hashes, integrity state, and a source-unchanged result. SQLite's backup API can
+reset the destination schema cookie, so the service copies the bound source
+snapshot's cookie into the in-memory target before migration and evidence
+capture. Final report evidence and the artifact digest come directly from the
+descriptor-bound manifest captured before atomic publication; the report never
+reopens the published target.
 
 Table evidence includes an exposed SQLite rowid where one exists and persistent
 `sqlite_stat*` planner-statistics tables. Delete/reinsert changes that preserve
@@ -124,16 +127,30 @@ before/after or source-unchanged comparison.
 
 Migration authorization permits only the read/evidence PRAGMAs the service
 requires plus the evidence-tracked `application_id` and `user_version` values.
-All other PRAGMAs, including `schema_version`, path, journaling, checkpoint,
-schema-trust, and process-global allocator controls, are denied. Native-pointer
-functions (`fts3_tokenizer` and `load_extension`), virtual-table DDL, savepoints,
-and caller-controlled transaction operations are also denied before execution.
+`schema_version` is readable for evidence but caller writes are denied. All
+other PRAGMAs, including path, journaling, checkpoint, schema-trust, and
+process-global allocator controls, are denied. Plan-invoked SQL functions,
+including `randomblob`, `fts3_tokenizer`, and `load_extension`, virtual-table
+DDL, savepoints, and caller-controlled transaction operations are also denied
+before execution. SQLite's internal `length`, `printf`, and `substr` calls are
+permitted only so its own `ALTER TABLE` implementation can rewrite the schema;
+plans are rejected if they name those reserved functions, and trigger/view
+calls remain denied.
 Parameter binding failures, including integers outside SQLite's signed 64-bit
 range, roll back and produce the same secret-free `migration_plan_failed`
 report as SQL execution failures.
 Migration execution also has a SQLite progress-handler deadline (30 seconds by
-default, configurable on the service); exceeding it interrupts the statement,
-rolls back the service-owned transaction, and returns `migration_plan_failed`.
+default, configurable on the service), checked again after each statement and
+before commit. Statements that exceed the deadline roll back even if a native
+SQLite operation returns without invoking the VM progress handler. The
+synthetic database can grow by at most 64 MiB by default (configurable from
+1 MiB to 1 GiB) through SQLite's per-database page limit. Exceeding either bound
+returns `migration_plan_failed`.
+
+The final bound live-source evidence check runs after the synthetic bytes and
+manifest have been verified but before the anonymous target is published. If
+that evidence capture fails, publication does not occur and closing the
+anonymous descriptor leaves no target artifact.
 
 Active WAL sources are supported. Initial and final source evidence is captured
 from bound SQLite read snapshots rather than by requiring a companion-free main

--- a/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
+++ b/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
@@ -170,7 +170,8 @@ allocation chains cannot accumulate between checks. The main and temporary
 synthetic databases can each grow by at most 64 MiB by default (configurable
 from 1 MiB to 1 GiB) through separate SQLite page limits. Plan-controlled TEMP
 DDL is denied as an additional boundary. Exceeding either time or storage bound
-returns `migration_plan_failed`.
+rolls back; deadline interruption returns `migration_deadline_exceeded`, while
+other resource or execution failures return `migration_plan_failed`.
 
 SQLite does not consistently send authorizer callbacks for functions embedded
 in copied CHECK constraints, generated columns, defaults, expression indexes,

--- a/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
+++ b/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
@@ -68,8 +68,14 @@ created, owner-only manifest reservation in place as a failure marker. It may
 be empty or contain incomplete JSON, but the command returns nonzero and
 `load_manifest` rejects it. Operators must inspect that marker and choose a new
 output path; this service never deletes or reuses it. If database publication
-itself fails after the manifest is complete, the valid manifest remains but its
-referenced database path is absent and verification fails closed.
+fails before the target is linked or cloned, the complete manifest remains and
+the database path is absent. If publication fails after that link or clone—for
+example, during the directory `fsync` or final identity check—the service
+deliberately preserves both the complete manifest and the published database as
+forensic artifacts while returning nonzero. Operators must inspect both,
+must not treat them as a successful operation even if a later verification
+passes, and must choose new output paths rather than deleting or reusing either
+artifact.
 
 ## Commands
 

--- a/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
+++ b/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
@@ -170,8 +170,18 @@ allocation chains cannot accumulate between checks. The main and temporary
 synthetic databases can each grow by at most 64 MiB by default (configurable
 from 1 MiB to 1 GiB) through separate SQLite page limits. Plan-controlled TEMP
 DDL is denied as an additional boundary. Exceeding either time or storage bound
-rolls back; deadline interruption returns `migration_deadline_exceeded`, while
-other resource or execution failures return `migration_plan_failed`.
+rolls back. A VM progress-handler interrupt returns
+`migration_progress_deadline_exceeded`; a deadline caught immediately after a
+statement returns `migration_deadline_exceeded`; other resource or execution
+failures return `migration_plan_failed`. The process-level regression also has
+a ten-second parent timeout, so a lost handler cannot hang the suite.
+
+Backup, restore, and synthetic migration copies are supported only when both
+the bound source file and its logical SQLite page image are at most 256 MiB by
+default. Operators may configure this from 1 MiB to 1 GiB. The check runs
+before the in-memory target is materialized; an oversized source fails closed
+without publishing a target. This is an explicit memory-safety boundary, not a
+promise that arbitrarily large databases can be copied in-process.
 
 SQLite does not consistently send authorizer callbacks for functions embedded
 in copied CHECK constraints, generated columns, defaults, expression indexes,
@@ -186,10 +196,10 @@ block and line comments outside quoted tokens are normalized to whitespace
 before matching, so comments between a function name and `(` cannot bypass the
 screen. Matching follows SQLite's line-comment rule: a bare carriage return
 does not end a `--` comment; line-feed or end-of-input does. A named schema
-function makes the dry run return
-`migration_plan_failed` without executing the plan. This conservative
-fail-closed policy can reject a harmless schema expression; such a migration
-needs a separately reviewed adapter rather than a bypass.
+function makes the dry run fail before quick/integrity checks, row evidence,
+target staging, or plan execution. This conservative fail-closed policy can
+reject a harmless schema expression; such a migration needs a separately
+reviewed adapter rather than a bypass.
 
 The final bound live-source evidence check runs after the synthetic bytes and
 manifest have been verified but before the anonymous target is published. If

--- a/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
+++ b/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
@@ -122,11 +122,15 @@ Table evidence includes an exposed SQLite rowid where one exists and persistent
 visible values and changes produced by `ANALYZE` therefore cannot evade the
 before/after or source-unchanged comparison.
 
-Migration authorization also denies SQLite pragmas that can affect paths,
-journaling, schema trust, checkpoints, or process-global allocator limits,
-including `hard_heap_limit` and `soft_heap_limit`. Parameter binding failures,
-including integers outside SQLite's signed 64-bit range, roll back and produce
-the same secret-free `migration_plan_failed` report as SQL execution failures.
+Migration authorization permits only the read/evidence PRAGMAs the service
+requires plus the evidence-tracked `application_id` and `user_version` values.
+All other PRAGMAs, including `schema_version`, path, journaling, checkpoint,
+schema-trust, and process-global allocator controls, are denied. Native-pointer
+functions (`fts3_tokenizer` and `load_extension`), virtual-table DDL, savepoints,
+and caller-controlled transaction operations are also denied before execution.
+Parameter binding failures, including integers outside SQLite's signed 64-bit
+range, roll back and produce the same secret-free `migration_plan_failed`
+report as SQL execution failures.
 Migration execution also has a SQLite progress-handler deadline (30 seconds by
 default, configurable on the service); exceeding it interrupts the statement,
 rolls back the service-owned transaction, and returns `migration_plan_failed`.

--- a/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
+++ b/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
@@ -11,13 +11,13 @@ SQLite `-wal`, `-shm`, and `-journal` companions are checked for safe type,
 link count, and stable identity while a snapshot is running. SQLite never opens
 the requested output path or any other filesystem target. Online backup and
 migration run in an in-memory SQLite database. The service serializes the exact
-finished image into an `O_EXCL|O_NOFOLLOW` file created with `openat` beneath a
-bound `O_DIRECTORY|O_NOFOLLOW` parent descriptor. The named staged inode starts
-with mode `000`, so another process cannot retain a writable descriptor before
-it is sealed read-only. The service then publishes that inode with
-descriptor-relative atomic no-replace rename and fsyncs the already-bound
-parent descriptor. The published descriptor is digested again and its lexical
-parent and target identities are revalidated before success. A public `-wal`, `-shm`, or
+finished image into an unlinked regular-file inode (`st_nlink == 0`) on the
+target filesystem. Linux uses `O_TMPFILE` and descriptor-only
+`linkat(AT_EMPTY_PATH)` publication; macOS uses an unlinked temporary descriptor
+and `fclonefileat`. Unsupported filesystems and platforms fail closed. The
+service fsyncs the already-bound parent descriptor after publication. The
+published descriptor is digested again and its lexical parent and target
+identities are revalidated before success. A public `-wal`, `-shm`, or
 `-journal` path is therefore never touched or deleted by the service or its
 SQLite connection. There is no staging directory that a concurrent process
 can replace with a symlink.
@@ -40,10 +40,9 @@ credentials, account identifiers, or broker configuration. They always state
 `authorizes_startup=false`.
 
 If backup, restore, or verification is interrupted, the source remains
-untouched. Any interrupted staged database is retained read-only in its private
-randomly named file for forensic inspection; the requested output path remains
-absent, there is no successful manifest, and the partial file cannot be reused
-as a target.
+untouched. The anonymous partial inode disappears when its held descriptor is
+closed; the requested output path remains absent, there is no successful
+manifest, and no partial file can be mistaken for a usable artifact.
 
 ## Commands
 

--- a/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
+++ b/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
@@ -117,11 +117,19 @@ state, and a source-unchanged result. Final report evidence and the artifact
 digest come directly from the descriptor-bound manifest captured before atomic
 publication; the report never reopens the published target.
 
+Table evidence includes an exposed SQLite rowid where one exists and persistent
+`sqlite_stat*` planner-statistics tables. Delete/reinsert changes that preserve
+visible values and changes produced by `ANALYZE` therefore cannot evade the
+before/after or source-unchanged comparison.
+
 Migration authorization also denies SQLite pragmas that can affect paths,
 journaling, schema trust, checkpoints, or process-global allocator limits,
 including `hard_heap_limit` and `soft_heap_limit`. Parameter binding failures,
 including integers outside SQLite's signed 64-bit range, roll back and produce
 the same secret-free `migration_plan_failed` report as SQL execution failures.
+Migration execution also has a SQLite progress-handler deadline (30 seconds by
+default, configurable on the service); exceeding it interrupts the statement,
+rolls back the service-owned transaction, and returns `migration_plan_failed`.
 
 Active WAL sources are supported. Initial and final source evidence is captured
 from bound SQLite read snapshots rather than by requiring a companion-free main

--- a/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
+++ b/docs/runbooks/PR4D_DATABASE_BACKUP_RESTORE.md
@@ -51,10 +51,13 @@ credentials, account identifiers, or broker configuration. They always state
 `contains_secrets=false`, `mutated_authoritative_state=false`, and
 `authorizes_startup=false`.
 
-If backup, restore, or verification is interrupted, the source remains
-untouched. The unlinked partial inode disappears when its held descriptor is
-closed; the requested output path remains absent, there is no successful
-manifest, and no partial file can be mistaken for a usable artifact.
+If backup, restore, or verification is interrupted, the authoritative main-file
+bytes and committed logical state are not modified. A normal read connection to
+a WAL-mode source may create SQLite-managed `-wal`/`-shm` companions; the
+service validates and preserves them and never deletes them. The unlinked
+partial output inode disappears when its held descriptor is closed; the
+requested output path remains absent, there is no successful manifest, and no
+partial file can be mistaken for a usable artifact.
 
 ## Commands
 
@@ -101,6 +104,22 @@ from bound SQLite read snapshots rather than by requiring a companion-free main
 file. Normal checkpoints may change the physical main-file bytes while the held
 read snapshot remains logically consistent; backup therefore does not treat a
 checkpoint as authoritative data mutation.
+
+A companion-free source is not assumed immutable. Ordinary backup and migration
+sources use SQLite's normal locking even when a cleanly closed database retains
+`journal_mode=WAL`; safe `-wal`/`-shm` files created while establishing the bound
+connection are adopted into the identity set and monitored for the operation.
+Only a companion-free, manifest-verified restore artifact uses SQLite immutable
+mode. This preserves atomic snapshot semantics if a legitimate writer begins
+after the initial filesystem inspection.
+
+Before publication, the service reads the exact descriptor-bound bytes back,
+deserializes that byte snapshot into SQLite memory, reruns integrity,
+foreign-key, schema, row-count, and deterministic table-hash evidence, and
+requires it to equal the evidence captured from the copied database. The
+manifest digest is then required to match that same byte snapshot. This catches
+retained-descriptor corruption within the supported trusted-identity boundary;
+OS-identity isolation remains the deployment requirement described above.
 
 ## Legacy multiuser migration quarantine
 

--- a/robo_trader/maintenance/__init__.py
+++ b/robo_trader/maintenance/__init__.py
@@ -1,0 +1,13 @@
+"""Dormant, non-authorizing SQLite maintenance primitives."""
+
+from .models import DatabaseEvidence, MaintenanceManifest, MigrationDryRunReport, TableEvidence
+from .sqlite_service import SQLiteMaintenanceError, SQLiteMaintenanceService
+
+__all__ = [
+    "DatabaseEvidence",
+    "MaintenanceManifest",
+    "MigrationDryRunReport",
+    "SQLiteMaintenanceError",
+    "SQLiteMaintenanceService",
+    "TableEvidence",
+]

--- a/robo_trader/maintenance/__init__.py
+++ b/robo_trader/maintenance/__init__.py
@@ -1,12 +1,21 @@
 """Dormant, non-authorizing SQLite maintenance primitives."""
 
-from .models import DatabaseEvidence, MaintenanceManifest, MigrationDryRunReport, TableEvidence
+from .models import (
+    DatabaseEvidence,
+    MaintenanceManifest,
+    MigrationDryRunReport,
+    MigrationPlan,
+    MigrationStep,
+    TableEvidence,
+)
 from .sqlite_service import SQLiteMaintenanceError, SQLiteMaintenanceService
 
 __all__ = [
     "DatabaseEvidence",
     "MaintenanceManifest",
     "MigrationDryRunReport",
+    "MigrationPlan",
+    "MigrationStep",
     "SQLiteMaintenanceError",
     "SQLiteMaintenanceService",
     "TableEvidence",

--- a/robo_trader/maintenance/models.py
+++ b/robo_trader/maintenance/models.py
@@ -10,7 +10,7 @@ from typing import Any, Mapping, Tuple
 class TableEvidence:
     """Deterministic logical evidence for one SQLite table."""
 
-    name: str
+    name_sha256: str
     row_count: int
     content_sha256: str
 
@@ -53,14 +53,14 @@ class DatabaseEvidence:
         for item in tables:
             _require_exact_keys(
                 item,
-                {"name", "row_count", "content_sha256"},
+                {"name_sha256", "row_count", "content_sha256"},
                 "table evidence",
             )
         return cls(
             schema_sha256=_required_string(value, "schema_sha256"),
             tables=tuple(
                 TableEvidence(
-                    name=_required_string(item, "name"),
+                    name_sha256=_required_string(item, "name_sha256"),
                     row_count=_required_int(item, "row_count"),
                     content_sha256=_required_string(item, "content_sha256"),
                 )
@@ -157,6 +157,26 @@ class MigrationDryRunReport:
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
+
+
+SQLiteParameter = str | int | float | bytes | None
+
+
+@dataclass(frozen=True, slots=True)
+class MigrationStep:
+    """One declarative SQL statement for a synthetic-copy dry run."""
+
+    sql: str
+    parameters: tuple[SQLiteParameter, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class MigrationPlan:
+    """A bounded public identifier and ordered declarative migration steps."""
+
+    migration_id: str
+    steps: tuple[MigrationStep, ...]
+    target_user_version: int | None = None
 
 
 def _required_string(value: Mapping[str, Any], key: str) -> str:

--- a/robo_trader/maintenance/models.py
+++ b/robo_trader/maintenance/models.py
@@ -167,7 +167,7 @@ SQLiteParameter = str | int | float | bytes | None
 
 @dataclass(frozen=True, slots=True)
 class MigrationStep:
-    """One declarative SQL statement for a synthetic-copy dry run."""
+    """One statement in the maintenance service's narrow migration grammar."""
 
     sql: str
     parameters: tuple[SQLiteParameter, ...] = ()

--- a/robo_trader/maintenance/models.py
+++ b/robo_trader/maintenance/models.py
@@ -1,0 +1,194 @@
+"""Secret-free evidence models for dormant SQLite maintenance tooling."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Mapping, Tuple
+
+
+@dataclass(frozen=True, slots=True)
+class TableEvidence:
+    """Deterministic logical evidence for one SQLite table."""
+
+    name: str
+    row_count: int
+    content_sha256: str
+
+
+@dataclass(frozen=True, slots=True)
+class DatabaseEvidence:
+    """Portable database evidence containing no paths or row values."""
+
+    schema_sha256: str
+    tables: Tuple[TableEvidence, ...]
+    quick_check: str
+    integrity_check: str
+    foreign_key_violations: int
+    application_id: int
+    user_version: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "DatabaseEvidence":
+        _require_exact_keys(
+            value,
+            {
+                "schema_sha256",
+                "tables",
+                "quick_check",
+                "integrity_check",
+                "foreign_key_violations",
+                "application_id",
+                "user_version",
+            },
+            "database evidence",
+        )
+        tables = value.get("tables")
+        if not isinstance(tables, (list, tuple)):
+            raise ValueError("database evidence tables must be a sequence")
+        if not all(isinstance(item, Mapping) for item in tables):
+            raise ValueError("database evidence table entries must be objects")
+        for item in tables:
+            _require_exact_keys(
+                item,
+                {"name", "row_count", "content_sha256"},
+                "table evidence",
+            )
+        return cls(
+            schema_sha256=_required_string(value, "schema_sha256"),
+            tables=tuple(
+                TableEvidence(
+                    name=_required_string(item, "name"),
+                    row_count=_required_int(item, "row_count"),
+                    content_sha256=_required_string(item, "content_sha256"),
+                )
+                for item in tables
+            ),
+            quick_check=_required_string(value, "quick_check"),
+            integrity_check=_required_string(value, "integrity_check"),
+            foreign_key_violations=_required_int(value, "foreign_key_violations"),
+            application_id=_required_int(value, "application_id"),
+            user_version=_required_int(value, "user_version"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class MaintenanceManifest:
+    """Portable manifest for one verified backup or clean-room restore."""
+
+    manifest_version: int
+    operation: str
+    created_at: str
+    artifact_sha256: str
+    artifact_size: int
+    evidence: DatabaseEvidence
+    input_artifact_sha256: str | None = None
+    contains_secrets: bool = False
+    mutated_authoritative_state: bool = False
+    authorizes_startup: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "MaintenanceManifest":
+        _require_exact_keys(
+            value,
+            {
+                "manifest_version",
+                "operation",
+                "created_at",
+                "artifact_sha256",
+                "artifact_size",
+                "evidence",
+                "input_artifact_sha256",
+                "contains_secrets",
+                "mutated_authoritative_state",
+                "authorizes_startup",
+            },
+            "maintenance manifest",
+        )
+        evidence = value.get("evidence")
+        if not isinstance(evidence, Mapping):
+            raise ValueError("manifest evidence must be an object")
+        manifest = cls(
+            manifest_version=_required_int(value, "manifest_version"),
+            operation=_required_string(value, "operation"),
+            created_at=_required_string(value, "created_at"),
+            artifact_sha256=_required_string(value, "artifact_sha256"),
+            artifact_size=_required_int(value, "artifact_size"),
+            evidence=DatabaseEvidence.from_mapping(evidence),
+            input_artifact_sha256=_optional_string(value, "input_artifact_sha256"),
+            contains_secrets=_required_bool(value, "contains_secrets"),
+            mutated_authoritative_state=_required_bool(value, "mutated_authoritative_state"),
+            authorizes_startup=_required_bool(value, "authorizes_startup"),
+        )
+        if manifest.manifest_version != 1:
+            raise ValueError("unsupported maintenance manifest version")
+        if manifest.operation not in {"backup", "restore"}:
+            raise ValueError("unsupported maintenance manifest operation")
+        if (
+            manifest.contains_secrets
+            or manifest.mutated_authoritative_state
+            or manifest.authorizes_startup
+        ):
+            raise ValueError("maintenance manifests cannot carry authority or secrets")
+        return manifest
+
+
+@dataclass(frozen=True, slots=True)
+class MigrationDryRunReport:
+    """Result of applying a migration only to a disposable snapshot."""
+
+    report_version: int
+    migration_id: str
+    created_at: str
+    outcome: str
+    before: DatabaseEvidence
+    after: DatabaseEvidence
+    source_unchanged: bool
+    target_artifact_sha256: str
+    error_code: str | None = None
+    contains_secrets: bool = False
+    mutated_authoritative_state: bool = False
+    authorizes_startup: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _required_string(value: Mapping[str, Any], key: str) -> str:
+    item = value.get(key)
+    if not isinstance(item, str) or not item:
+        raise ValueError(f"{key} must be a non-empty string")
+    return item
+
+
+def _optional_string(value: Mapping[str, Any], key: str) -> str | None:
+    item = value.get(key)
+    if item is None:
+        return None
+    if not isinstance(item, str) or not item:
+        raise ValueError(f"{key} must be null or a non-empty string")
+    return item
+
+
+def _required_int(value: Mapping[str, Any], key: str) -> int:
+    item = value.get(key)
+    if isinstance(item, bool) or not isinstance(item, int):
+        raise ValueError(f"{key} must be an integer")
+    return item
+
+
+def _required_bool(value: Mapping[str, Any], key: str) -> bool:
+    item = value.get(key)
+    if not isinstance(item, bool):
+        raise ValueError(f"{key} must be a boolean")
+    return item
+
+
+def _require_exact_keys(value: Mapping[str, Any], expected: set[str], label: str) -> None:
+    if set(value) != expected:
+        raise ValueError(f"{label} has missing or unknown fields")

--- a/robo_trader/maintenance/models.py
+++ b/robo_trader/maintenance/models.py
@@ -26,6 +26,7 @@ class DatabaseEvidence:
     foreign_key_violations: int
     application_id: int
     user_version: int
+    schema_version: int
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -42,6 +43,7 @@ class DatabaseEvidence:
                 "foreign_key_violations",
                 "application_id",
                 "user_version",
+                "schema_version",
             },
             "database evidence",
         )
@@ -71,6 +73,7 @@ class DatabaseEvidence:
             foreign_key_violations=_required_int(value, "foreign_key_violations"),
             application_id=_required_int(value, "application_id"),
             user_version=_required_int(value, "user_version"),
+            schema_version=_required_int(value, "schema_version"),
         )
 
 

--- a/robo_trader/maintenance/sqlite_service.py
+++ b/robo_trader/maintenance/sqlite_service.py
@@ -997,7 +997,26 @@ def _table_evidence(connection: sqlite3.Connection, table_name: str) -> TableEvi
     quoted = '"' + table_name.replace('"', '""') + '"'
     # The identifier comes only from sqlite_master and is escaped as a quoted
     # SQLite identifier; DB-API parameters cannot represent identifiers.
-    cursor = connection.execute(f"SELECT * FROM {quoted}")  # nosec B608
+    column_names = {
+        str(row[1]).casefold()
+        for row in connection.execute(f"PRAGMA table_xinfo({quoted})").fetchall()  # nosec B608
+    }
+    rowid_alias = next(
+        (alias for alias in ("rowid", "_rowid_", "oid") if alias not in column_names),
+        None,
+    )
+    if rowid_alias is None:
+        cursor = connection.execute(f"SELECT * FROM {quoted}")  # nosec B608
+    else:
+        try:
+            # An unshadowed SQLite rowid alias captures row identity that is
+            # intentionally omitted by SELECT *. WITHOUT ROWID tables reject
+            # the alias and use their complete declared primary key instead.
+            cursor = connection.execute(f"SELECT {rowid_alias},* FROM {quoted}")  # nosec B608
+        except sqlite3.OperationalError as exc:
+            if "no such column" not in str(exc).casefold():
+                raise
+            cursor = connection.execute(f"SELECT * FROM {quoted}")  # nosec B608
     row_hashes: list[bytes] = []
     row_count = 0
     for row in cursor:

--- a/robo_trader/maintenance/sqlite_service.py
+++ b/robo_trader/maintenance/sqlite_service.py
@@ -34,6 +34,7 @@ from robo_trader.safety.sqlite_identity import (
     SQLiteIdentityError,
     SQLitePathBinding,
     lexical_path_preserving_leaf,
+    sqlite_connection_deserialize,
     sqlite_connection_file_identity,
     sqlite_connection_serialize,
 )
@@ -89,6 +90,14 @@ class _StagedTarget:
     def digest(self) -> tuple[str, int]:
         self.assert_identity()
         result = _descriptor_digest(self.guardian_file_descriptor)
+        self.assert_identity()
+        return result
+
+    def read_database_image(self) -> bytes:
+        """Read one stable snapshot of the descriptor-bound staged bytes."""
+
+        self.assert_identity()
+        result = _descriptor_payload(self.guardian_file_descriptor)
         self.assert_identity()
         return result
 
@@ -386,21 +395,17 @@ class SQLiteMaintenanceService:
         """Capture logical evidence from a bound read snapshot, including WAL state."""
 
         source_candidate = _absolute_canonical_path(source_path)
-        companions = _safe_companion_identities(source_candidate)
+        initial_companions = _safe_companion_identities(source_candidate)
         source = self._open_source(source_candidate)
         connection: sqlite3.Connection | None = None
         try:
             connection, source = self._connect_bound(
                 source,
                 readonly=True,
-                # A cleanly closed WAL database has no companions, but a
-                # conventional read-only open may create its own -wal/-shm
-                # files.  Immutable mode is safe only in the companion-free
-                # case and keeps the identity set stable while we inspect it.
-                immutable_readonly=not companions,
             )
             connection.execute("BEGIN")
             evidence = _database_evidence(connection)
+            companions = _adopt_connection_companions(source.path, initial_companions)
             source.assert_connection_identity(sqlite_connection_file_identity(connection))
             _assert_single_link(source)
             _assert_companion_identities(source.path, companions)
@@ -500,20 +505,28 @@ class SQLiteMaintenanceService:
         target_candidate = _absolute_canonical_path(target_path)
         if _sqlite_resource_family(source_candidate) & _sqlite_resource_family(target_candidate):
             raise SQLiteMaintenanceError("source and target SQLite resource families overlap")
-        source_companions = _safe_companion_identities(source_candidate)
+        initial_source_companions = _safe_companion_identities(source_candidate)
+        if expected_source_manifest is not None and initial_source_companions:
+            raise SQLiteMaintenanceError(
+                "manifest restore requires a sealed database without SQLite companions"
+            )
         source = self._open_source(source_candidate)
         source_connection: sqlite3.Connection | None = None
         try:
             source_connection, source = self._connect_bound(
                 source,
                 readonly=True,
-                # Manifest restore inputs are sealed standalone artifacts.
-                # A companion-free WAL database is likewise checkpointed and
-                # can be opened immutably, avoiding service-created sidecars.
-                immutable_readonly=(expected_source_manifest is not None or not source_companions),
+                # Only a manifest-verified standalone artifact is immutable.
+                # Ordinary sources need SQLite locking even when a cleanly
+                # closed WAL database initially has no companion files.
+                immutable_readonly=expected_source_manifest is not None,
             )
             source_connection.execute("BEGIN")
             source_evidence = _database_evidence(source_connection)
+            source_companions = _adopt_connection_companions(
+                source.path,
+                initial_source_companions,
+            )
             source_artifact_sha256: str | None = None
             source_artifact_size: int | None = None
             if expected_source_manifest is not None:
@@ -595,13 +608,26 @@ class SQLiteMaintenanceService:
                 hook_result = target_hook(target_connection, evidence)
                 staged_target.assert_identity()
                 evidence = _database_evidence(target_connection)
-            database_image = sqlite_connection_serialize(target_connection)
+            database_image = _standalone_database_image(
+                sqlite_connection_serialize(target_connection)
+            )
             target_connection.close()
             target_connection = None
             staged_target.write_database_image(database_image)
             staged_target.seal_readonly()
             os.fsync(staged_target.parent_file_descriptor)
+            artifact_image = staged_target.read_database_image()
+            artifact_evidence = _database_image_evidence(artifact_image)
+            if artifact_evidence != evidence:
+                raise SQLiteMaintenanceError(
+                    "descriptor-bound artifact evidence differs from copied database"
+                )
+            expected_artifact_sha256 = hashlib.sha256(artifact_image).hexdigest()
             artifact_sha256, artifact_size = staged_target.digest()
+            if artifact_sha256 != expected_artifact_sha256 or artifact_size != len(artifact_image):
+                raise SQLiteMaintenanceError(
+                    "descriptor-bound artifact changed during verification"
+                )
             manifest = MaintenanceManifest(
                 manifest_version=1,
                 operation=operation,
@@ -1103,6 +1129,18 @@ def _assert_companion_identities(
         raise SQLiteMaintenanceError("SQLite companion identity changed during operation")
 
 
+def _adopt_connection_companions(
+    path: Path,
+    initial: Mapping[str, tuple[int, int]],
+) -> dict[str, tuple[int, int]]:
+    """Adopt safe companions created by a normal bound SQLite connection."""
+
+    current = _safe_companion_identities(path)
+    if any(current.get(suffix) != identity for suffix, identity in initial.items()):
+        raise SQLiteMaintenanceError("SQLite companion identity changed during connection open")
+    return current
+
+
 def _descriptor_digest(descriptor: int) -> tuple[str, int]:
     metadata = os.fstat(descriptor)
     digest = hashlib.sha256()
@@ -1118,6 +1156,55 @@ def _descriptor_digest(descriptor: int) -> tuple[str, int]:
     if any(getattr(metadata, field) != getattr(after, field) for field in stable):
         raise SQLiteMaintenanceError("database changed while hashing")
     return digest.hexdigest(), metadata.st_size
+
+
+def _descriptor_payload(descriptor: int) -> bytes:
+    metadata = os.fstat(descriptor)
+    chunks: list[bytes] = []
+    offset = 0
+    while offset < metadata.st_size:
+        chunk = os.pread(descriptor, min(128 * 1024, metadata.st_size - offset), offset)
+        if not chunk:
+            raise SQLiteMaintenanceError("database ended while reading")
+        chunks.append(chunk)
+        offset += len(chunk)
+    after = os.fstat(descriptor)
+    stable = ("st_dev", "st_ino", "st_size", "st_mtime_ns", "st_ctime_ns")
+    if any(getattr(metadata, field) != getattr(after, field) for field in stable):
+        raise SQLiteMaintenanceError("database changed while reading")
+    return b"".join(chunks)
+
+
+def _database_image_evidence(payload: bytes) -> DatabaseEvidence:
+    connection = sqlite3.connect(":memory:", timeout=10.0)
+    retained_buffer: object | None = None
+    try:
+        retained_buffer = sqlite_connection_deserialize(connection, payload)
+        evidence = _database_evidence(connection)
+        if evidence.integrity_check != "ok" or evidence.foreign_key_violations:
+            raise SQLiteMaintenanceError("descriptor-bound artifact is invalid")
+        return evidence
+    finally:
+        # Keep the ctypes allocation alive until SQLite has finished reading it.
+        _ = retained_buffer
+        connection.close()
+
+
+def _standalone_database_image(payload: bytes) -> bytes:
+    """Convert a serialized WAL-header snapshot into a standalone DB image."""
+
+    if len(payload) < 100 or payload[:16] != b"SQLite format 3\x00":
+        raise SQLiteMaintenanceError("serialized database has an invalid SQLite header")
+    if payload[18] not in (1, 2) or payload[19] not in (1, 2):
+        raise SQLiteMaintenanceError("serialized database has invalid journal header bytes")
+    standalone = bytearray(payload)
+    # Bytes 18 and 19 are the SQLite file-format read/write versions. A value
+    # of 2 requests WAL and therefore a sidecar namespace; the serialized image
+    # already contains the complete committed snapshot, so publish it in the
+    # standalone rollback-journal format instead.
+    standalone[18] = 1
+    standalone[19] = 1
+    return bytes(standalone)
 
 
 def _fsync_directory(path: Path) -> None:

--- a/robo_trader/maintenance/sqlite_service.py
+++ b/robo_trader/maintenance/sqlite_service.py
@@ -301,6 +301,7 @@ class SQLiteMaintenanceService:
         max_copy_seconds: float = 120.0,
         max_migration_seconds: float = 30.0,
         max_migration_growth_bytes: int = 64 * 1024 * 1024,
+        max_source_bytes: int = 256 * 1024 * 1024,
     ) -> None:
         if not math.isfinite(max_copy_seconds) or not 1.0 <= max_copy_seconds <= 3600.0:
             raise ValueError("max_copy_seconds must be between 1 and 3600")
@@ -311,10 +312,16 @@ class SQLiteMaintenanceService:
             or not 1024 * 1024 <= max_migration_growth_bytes <= 1024 * 1024 * 1024
         ):
             raise ValueError("max_migration_growth_bytes must be between 1 MiB and 1 GiB")
+        if (
+            type(max_source_bytes) is not int
+            or not 1024 * 1024 <= max_source_bytes <= 1024 * 1024 * 1024
+        ):
+            raise ValueError("max_source_bytes must be between 1 MiB and 1 GiB")
         self._progress_hook = progress_hook
         self._max_copy_seconds = max_copy_seconds
         self._max_migration_seconds = max_migration_seconds
         self._max_migration_growth_bytes = max_migration_growth_bytes
+        self._max_source_bytes = max_source_bytes
 
     def verify(
         self,
@@ -413,12 +420,12 @@ class SQLiteMaintenanceService:
 
         _validate_migration_plan(plan)
         plan_can_write = any(step.sql.strip().upper() != "SELECT 1" for step in plan.steps)
-        source_schema_functions: tuple[str, ...] = ()
 
         def screen_source_schema(connection: sqlite3.Connection) -> None:
-            nonlocal source_schema_functions
-            if plan_can_write:
-                source_schema_functions = _schema_function_calls(connection)
+            if plan_can_write and _schema_function_calls(connection):
+                raise SQLiteMaintenanceError(
+                    "write-capable migration rejects callable expressions in source schema"
+                )
 
         def apply_plan(
             connection: sqlite3.Connection,
@@ -426,7 +433,7 @@ class SQLiteMaintenanceService:
         ) -> tuple[DatabaseEvidence, str, str | None]:
             outcome = "applied_to_synthetic_copy"
             error_code: str | None = None
-            if plan_can_write and (source_schema_functions or _schema_function_calls(connection)):
+            if plan_can_write and _schema_function_calls(connection):
                 connection.set_authorizer(_post_migration_authorizer)
                 return before, "rolled_back", "migration_plan_failed"
             page_size = int(connection.execute("PRAGMA page_size").fetchone()[0])
@@ -455,6 +462,7 @@ class SQLiteMaintenanceService:
             connection.set_authorizer(_migration_authorizer)
             migration_started = time.monotonic()
             migration_deadline_interrupted = False
+            migration_progress_interrupted = False
 
             def migration_deadline_exceeded() -> bool:
                 nonlocal migration_deadline_interrupted
@@ -463,7 +471,11 @@ class SQLiteMaintenanceService:
                 return migration_deadline_interrupted
 
             def enforce_migration_deadline() -> int:
-                return int(migration_deadline_exceeded())
+                nonlocal migration_progress_interrupted
+                if migration_deadline_exceeded():
+                    migration_progress_interrupted = True
+                    return 1
+                return 0
 
             try:
                 connection.set_progress_handler(enforce_migration_deadline, 1)
@@ -491,9 +503,13 @@ class SQLiteMaintenanceService:
                 connection.rollback()
                 outcome = "rolled_back"
                 error_code = (
-                    "migration_deadline_exceeded"
-                    if migration_deadline_interrupted
-                    else "migration_plan_failed"
+                    "migration_progress_deadline_exceeded"
+                    if migration_progress_interrupted
+                    else (
+                        "migration_deadline_exceeded"
+                        if migration_deadline_interrupted
+                        else "migration_plan_failed"
+                    )
                 )
             else:
                 connection.set_authorizer(_migration_completion_authorizer)
@@ -740,6 +756,11 @@ class SQLiteMaintenanceService:
             source_connection.execute("BEGIN")
             if source_pre_evidence_hook is not None:
                 source_pre_evidence_hook(source_connection)
+            _assert_supported_copy_source_size(
+                source_connection,
+                source,
+                max_source_bytes=self._max_source_bytes,
+            )
             source_evidence = _database_evidence(source_connection)
             source_companions = _adopt_connection_companions(
                 source.path,
@@ -1189,6 +1210,24 @@ def _schema_function_calls(connection: sqlite3.Connection) -> tuple[str, ...]:
         ):
             found.append(name)
     return tuple(found)
+
+
+def _assert_supported_copy_source_size(
+    connection: sqlite3.Connection,
+    binding: SQLitePathBinding,
+    *,
+    max_source_bytes: int,
+) -> None:
+    """Reject copy inputs before an in-memory database image is materialized."""
+
+    descriptor_size = os.fstat(binding.guardian_file_descriptor).st_size
+    page_size = int(connection.execute("PRAGMA page_size").fetchone()[0])
+    page_count = int(connection.execute("PRAGMA page_count").fetchone()[0])
+    logical_size = page_size * page_count
+    if descriptor_size > max_source_bytes or logical_size > max_source_bytes:
+        raise SQLiteMaintenanceError(
+            "copy source exceeds the configured in-memory artifact size limit"
+        )
 
 
 def _schema_sql_without_comments(sql: str) -> str:

--- a/robo_trader/maintenance/sqlite_service.py
+++ b/robo_trader/maintenance/sqlite_service.py
@@ -12,6 +12,7 @@ import json
 import math
 import os
 import re
+import secrets
 import sqlite3
 import stat
 import sys
@@ -44,77 +45,40 @@ class SQLiteMaintenanceError(RuntimeError):
 
 
 @dataclass(slots=True)
-class _TargetReservation:
-    """Exclusive reservation for a new database and all SQLite sidecar names."""
+class _StagedTarget:
+    """Private SQLite namespace published only after the connection is closed."""
 
     binding: SQLitePathBinding
-    companions: dict[Path, tuple[int, int, int]]
-    quarantine_directory: Path
+    requested_path: Path
+    staging_directory: Path
+    published: bool = False
 
-    def release(self) -> None:
-        """Relinquish sidecar names without ever unlinking a re-resolved path.
+    def publish(self) -> None:
+        """Publish the sealed main inode without exposing SQLite to target sidecars."""
 
-        SQLite is allowed to consume an empty reservation itself.  Reservations
-        that remain are moved with a kernel-enforced no-replace rename into the
-        operation's private quarantine directory.  They are deliberately left
-        there as zero-byte tombstones: POSIX has no pathname unlink primitive
-        that is bound to an already-open descriptor, so deleting them would
-        reintroduce a check/use race against same-user pathname substitution.
-        """
-
-        error: SQLiteMaintenanceError | None = None
-        for path, (descriptor, device, inode) in self.companions.items():
-            try:
-                descriptor_metadata = os.fstat(descriptor)
-                if (
-                    not stat.S_ISREG(descriptor_metadata.st_mode)
-                    or descriptor_metadata.st_size != 0
-                    or (descriptor_metadata.st_dev, descriptor_metadata.st_ino) != (device, inode)
-                ):
-                    raise SQLiteMaintenanceError(
-                        "target SQLite sidecar reservation changed during operation"
-                    )
-                try:
-                    os.lstat(path)
-                except FileNotFoundError:
-                    if descriptor_metadata.st_nlink != 0:
-                        raise SQLiteMaintenanceError(
-                            "target SQLite sidecar reservation moved during operation"
-                        )
-                    continue
-
-                tombstone = self.quarantine_directory / path.name
-                _rename_noreplace(path, tombstone)
-                tombstone_metadata = os.lstat(tombstone)
-                descriptor_after = os.fstat(descriptor)
-                if (
-                    not stat.S_ISREG(tombstone_metadata.st_mode)
-                    or (tombstone_metadata.st_dev, tombstone_metadata.st_ino) != (device, inode)
-                    or (descriptor_after.st_dev, descriptor_after.st_ino) != (device, inode)
-                    or descriptor_after.st_nlink != 1
-                    or descriptor_after.st_size != 0
-                ):
-                    # The atomically claimed object was not ours.  Restore it
-                    # to its original name without overwriting any new racer;
-                    # if that name is already occupied, both objects remain
-                    # preserved and the operation still fails closed.
-                    try:
-                        _rename_noreplace(tombstone, path)
-                    except (OSError, SQLiteMaintenanceError):
-                        pass
-                    raise SQLiteMaintenanceError(
-                        "target SQLite sidecar pathname was substituted during operation"
-                    )
-            except (OSError, SQLiteMaintenanceError) as exc:
-                error = SQLiteMaintenanceError(
-                    "target SQLite sidecar reservation could not be released safely"
-                )
-                error.__cause__ = exc
-            finally:
-                os.close(descriptor)
-        self.companions.clear()
-        if error is not None:
-            raise error
+        self.binding.assert_path_identity()
+        if _safe_companion_identities(self.binding.path):
+            raise SQLiteMaintenanceError("private staged SQLite database retained companion files")
+        _assert_target_family_absent(self.requested_path)
+        _rename_noreplace(self.binding.path, self.requested_path)
+        self.published = True
+        descriptor_metadata = os.fstat(self.binding.guardian_file_descriptor)
+        path_metadata = os.lstat(self.requested_path)
+        expected = (self.binding.device, self.binding.inode)
+        if (
+            not stat.S_ISREG(descriptor_metadata.st_mode)
+            or descriptor_metadata.st_nlink != 1
+            or (descriptor_metadata.st_dev, descriptor_metadata.st_ino) != expected
+            or stat.S_ISLNK(path_metadata.st_mode)
+            or not stat.S_ISREG(path_metadata.st_mode)
+            or (path_metadata.st_dev, path_metadata.st_ino) != expected
+        ):
+            raise SQLiteMaintenanceError("published database identity changed")
+        if _safe_companion_identities(self.requested_path):
+            raise SQLiteMaintenanceError(
+                "target SQLite companion appeared during atomic publication"
+            )
+        _fsync_directory(self.requested_path.parent)
 
 
 class SQLiteMaintenanceService:
@@ -264,7 +228,7 @@ class SQLiteMaintenanceService:
             connection.set_authorizer(_post_migration_authorizer)
             return before, outcome, error_code
 
-        _copy_manifest, migration_result = self._online_copy(
+        copy_manifest, migration_result = self._online_copy(
             source_path,
             synthetic_target_path,
             operation="backup",
@@ -275,14 +239,13 @@ class SQLiteMaintenanceService:
             raise SQLiteMaintenanceError("migration result is unavailable")
         before, outcome, error_code = migration_result
 
-        after = self.verify(synthetic_target_path)
+        after = copy_manifest.evidence
         source_after = self.verify(source_path)
         source_after_hash, _ = _path_digest(_absolute_canonical_path(source_path))
         source_unchanged = source_before == source_after and source_before_hash == source_after_hash
         if not source_unchanged:
             outcome = "source_changed_fail_closed"
             error_code = "authoritative_source_changed"
-        artifact_sha256, _ = _path_digest(_absolute_canonical_path(synthetic_target_path))
         return MigrationDryRunReport(
             report_version=1,
             migration_id=plan.migration_id,
@@ -291,7 +254,7 @@ class SQLiteMaintenanceService:
             before=before,
             after=after,
             source_unchanged=source_unchanged,
-            target_artifact_sha256=artifact_sha256,
+            target_artifact_sha256=copy_manifest.artifact_sha256,
             error_code=error_code,
         )
 
@@ -403,8 +366,8 @@ class SQLiteMaintenanceService:
                 or expected_source_manifest.evidence != source_evidence
             ):
                 raise SQLiteMaintenanceError("copy source does not match the supplied manifest")
-            reservation = self._reserve_target(target_candidate)
-            target = reservation.binding
+            staged_target = self._stage_target(target_candidate)
+            target = staged_target.binding
         except (sqlite3.Error, SQLiteIdentityError, OSError) as exc:
             if source_connection is not None:
                 source_connection.close()
@@ -487,12 +450,7 @@ class SQLiteMaintenanceService:
                 artifact_size=artifact_size,
                 evidence=evidence,
             )
-            reservation.release()
-            if _safe_companion_identities(target.path):
-                raise SQLiteMaintenanceError(
-                    "target SQLite companions appeared after reservation release"
-                )
-            _fsync_directory(target.path.parent)
+            staged_target.publish()
             succeeded = True
             return manifest, hook_result
         except (sqlite3.Error, SQLiteIdentityError, OSError) as exc:
@@ -505,8 +463,6 @@ class SQLiteMaintenanceService:
             try:
                 if not succeeded:
                     _seal_forensic_target(target)
-                if reservation.companions:
-                    reservation.release()
             finally:
                 source.close()
                 target.close()
@@ -538,7 +494,7 @@ class SQLiteMaintenanceService:
         return binding
 
     @staticmethod
-    def _reserve_target(target_path: Path | str) -> _TargetReservation:
+    def _stage_target(target_path: Path | str) -> _StagedTarget:
         path = _absolute_canonical_path(target_path)
         try:
             parent = os.lstat(path.parent)
@@ -546,47 +502,35 @@ class SQLiteMaintenanceService:
             raise SQLiteMaintenanceError("target parent does not exist") from exc
         if stat.S_ISLNK(parent.st_mode) or not stat.S_ISDIR(parent.st_mode):
             raise SQLiteMaintenanceError("target parent must be a non-symlink directory")
-        family = _sqlite_resource_family(path)
-        for member in family:
+        _assert_target_family_absent(path)
+        for _attempt in range(4):
+            staging_directory = path.parent / (
+                f".{path.name}.robo-trader-stage-{secrets.token_hex(16)}"
+            )
             try:
-                os.lstat(member)
-            except FileNotFoundError:
+                os.mkdir(staging_directory, 0o700)
+            except FileExistsError:
                 continue
             except OSError as exc:
-                raise SQLiteMaintenanceError("target SQLite family cannot be inspected") from exc
-            raise SQLiteMaintenanceError("target must be a new exclusively-created SQLite family")
-        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
-        companions: dict[Path, tuple[int, int, int]] = {}
-        binding: SQLitePathBinding | None = None
-        quarantine_directory = path.parent / f".{path.name}.robo-trader-reservations"
-        try:
-            os.mkdir(quarantine_directory, 0o700)
-            for suffix in ("-journal", "-shm", "-wal"):
-                companion = path.with_name(path.name + suffix)
-                descriptor = os.open(companion, flags, 0o400)
-                metadata = os.fstat(descriptor)
-                companions[companion] = (descriptor, metadata.st_dev, metadata.st_ino)
-            binding = SQLitePathBinding.open_for_initialization(path, create=True)
-            return _TargetReservation(
-                binding=binding,
-                companions=companions,
-                quarantine_directory=quarantine_directory,
-            )
-        except Exception as exc:
-            if binding is not None:
-                binding.close()
-            reservation = _TargetReservation(  # type: ignore[arg-type]
-                binding=binding,
-                companions=companions,
-                quarantine_directory=quarantine_directory,
-            )
+                raise SQLiteMaintenanceError(
+                    "private target staging directory cannot be created"
+                ) from exc
+            staged_path = staging_directory / "database.db"
             try:
-                reservation.release()
-            except SQLiteMaintenanceError:
-                pass
-            raise SQLiteMaintenanceError(
-                "target must be a new exclusively-created SQLite family"
-            ) from exc
+                binding = SQLitePathBinding.open_for_initialization(
+                    staged_path,
+                    create=True,
+                )
+            except SQLiteIdentityError as exc:
+                raise SQLiteMaintenanceError(
+                    "private staged database identity cannot be established"
+                ) from exc
+            return _StagedTarget(
+                binding=binding,
+                requested_path=path,
+                staging_directory=staging_directory,
+            )
+        raise SQLiteMaintenanceError("private target staging name could not be reserved")
 
     @staticmethod
     def _connect_bound(
@@ -932,6 +876,17 @@ def _sqlite_resource_family(path: Path) -> frozenset[Path]:
             path.with_name(path.name + "-wal"),
         }
     )
+
+
+def _assert_target_family_absent(path: Path) -> None:
+    for member in _sqlite_resource_family(path):
+        try:
+            os.lstat(member)
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise SQLiteMaintenanceError("target SQLite family cannot be inspected") from exc
+        raise SQLiteMaintenanceError("target must be a new exclusively-created SQLite family")
 
 
 def _safe_companion_identities(path: Path) -> dict[str, tuple[int, int]]:

--- a/robo_trader/maintenance/sqlite_service.py
+++ b/robo_trader/maintenance/sqlite_service.py
@@ -1,0 +1,673 @@
+"""Descriptor-bound SQLite backup, verification, and clean-room restore.
+
+This module is deliberately dormant.  It has no runtime imports, broker access,
+startup authority, or operation that replaces an existing database path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import re
+import sqlite3
+import stat
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Iterable, Mapping, Sequence
+
+from robo_trader.maintenance.models import (
+    DatabaseEvidence,
+    MaintenanceManifest,
+    MigrationDryRunReport,
+    TableEvidence,
+)
+from robo_trader.safety.sqlite_identity import (
+    SQLiteIdentityError,
+    SQLitePathBinding,
+    lexical_path_preserving_leaf,
+    sqlite_connection_file_identity,
+)
+
+MigrationCallback = Callable[[sqlite3.Connection], None]
+ProgressHook = Callable[[str, int, int], None]
+
+
+class SQLiteMaintenanceError(RuntimeError):
+    """A maintenance operation failed closed."""
+
+
+class SQLiteMaintenanceService:
+    """Operate only on explicit, descriptor-bound SQLite files."""
+
+    def __init__(
+        self,
+        *,
+        progress_hook: ProgressHook | None = None,
+        max_copy_seconds: float = 120.0,
+    ) -> None:
+        if not math.isfinite(max_copy_seconds) or not 1.0 <= max_copy_seconds <= 3600.0:
+            raise ValueError("max_copy_seconds must be between 1 and 3600")
+        self._progress_hook = progress_hook
+        self._max_copy_seconds = max_copy_seconds
+
+    def verify(
+        self,
+        database_path: Path | str,
+        manifest: MaintenanceManifest | None = None,
+    ) -> DatabaseEvidence:
+        """Verify one existing database without mutating it."""
+
+        database_candidate = _absolute_canonical_path(database_path)
+        companions = _safe_companion_identities(database_candidate)
+        binding = self._open_source(database_candidate)
+        connection: sqlite3.Connection | None = None
+        try:
+            connection, binding = self._connect_bound(binding, readonly=True)
+            evidence = _database_evidence(connection)
+            binding.assert_connection_identity(sqlite_connection_file_identity(connection))
+            artifact_sha256, artifact_size = _descriptor_digest(binding.guardian_file_descriptor)
+            binding.assert_path_identity()
+            _assert_companion_identities(binding.path, companions)
+            if manifest is not None:
+                if (
+                    manifest.artifact_sha256 != artifact_sha256
+                    or manifest.artifact_size != artifact_size
+                    or manifest.evidence != evidence
+                ):
+                    raise SQLiteMaintenanceError("database does not match the supplied manifest")
+            return evidence
+        except (sqlite3.Error, SQLiteIdentityError, OSError) as exc:
+            raise SQLiteMaintenanceError("SQLite verification failed") from exc
+        finally:
+            if connection is not None:
+                connection.close()
+            binding.close()
+
+    def backup(
+        self,
+        source_path: Path | str,
+        target_path: Path | str,
+    ) -> MaintenanceManifest:
+        """Create and verify a WAL-safe snapshot at an exclusive new path."""
+
+        return self._online_copy(source_path, target_path, operation="backup")
+
+    def restore_clean_room(
+        self,
+        backup_path: Path | str,
+        target_path: Path | str,
+        manifest: MaintenanceManifest,
+    ) -> MaintenanceManifest:
+        """Restore a verified backup only into an exclusive clean-room path."""
+
+        if manifest.operation != "backup":
+            raise SQLiteMaintenanceError("clean-room restore requires a backup manifest")
+        self.verify(backup_path, manifest)
+        restored = self._online_copy(backup_path, target_path, operation="restore")
+        if restored.evidence != manifest.evidence:
+            raise SQLiteMaintenanceError("clean-room restore evidence differs from backup")
+        return MaintenanceManifest(
+            manifest_version=restored.manifest_version,
+            operation="restore",
+            created_at=restored.created_at,
+            artifact_sha256=restored.artifact_sha256,
+            artifact_size=restored.artifact_size,
+            evidence=restored.evidence,
+            input_artifact_sha256=manifest.artifact_sha256,
+        )
+
+    def dry_run_migration(
+        self,
+        source_path: Path | str,
+        synthetic_target_path: Path | str,
+        *,
+        migration_id: str,
+        migration: MigrationCallback,
+    ) -> MigrationDryRunReport:
+        """Apply a callback transactionally to a new synthetic snapshot only.
+
+        The callback receives the disposable target connection.  Transaction,
+        ATTACH, and DETACH statements are denied so the service retains the
+        rollback boundary and the callback cannot reach another database.
+        """
+
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", migration_id):
+            raise SQLiteMaintenanceError("migration_id must be a bounded public identifier")
+        source_before = self.verify(source_path)
+        self._online_copy(source_path, synthetic_target_path, operation="backup", seal=False)
+        target = self._open_source(synthetic_target_path, writable=True)
+        connection: sqlite3.Connection | None = None
+        outcome = "applied_to_synthetic_copy"
+        error_code: str | None = None
+        try:
+            connection, target = self._connect_bound(target, readonly=False)
+            before = _database_evidence(connection)
+            connection.execute("BEGIN IMMEDIATE")
+            connection.set_authorizer(_migration_authorizer)
+            try:
+                migration(connection)
+                interim = _database_evidence(connection)
+                if interim.integrity_check != "ok" or interim.foreign_key_violations:
+                    raise SQLiteMaintenanceError("migration produced invalid SQLite state")
+            except BaseException:
+                connection.set_authorizer(None)
+                connection.rollback()
+                outcome = "rolled_back"
+                error_code = "migration_callback_failed"
+            else:
+                connection.set_authorizer(None)
+                connection.commit()
+            target.assert_connection_identity(sqlite_connection_file_identity(connection))
+        finally:
+            if connection is not None:
+                connection.close()
+            try:
+                _seal_readonly(target)
+                _fsync_directory(target.path.parent)
+            finally:
+                target.close()
+
+        after = self.verify(synthetic_target_path)
+        source_after = self.verify(source_path)
+        artifact_sha256, _ = _path_digest(_absolute_canonical_path(synthetic_target_path))
+        return MigrationDryRunReport(
+            report_version=1,
+            migration_id=migration_id,
+            created_at=_utc_now(),
+            outcome=outcome,
+            before=before,
+            after=after,
+            source_unchanged=source_before == source_after,
+            target_artifact_sha256=artifact_sha256,
+            error_code=error_code,
+        )
+
+    def write_manifest(
+        self,
+        manifest: MaintenanceManifest | MigrationDryRunReport,
+        target_path: Path | str,
+    ) -> None:
+        """Write one canonical JSON report to an exclusive owner-only path."""
+
+        path = _absolute_canonical_path(target_path)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+        try:
+            descriptor = os.open(path, flags, 0o600)
+        except OSError as exc:
+            raise SQLiteMaintenanceError("manifest target must be a new exclusive path") from exc
+        try:
+            payload = (
+                json.dumps(manifest.to_dict(), sort_keys=True, separators=(",", ":")).encode(
+                    "utf-8"
+                )
+                + b"\n"
+            )
+            _write_all(descriptor, payload)
+            os.fsync(descriptor)
+            os.fchmod(descriptor, 0o400)
+            os.fsync(descriptor)
+            _fsync_directory(path.parent)
+            metadata = os.fstat(descriptor)
+            current = os.lstat(path)
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_nlink != 1
+                or (metadata.st_dev, metadata.st_ino) != (current.st_dev, current.st_ino)
+            ):
+                raise SQLiteMaintenanceError("manifest identity changed while writing")
+        except OSError as exc:
+            raise SQLiteMaintenanceError("manifest write failed closed") from exc
+        finally:
+            os.close(descriptor)
+
+    def load_manifest(self, path: Path | str) -> MaintenanceManifest:
+        """Load a bounded, single-link manifest without following its leaf."""
+
+        manifest_path = _absolute_canonical_path(path)
+        flags = os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+        try:
+            descriptor = os.open(manifest_path, flags)
+        except OSError as exc:
+            raise SQLiteMaintenanceError("manifest cannot be opened safely") from exc
+        try:
+            metadata = os.fstat(descriptor)
+            current = os.lstat(manifest_path)
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_nlink != 1
+                or metadata.st_size > 4 * 1024 * 1024
+                or (metadata.st_dev, metadata.st_ino) != (current.st_dev, current.st_ino)
+            ):
+                raise SQLiteMaintenanceError("manifest must be a bounded single-link file")
+            payload = _read_exact(descriptor, metadata.st_size)
+            after = os.fstat(descriptor)
+            current_after = os.lstat(manifest_path)
+            stable = ("st_dev", "st_ino", "st_size", "st_mtime_ns", "st_ctime_ns")
+            if any(getattr(metadata, field) != getattr(after, field) for field in stable) or (
+                after.st_dev,
+                after.st_ino,
+            ) != (current_after.st_dev, current_after.st_ino):
+                raise SQLiteMaintenanceError("manifest changed while reading")
+            raw = json.loads(payload.decode("utf-8"))
+            if not isinstance(raw, Mapping):
+                raise SQLiteMaintenanceError("manifest must contain a JSON object")
+            return MaintenanceManifest.from_mapping(raw)
+        except (UnicodeError, json.JSONDecodeError, ValueError, OSError) as exc:
+            raise SQLiteMaintenanceError("manifest is invalid") from exc
+        finally:
+            os.close(descriptor)
+
+    def _online_copy(
+        self,
+        source_path: Path | str,
+        target_path: Path | str,
+        *,
+        operation: str,
+        seal: bool = True,
+    ) -> MaintenanceManifest:
+        source_candidate = _absolute_canonical_path(source_path)
+        target_candidate = _absolute_canonical_path(target_path)
+        if _sqlite_resource_family(source_candidate) & _sqlite_resource_family(target_candidate):
+            raise SQLiteMaintenanceError("source and target SQLite resource families overlap")
+        source_companions = _safe_companion_identities(source_candidate)
+        source = self._open_source(source_candidate)
+        try:
+            target = self._reserve_target(target_candidate)
+        except BaseException:
+            source.close()
+            raise
+        source_connection: sqlite3.Connection | None = None
+        target_connection: sqlite3.Connection | None = None
+        succeeded = False
+        try:
+            if (source.device, source.inode) == (target.device, target.inode):
+                raise SQLiteMaintenanceError("source and target identities must differ")
+            source_connection, source = self._connect_bound(source, readonly=True)
+            target_connection, target = self._connect_bound(target, readonly=False)
+            source_db = source_connection
+            target_db = target_connection
+            copy_started = time.monotonic()
+
+            def progress(_status: int, remaining: int, total: int) -> None:
+                if time.monotonic() - copy_started > self._max_copy_seconds:
+                    raise SQLiteMaintenanceError("SQLite online copy exceeded its deadline")
+                source.assert_connection_identity(sqlite_connection_file_identity(source_db))
+                target.assert_connection_identity(sqlite_connection_file_identity(target_db))
+                _assert_single_link(source)
+                _assert_single_link(target)
+                _assert_companion_identities(source.path, source_companions)
+                if self._progress_hook is not None:
+                    self._progress_hook(operation, remaining, total)
+
+            source_connection.backup(target_connection, pages=64, progress=progress, sleep=0.001)
+            target_connection.commit()
+            source.assert_connection_identity(sqlite_connection_file_identity(source_connection))
+            target.assert_connection_identity(sqlite_connection_file_identity(target_connection))
+            _assert_single_link(source)
+            _assert_single_link(target)
+            _assert_companion_identities(source.path, source_companions)
+            evidence = _database_evidence(target_connection)
+            target_connection.close()
+            target_connection = None
+            if seal:
+                _seal_readonly(target)
+            else:
+                os.fsync(target.guardian_file_descriptor)
+                _assert_single_link(target)
+            _fsync_directory(target.path.parent)
+            artifact_sha256, artifact_size = _descriptor_digest(target.guardian_file_descriptor)
+            target.assert_path_identity()
+            manifest = MaintenanceManifest(
+                manifest_version=1,
+                operation=operation,
+                created_at=_utc_now(),
+                artifact_sha256=artifact_sha256,
+                artifact_size=artifact_size,
+                evidence=evidence,
+            )
+            succeeded = True
+            return manifest
+        except (sqlite3.Error, SQLiteIdentityError, OSError) as exc:
+            raise SQLiteMaintenanceError("SQLite online copy failed closed") from exc
+        finally:
+            if target_connection is not None:
+                target_connection.close()
+            if source_connection is not None:
+                source_connection.close()
+            if not succeeded:
+                _seal_forensic_target(target)
+            source.close()
+            target.close()
+
+    @staticmethod
+    def _open_source(
+        source_path: Path | str,
+        *,
+        writable: bool = False,
+    ) -> SQLitePathBinding:
+        path = _absolute_canonical_path(source_path)
+        try:
+            metadata = os.lstat(path)
+        except OSError as exc:
+            raise SQLiteMaintenanceError("database source does not exist") from exc
+        if (
+            stat.S_ISLNK(metadata.st_mode)
+            or not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+        ):
+            raise SQLiteMaintenanceError("database source must be a single-link regular file")
+        try:
+            binding = SQLitePathBinding.open_readonly(path)
+        except SQLiteIdentityError as exc:
+            raise SQLiteMaintenanceError("database identity cannot be established") from exc
+        if writable and not os.access(path, os.W_OK):
+            binding.close()
+            raise SQLiteMaintenanceError("synthetic migration target must be writable")
+        return binding
+
+    @staticmethod
+    def _reserve_target(target_path: Path | str) -> SQLitePathBinding:
+        path = _absolute_canonical_path(target_path)
+        try:
+            parent = os.lstat(path.parent)
+        except OSError as exc:
+            raise SQLiteMaintenanceError("target parent does not exist") from exc
+        if stat.S_ISLNK(parent.st_mode) or not stat.S_ISDIR(parent.st_mode):
+            raise SQLiteMaintenanceError("target parent must be a non-symlink directory")
+        try:
+            return SQLitePathBinding.open_for_initialization(path, create=True)
+        except Exception as exc:
+            raise SQLiteMaintenanceError("target must be a new exclusively-created path") from exc
+
+    @staticmethod
+    def _connect_bound(
+        binding: SQLitePathBinding,
+        *,
+        readonly: bool,
+    ) -> tuple[sqlite3.Connection, SQLitePathBinding]:
+        mode = "ro" if readonly else "rw"
+        connection = sqlite3.connect(
+            binding.path.as_uri() + f"?mode={mode}",
+            uri=True,
+            timeout=10.0,
+        )
+        try:
+            binding = binding.bind_sqlite_connection(sqlite_connection_file_identity(connection))
+            binding.assert_connection_identity(sqlite_connection_file_identity(connection))
+            if readonly:
+                connection.execute("PRAGMA query_only=ON")
+            connection.execute("PRAGMA foreign_keys=ON")
+            return connection, binding
+        except BaseException:
+            connection.close()
+            raise
+
+
+def _absolute_canonical_path(path: Path | str) -> Path:
+    candidate = Path(path).expanduser()
+    if not candidate.is_absolute():
+        raise SQLiteMaintenanceError("maintenance paths must be absolute")
+    protected = lexical_path_preserving_leaf(candidate)
+    if protected != candidate:
+        raise SQLiteMaintenanceError("maintenance path parent must be canonical")
+    return protected
+
+
+def _database_evidence(connection: sqlite3.Connection) -> DatabaseEvidence:
+    quick = _single_check(connection, "quick_check")
+    integrity = _single_check(connection, "integrity_check")
+    if quick != "ok" or integrity != "ok":
+        raise SQLiteMaintenanceError("database failed SQLite integrity verification")
+    foreign_key_rows = connection.execute("PRAGMA foreign_key_check").fetchall()
+    if foreign_key_rows:
+        raise SQLiteMaintenanceError("database contains foreign-key violations")
+
+    schema_rows = connection.execute(
+        "SELECT type,name,tbl_name,COALESCE(sql,'') FROM sqlite_master "
+        "ORDER BY type,name,tbl_name,COALESCE(sql,'')"
+    ).fetchall()
+    schema_hash = _hash_rows(schema_rows)
+    table_names = [
+        str(row[0])
+        for row in connection.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND (name NOT LIKE 'sqlite_%' OR name='sqlite_sequence') "
+            "ORDER BY name"
+        ).fetchall()
+    ]
+    tables = tuple(_table_evidence(connection, name) for name in table_names)
+    application_id = int(connection.execute("PRAGMA application_id").fetchone()[0])
+    user_version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+    return DatabaseEvidence(
+        schema_sha256=schema_hash,
+        tables=tables,
+        quick_check=quick,
+        integrity_check=integrity,
+        foreign_key_violations=0,
+        application_id=application_id,
+        user_version=user_version,
+    )
+
+
+def _single_check(connection: sqlite3.Connection, pragma: str) -> str:
+    rows = connection.execute(f"PRAGMA {pragma}").fetchall()
+    if rows == [("ok",)]:
+        return "ok"
+    return "failed"
+
+
+def _table_evidence(connection: sqlite3.Connection, table_name: str) -> TableEvidence:
+    quoted = '"' + table_name.replace('"', '""') + '"'
+    # The identifier comes only from sqlite_master and is escaped as a quoted
+    # SQLite identifier; DB-API parameters cannot represent identifiers.
+    cursor = connection.execute(f"SELECT * FROM {quoted}")  # nosec B608
+    row_hashes: list[bytes] = []
+    row_count = 0
+    for row in cursor:
+        row_hashes.append(hashlib.sha256(_encode_row(row)).digest())
+        row_count += 1
+    row_hashes.sort()
+    digest = hashlib.sha256()
+    for row_hash in row_hashes:
+        digest.update(row_hash)
+    return TableEvidence(table_name, row_count, digest.hexdigest())
+
+
+def _hash_rows(rows: Iterable[Sequence[object]]) -> str:
+    digest = hashlib.sha256()
+    for row in rows:
+        item = _encode_row(row)
+        digest.update(len(item).to_bytes(8, "big"))
+        digest.update(item)
+    return digest.hexdigest()
+
+
+def _encode_row(row: Sequence[object]) -> bytes:
+    return json.dumps(
+        [_encode_value(value) for value in row],
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("ascii")
+
+
+def _encode_value(value: object) -> object:
+    if value is None or isinstance(value, (str, int)):
+        return [type(value).__name__, value]
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise SQLiteMaintenanceError("database contains a non-finite numeric value")
+        return ["float", value.hex()]
+    if isinstance(value, bytes):
+        return ["bytes", value.hex()]
+    raise SQLiteMaintenanceError("database contains an unsupported SQLite value")
+
+
+def _migration_authorizer(
+    action: int,
+    arg1: str | None,
+    _arg2: str | None,
+    _db: str | None,
+    _trigger: str | None,
+) -> int:
+    denied = {
+        sqlite3.SQLITE_ATTACH,
+        sqlite3.SQLITE_DETACH,
+        sqlite3.SQLITE_TRANSACTION,
+    }
+    dangerous_pragmas = {
+        "data_store_directory",
+        "journal_mode",
+        "temp_store_directory",
+        "wal_checkpoint",
+        "writable_schema",
+    }
+    if action in denied or (
+        action == sqlite3.SQLITE_PRAGMA
+        and isinstance(arg1, str)
+        and arg1.lower() in dangerous_pragmas
+    ):
+        return sqlite3.SQLITE_DENY
+    return sqlite3.SQLITE_OK
+
+
+def _assert_single_link(binding: SQLitePathBinding) -> None:
+    metadata = os.fstat(binding.guardian_file_descriptor)
+    if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+        raise SQLiteMaintenanceError("database acquired another filesystem link")
+    try:
+        binding.assert_path_identity()
+    except SQLiteIdentityError as exc:
+        raise SQLiteMaintenanceError("database path identity changed") from exc
+
+
+def _seal_readonly(binding: SQLitePathBinding) -> None:
+    _assert_single_link(binding)
+    os.fsync(binding.guardian_file_descriptor)
+    os.fchmod(binding.guardian_file_descriptor, 0o400)
+    os.fsync(binding.guardian_file_descriptor)
+    _assert_single_link(binding)
+
+
+def _seal_forensic_target(binding: SQLitePathBinding) -> None:
+    try:
+        os.fsync(binding.guardian_file_descriptor)
+    except OSError:
+        pass
+    try:
+        os.fchmod(binding.guardian_file_descriptor, 0o400)
+    except OSError:
+        pass
+    try:
+        os.fsync(binding.guardian_file_descriptor)
+        _fsync_directory(binding.path.parent)
+    except OSError:
+        pass
+
+
+def _sqlite_resource_family(path: Path) -> frozenset[Path]:
+    return frozenset(
+        {
+            path,
+            path.with_name(path.name + "-journal"),
+            path.with_name(path.name + "-shm"),
+            path.with_name(path.name + "-wal"),
+        }
+    )
+
+
+def _safe_companion_identities(path: Path) -> dict[str, tuple[int, int]]:
+    identities: dict[str, tuple[int, int]] = {}
+    for suffix in ("-journal", "-shm", "-wal"):
+        companion = path.with_name(path.name + suffix)
+        try:
+            metadata = os.lstat(companion)
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise SQLiteMaintenanceError("SQLite companion cannot be inspected") from exc
+        if (
+            stat.S_ISLNK(metadata.st_mode)
+            or not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+        ):
+            raise SQLiteMaintenanceError(
+                "SQLite companions must be single-link non-symlink regular files"
+            )
+        identities[suffix] = (metadata.st_dev, metadata.st_ino)
+    return identities
+
+
+def _assert_companion_identities(
+    path: Path,
+    expected: Mapping[str, tuple[int, int]],
+) -> None:
+    current = _safe_companion_identities(path)
+    for suffix, identity in expected.items():
+        if current.get(suffix) != identity:
+            raise SQLiteMaintenanceError("SQLite companion identity changed during operation")
+
+
+def _descriptor_digest(descriptor: int) -> tuple[str, int]:
+    metadata = os.fstat(descriptor)
+    digest = hashlib.sha256()
+    offset = 0
+    while offset < metadata.st_size:
+        chunk = os.pread(descriptor, min(128 * 1024, metadata.st_size - offset), offset)
+        if not chunk:
+            raise SQLiteMaintenanceError("database ended while hashing")
+        digest.update(chunk)
+        offset += len(chunk)
+    after = os.fstat(descriptor)
+    stable = ("st_dev", "st_ino", "st_size", "st_mtime_ns", "st_ctime_ns")
+    if any(getattr(metadata, field) != getattr(after, field) for field in stable):
+        raise SQLiteMaintenanceError("database changed while hashing")
+    return digest.hexdigest(), metadata.st_size
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_CLOEXEC", 0)
+    descriptor = os.open(path, flags)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _path_digest(path: Path) -> tuple[str, int]:
+    flags = os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    descriptor = os.open(path, flags)
+    try:
+        return _descriptor_digest(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _write_all(descriptor: int, payload: bytes) -> None:
+    offset = 0
+    while offset < len(payload):
+        written = os.write(descriptor, payload[offset:])
+        if written <= 0:
+            raise SQLiteMaintenanceError("manifest write did not make progress")
+        offset += written
+
+
+def _read_exact(descriptor: int, size: int) -> bytes:
+    chunks: list[bytes] = []
+    remaining = size
+    while remaining:
+        chunk = os.read(descriptor, min(128 * 1024, remaining))
+        if not chunk:
+            raise SQLiteMaintenanceError("manifest ended while reading")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    if os.read(descriptor, 1):
+        raise SQLiteMaintenanceError("manifest grew while reading")
+    return b"".join(chunks)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/robo_trader/maintenance/sqlite_service.py
+++ b/robo_trader/maintenance/sqlite_service.py
@@ -1080,28 +1080,40 @@ def _encode_value(value: object) -> object:
 def _migration_authorizer(
     action: int,
     arg1: str | None,
-    _arg2: str | None,
+    arg2: str | None,
     _db: str | None,
     _trigger: str | None,
 ) -> int:
     denied = {
         sqlite3.SQLITE_ATTACH,
+        sqlite3.SQLITE_CREATE_VTABLE,
         sqlite3.SQLITE_DETACH,
+        sqlite3.SQLITE_DROP_VTABLE,
+        sqlite3.SQLITE_SAVEPOINT,
         sqlite3.SQLITE_TRANSACTION,
     }
-    dangerous_pragmas = {
-        "data_store_directory",
-        "hard_heap_limit",
-        "journal_mode",
-        "soft_heap_limit",
-        "temp_store_directory",
-        "wal_checkpoint",
-        "writable_schema",
+    allowed_pragmas = {
+        "application_id",
+        "foreign_key_check",
+        "integrity_check",
+        "page_count",
+        "quick_check",
+        "table_xinfo",
+        "user_version",
     }
-    if action in denied or (
-        action == sqlite3.SQLITE_PRAGMA
-        and isinstance(arg1, str)
-        and arg1.lower() in dangerous_pragmas
+    native_code_functions = {"fts3_tokenizer", "load_extension"}
+    function_name = arg2 if isinstance(arg2, str) else arg1
+    if (
+        action in denied
+        or (
+            action == sqlite3.SQLITE_PRAGMA
+            and (not isinstance(arg1, str) or arg1.lower() not in allowed_pragmas)
+        )
+        or (
+            action == sqlite3.SQLITE_FUNCTION
+            and isinstance(function_name, str)
+            and function_name.lower() in native_code_functions
+        )
     ):
         return sqlite3.SQLITE_DENY
     return sqlite3.SQLITE_OK

--- a/robo_trader/maintenance/sqlite_service.py
+++ b/robo_trader/maintenance/sqlite_service.py
@@ -299,11 +299,15 @@ class SQLiteMaintenanceService:
         *,
         progress_hook: ProgressHook | None = None,
         max_copy_seconds: float = 120.0,
+        max_migration_seconds: float = 30.0,
     ) -> None:
         if not math.isfinite(max_copy_seconds) or not 1.0 <= max_copy_seconds <= 3600.0:
             raise ValueError("max_copy_seconds must be between 1 and 3600")
+        if not math.isfinite(max_migration_seconds) or not 0.01 <= max_migration_seconds <= 3600.0:
+            raise ValueError("max_migration_seconds must be between 0.01 and 3600")
         self._progress_hook = progress_hook
         self._max_copy_seconds = max_copy_seconds
+        self._max_migration_seconds = max_migration_seconds
 
     def verify(
         self,
@@ -410,14 +414,23 @@ class SQLiteMaintenanceService:
             error_code: str | None = None
             connection.execute("BEGIN IMMEDIATE")
             connection.set_authorizer(_migration_authorizer)
+            migration_started = time.monotonic()
+
+            def enforce_migration_deadline() -> int:
+                return int(time.monotonic() - migration_started > self._max_migration_seconds)
+
             try:
-                for step in plan.steps:
-                    connection.execute(step.sql, step.parameters)
-                if plan.target_user_version is not None:
-                    connection.execute(f"PRAGMA user_version={plan.target_user_version}")
-                interim = _database_evidence(connection)
-                if interim.integrity_check != "ok" or interim.foreign_key_violations:
-                    raise SQLiteMaintenanceError("migration produced invalid SQLite state")
+                connection.set_progress_handler(enforce_migration_deadline, 1000)
+                try:
+                    for step in plan.steps:
+                        connection.execute(step.sql, step.parameters)
+                    if plan.target_user_version is not None:
+                        connection.execute(f"PRAGMA user_version={plan.target_user_version}")
+                    interim = _database_evidence(connection)
+                    if interim.integrity_check != "ok" or interim.foreign_key_violations:
+                        raise SQLiteMaintenanceError("migration produced invalid SQLite state")
+                finally:
+                    connection.set_progress_handler(None, 0)
             except (sqlite3.Error, SQLiteMaintenanceError, OverflowError):
                 # Python 3.10 cannot reliably disable an authorizer by passing
                 # None.  Replace it with a completion-only policy before the
@@ -968,7 +981,8 @@ def _database_evidence(connection: sqlite3.Connection) -> DatabaseEvidence:
         str(row[0])
         for row in connection.execute(
             "SELECT name FROM sqlite_master WHERE type='table' "
-            "AND (name NOT LIKE 'sqlite_%' OR name='sqlite_sequence') "
+            "AND (name NOT LIKE 'sqlite_%' OR name='sqlite_sequence' "
+            "OR name GLOB 'sqlite_stat*') "
             "ORDER BY name"
         ).fetchall()
     ]

--- a/robo_trader/maintenance/sqlite_service.py
+++ b/robo_trader/maintenance/sqlite_service.py
@@ -35,6 +35,7 @@ from robo_trader.safety.sqlite_identity import (
     SQLitePathBinding,
     lexical_path_preserving_leaf,
     sqlite_connection_file_identity,
+    sqlite_connection_serialize,
 )
 
 ProgressHook = Callable[[str, int, int], None]
@@ -46,25 +47,86 @@ class SQLiteMaintenanceError(RuntimeError):
 
 @dataclass(slots=True)
 class _StagedTarget:
-    """Private SQLite namespace published only after the connection is closed."""
+    """Descriptor-bound artifact that SQLite never opens by pathname."""
 
-    binding: SQLitePathBinding
     requested_path: Path
-    staging_directory: Path
+    parent_file_descriptor: int
+    staging_name: str
+    guardian_file_descriptor: int
+    device: int
+    inode: int
     published: bool = False
 
-    def publish(self) -> None:
-        """Publish the sealed main inode without exposing SQLite to target sidecars."""
+    @property
+    def forensic_path(self) -> Path:
+        return self.requested_path.parent / self.staging_name
 
-        self.binding.assert_path_identity()
-        if _safe_companion_identities(self.binding.path):
-            raise SQLiteMaintenanceError("private staged SQLite database retained companion files")
-        _assert_target_family_absent(self.requested_path)
-        _rename_noreplace(self.binding.path, self.requested_path)
+    def assert_identity(self) -> None:
+        parent = os.fstat(self.parent_file_descriptor)
+        current_parent = os.lstat(self.requested_path.parent)
+        guardian = os.fstat(self.guardian_file_descriptor)
+        staged = os.stat(
+            self.staging_name,
+            dir_fd=self.parent_file_descriptor,
+            follow_symlinks=False,
+        )
+        if (
+            not stat.S_ISDIR(parent.st_mode)
+            or stat.S_ISLNK(current_parent.st_mode)
+            or not stat.S_ISDIR(current_parent.st_mode)
+            or (parent.st_dev, parent.st_ino) != (current_parent.st_dev, current_parent.st_ino)
+            or not stat.S_ISREG(guardian.st_mode)
+            or guardian.st_nlink != 1
+            or (guardian.st_dev, guardian.st_ino) != (self.device, self.inode)
+            or stat.S_ISLNK(staged.st_mode)
+            or not stat.S_ISREG(staged.st_mode)
+            or (staged.st_dev, staged.st_ino) != (self.device, self.inode)
+        ):
+            raise SQLiteMaintenanceError("staged database identity changed")
+
+    def write_database_image(self, payload: bytes) -> None:
+        self.assert_identity()
+        if os.fstat(self.guardian_file_descriptor).st_size != 0:
+            raise SQLiteMaintenanceError("staged database is not empty")
+        _pwrite_all(self.guardian_file_descriptor, payload)
+        self.assert_identity()
+
+    def seal_readonly(self) -> None:
+        self.assert_identity()
+        os.fsync(self.guardian_file_descriptor)
+        os.fchmod(self.guardian_file_descriptor, 0o400)
+        os.fsync(self.guardian_file_descriptor)
+        self.assert_identity()
+
+    def digest(self) -> tuple[str, int]:
+        self.assert_identity()
+        result = _descriptor_digest(self.guardian_file_descriptor)
+        self.assert_identity()
+        return result
+
+    def publish(self) -> None:
+        """Publish the sealed main inode with descriptor-relative no-replace rename."""
+
+        self.assert_identity()
+        _assert_target_family_absent_at(
+            self.parent_file_descriptor,
+            self.requested_path.name,
+        )
+        _rename_noreplace_at(
+            self.parent_file_descriptor,
+            self.staging_name,
+            self.parent_file_descriptor,
+            self.requested_path.name,
+        )
         self.published = True
-        descriptor_metadata = os.fstat(self.binding.guardian_file_descriptor)
+        descriptor_metadata = os.fstat(self.guardian_file_descriptor)
         path_metadata = os.lstat(self.requested_path)
-        expected = (self.binding.device, self.binding.inode)
+        bound_metadata = os.stat(
+            self.requested_path.name,
+            dir_fd=self.parent_file_descriptor,
+            follow_symlinks=False,
+        )
+        expected = (self.device, self.inode)
         if (
             not stat.S_ISREG(descriptor_metadata.st_mode)
             or descriptor_metadata.st_nlink != 1
@@ -72,6 +134,9 @@ class _StagedTarget:
             or stat.S_ISLNK(path_metadata.st_mode)
             or not stat.S_ISREG(path_metadata.st_mode)
             or (path_metadata.st_dev, path_metadata.st_ino) != expected
+            or stat.S_ISLNK(bound_metadata.st_mode)
+            or not stat.S_ISREG(bound_metadata.st_mode)
+            or (bound_metadata.st_dev, bound_metadata.st_ino) != expected
         ):
             raise SQLiteMaintenanceError("published database identity changed")
         if _safe_companion_identities(self.requested_path):
@@ -79,6 +144,33 @@ class _StagedTarget:
                 "target SQLite companion appeared during atomic publication"
             )
         _fsync_directory(self.requested_path.parent)
+
+    def seal_forensic(self) -> None:
+        try:
+            os.fsync(self.guardian_file_descriptor)
+        except OSError:
+            pass
+        try:
+            os.fchmod(self.guardian_file_descriptor, 0o400)
+        except OSError:
+            pass
+        try:
+            os.fsync(self.guardian_file_descriptor)
+            os.fsync(self.parent_file_descriptor)
+        except OSError:
+            pass
+
+    def close(self) -> None:
+        errors: list[OSError] = []
+        for descriptor in (self.guardian_file_descriptor, self.parent_file_descriptor):
+            try:
+                os.close(descriptor)
+            except OSError as exc:
+                errors.append(exc)
+        if errors:
+            raise SQLiteMaintenanceError(
+                "staged database descriptor was already closed"
+            ) from errors[0]
 
 
 class SQLiteMaintenanceService:
@@ -367,7 +459,6 @@ class SQLiteMaintenanceService:
             ):
                 raise SQLiteMaintenanceError("copy source does not match the supplied manifest")
             staged_target = self._stage_target(target_candidate)
-            target = staged_target.binding
         except (sqlite3.Error, SQLiteIdentityError, OSError) as exc:
             if source_connection is not None:
                 source_connection.close()
@@ -383,22 +474,28 @@ class SQLiteMaintenanceService:
         try:
             if source_connection is None:
                 raise SQLiteMaintenanceError("copy source connection is unavailable")
-            if (source.device, source.inode) == (target.device, target.inode):
+            if (source.device, source.inode) == (
+                staged_target.device,
+                staged_target.inode,
+            ):
                 raise SQLiteMaintenanceError("source and target identities must differ")
-            target_connection, target = self._connect_bound(
-                target, readonly=False, journal_off=True
-            )
+            # SQLite operates only on an in-memory database.  The finished
+            # image is serialized into the descriptor-bound staged file, so no
+            # SQLite journal/WAL pathname can ever be redirected or removed.
+            target_connection = sqlite3.connect(":memory:", timeout=10.0)
+            mode_row = target_connection.execute("PRAGMA journal_mode=MEMORY").fetchone()
+            if mode_row is None or str(mode_row[0]).lower() != "memory":
+                raise SQLiteMaintenanceError("copy target in-memory journaling is unavailable")
+            target_connection.execute("PRAGMA foreign_keys=ON")
             source_db = source_connection
-            target_db = target_connection
             copy_started = time.monotonic()
 
             def progress(_status: int, remaining: int, total: int) -> None:
                 if time.monotonic() - copy_started > self._max_copy_seconds:
                     raise SQLiteMaintenanceError("SQLite online copy exceeded its deadline")
                 source.assert_connection_identity(sqlite_connection_file_identity(source_db))
-                target.assert_connection_identity(sqlite_connection_file_identity(target_db))
                 _assert_single_link(source)
-                _assert_single_link(target)
+                staged_target.assert_identity()
                 _assert_companion_identities(source.path, source_companions)
                 if self._progress_hook is not None:
                     self._progress_hook(operation, remaining, total)
@@ -406,9 +503,8 @@ class SQLiteMaintenanceService:
             source_connection.backup(target_connection, pages=64, progress=progress, sleep=0.001)
             target_connection.commit()
             source.assert_connection_identity(sqlite_connection_file_identity(source_connection))
-            target.assert_connection_identity(sqlite_connection_file_identity(target_connection))
             _assert_single_link(source)
-            _assert_single_link(target)
+            staged_target.assert_identity()
             _assert_companion_identities(source.path, source_companions)
             evidence = _database_evidence(target_connection)
             final_source_sha256, final_source_size = _descriptor_digest(
@@ -426,22 +522,17 @@ class SQLiteMaintenanceService:
                 raise SQLiteMaintenanceError("copied evidence differs from supplied manifest")
             hook_result: object | None = None
             if target_hook is not None:
-                target.assert_connection_identity(
-                    sqlite_connection_file_identity(target_connection)
-                )
-                _assert_single_link(target)
+                staged_target.assert_identity()
                 hook_result = target_hook(target_connection, evidence)
-                target.assert_connection_identity(
-                    sqlite_connection_file_identity(target_connection)
-                )
-                _assert_single_link(target)
+                staged_target.assert_identity()
                 evidence = _database_evidence(target_connection)
+            database_image = sqlite_connection_serialize(target_connection)
             target_connection.close()
             target_connection = None
-            _seal_readonly(target)
-            _fsync_directory(target.path.parent)
-            artifact_sha256, artifact_size = _descriptor_digest(target.guardian_file_descriptor)
-            target.assert_path_identity()
+            staged_target.write_database_image(database_image)
+            staged_target.seal_readonly()
+            os.fsync(staged_target.parent_file_descriptor)
+            artifact_sha256, artifact_size = staged_target.digest()
             manifest = MaintenanceManifest(
                 manifest_version=1,
                 operation=operation,
@@ -462,10 +553,10 @@ class SQLiteMaintenanceService:
                 source_connection.close()
             try:
                 if not succeeded:
-                    _seal_forensic_target(target)
+                    staged_target.seal_forensic()
             finally:
                 source.close()
-                target.close()
+                staged_target.close()
 
     @staticmethod
     def _open_source(
@@ -496,41 +587,68 @@ class SQLiteMaintenanceService:
     @staticmethod
     def _stage_target(target_path: Path | str) -> _StagedTarget:
         path = _absolute_canonical_path(target_path)
+        if not hasattr(os, "O_NOFOLLOW") or not hasattr(os, "O_DIRECTORY"):
+            raise SQLiteMaintenanceError("platform lacks descriptor-relative target isolation")
+        parent_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
         try:
-            parent = os.lstat(path.parent)
+            parent_file_descriptor = os.open(path.parent, parent_flags)
         except OSError as exc:
-            raise SQLiteMaintenanceError("target parent does not exist") from exc
-        if stat.S_ISLNK(parent.st_mode) or not stat.S_ISDIR(parent.st_mode):
-            raise SQLiteMaintenanceError("target parent must be a non-symlink directory")
-        _assert_target_family_absent(path)
-        for _attempt in range(4):
-            staging_directory = path.parent / (
-                f".{path.name}.robo-trader-stage-{secrets.token_hex(16)}"
-            )
-            try:
-                os.mkdir(staging_directory, 0o700)
-            except FileExistsError:
-                continue
-            except OSError as exc:
-                raise SQLiteMaintenanceError(
-                    "private target staging directory cannot be created"
-                ) from exc
-            staged_path = staging_directory / "database.db"
-            try:
-                binding = SQLitePathBinding.open_for_initialization(
-                    staged_path,
-                    create=True,
-                )
-            except SQLiteIdentityError as exc:
-                raise SQLiteMaintenanceError(
-                    "private staged database identity cannot be established"
-                ) from exc
-            return _StagedTarget(
-                binding=binding,
-                requested_path=path,
-                staging_directory=staging_directory,
-            )
-        raise SQLiteMaintenanceError("private target staging name could not be reserved")
+            raise SQLiteMaintenanceError("target parent cannot be opened safely") from exc
+        try:
+            parent = os.fstat(parent_file_descriptor)
+            current_parent = os.lstat(path.parent)
+            if (
+                not stat.S_ISDIR(parent.st_mode)
+                or stat.S_ISLNK(current_parent.st_mode)
+                or not stat.S_ISDIR(current_parent.st_mode)
+                or (parent.st_dev, parent.st_ino) != (current_parent.st_dev, current_parent.st_ino)
+            ):
+                raise SQLiteMaintenanceError("target parent identity changed")
+            _assert_target_family_absent_at(parent_file_descriptor, path.name)
+            flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+            for _attempt in range(4):
+                staging_name = f".{path.name}.robo-trader-stage-{secrets.token_hex(16)}"
+                try:
+                    guardian = os.open(
+                        staging_name,
+                        flags,
+                        0o600,
+                        dir_fd=parent_file_descriptor,
+                    )
+                except FileExistsError:
+                    continue
+                except OSError as exc:
+                    raise SQLiteMaintenanceError(
+                        "private staged database cannot be created"
+                    ) from exc
+                try:
+                    metadata = os.fstat(guardian)
+                    staged = os.stat(
+                        staging_name,
+                        dir_fd=parent_file_descriptor,
+                        follow_symlinks=False,
+                    )
+                    if (
+                        not stat.S_ISREG(metadata.st_mode)
+                        or metadata.st_nlink != 1
+                        or (metadata.st_dev, metadata.st_ino) != (staged.st_dev, staged.st_ino)
+                    ):
+                        raise SQLiteMaintenanceError("private staged database identity changed")
+                    return _StagedTarget(
+                        requested_path=path,
+                        parent_file_descriptor=parent_file_descriptor,
+                        staging_name=staging_name,
+                        guardian_file_descriptor=guardian,
+                        device=metadata.st_dev,
+                        inode=metadata.st_ino,
+                    )
+                except BaseException:
+                    os.close(guardian)
+                    raise
+            raise SQLiteMaintenanceError("private target staging name could not be reserved")
+        except BaseException:
+            os.close(parent_file_descriptor)
+            raise
 
     @staticmethod
     def _connect_bound(
@@ -782,7 +900,12 @@ def _post_migration_authorizer(
     return _migration_authorizer(action, arg1, arg2, database, trigger)
 
 
-def _rename_noreplace(source: Path, target: Path) -> None:
+def _rename_noreplace_at(
+    source_directory_descriptor: int,
+    source_name: str,
+    target_directory_descriptor: int,
+    target_name: str,
+) -> None:
     """Atomically move a pathname without replacing any destination.
 
     Python does not expose the platform no-replace rename flags.  Maintenance
@@ -791,9 +914,8 @@ def _rename_noreplace(source: Path, target: Path) -> None:
     """
 
     libc = ctypes.CDLL(None, use_errno=True)
-    at_fdcwd = -100
-    source_bytes = os.fsencode(source)
-    target_bytes = os.fsencode(target)
+    source_bytes = os.fsencode(source_name)
+    target_bytes = os.fsencode(target_name)
     if sys.platform.startswith("linux"):
         try:
             rename = libc.renameat2
@@ -809,7 +931,13 @@ def _rename_noreplace(source: Path, target: Path) -> None:
             ctypes.c_uint,
         )
         rename.restype = ctypes.c_int
-        result = rename(at_fdcwd, source_bytes, at_fdcwd, target_bytes, 1)
+        result = rename(
+            source_directory_descriptor,
+            source_bytes,
+            target_directory_descriptor,
+            target_bytes,
+            1,
+        )
     elif sys.platform == "darwin":
         try:
             rename = libc.renameatx_np
@@ -825,12 +953,18 @@ def _rename_noreplace(source: Path, target: Path) -> None:
             ctypes.c_uint,
         )
         rename.restype = ctypes.c_int
-        result = rename(at_fdcwd, source_bytes, at_fdcwd, target_bytes, 0x00000004)
+        result = rename(
+            source_directory_descriptor,
+            source_bytes,
+            target_directory_descriptor,
+            target_bytes,
+            0x00000004,
+        )
     else:
         raise SQLiteMaintenanceError("platform cannot quarantine a reservation without replacement")
     if result != 0:
         error_number = ctypes.get_errno()
-        raise OSError(error_number, os.strerror(error_number), str(source))
+        raise OSError(error_number, os.strerror(error_number), source_name)
 
 
 def _assert_single_link(binding: SQLitePathBinding) -> None:
@@ -841,30 +975,6 @@ def _assert_single_link(binding: SQLitePathBinding) -> None:
         binding.assert_path_identity()
     except SQLiteIdentityError as exc:
         raise SQLiteMaintenanceError("database path identity changed") from exc
-
-
-def _seal_readonly(binding: SQLitePathBinding) -> None:
-    _assert_single_link(binding)
-    os.fsync(binding.guardian_file_descriptor)
-    os.fchmod(binding.guardian_file_descriptor, 0o400)
-    os.fsync(binding.guardian_file_descriptor)
-    _assert_single_link(binding)
-
-
-def _seal_forensic_target(binding: SQLitePathBinding) -> None:
-    try:
-        os.fsync(binding.guardian_file_descriptor)
-    except OSError:
-        pass
-    try:
-        os.fchmod(binding.guardian_file_descriptor, 0o400)
-    except OSError:
-        pass
-    try:
-        os.fsync(binding.guardian_file_descriptor)
-        _fsync_directory(binding.path.parent)
-    except OSError:
-        pass
 
 
 def _sqlite_resource_family(path: Path) -> frozenset[Path]:
@@ -882,6 +992,21 @@ def _assert_target_family_absent(path: Path) -> None:
     for member in _sqlite_resource_family(path):
         try:
             os.lstat(member)
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise SQLiteMaintenanceError("target SQLite family cannot be inspected") from exc
+        raise SQLiteMaintenanceError("target must be a new exclusively-created SQLite family")
+
+
+def _assert_target_family_absent_at(parent_descriptor: int, database_name: str) -> None:
+    for suffix in ("", "-journal", "-shm", "-wal"):
+        try:
+            os.stat(
+                database_name + suffix,
+                dir_fd=parent_descriptor,
+                follow_symlinks=False,
+            )
         except FileNotFoundError:
             continue
         except OSError as exc:
@@ -961,6 +1086,15 @@ def _write_all(descriptor: int, payload: bytes) -> None:
         written = os.write(descriptor, payload[offset:])
         if written <= 0:
             raise SQLiteMaintenanceError("manifest write did not make progress")
+        offset += written
+
+
+def _pwrite_all(descriptor: int, payload: bytes) -> None:
+    offset = 0
+    while offset < len(payload):
+        written = os.pwrite(descriptor, payload[offset:], offset)
+        if written <= 0:
+            raise SQLiteMaintenanceError("database image write did not make progress")
         offset += written
 
 

--- a/robo_trader/maintenance/sqlite_service.py
+++ b/robo_trader/maintenance/sqlite_service.py
@@ -300,14 +300,21 @@ class SQLiteMaintenanceService:
         progress_hook: ProgressHook | None = None,
         max_copy_seconds: float = 120.0,
         max_migration_seconds: float = 30.0,
+        max_migration_growth_bytes: int = 64 * 1024 * 1024,
     ) -> None:
         if not math.isfinite(max_copy_seconds) or not 1.0 <= max_copy_seconds <= 3600.0:
             raise ValueError("max_copy_seconds must be between 1 and 3600")
         if not math.isfinite(max_migration_seconds) or not 0.01 <= max_migration_seconds <= 3600.0:
             raise ValueError("max_migration_seconds must be between 0.01 and 3600")
+        if (
+            type(max_migration_growth_bytes) is not int
+            or not 1024 * 1024 <= max_migration_growth_bytes <= 1024 * 1024 * 1024
+        ):
+            raise ValueError("max_migration_growth_bytes must be between 1 MiB and 1 GiB")
         self._progress_hook = progress_hook
         self._max_copy_seconds = max_copy_seconds
         self._max_migration_seconds = max_migration_seconds
+        self._max_migration_growth_bytes = max_migration_growth_bytes
 
     def verify(
         self,
@@ -412,21 +419,39 @@ class SQLiteMaintenanceService:
         ) -> tuple[DatabaseEvidence, str, str | None]:
             outcome = "applied_to_synthetic_copy"
             error_code: str | None = None
+            page_size = int(connection.execute("PRAGMA page_size").fetchone()[0])
+            page_count = int(connection.execute("PRAGMA page_count").fetchone()[0])
+            growth_pages = math.ceil(self._max_migration_growth_bytes / page_size)
+            maximum_page_count = page_count + growth_pages
+            configured_maximum = int(
+                connection.execute(f"PRAGMA max_page_count={maximum_page_count}").fetchone()[0]
+            )
+            if configured_maximum != maximum_page_count:
+                raise SQLiteMaintenanceError("synthetic migration growth limit is unavailable")
             connection.execute("BEGIN IMMEDIATE")
             connection.set_authorizer(_migration_authorizer)
             migration_started = time.monotonic()
 
+            def migration_deadline_exceeded() -> bool:
+                return time.monotonic() - migration_started > self._max_migration_seconds
+
             def enforce_migration_deadline() -> int:
-                return int(time.monotonic() - migration_started > self._max_migration_seconds)
+                return int(migration_deadline_exceeded())
 
             try:
                 connection.set_progress_handler(enforce_migration_deadline, 1000)
                 try:
                     for step in plan.steps:
                         connection.execute(step.sql, step.parameters)
+                        if migration_deadline_exceeded():
+                            raise SQLiteMaintenanceError("migration exceeded its deadline")
                     if plan.target_user_version is not None:
                         connection.execute(f"PRAGMA user_version={plan.target_user_version}")
+                    if migration_deadline_exceeded():
+                        raise SQLiteMaintenanceError("migration exceeded its deadline")
                     interim = _database_evidence(connection)
+                    if migration_deadline_exceeded():
+                        raise SQLiteMaintenanceError("migration exceeded its deadline")
                     if interim.integrity_check != "ok" or interim.foreign_key_violations:
                         raise SQLiteMaintenanceError("migration produced invalid SQLite state")
                 finally:
@@ -445,18 +470,30 @@ class SQLiteMaintenanceService:
             connection.set_authorizer(_post_migration_authorizer)
             return before, outcome, error_code
 
+        def capture_final_source_evidence(
+            _manifest: MaintenanceManifest,
+            migration_result: object | None,
+        ) -> tuple[DatabaseEvidence, str, str | None, DatabaseEvidence]:
+            if not isinstance(migration_result, tuple) or len(migration_result) != 3:
+                raise SQLiteMaintenanceError("migration result is unavailable")
+            before, outcome, error_code = migration_result
+            if not isinstance(before, DatabaseEvidence):
+                raise SQLiteMaintenanceError("migration evidence is unavailable")
+            source_after = self._live_source_evidence(source_path)
+            return before, outcome, error_code, source_after
+
         copy_manifest, migration_result = self._online_copy(
             source_path,
             synthetic_target_path,
             operation="backup",
             target_hook=apply_plan,
+            pre_publish_hook=capture_final_source_evidence,
         )
-        if not isinstance(migration_result, tuple) or len(migration_result) != 3:
+        if not isinstance(migration_result, tuple) or len(migration_result) != 4:
             raise SQLiteMaintenanceError("migration result is unavailable")
-        before, outcome, error_code = migration_result
+        before, outcome, error_code, source_after = migration_result
 
         after = copy_manifest.evidence
-        source_after = self._live_source_evidence(source_path)
         source_unchanged = before == source_after
         if not source_unchanged:
             outcome = "source_changed_fail_closed"
@@ -638,6 +675,7 @@ class SQLiteMaintenanceService:
         operation: str,
         expected_source_manifest: MaintenanceManifest | None = None,
         target_hook: Callable[[sqlite3.Connection, DatabaseEvidence], object] | None = None,
+        pre_publish_hook: Callable[[MaintenanceManifest, object | None], object] | None = None,
         manifest_reservation: _ManifestReservation | None = None,
     ) -> tuple[MaintenanceManifest, object | None]:
         source_candidate = _absolute_canonical_path(source_path)
@@ -728,6 +766,11 @@ class SQLiteMaintenanceService:
 
             source_connection.backup(target_connection, pages=64, progress=progress, sleep=0.001)
             target_connection.commit()
+            # SQLite's backup API may advance/reset the destination schema
+            # cookie as it replaces the in-memory destination. Preserve the
+            # bound source snapshot's cookie so evidence and the serialized
+            # artifact describe the same complete database state.
+            target_connection.execute(f"PRAGMA schema_version={source_evidence.schema_version}")
             source.assert_connection_identity(sqlite_connection_file_identity(source_connection))
             _assert_single_link(source)
             staged_target.assert_identity()
@@ -786,6 +829,8 @@ class SQLiteMaintenanceService:
                     else None
                 ),
             )
+            if pre_publish_hook is not None:
+                hook_result = pre_publish_hook(manifest, hook_result)
             if manifest_reservation is not None:
                 self.write_reserved_manifest(manifest, manifest_reservation)
             staged_target.publish()
@@ -948,6 +993,8 @@ def _validate_migration_plan(plan: MigrationPlan) -> None:
             or len(step.parameters) > 1024
         ):
             raise SQLiteMaintenanceError("migration plan contains an invalid step")
+        if re.search(r"\b(?:length|printf|substr)\b", step.sql, flags=re.IGNORECASE):
+            raise SQLiteMaintenanceError("migration plan calls a reserved SQLite function")
         for parameter in step.parameters:
             if type(parameter) not in (str, int, float, bytes, type(None)):
                 raise SQLiteMaintenanceError("migration step parameter type is unsupported")
@@ -973,22 +1020,26 @@ def _database_evidence(connection: sqlite3.Connection) -> DatabaseEvidence:
         raise SQLiteMaintenanceError("database contains foreign-key violations")
 
     schema_rows = connection.execute(
-        "SELECT type,name,tbl_name,COALESCE(sql,'') FROM sqlite_master "
-        "ORDER BY type,name,tbl_name,COALESCE(sql,'')"
+        "SELECT type,name,tbl_name,sql FROM sqlite_master " "ORDER BY type,name,tbl_name,sql"
     ).fetchall()
     schema_hash = _hash_rows(schema_rows)
-    table_names = [
+    all_table_names = [
         str(row[0])
         for row in connection.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' "
-            "AND (name NOT LIKE 'sqlite_%' OR name='sqlite_sequence' "
-            "OR name GLOB 'sqlite_stat*') "
-            "ORDER BY name"
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
         ).fetchall()
+    ]
+    table_names = [
+        name
+        for name in all_table_names
+        if not name.startswith("sqlite_")
+        or name == "sqlite_sequence"
+        or name.startswith("sqlite_stat")
     ]
     tables = tuple(_table_evidence(connection, name) for name in table_names)
     application_id = int(connection.execute("PRAGMA application_id").fetchone()[0])
     user_version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+    schema_version = int(connection.execute("PRAGMA schema_version").fetchone()[0])
     return DatabaseEvidence(
         schema_sha256=schema_hash,
         tables=tables,
@@ -997,6 +1048,7 @@ def _database_evidence(connection: sqlite3.Connection) -> DatabaseEvidence:
         foreign_key_violations=0,
         application_id=application_id,
         user_version=user_version,
+        schema_version=schema_version,
     )
 
 
@@ -1082,7 +1134,7 @@ def _migration_authorizer(
     arg1: str | None,
     arg2: str | None,
     _db: str | None,
-    _trigger: str | None,
+    trigger: str | None,
 ) -> int:
     denied = {
         sqlite3.SQLITE_ATTACH,
@@ -1101,18 +1153,31 @@ def _migration_authorizer(
         "table_xinfo",
         "user_version",
     }
-    native_code_functions = {"fts3_tokenizer", "load_extension"}
+    readonly_pragmas = {"schema_version"}
+    # SQLite's own ALTER TABLE implementation invokes these while rewriting
+    # sqlite_master. Plans are lexically barred from naming them, and calls
+    # reached through database triggers remain denied.
+    allowed_internal_functions = {"length", "printf", "substr"}
     function_name = arg2 if isinstance(arg2, str) else arg1
     if (
         action in denied
         or (
             action == sqlite3.SQLITE_PRAGMA
-            and (not isinstance(arg1, str) or arg1.lower() not in allowed_pragmas)
+            and (
+                not isinstance(arg1, str)
+                or (
+                    arg1.lower() not in allowed_pragmas
+                    and not (arg1.lower() in readonly_pragmas and arg2 is None)
+                )
+            )
         )
         or (
             action == sqlite3.SQLITE_FUNCTION
-            and isinstance(function_name, str)
-            and function_name.lower() in native_code_functions
+            and (
+                not isinstance(function_name, str)
+                or function_name.lower() not in allowed_internal_functions
+                or trigger is not None
+            )
         )
     ):
         return sqlite3.SQLITE_DENY

--- a/robo_trader/maintenance/sqlite_service.py
+++ b/robo_trader/maintenance/sqlite_service.py
@@ -412,6 +412,13 @@ class SQLiteMaintenanceService:
         """
 
         _validate_migration_plan(plan)
+        plan_can_write = any(step.sql.strip().upper() != "SELECT 1" for step in plan.steps)
+        source_schema_functions: tuple[str, ...] = ()
+
+        def screen_source_schema(connection: sqlite3.Connection) -> None:
+            nonlocal source_schema_functions
+            if plan_can_write:
+                source_schema_functions = _schema_function_calls(connection)
 
         def apply_plan(
             connection: sqlite3.Connection,
@@ -419,8 +426,7 @@ class SQLiteMaintenanceService:
         ) -> tuple[DatabaseEvidence, str, str | None]:
             outcome = "applied_to_synthetic_copy"
             error_code: str | None = None
-            plan_can_write = any(step.sql.strip().upper() != "SELECT 1" for step in plan.steps)
-            if plan_can_write and _schema_function_calls(connection):
+            if plan_can_write and (source_schema_functions or _schema_function_calls(connection)):
                 connection.set_authorizer(_post_migration_authorizer)
                 return before, "rolled_back", "migration_plan_failed"
             page_size = int(connection.execute("PRAGMA page_size").fetchone()[0])
@@ -511,6 +517,7 @@ class SQLiteMaintenanceService:
             source_path,
             synthetic_target_path,
             operation="backup",
+            source_pre_evidence_hook=screen_source_schema,
             target_hook=apply_plan,
             pre_publish_hook=capture_final_source_evidence,
         )
@@ -699,6 +706,7 @@ class SQLiteMaintenanceService:
         *,
         operation: str,
         expected_source_manifest: MaintenanceManifest | None = None,
+        source_pre_evidence_hook: Callable[[sqlite3.Connection], None] | None = None,
         target_hook: Callable[[sqlite3.Connection, DatabaseEvidence], object] | None = None,
         pre_publish_hook: Callable[[MaintenanceManifest, object | None], object] | None = None,
         manifest_reservation: _ManifestReservation | None = None,
@@ -730,6 +738,8 @@ class SQLiteMaintenanceService:
                 immutable_readonly=expected_source_manifest is not None,
             )
             source_connection.execute("BEGIN")
+            if source_pre_evidence_hook is not None:
+                source_pre_evidence_hook(source_connection)
             source_evidence = _database_evidence(source_connection)
             source_companions = _adopt_connection_companions(
                 source.path,
@@ -1248,26 +1258,37 @@ def _table_evidence(connection: sqlite3.Connection, table_name: str) -> TableEvi
     quoted = '"' + table_name.replace('"', '""') + '"'
     # The identifier comes only from sqlite_master and is escaped as a quoted
     # SQLite identifier; DB-API parameters cannot represent identifiers.
-    column_names = {
-        str(row[1]).casefold()
-        for row in connection.execute(f"PRAGMA table_xinfo({quoted})").fetchall()  # nosec B608
-    }
+    column_rows = connection.execute(f"PRAGMA table_xinfo({quoted})").fetchall()  # nosec B608
+    column_names = {str(row[1]).casefold() for row in column_rows}
+    # VIRTUAL generated values are derived from schema SQL plus stored base
+    # columns. Selecting them would evaluate schema functions during evidence
+    # capture, before a migration can fail closed. Preserve ordinary and STORED
+    # generated values; keep virtual-table hidden columns excluded as SELECT *
+    # did historically.
+    stored_column_names = [str(row[1]) for row in column_rows if int(row[6]) in {0, 3}]
+    if not stored_column_names:
+        raise SQLiteMaintenanceError("table has no stored evidence columns")
+    stored_projection = ",".join(
+        '"' + column_name.replace('"', '""') + '"' for column_name in stored_column_names
+    )
     rowid_alias = next(
         (alias for alias in ("rowid", "_rowid_", "oid") if alias not in column_names),
         None,
     )
     if rowid_alias is None:
-        cursor = connection.execute(f"SELECT * FROM {quoted}")  # nosec B608
+        cursor = connection.execute(f"SELECT {stored_projection} FROM {quoted}")  # nosec B608
     else:
         try:
             # An unshadowed SQLite rowid alias captures row identity that is
             # intentionally omitted by SELECT *. WITHOUT ROWID tables reject
             # the alias and use their complete declared primary key instead.
-            cursor = connection.execute(f"SELECT {rowid_alias},* FROM {quoted}")  # nosec B608
+            cursor = connection.execute(
+                f"SELECT {rowid_alias},{stored_projection} FROM {quoted}"  # nosec B608
+            )
         except sqlite3.OperationalError as exc:
             if "no such column" not in str(exc).casefold():
                 raise
-            cursor = connection.execute(f"SELECT * FROM {quoted}")  # nosec B608
+            cursor = connection.execute(f"SELECT {stored_projection} FROM {quoted}")  # nosec B608
     row_hashes: list[bytes] = []
     row_count = 0
     for row in cursor:

--- a/robo_trader/maintenance/sqlite_service.py
+++ b/robo_trader/maintenance/sqlite_service.py
@@ -112,6 +112,8 @@ class _StagedTarget:
             raise SQLiteMaintenanceError("platform cannot publish an anonymous database safely")
         self.published = True
         self._assert_published_identity()
+        os.fsync(self.parent_file_descriptor)
+        self._assert_published_identity()
 
     def _clone_anonymous_on_macos(self) -> None:
         """Clone an unlinked source fd into an exclusive APFS destination."""
@@ -140,8 +142,6 @@ class _StagedTarget:
         self.guardian_file_descriptor = published_descriptor
         self.device = metadata.st_dev
         self.inode = metadata.st_ino
-        os.fsync(self.parent_file_descriptor)
-        self._assert_published_identity()
 
     def _assert_published_identity(self) -> None:
         """Bind the requested lexical path to the published inode and parent."""
@@ -390,7 +390,15 @@ class SQLiteMaintenanceService:
         source = self._open_source(source_candidate)
         connection: sqlite3.Connection | None = None
         try:
-            connection, source = self._connect_bound(source, readonly=True)
+            connection, source = self._connect_bound(
+                source,
+                readonly=True,
+                # A cleanly closed WAL database has no companions, but a
+                # conventional read-only open may create its own -wal/-shm
+                # files.  Immutable mode is safe only in the companion-free
+                # case and keeps the identity set stable while we inspect it.
+                immutable_readonly=not companions,
+            )
             connection.execute("BEGIN")
             evidence = _database_evidence(connection)
             source.assert_connection_identity(sqlite_connection_file_identity(connection))
@@ -499,7 +507,10 @@ class SQLiteMaintenanceService:
             source_connection, source = self._connect_bound(
                 source,
                 readonly=True,
-                immutable_readonly=expected_source_manifest is not None,
+                # Manifest restore inputs are sealed standalone artifacts.
+                # A companion-free WAL database is likewise checkpointed and
+                # can be opened immutably, avoiding service-created sidecars.
+                immutable_readonly=(expected_source_manifest is not None or not source_companions),
             )
             source_connection.execute("BEGIN")
             source_evidence = _database_evidence(source_connection)

--- a/robo_trader/maintenance/sqlite_service.py
+++ b/robo_trader/maintenance/sqlite_service.py
@@ -419,6 +419,10 @@ class SQLiteMaintenanceService:
         ) -> tuple[DatabaseEvidence, str, str | None]:
             outcome = "applied_to_synthetic_copy"
             error_code: str | None = None
+            plan_can_write = any(step.sql.strip().upper() != "SELECT 1" for step in plan.steps)
+            if plan_can_write and _schema_function_calls(connection):
+                connection.set_authorizer(_post_migration_authorizer)
+                return before, "rolled_back", "migration_plan_failed"
             page_size = int(connection.execute("PRAGMA page_size").fetchone()[0])
             page_count = int(connection.execute("PRAGMA page_count").fetchone()[0])
             growth_pages = math.ceil(self._max_migration_growth_bytes / page_size)
@@ -428,6 +432,19 @@ class SQLiteMaintenanceService:
             )
             if configured_maximum != maximum_page_count:
                 raise SQLiteMaintenanceError("synthetic migration growth limit is unavailable")
+            temp_page_size = int(connection.execute("PRAGMA temp.page_size").fetchone()[0])
+            temp_page_count = int(connection.execute("PRAGMA temp.page_count").fetchone()[0])
+            temp_growth_pages = math.ceil(self._max_migration_growth_bytes / temp_page_size)
+            maximum_temp_page_count = temp_page_count + temp_growth_pages
+            configured_temp_maximum = int(
+                connection.execute(
+                    f"PRAGMA temp.max_page_count={maximum_temp_page_count}"
+                ).fetchone()[0]
+            )
+            if configured_temp_maximum != maximum_temp_page_count:
+                raise SQLiteMaintenanceError(
+                    "synthetic migration temporary growth limit is unavailable"
+                )
             connection.execute("BEGIN IMMEDIATE")
             connection.set_authorizer(_migration_authorizer)
             migration_started = time.monotonic()
@@ -439,7 +456,7 @@ class SQLiteMaintenanceService:
                 return int(migration_deadline_exceeded())
 
             try:
-                connection.set_progress_handler(enforce_migration_deadline, 1000)
+                connection.set_progress_handler(enforce_migration_deadline, 1)
                 try:
                     for step in plan.steps:
                         connection.execute(step.sql, step.parameters)
@@ -983,6 +1000,7 @@ def _validate_migration_plan(plan: MigrationPlan) -> None:
         raise SQLiteMaintenanceError("migration plan has an invalid public identifier")
     if type(plan.steps) is not tuple or not 1 <= len(plan.steps) <= 256:
         raise SQLiteMaintenanceError("migration plan must contain 1-256 ordered steps")
+    total_parameter_bytes = 0
     for step in plan.steps:
         if (
             type(step) is not MigrationStep
@@ -993,21 +1011,90 @@ def _validate_migration_plan(plan: MigrationPlan) -> None:
             or len(step.parameters) > 1024
         ):
             raise SQLiteMaintenanceError("migration plan contains an invalid step")
-        if re.search(r"\b(?:length|printf|substr)\b", step.sql, flags=re.IGNORECASE):
-            raise SQLiteMaintenanceError("migration plan calls a reserved SQLite function")
+        _validate_migration_statement(step)
         for parameter in step.parameters:
             if type(parameter) not in (str, int, float, bytes, type(None)):
                 raise SQLiteMaintenanceError("migration step parameter type is unsupported")
             if isinstance(parameter, float) and not math.isfinite(parameter):
                 raise SQLiteMaintenanceError("migration step parameter must be finite")
-            if isinstance(parameter, (str, bytes)) and len(parameter) > 4 * 1024 * 1024:
+            if isinstance(parameter, str):
+                parameter_size = len(parameter.encode("utf-8"))
+            elif isinstance(parameter, bytes):
+                parameter_size = len(parameter)
+            else:
+                parameter_size = 0
+            if parameter_size > 4 * 1024 * 1024:
                 raise SQLiteMaintenanceError("migration step parameter is too large")
+            total_parameter_bytes += parameter_size
+            if total_parameter_bytes > 16 * 1024 * 1024:
+                raise SQLiteMaintenanceError("migration plan parameters are too large")
     if plan.target_user_version is not None and (
         isinstance(plan.target_user_version, bool)
         or not isinstance(plan.target_user_version, int)
         or not 0 <= plan.target_user_version <= 2_147_483_647
     ):
         raise SQLiteMaintenanceError("migration target user version is invalid")
+
+
+_MIGRATION_IDENTIFIER = r"[A-Za-z_][A-Za-z0-9_]*"
+_MIGRATION_TYPE = r"(?:INTEGER|REAL|TEXT|BLOB|NUMERIC)"
+_MIGRATION_LITERAL = r"(?:NULL|[-+]?(?:\d+(?:\.\d*)?|\.\d+)|'(?:''|[^'])*')"
+_MIGRATION_COLUMN = (
+    rf"{_MIGRATION_IDENTIFIER}\s+{_MIGRATION_TYPE}"
+    rf"(?:\s+PRIMARY\s+KEY)?(?:\s+NOT\s+NULL)?"
+    rf"(?:\s+DEFAULT\s+{_MIGRATION_LITERAL})?"
+)
+_MIGRATION_STATEMENTS = (
+    re.compile(r"SELECT\s+1", re.IGNORECASE | re.ASCII),
+    re.compile(
+        rf"CREATE\s+TABLE\s+{_MIGRATION_IDENTIFIER}\s*\(\s*"
+        rf"{_MIGRATION_COLUMN}(?:\s*,\s*{_MIGRATION_COLUMN})*\s*\)",
+        re.IGNORECASE | re.ASCII,
+    ),
+    re.compile(
+        rf"DROP\s+TABLE\s+{_MIGRATION_IDENTIFIER}",
+        re.IGNORECASE | re.ASCII,
+    ),
+    re.compile(
+        rf"ALTER\s+TABLE\s+{_MIGRATION_IDENTIFIER}\s+ADD\s+COLUMN\s+" rf"{_MIGRATION_COLUMN}",
+        re.IGNORECASE | re.ASCII,
+    ),
+    re.compile(
+        rf"INSERT\s+INTO\s+{_MIGRATION_IDENTIFIER}\s*\(\s*"
+        rf"{_MIGRATION_IDENTIFIER}(?:\s*,\s*{_MIGRATION_IDENTIFIER})*\s*\)"
+        rf"\s+VALUES\s*\(\s*\?(?:\s*,\s*\?)*\s*\)",
+        re.IGNORECASE | re.ASCII,
+    ),
+    re.compile(
+        rf"UPDATE\s+{_MIGRATION_IDENTIFIER}\s+SET\s+{_MIGRATION_IDENTIFIER}\s*=\s*\?"
+        rf"\s+WHERE\s+{_MIGRATION_IDENTIFIER}\s*=\s*\?"
+        rf"(?:\s+AND\s+{_MIGRATION_IDENTIFIER}\s*=\s*\?)*",
+        re.IGNORECASE | re.ASCII,
+    ),
+    re.compile(
+        rf"DELETE\s+FROM\s+{_MIGRATION_IDENTIFIER}"
+        rf"\s+WHERE\s+{_MIGRATION_IDENTIFIER}\s*=\s*\?"
+        rf"(?:\s+AND\s+{_MIGRATION_IDENTIFIER}\s*=\s*\?)*",
+        re.IGNORECASE | re.ASCII,
+    ),
+)
+
+
+def _validate_migration_statement(step: MigrationStep) -> None:
+    """Accept only the small reviewed migration grammar.
+
+    SQLite's authorizer and resource limits remain defense in depth; raw SQL is
+    not treated as a sandbox. Identifiers are simple ASCII names, values in DML
+    are parameters, UPDATE/DELETE require equality predicates, and schema
+    expressions, TEMP objects, PRAGMAs, functions, comments, and transaction
+    controls have no grammar production.
+    """
+
+    statement = step.sql.strip()
+    if not any(pattern.fullmatch(statement) for pattern in _MIGRATION_STATEMENTS):
+        raise SQLiteMaintenanceError("migration statement is outside the supported grammar")
+    if statement.count("?") != len(step.parameters):
+        raise SQLiteMaintenanceError("migration statement parameter count does not match")
 
 
 def _database_evidence(connection: sqlite3.Connection) -> DatabaseEvidence:
@@ -1050,6 +1137,40 @@ def _database_evidence(connection: sqlite3.Connection) -> DatabaseEvidence:
         user_version=user_version,
         schema_version=schema_version,
     )
+
+
+def _schema_function_calls(connection: sqlite3.Connection) -> tuple[str, ...]:
+    """Find callable SQLite functions embedded in persistent schema SQL.
+
+    SQLite does not consistently emit an authorizer callback while evaluating
+    functions stored in CHECK constraints, generated columns, defaults,
+    expression indexes, views, or triggers. A synthetic migration therefore
+    fails closed before plan writes when the copied schema names any function
+    registered on this isolated connection.
+    """
+
+    function_names = {
+        str(row[0]).casefold()
+        for row in connection.execute("PRAGMA function_list").fetchall()
+        if row and isinstance(row[0], str) and row[0]
+    }
+    schema_fragments = [
+        str(row[0])
+        for row in connection.execute(
+            "SELECT sql FROM sqlite_master WHERE sql IS NOT NULL"
+        ).fetchall()
+    ]
+    combined_schema = "\n".join(schema_fragments)
+    found: list[str] = []
+    for name in sorted(function_names):
+        escaped = re.escape(name)
+        if re.search(
+            rf'(?<![A-Za-z0-9_])(?:["`\[])?{escaped}(?:["`\]])?\s*\(',
+            combined_schema,
+            flags=re.IGNORECASE,
+        ):
+            found.append(name)
+    return tuple(found)
 
 
 def _single_check(connection: sqlite3.Connection, pragma: str) -> str:
@@ -1138,8 +1259,16 @@ def _migration_authorizer(
 ) -> int:
     denied = {
         sqlite3.SQLITE_ATTACH,
+        sqlite3.SQLITE_CREATE_TEMP_INDEX,
+        sqlite3.SQLITE_CREATE_TEMP_TABLE,
+        sqlite3.SQLITE_CREATE_TEMP_TRIGGER,
+        sqlite3.SQLITE_CREATE_TEMP_VIEW,
         sqlite3.SQLITE_CREATE_VTABLE,
         sqlite3.SQLITE_DETACH,
+        sqlite3.SQLITE_DROP_TEMP_INDEX,
+        sqlite3.SQLITE_DROP_TEMP_TABLE,
+        sqlite3.SQLITE_DROP_TEMP_TRIGGER,
+        sqlite3.SQLITE_DROP_TEMP_VIEW,
         sqlite3.SQLITE_DROP_VTABLE,
         sqlite3.SQLITE_SAVEPOINT,
         sqlite3.SQLITE_TRANSACTION,

--- a/robo_trader/maintenance/sqlite_service.py
+++ b/robo_trader/maintenance/sqlite_service.py
@@ -14,6 +14,7 @@ import re
 import sqlite3
 import stat
 import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Iterable, Mapping, Sequence
@@ -22,6 +23,8 @@ from robo_trader.maintenance.models import (
     DatabaseEvidence,
     MaintenanceManifest,
     MigrationDryRunReport,
+    MigrationPlan,
+    MigrationStep,
     TableEvidence,
 )
 from robo_trader.safety.sqlite_identity import (
@@ -31,12 +34,47 @@ from robo_trader.safety.sqlite_identity import (
     sqlite_connection_file_identity,
 )
 
-MigrationCallback = Callable[[sqlite3.Connection], None]
 ProgressHook = Callable[[str, int, int], None]
 
 
 class SQLiteMaintenanceError(RuntimeError):
     """A maintenance operation failed closed."""
+
+
+@dataclass(slots=True)
+class _TargetReservation:
+    """Exclusive reservation for a new database and all SQLite sidecar names."""
+
+    binding: SQLitePathBinding
+    companions: dict[Path, tuple[int, int, int]]
+
+    def release(self) -> None:
+        error: SQLiteMaintenanceError | None = None
+        for path, (descriptor, device, inode) in self.companions.items():
+            try:
+                descriptor_metadata = os.fstat(descriptor)
+                path_metadata = os.lstat(path)
+                if (
+                    not stat.S_ISREG(descriptor_metadata.st_mode)
+                    or descriptor_metadata.st_nlink != 1
+                    or descriptor_metadata.st_size != 0
+                    or (descriptor_metadata.st_dev, descriptor_metadata.st_ino) != (device, inode)
+                    or (path_metadata.st_dev, path_metadata.st_ino) != (device, inode)
+                ):
+                    raise SQLiteMaintenanceError(
+                        "target SQLite sidecar reservation changed during operation"
+                    )
+                os.unlink(path)
+            except (OSError, SQLiteMaintenanceError) as exc:
+                error = SQLiteMaintenanceError(
+                    "target SQLite sidecar reservation could not be released safely"
+                )
+                error.__cause__ = exc
+            finally:
+                os.close(descriptor)
+        self.companions.clear()
+        if error is not None:
+            raise error
 
 
 class SQLiteMaintenanceService:
@@ -62,10 +100,16 @@ class SQLiteMaintenanceService:
 
         database_candidate = _absolute_canonical_path(database_path)
         companions = _safe_companion_identities(database_candidate)
+        if companions:
+            raise SQLiteMaintenanceError(
+                "read-only verification requires a sealed database without SQLite companions"
+            )
         binding = self._open_source(database_candidate)
         connection: sqlite3.Connection | None = None
         try:
-            connection, binding = self._connect_bound(binding, readonly=True)
+            connection, binding = self._connect_bound(
+                binding, readonly=True, immutable_readonly=True
+            )
             evidence = _database_evidence(connection)
             binding.assert_connection_identity(sqlite_connection_file_identity(connection))
             artifact_sha256, artifact_size = _descriptor_digest(binding.guardian_file_descriptor)
@@ -105,8 +149,12 @@ class SQLiteMaintenanceService:
 
         if manifest.operation != "backup":
             raise SQLiteMaintenanceError("clean-room restore requires a backup manifest")
-        self.verify(backup_path, manifest)
-        restored = self._online_copy(backup_path, target_path, operation="restore")
+        restored = self._online_copy(
+            backup_path,
+            target_path,
+            operation="restore",
+            expected_source_manifest=manifest,
+        )
         if restored.evidence != manifest.evidence:
             raise SQLiteMaintenanceError("clean-room restore evidence differs from backup")
         return MaintenanceManifest(
@@ -124,20 +172,33 @@ class SQLiteMaintenanceService:
         source_path: Path | str,
         synthetic_target_path: Path | str,
         *,
-        migration_id: str,
-        migration: MigrationCallback,
+        plan: MigrationPlan,
     ) -> MigrationDryRunReport:
-        """Apply a callback transactionally to a new synthetic snapshot only.
+        """Apply a declarative plan transactionally to a synthetic snapshot.
 
-        The callback receives the disposable target connection.  Transaction,
-        ATTACH, and DETACH statements are denied so the service retains the
-        rollback boundary and the callback cannot reach another database.
+        Callers never receive the SQLite connection. Transaction, ATTACH, and
+        DETACH statements are denied so the service retains the rollback
+        boundary and the plan cannot reach another database.
         """
 
-        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", migration_id):
-            raise SQLiteMaintenanceError("migration_id must be a bounded public identifier")
+        _validate_migration_plan(plan)
         source_before = self.verify(source_path)
-        self._online_copy(source_path, synthetic_target_path, operation="backup", seal=False)
+        source_before_hash, source_before_size = _path_digest(_absolute_canonical_path(source_path))
+        source_manifest = MaintenanceManifest(
+            manifest_version=1,
+            operation="backup",
+            created_at=_utc_now(),
+            artifact_sha256=source_before_hash,
+            artifact_size=source_before_size,
+            evidence=source_before,
+        )
+        self._online_copy(
+            source_path,
+            synthetic_target_path,
+            operation="backup",
+            seal=False,
+            expected_source_manifest=source_manifest,
+        )
         target = self._open_source(synthetic_target_path, writable=True)
         connection: sqlite3.Connection | None = None
         outcome = "applied_to_synthetic_copy"
@@ -148,7 +209,10 @@ class SQLiteMaintenanceService:
             connection.execute("BEGIN IMMEDIATE")
             connection.set_authorizer(_migration_authorizer)
             try:
-                migration(connection)
+                for step in plan.steps:
+                    connection.execute(step.sql, step.parameters)
+                if plan.target_user_version is not None:
+                    connection.execute(f"PRAGMA user_version={plan.target_user_version}")
                 interim = _database_evidence(connection)
                 if interim.integrity_check != "ok" or interim.foreign_key_violations:
                     raise SQLiteMaintenanceError("migration produced invalid SQLite state")
@@ -156,7 +220,7 @@ class SQLiteMaintenanceService:
                 connection.set_authorizer(None)
                 connection.rollback()
                 outcome = "rolled_back"
-                error_code = "migration_callback_failed"
+                error_code = "migration_plan_failed"
             else:
                 connection.set_authorizer(None)
                 connection.commit()
@@ -172,15 +236,20 @@ class SQLiteMaintenanceService:
 
         after = self.verify(synthetic_target_path)
         source_after = self.verify(source_path)
+        source_after_hash, _ = _path_digest(_absolute_canonical_path(source_path))
+        source_unchanged = source_before == source_after and source_before_hash == source_after_hash
+        if not source_unchanged:
+            outcome = "source_changed_fail_closed"
+            error_code = "authoritative_source_changed"
         artifact_sha256, _ = _path_digest(_absolute_canonical_path(synthetic_target_path))
         return MigrationDryRunReport(
             report_version=1,
-            migration_id=migration_id,
+            migration_id=plan.migration_id,
             created_at=_utc_now(),
             outcome=outcome,
             before=before,
             after=after,
-            source_unchanged=source_before == source_after,
+            source_unchanged=source_unchanged,
             target_artifact_sha256=artifact_sha256,
             error_code=error_code,
         )
@@ -267,6 +336,7 @@ class SQLiteMaintenanceService:
         *,
         operation: str,
         seal: bool = True,
+        expected_source_manifest: MaintenanceManifest | None = None,
     ) -> MaintenanceManifest:
         source_candidate = _absolute_canonical_path(source_path)
         target_candidate = _absolute_canonical_path(target_path)
@@ -274,19 +344,46 @@ class SQLiteMaintenanceService:
             raise SQLiteMaintenanceError("source and target SQLite resource families overlap")
         source_companions = _safe_companion_identities(source_candidate)
         source = self._open_source(source_candidate)
+        source_connection: sqlite3.Connection | None = None
         try:
-            target = self._reserve_target(target_candidate)
+            source_connection, source = self._connect_bound(
+                source,
+                readonly=True,
+                immutable_readonly=expected_source_manifest is not None,
+            )
+            source_connection.execute("BEGIN")
+            source_evidence = _database_evidence(source_connection)
+            source_artifact_sha256, source_artifact_size = _descriptor_digest(
+                source.guardian_file_descriptor
+            )
+            if expected_source_manifest is not None and (
+                expected_source_manifest.artifact_sha256 != source_artifact_sha256
+                or expected_source_manifest.artifact_size != source_artifact_size
+                or expected_source_manifest.evidence != source_evidence
+            ):
+                raise SQLiteMaintenanceError("copy source does not match the supplied manifest")
+            reservation = self._reserve_target(target_candidate)
+            target = reservation.binding
+        except (sqlite3.Error, SQLiteIdentityError, OSError) as exc:
+            if source_connection is not None:
+                source_connection.close()
+            source.close()
+            raise SQLiteMaintenanceError("copy source verification failed closed") from exc
         except BaseException:
+            if source_connection is not None:
+                source_connection.close()
             source.close()
             raise
-        source_connection: sqlite3.Connection | None = None
         target_connection: sqlite3.Connection | None = None
         succeeded = False
         try:
+            if source_connection is None:
+                raise SQLiteMaintenanceError("copy source connection is unavailable")
             if (source.device, source.inode) == (target.device, target.inode):
                 raise SQLiteMaintenanceError("source and target identities must differ")
-            source_connection, source = self._connect_bound(source, readonly=True)
-            target_connection, target = self._connect_bound(target, readonly=False)
+            target_connection, target = self._connect_bound(
+                target, readonly=False, journal_off=True
+            )
             source_db = source_connection
             target_db = target_connection
             copy_started = time.monotonic()
@@ -310,6 +407,19 @@ class SQLiteMaintenanceService:
             _assert_single_link(target)
             _assert_companion_identities(source.path, source_companions)
             evidence = _database_evidence(target_connection)
+            final_source_sha256, final_source_size = _descriptor_digest(
+                source.guardian_file_descriptor
+            )
+            if (
+                final_source_sha256 != source_artifact_sha256
+                or final_source_size != source_artifact_size
+            ):
+                raise SQLiteMaintenanceError("copy source changed during operation")
+            if (
+                expected_source_manifest is not None
+                and evidence != expected_source_manifest.evidence
+            ):
+                raise SQLiteMaintenanceError("copied evidence differs from supplied manifest")
             target_connection.close()
             target_connection = None
             if seal:
@@ -328,6 +438,12 @@ class SQLiteMaintenanceService:
                 artifact_size=artifact_size,
                 evidence=evidence,
             )
+            reservation.release()
+            if _safe_companion_identities(target.path):
+                raise SQLiteMaintenanceError(
+                    "target SQLite companions appeared after reservation release"
+                )
+            _fsync_directory(target.path.parent)
             succeeded = True
             return manifest
         except (sqlite3.Error, SQLiteIdentityError, OSError) as exc:
@@ -337,10 +453,14 @@ class SQLiteMaintenanceService:
                 target_connection.close()
             if source_connection is not None:
                 source_connection.close()
-            if not succeeded:
-                _seal_forensic_target(target)
-            source.close()
-            target.close()
+            try:
+                if not succeeded:
+                    _seal_forensic_target(target)
+                if reservation.companions:
+                    reservation.release()
+            finally:
+                source.close()
+                target.close()
 
     @staticmethod
     def _open_source(
@@ -369,7 +489,7 @@ class SQLiteMaintenanceService:
         return binding
 
     @staticmethod
-    def _reserve_target(target_path: Path | str) -> SQLitePathBinding:
+    def _reserve_target(target_path: Path | str) -> _TargetReservation:
         path = _absolute_canonical_path(target_path)
         try:
             parent = os.lstat(path.parent)
@@ -377,20 +497,50 @@ class SQLiteMaintenanceService:
             raise SQLiteMaintenanceError("target parent does not exist") from exc
         if stat.S_ISLNK(parent.st_mode) or not stat.S_ISDIR(parent.st_mode):
             raise SQLiteMaintenanceError("target parent must be a non-symlink directory")
+        family = _sqlite_resource_family(path)
+        for member in family:
+            try:
+                os.lstat(member)
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                raise SQLiteMaintenanceError("target SQLite family cannot be inspected") from exc
+            raise SQLiteMaintenanceError("target must be a new exclusively-created SQLite family")
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+        companions: dict[Path, tuple[int, int, int]] = {}
+        binding: SQLitePathBinding | None = None
         try:
-            return SQLitePathBinding.open_for_initialization(path, create=True)
+            for suffix in ("-journal", "-shm", "-wal"):
+                companion = path.with_name(path.name + suffix)
+                descriptor = os.open(companion, flags, 0o400)
+                metadata = os.fstat(descriptor)
+                companions[companion] = (descriptor, metadata.st_dev, metadata.st_ino)
+            binding = SQLitePathBinding.open_for_initialization(path, create=True)
+            return _TargetReservation(binding=binding, companions=companions)
         except Exception as exc:
-            raise SQLiteMaintenanceError("target must be a new exclusively-created path") from exc
+            if binding is not None:
+                binding.close()
+            reservation = _TargetReservation(binding=binding, companions=companions)  # type: ignore[arg-type]
+            try:
+                reservation.release()
+            except SQLiteMaintenanceError:
+                pass
+            raise SQLiteMaintenanceError(
+                "target must be a new exclusively-created SQLite family"
+            ) from exc
 
     @staticmethod
     def _connect_bound(
         binding: SQLitePathBinding,
         *,
         readonly: bool,
+        journal_off: bool = False,
+        immutable_readonly: bool = False,
     ) -> tuple[sqlite3.Connection, SQLitePathBinding]:
         mode = "ro" if readonly else "rw"
+        immutable = "&immutable=1" if immutable_readonly else ""
         connection = sqlite3.connect(
-            binding.path.as_uri() + f"?mode={mode}",
+            binding.path.as_uri() + f"?mode={mode}{immutable}",
             uri=True,
             timeout=10.0,
         )
@@ -399,6 +549,10 @@ class SQLiteMaintenanceService:
             binding.assert_connection_identity(sqlite_connection_file_identity(connection))
             if readonly:
                 connection.execute("PRAGMA query_only=ON")
+            if journal_off:
+                mode_row = connection.execute("PRAGMA journal_mode=OFF").fetchone()
+                if mode_row is None or str(mode_row[0]).lower() != "off":
+                    raise SQLiteMaintenanceError("copy target journaling could not be disabled")
             connection.execute("PRAGMA foreign_keys=ON")
             return connection, binding
         except BaseException:
@@ -414,6 +568,38 @@ def _absolute_canonical_path(path: Path | str) -> Path:
     if protected != candidate:
         raise SQLiteMaintenanceError("maintenance path parent must be canonical")
     return protected
+
+
+def _validate_migration_plan(plan: MigrationPlan) -> None:
+    if type(plan) is not MigrationPlan or not re.fullmatch(
+        r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", plan.migration_id
+    ):
+        raise SQLiteMaintenanceError("migration plan has an invalid public identifier")
+    if type(plan.steps) is not tuple or not 1 <= len(plan.steps) <= 256:
+        raise SQLiteMaintenanceError("migration plan must contain 1-256 ordered steps")
+    for step in plan.steps:
+        if (
+            type(step) is not MigrationStep
+            or type(step.sql) is not str
+            or not step.sql.strip()
+            or len(step.sql.encode("utf-8")) > 128 * 1024
+            or type(step.parameters) is not tuple
+            or len(step.parameters) > 1024
+        ):
+            raise SQLiteMaintenanceError("migration plan contains an invalid step")
+        for parameter in step.parameters:
+            if type(parameter) not in (str, int, float, bytes, type(None)):
+                raise SQLiteMaintenanceError("migration step parameter type is unsupported")
+            if isinstance(parameter, float) and not math.isfinite(parameter):
+                raise SQLiteMaintenanceError("migration step parameter must be finite")
+            if isinstance(parameter, (str, bytes)) and len(parameter) > 4 * 1024 * 1024:
+                raise SQLiteMaintenanceError("migration step parameter is too large")
+    if plan.target_user_version is not None and (
+        isinstance(plan.target_user_version, bool)
+        or not isinstance(plan.target_user_version, int)
+        or not 0 <= plan.target_user_version <= 2_147_483_647
+    ):
+        raise SQLiteMaintenanceError("migration target user version is invalid")
 
 
 def _database_evidence(connection: sqlite3.Connection) -> DatabaseEvidence:
@@ -473,7 +659,11 @@ def _table_evidence(connection: sqlite3.Connection, table_name: str) -> TableEvi
     digest = hashlib.sha256()
     for row_hash in row_hashes:
         digest.update(row_hash)
-    return TableEvidence(table_name, row_count, digest.hexdigest())
+    return TableEvidence(
+        hashlib.sha256(table_name.encode("utf-8")).hexdigest(),
+        row_count,
+        digest.hexdigest(),
+    )
 
 
 def _hash_rows(rows: Iterable[Sequence[object]]) -> str:
@@ -606,9 +796,8 @@ def _assert_companion_identities(
     expected: Mapping[str, tuple[int, int]],
 ) -> None:
     current = _safe_companion_identities(path)
-    for suffix, identity in expected.items():
-        if current.get(suffix) != identity:
-            raise SQLiteMaintenanceError("SQLite companion identity changed during operation")
+    if current != expected:
+        raise SQLiteMaintenanceError("SQLite companion identity changed during operation")
 
 
 def _descriptor_digest(descriptor: int) -> tuple[str, int]:

--- a/robo_trader/maintenance/sqlite_service.py
+++ b/robo_trader/maintenance/sqlite_service.py
@@ -119,6 +119,15 @@ class _StagedTarget:
             self.requested_path.name,
         )
         self.published = True
+        self._assert_published_identity()
+        os.fsync(self.parent_file_descriptor)
+        self._assert_published_identity()
+
+    def _assert_published_identity(self) -> None:
+        """Bind the requested lexical path to the published inode and parent."""
+
+        parent = os.fstat(self.parent_file_descriptor)
+        current_parent = os.lstat(self.requested_path.parent)
         descriptor_metadata = os.fstat(self.guardian_file_descriptor)
         path_metadata = os.lstat(self.requested_path)
         bound_metadata = os.stat(
@@ -128,7 +137,11 @@ class _StagedTarget:
         )
         expected = (self.device, self.inode)
         if (
-            not stat.S_ISREG(descriptor_metadata.st_mode)
+            not stat.S_ISDIR(parent.st_mode)
+            or stat.S_ISLNK(current_parent.st_mode)
+            or not stat.S_ISDIR(current_parent.st_mode)
+            or (parent.st_dev, parent.st_ino) != (current_parent.st_dev, current_parent.st_ino)
+            or not stat.S_ISREG(descriptor_metadata.st_mode)
             or descriptor_metadata.st_nlink != 1
             or (descriptor_metadata.st_dev, descriptor_metadata.st_ino) != expected
             or stat.S_ISLNK(path_metadata.st_mode)
@@ -143,7 +156,18 @@ class _StagedTarget:
             raise SQLiteMaintenanceError(
                 "target SQLite companion appeared during atomic publication"
             )
-        _fsync_directory(self.requested_path.parent)
+        current_parent_after = os.lstat(self.requested_path.parent)
+        path_after = os.lstat(self.requested_path)
+        if (
+            stat.S_ISLNK(current_parent_after.st_mode)
+            or not stat.S_ISDIR(current_parent_after.st_mode)
+            or (current_parent_after.st_dev, current_parent_after.st_ino)
+            != (parent.st_dev, parent.st_ino)
+            or stat.S_ISLNK(path_after.st_mode)
+            or not stat.S_ISREG(path_after.st_mode)
+            or (path_after.st_dev, path_after.st_ino) != expected
+        ):
+            raise SQLiteMaintenanceError("published database identity changed")
 
     def seal_forensic(self) -> None:
         try:
@@ -279,16 +303,6 @@ class SQLiteMaintenanceService:
         """
 
         _validate_migration_plan(plan)
-        source_before = self.verify(source_path)
-        source_before_hash, source_before_size = _path_digest(_absolute_canonical_path(source_path))
-        source_manifest = MaintenanceManifest(
-            manifest_version=1,
-            operation="backup",
-            created_at=_utc_now(),
-            artifact_sha256=source_before_hash,
-            artifact_size=source_before_size,
-            evidence=source_before,
-        )
 
         def apply_plan(
             connection: sqlite3.Connection,
@@ -324,7 +338,6 @@ class SQLiteMaintenanceService:
             source_path,
             synthetic_target_path,
             operation="backup",
-            expected_source_manifest=source_manifest,
             target_hook=apply_plan,
         )
         if not isinstance(migration_result, tuple) or len(migration_result) != 3:
@@ -332,9 +345,8 @@ class SQLiteMaintenanceService:
         before, outcome, error_code = migration_result
 
         after = copy_manifest.evidence
-        source_after = self.verify(source_path)
-        source_after_hash, _ = _path_digest(_absolute_canonical_path(source_path))
-        source_unchanged = source_before == source_after and source_before_hash == source_after_hash
+        source_after = self._live_source_evidence(source_path)
+        source_unchanged = before == source_after
         if not source_unchanged:
             outcome = "source_changed_fail_closed"
             error_code = "authoritative_source_changed"
@@ -349,6 +361,28 @@ class SQLiteMaintenanceService:
             target_artifact_sha256=copy_manifest.artifact_sha256,
             error_code=error_code,
         )
+
+    def _live_source_evidence(self, source_path: Path | str) -> DatabaseEvidence:
+        """Capture logical evidence from a bound read snapshot, including WAL state."""
+
+        source_candidate = _absolute_canonical_path(source_path)
+        companions = _safe_companion_identities(source_candidate)
+        source = self._open_source(source_candidate)
+        connection: sqlite3.Connection | None = None
+        try:
+            connection, source = self._connect_bound(source, readonly=True)
+            connection.execute("BEGIN")
+            evidence = _database_evidence(connection)
+            source.assert_connection_identity(sqlite_connection_file_identity(connection))
+            _assert_single_link(source)
+            _assert_companion_identities(source.path, companions)
+            return evidence
+        except (sqlite3.Error, SQLiteIdentityError, OSError) as exc:
+            raise SQLiteMaintenanceError("live SQLite evidence failed closed") from exc
+        finally:
+            if connection is not None:
+                connection.close()
+            source.close()
 
     def write_manifest(
         self,
@@ -449,15 +483,18 @@ class SQLiteMaintenanceService:
             )
             source_connection.execute("BEGIN")
             source_evidence = _database_evidence(source_connection)
-            source_artifact_sha256, source_artifact_size = _descriptor_digest(
-                source.guardian_file_descriptor
-            )
-            if expected_source_manifest is not None and (
-                expected_source_manifest.artifact_sha256 != source_artifact_sha256
-                or expected_source_manifest.artifact_size != source_artifact_size
-                or expected_source_manifest.evidence != source_evidence
-            ):
-                raise SQLiteMaintenanceError("copy source does not match the supplied manifest")
+            source_artifact_sha256: str | None = None
+            source_artifact_size: int | None = None
+            if expected_source_manifest is not None:
+                source_artifact_sha256, source_artifact_size = _descriptor_digest(
+                    source.guardian_file_descriptor
+                )
+                if (
+                    expected_source_manifest.artifact_sha256 != source_artifact_sha256
+                    or expected_source_manifest.artifact_size != source_artifact_size
+                    or expected_source_manifest.evidence != source_evidence
+                ):
+                    raise SQLiteMaintenanceError("copy source does not match the supplied manifest")
             staged_target = self._stage_target(target_candidate)
         except (sqlite3.Error, SQLiteIdentityError, OSError) as exc:
             if source_connection is not None:
@@ -507,14 +544,15 @@ class SQLiteMaintenanceService:
             staged_target.assert_identity()
             _assert_companion_identities(source.path, source_companions)
             evidence = _database_evidence(target_connection)
-            final_source_sha256, final_source_size = _descriptor_digest(
-                source.guardian_file_descriptor
-            )
-            if (
-                final_source_sha256 != source_artifact_sha256
-                or final_source_size != source_artifact_size
-            ):
-                raise SQLiteMaintenanceError("copy source changed during operation")
+            if expected_source_manifest is not None:
+                final_source_sha256, final_source_size = _descriptor_digest(
+                    source.guardian_file_descriptor
+                )
+                if (
+                    final_source_sha256 != source_artifact_sha256
+                    or final_source_size != source_artifact_size
+                ):
+                    raise SQLiteMaintenanceError("copy source changed during operation")
             if (
                 expected_source_manifest is not None
                 and evidence != expected_source_manifest.evidence
@@ -542,6 +580,15 @@ class SQLiteMaintenanceService:
                 evidence=evidence,
             )
             staged_target.publish()
+            published_sha256, published_size = _descriptor_digest(
+                staged_target.guardian_file_descriptor
+            )
+            staged_target._assert_published_identity()
+            if (
+                published_sha256 != manifest.artifact_sha256
+                or published_size != manifest.artifact_size
+            ):
+                raise SQLiteMaintenanceError("published database changed after manifest capture")
             succeeded = True
             return manifest, hook_result
         except (sqlite3.Error, SQLiteIdentityError, OSError) as exc:
@@ -612,7 +659,7 @@ class SQLiteMaintenanceService:
                     guardian = os.open(
                         staging_name,
                         flags,
-                        0o600,
+                        0o000,
                         dir_fd=parent_file_descriptor,
                     )
                 except FileExistsError:

--- a/robo_trader/maintenance/sqlite_service.py
+++ b/robo_trader/maintenance/sqlite_service.py
@@ -6,6 +6,7 @@ startup authority, or operation that replaces an existing database path.
 
 from __future__ import annotations
 
+import ctypes
 import hashlib
 import json
 import math
@@ -13,6 +14,7 @@ import os
 import re
 import sqlite3
 import stat
+import sys
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -47,24 +49,62 @@ class _TargetReservation:
 
     binding: SQLitePathBinding
     companions: dict[Path, tuple[int, int, int]]
+    quarantine_directory: Path
 
     def release(self) -> None:
+        """Relinquish sidecar names without ever unlinking a re-resolved path.
+
+        SQLite is allowed to consume an empty reservation itself.  Reservations
+        that remain are moved with a kernel-enforced no-replace rename into the
+        operation's private quarantine directory.  They are deliberately left
+        there as zero-byte tombstones: POSIX has no pathname unlink primitive
+        that is bound to an already-open descriptor, so deleting them would
+        reintroduce a check/use race against same-user pathname substitution.
+        """
+
         error: SQLiteMaintenanceError | None = None
         for path, (descriptor, device, inode) in self.companions.items():
             try:
                 descriptor_metadata = os.fstat(descriptor)
-                path_metadata = os.lstat(path)
                 if (
                     not stat.S_ISREG(descriptor_metadata.st_mode)
-                    or descriptor_metadata.st_nlink != 1
                     or descriptor_metadata.st_size != 0
                     or (descriptor_metadata.st_dev, descriptor_metadata.st_ino) != (device, inode)
-                    or (path_metadata.st_dev, path_metadata.st_ino) != (device, inode)
                 ):
                     raise SQLiteMaintenanceError(
                         "target SQLite sidecar reservation changed during operation"
                     )
-                os.unlink(path)
+                try:
+                    os.lstat(path)
+                except FileNotFoundError:
+                    if descriptor_metadata.st_nlink != 0:
+                        raise SQLiteMaintenanceError(
+                            "target SQLite sidecar reservation moved during operation"
+                        )
+                    continue
+
+                tombstone = self.quarantine_directory / path.name
+                _rename_noreplace(path, tombstone)
+                tombstone_metadata = os.lstat(tombstone)
+                descriptor_after = os.fstat(descriptor)
+                if (
+                    not stat.S_ISREG(tombstone_metadata.st_mode)
+                    or (tombstone_metadata.st_dev, tombstone_metadata.st_ino) != (device, inode)
+                    or (descriptor_after.st_dev, descriptor_after.st_ino) != (device, inode)
+                    or descriptor_after.st_nlink != 1
+                    or descriptor_after.st_size != 0
+                ):
+                    # The atomically claimed object was not ours.  Restore it
+                    # to its original name without overwriting any new racer;
+                    # if that name is already occupied, both objects remain
+                    # preserved and the operation still fails closed.
+                    try:
+                        _rename_noreplace(tombstone, path)
+                    except (OSError, SQLiteMaintenanceError):
+                        pass
+                    raise SQLiteMaintenanceError(
+                        "target SQLite sidecar pathname was substituted during operation"
+                    )
             except (OSError, SQLiteMaintenanceError) as exc:
                 error = SQLiteMaintenanceError(
                     "target SQLite sidecar reservation could not be released safely"
@@ -137,7 +177,8 @@ class SQLiteMaintenanceService:
     ) -> MaintenanceManifest:
         """Create and verify a WAL-safe snapshot at an exclusive new path."""
 
-        return self._online_copy(source_path, target_path, operation="backup")
+        manifest, _ = self._online_copy(source_path, target_path, operation="backup")
+        return manifest
 
     def restore_clean_room(
         self,
@@ -149,7 +190,7 @@ class SQLiteMaintenanceService:
 
         if manifest.operation != "backup":
             raise SQLiteMaintenanceError("clean-room restore requires a backup manifest")
-        restored = self._online_copy(
+        restored, _ = self._online_copy(
             backup_path,
             target_path,
             operation="restore",
@@ -192,20 +233,13 @@ class SQLiteMaintenanceService:
             artifact_size=source_before_size,
             evidence=source_before,
         )
-        self._online_copy(
-            source_path,
-            synthetic_target_path,
-            operation="backup",
-            seal=False,
-            expected_source_manifest=source_manifest,
-        )
-        target = self._open_source(synthetic_target_path, writable=True)
-        connection: sqlite3.Connection | None = None
-        outcome = "applied_to_synthetic_copy"
-        error_code: str | None = None
-        try:
-            connection, target = self._connect_bound(target, readonly=False)
-            before = _database_evidence(connection)
+
+        def apply_plan(
+            connection: sqlite3.Connection,
+            before: DatabaseEvidence,
+        ) -> tuple[DatabaseEvidence, str, str | None]:
+            outcome = "applied_to_synthetic_copy"
+            error_code: str | None = None
             connection.execute("BEGIN IMMEDIATE")
             connection.set_authorizer(_migration_authorizer)
             try:
@@ -216,23 +250,30 @@ class SQLiteMaintenanceService:
                 interim = _database_evidence(connection)
                 if interim.integrity_check != "ok" or interim.foreign_key_violations:
                     raise SQLiteMaintenanceError("migration produced invalid SQLite state")
-            except BaseException:
-                connection.set_authorizer(None)
+            except (sqlite3.Error, SQLiteMaintenanceError):
+                # Python 3.10 cannot reliably disable an authorizer by passing
+                # None.  Replace it with a completion-only policy before the
+                # service-owned rollback instead.
+                connection.set_authorizer(_migration_completion_authorizer)
                 connection.rollback()
                 outcome = "rolled_back"
                 error_code = "migration_plan_failed"
             else:
-                connection.set_authorizer(None)
+                connection.set_authorizer(_migration_completion_authorizer)
                 connection.commit()
-            target.assert_connection_identity(sqlite_connection_file_identity(connection))
-        finally:
-            if connection is not None:
-                connection.close()
-            try:
-                _seal_readonly(target)
-                _fsync_directory(target.path.parent)
-            finally:
-                target.close()
+            connection.set_authorizer(_post_migration_authorizer)
+            return before, outcome, error_code
+
+        _copy_manifest, migration_result = self._online_copy(
+            source_path,
+            synthetic_target_path,
+            operation="backup",
+            expected_source_manifest=source_manifest,
+            target_hook=apply_plan,
+        )
+        if not isinstance(migration_result, tuple) or len(migration_result) != 3:
+            raise SQLiteMaintenanceError("migration result is unavailable")
+        before, outcome, error_code = migration_result
 
         after = self.verify(synthetic_target_path)
         source_after = self.verify(source_path)
@@ -335,9 +376,9 @@ class SQLiteMaintenanceService:
         target_path: Path | str,
         *,
         operation: str,
-        seal: bool = True,
         expected_source_manifest: MaintenanceManifest | None = None,
-    ) -> MaintenanceManifest:
+        target_hook: Callable[[sqlite3.Connection, DatabaseEvidence], object] | None = None,
+    ) -> tuple[MaintenanceManifest, object | None]:
         source_candidate = _absolute_canonical_path(source_path)
         target_candidate = _absolute_canonical_path(target_path)
         if _sqlite_resource_family(source_candidate) & _sqlite_resource_family(target_candidate):
@@ -420,13 +461,21 @@ class SQLiteMaintenanceService:
                 and evidence != expected_source_manifest.evidence
             ):
                 raise SQLiteMaintenanceError("copied evidence differs from supplied manifest")
+            hook_result: object | None = None
+            if target_hook is not None:
+                target.assert_connection_identity(
+                    sqlite_connection_file_identity(target_connection)
+                )
+                _assert_single_link(target)
+                hook_result = target_hook(target_connection, evidence)
+                target.assert_connection_identity(
+                    sqlite_connection_file_identity(target_connection)
+                )
+                _assert_single_link(target)
+                evidence = _database_evidence(target_connection)
             target_connection.close()
             target_connection = None
-            if seal:
-                _seal_readonly(target)
-            else:
-                os.fsync(target.guardian_file_descriptor)
-                _assert_single_link(target)
+            _seal_readonly(target)
             _fsync_directory(target.path.parent)
             artifact_sha256, artifact_size = _descriptor_digest(target.guardian_file_descriptor)
             target.assert_path_identity()
@@ -445,7 +494,7 @@ class SQLiteMaintenanceService:
                 )
             _fsync_directory(target.path.parent)
             succeeded = True
-            return manifest
+            return manifest, hook_result
         except (sqlite3.Error, SQLiteIdentityError, OSError) as exc:
             raise SQLiteMaintenanceError("SQLite online copy failed closed") from exc
         finally:
@@ -509,18 +558,28 @@ class SQLiteMaintenanceService:
         flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
         companions: dict[Path, tuple[int, int, int]] = {}
         binding: SQLitePathBinding | None = None
+        quarantine_directory = path.parent / f".{path.name}.robo-trader-reservations"
         try:
+            os.mkdir(quarantine_directory, 0o700)
             for suffix in ("-journal", "-shm", "-wal"):
                 companion = path.with_name(path.name + suffix)
                 descriptor = os.open(companion, flags, 0o400)
                 metadata = os.fstat(descriptor)
                 companions[companion] = (descriptor, metadata.st_dev, metadata.st_ino)
             binding = SQLitePathBinding.open_for_initialization(path, create=True)
-            return _TargetReservation(binding=binding, companions=companions)
+            return _TargetReservation(
+                binding=binding,
+                companions=companions,
+                quarantine_directory=quarantine_directory,
+            )
         except Exception as exc:
             if binding is not None:
                 binding.close()
-            reservation = _TargetReservation(binding=binding, companions=companions)  # type: ignore[arg-type]
+            reservation = _TargetReservation(  # type: ignore[arg-type]
+                binding=binding,
+                companions=companions,
+                quarantine_directory=quarantine_directory,
+            )
             try:
                 reservation.release()
             except SQLiteMaintenanceError:
@@ -722,6 +781,112 @@ def _migration_authorizer(
     ):
         return sqlite3.SQLITE_DENY
     return sqlite3.SQLITE_OK
+
+
+def _migration_completion_authorizer(
+    action: int,
+    arg1: str | None,
+    arg2: str | None,
+    database: str | None,
+    trigger: str | None,
+) -> int:
+    """Permit only the service-owned transaction completion operation."""
+
+    if action == sqlite3.SQLITE_TRANSACTION:
+        return sqlite3.SQLITE_OK
+    return _migration_authorizer(action, arg1, arg2, database, trigger)
+
+
+def _post_migration_authorizer(
+    action: int,
+    arg1: str | None,
+    arg2: str | None,
+    database: str | None,
+    trigger: str | None,
+) -> int:
+    """Make the still-bound connection read-only for final evidence capture."""
+
+    write_actions = {
+        sqlite3.SQLITE_ALTER_TABLE,
+        sqlite3.SQLITE_ANALYZE,
+        sqlite3.SQLITE_CREATE_INDEX,
+        sqlite3.SQLITE_CREATE_TABLE,
+        sqlite3.SQLITE_CREATE_TEMP_INDEX,
+        sqlite3.SQLITE_CREATE_TEMP_TABLE,
+        sqlite3.SQLITE_CREATE_TEMP_TRIGGER,
+        sqlite3.SQLITE_CREATE_TEMP_VIEW,
+        sqlite3.SQLITE_CREATE_TRIGGER,
+        sqlite3.SQLITE_CREATE_VIEW,
+        sqlite3.SQLITE_CREATE_VTABLE,
+        sqlite3.SQLITE_DELETE,
+        sqlite3.SQLITE_DROP_INDEX,
+        sqlite3.SQLITE_DROP_TABLE,
+        sqlite3.SQLITE_DROP_TEMP_INDEX,
+        sqlite3.SQLITE_DROP_TEMP_TABLE,
+        sqlite3.SQLITE_DROP_TEMP_TRIGGER,
+        sqlite3.SQLITE_DROP_TEMP_VIEW,
+        sqlite3.SQLITE_DROP_TRIGGER,
+        sqlite3.SQLITE_DROP_VIEW,
+        sqlite3.SQLITE_DROP_VTABLE,
+        sqlite3.SQLITE_INSERT,
+        sqlite3.SQLITE_REINDEX,
+        sqlite3.SQLITE_SAVEPOINT,
+        sqlite3.SQLITE_UPDATE,
+    }
+    if action in write_actions:
+        return sqlite3.SQLITE_DENY
+    return _migration_authorizer(action, arg1, arg2, database, trigger)
+
+
+def _rename_noreplace(source: Path, target: Path) -> None:
+    """Atomically move a pathname without replacing any destination.
+
+    Python does not expose the platform no-replace rename flags.  Maintenance
+    fails closed on unsupported Unix VFS platforms instead of falling back to
+    ``rename(2)``, whose overwrite behavior could destroy an interposed file.
+    """
+
+    libc = ctypes.CDLL(None, use_errno=True)
+    at_fdcwd = -100
+    source_bytes = os.fsencode(source)
+    target_bytes = os.fsencode(target)
+    if sys.platform.startswith("linux"):
+        try:
+            rename = libc.renameat2
+        except AttributeError as exc:
+            raise SQLiteMaintenanceError(
+                "platform cannot quarantine a reservation without replacement"
+            ) from exc
+        rename.argtypes = (
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_uint,
+        )
+        rename.restype = ctypes.c_int
+        result = rename(at_fdcwd, source_bytes, at_fdcwd, target_bytes, 1)
+    elif sys.platform == "darwin":
+        try:
+            rename = libc.renameatx_np
+        except AttributeError as exc:
+            raise SQLiteMaintenanceError(
+                "platform cannot quarantine a reservation without replacement"
+            ) from exc
+        rename.argtypes = (
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_uint,
+        )
+        rename.restype = ctypes.c_int
+        result = rename(at_fdcwd, source_bytes, at_fdcwd, target_bytes, 0x00000004)
+    else:
+        raise SQLiteMaintenanceError("platform cannot quarantine a reservation without replacement")
+    if result != 0:
+        error_number = ctypes.get_errno()
+        raise OSError(error_number, os.strerror(error_number), str(source))
 
 
 def _assert_single_link(binding: SQLitePathBinding) -> None:

--- a/robo_trader/maintenance/sqlite_service.py
+++ b/robo_trader/maintenance/sqlite_service.py
@@ -1168,7 +1168,7 @@ def _schema_function_calls(connection: sqlite3.Connection) -> tuple[str, ...]:
             "SELECT sql FROM sqlite_master WHERE sql IS NOT NULL"
         ).fetchall()
     ]
-    combined_schema = "\n".join(schema_fragments)
+    combined_schema = _schema_sql_without_comments("\n".join(schema_fragments))
     found: list[str] = []
     for name in sorted(function_names):
         escaped = re.escape(name)
@@ -1179,6 +1179,62 @@ def _schema_function_calls(connection: sqlite3.Connection) -> tuple[str, ...]:
         ):
             found.append(name)
     return tuple(found)
+
+
+def _schema_sql_without_comments(sql: str) -> str:
+    """Replace SQLite comments outside quoted tokens with whitespace."""
+
+    normalized: list[str] = []
+    index = 0
+    quote: str | None = None
+    while index < len(sql):
+        character = sql[index]
+        if quote is not None:
+            normalized.append(character)
+            if quote == "[":
+                if character == "]":
+                    quote = None
+                index += 1
+                continue
+            if character == quote:
+                if index + 1 < len(sql) and sql[index + 1] == quote:
+                    normalized.append(sql[index + 1])
+                    index += 2
+                    continue
+                quote = None
+            index += 1
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+            normalized.append(character)
+            index += 1
+            continue
+        if character == "[":
+            quote = character
+            normalized.append(character)
+            index += 1
+            continue
+        if sql.startswith("--", index):
+            normalized.extend((" ", " "))
+            index += 2
+            while index < len(sql) and sql[index] not in {"\r", "\n"}:
+                normalized.append(" ")
+                index += 1
+            continue
+        if sql.startswith("/*", index):
+            normalized.extend((" ", " "))
+            index += 2
+            while index < len(sql):
+                if sql.startswith("*/", index):
+                    normalized.extend((" ", " "))
+                    index += 2
+                    break
+                normalized.append(sql[index] if sql[index] in {"\r", "\n"} else " ")
+                index += 1
+            continue
+        normalized.append(character)
+        index += 1
+    return "".join(normalized)
 
 
 def _single_check(connection: sqlite3.Connection, pragma: str) -> str:

--- a/robo_trader/maintenance/sqlite_service.py
+++ b/robo_trader/maintenance/sqlite_service.py
@@ -226,6 +226,71 @@ class _StagedTarget:
             ) from errors[0]
 
 
+@dataclass(slots=True)
+class _ManifestReservation:
+    """Exclusive manifest pathname held open before a database is published."""
+
+    requested_path: Path
+    parent_file_descriptor: int
+    guardian_file_descriptor: int
+    device: int
+    inode: int
+    completed: bool = False
+    closed: bool = False
+
+    def assert_identity(self) -> None:
+        if self.closed:
+            raise SQLiteMaintenanceError("manifest reservation is closed")
+        parent = os.fstat(self.parent_file_descriptor)
+        current_parent = os.lstat(self.requested_path.parent)
+        guardian = os.fstat(self.guardian_file_descriptor)
+        current = os.stat(
+            self.requested_path.name,
+            dir_fd=self.parent_file_descriptor,
+            follow_symlinks=False,
+        )
+        if (
+            not stat.S_ISDIR(parent.st_mode)
+            or stat.S_ISLNK(current_parent.st_mode)
+            or not stat.S_ISDIR(current_parent.st_mode)
+            or (parent.st_dev, parent.st_ino) != (current_parent.st_dev, current_parent.st_ino)
+            or not stat.S_ISREG(guardian.st_mode)
+            or guardian.st_nlink != 1
+            or (guardian.st_dev, guardian.st_ino) != (self.device, self.inode)
+            or not stat.S_ISREG(current.st_mode)
+            or (current.st_dev, current.st_ino) != (self.device, self.inode)
+        ):
+            raise SQLiteMaintenanceError("manifest reservation identity changed")
+
+    def write_payload(self, payload: bytes) -> None:
+        self.assert_identity()
+        if self.completed or os.fstat(self.guardian_file_descriptor).st_size != 0:
+            raise SQLiteMaintenanceError("manifest reservation is not empty")
+        os.lseek(self.guardian_file_descriptor, 0, os.SEEK_SET)
+        _write_all(self.guardian_file_descriptor, payload)
+        os.fsync(self.guardian_file_descriptor)
+        os.fchmod(self.guardian_file_descriptor, 0o400)
+        os.fsync(self.guardian_file_descriptor)
+        os.fsync(self.parent_file_descriptor)
+        self.assert_identity()
+        self.completed = True
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        self.closed = True
+        errors: list[OSError] = []
+        for descriptor in (self.guardian_file_descriptor, self.parent_file_descriptor):
+            try:
+                os.close(descriptor)
+            except OSError as exc:
+                errors.append(exc)
+        if errors:
+            raise SQLiteMaintenanceError(
+                "manifest reservation descriptor was already closed"
+            ) from errors[0]
+
+
 class SQLiteMaintenanceService:
     """Operate only on explicit, descriptor-bound SQLite files."""
 
@@ -349,7 +414,7 @@ class SQLiteMaintenanceService:
                 interim = _database_evidence(connection)
                 if interim.integrity_check != "ok" or interim.foreign_key_violations:
                     raise SQLiteMaintenanceError("migration produced invalid SQLite state")
-            except (sqlite3.Error, SQLiteMaintenanceError):
+            except (sqlite3.Error, SQLiteMaintenanceError, OverflowError):
                 # Python 3.10 cannot reliably disable an authorizer by passing
                 # None.  Replace it with a completion-only policy before the
                 # service-owned rollback instead.
@@ -424,36 +489,92 @@ class SQLiteMaintenanceService:
     ) -> None:
         """Write one canonical JSON report to an exclusive owner-only path."""
 
+        reservation = self.reserve_manifest(target_path)
+        try:
+            self.write_reserved_manifest(manifest, reservation)
+        finally:
+            reservation.close()
+
+    def reserve_manifest(self, target_path: Path | str) -> _ManifestReservation:
+        """Reserve a manifest pathname before publishing its database artifact."""
+
         path = _absolute_canonical_path(target_path)
-        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+        if not hasattr(os, "O_NOFOLLOW") or not hasattr(os, "O_DIRECTORY"):
+            raise SQLiteMaintenanceError("platform lacks descriptor-relative manifest isolation")
+        parent_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
         try:
-            descriptor = os.open(path, flags, 0o600)
+            parent_descriptor = os.open(path.parent, parent_flags)
         except OSError as exc:
-            raise SQLiteMaintenanceError("manifest target must be a new exclusive path") from exc
+            raise SQLiteMaintenanceError("manifest parent cannot be opened safely") from exc
+        descriptor: int | None = None
         try:
-            payload = (
-                json.dumps(manifest.to_dict(), sort_keys=True, separators=(",", ":")).encode(
-                    "utf-8"
-                )
-                + b"\n"
-            )
-            _write_all(descriptor, payload)
-            os.fsync(descriptor)
-            os.fchmod(descriptor, 0o400)
-            os.fsync(descriptor)
-            _fsync_directory(path.parent)
-            metadata = os.fstat(descriptor)
-            current = os.lstat(path)
+            parent = os.fstat(parent_descriptor)
+            current_parent = os.lstat(path.parent)
             if (
-                not stat.S_ISREG(metadata.st_mode)
-                or metadata.st_nlink != 1
-                or (metadata.st_dev, metadata.st_ino) != (current.st_dev, current.st_ino)
+                not stat.S_ISDIR(parent.st_mode)
+                or stat.S_ISLNK(current_parent.st_mode)
+                or not stat.S_ISDIR(current_parent.st_mode)
+                or (parent.st_dev, parent.st_ino) != (current_parent.st_dev, current_parent.st_ino)
             ):
-                raise SQLiteMaintenanceError("manifest identity changed while writing")
+                raise SQLiteMaintenanceError("manifest parent identity changed")
+            flags = (
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+            )
+            descriptor = os.open(path.name, flags, 0o600, dir_fd=parent_descriptor)
+            metadata = os.fstat(descriptor)
+            reservation = _ManifestReservation(
+                requested_path=path,
+                parent_file_descriptor=parent_descriptor,
+                guardian_file_descriptor=descriptor,
+                device=metadata.st_dev,
+                inode=metadata.st_ino,
+            )
+            reservation.assert_identity()
+            os.fsync(parent_descriptor)
+            reservation.assert_identity()
+            return reservation
+        except OSError as exc:
+            if descriptor is not None:
+                os.close(descriptor)
+            os.close(parent_descriptor)
+            raise SQLiteMaintenanceError("manifest target must be a new exclusive path") from exc
+        except BaseException:
+            if descriptor is not None:
+                os.close(descriptor)
+            os.close(parent_descriptor)
+            raise
+
+    @staticmethod
+    def write_reserved_manifest(
+        manifest: MaintenanceManifest | MigrationDryRunReport,
+        reservation: _ManifestReservation,
+    ) -> None:
+        """Finish one already-reserved manifest without reopening its pathname."""
+
+        payload = (
+            json.dumps(manifest.to_dict(), sort_keys=True, separators=(",", ":")).encode("utf-8")
+            + b"\n"
+        )
+        try:
+            reservation.write_payload(payload)
         except OSError as exc:
             raise SQLiteMaintenanceError("manifest write failed closed") from exc
-        finally:
-            os.close(descriptor)
+
+    @staticmethod
+    def assert_report_paths_disjoint(
+        *,
+        database_paths: Sequence[Path | str],
+        report_paths: Sequence[Path | str],
+    ) -> None:
+        """Reject reports that alias a database or any SQLite companion path."""
+
+        databases = tuple(_absolute_canonical_path(path) for path in database_paths)
+        reports = tuple(_absolute_canonical_path(path) for path in report_paths)
+        if len(set(reports)) != len(reports):
+            raise SQLiteMaintenanceError("report paths must be distinct")
+        database_resources = set().union(*(_sqlite_resource_family(path) for path in databases))
+        if any(report in database_resources for report in reports):
+            raise SQLiteMaintenanceError("report path overlaps a SQLite resource family")
 
     def load_manifest(self, path: Path | str) -> MaintenanceManifest:
         """Load a bounded, single-link manifest without following its leaf."""
@@ -919,7 +1040,9 @@ def _migration_authorizer(
     }
     dangerous_pragmas = {
         "data_store_directory",
+        "hard_heap_limit",
         "journal_mode",
+        "soft_heap_limit",
         "temp_store_directory",
         "wal_checkpoint",
         "writable_schema",

--- a/robo_trader/maintenance/sqlite_service.py
+++ b/robo_trader/maintenance/sqlite_service.py
@@ -1217,7 +1217,7 @@ def _schema_sql_without_comments(sql: str) -> str:
         if sql.startswith("--", index):
             normalized.extend((" ", " "))
             index += 2
-            while index < len(sql) and sql[index] not in {"\r", "\n"}:
+            while index < len(sql) and sql[index] != "\n":
                 normalized.append(" ")
                 index += 1
             continue

--- a/robo_trader/maintenance/sqlite_service.py
+++ b/robo_trader/maintenance/sqlite_service.py
@@ -12,10 +12,10 @@ import json
 import math
 import os
 import re
-import secrets
 import sqlite3
 import stat
 import sys
+import tempfile
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -47,40 +47,28 @@ class SQLiteMaintenanceError(RuntimeError):
 
 @dataclass(slots=True)
 class _StagedTarget:
-    """Descriptor-bound artifact that SQLite never opens by pathname."""
+    """Unlinked artifact published from its descriptor after verification."""
 
     requested_path: Path
     parent_file_descriptor: int
-    staging_name: str
     guardian_file_descriptor: int
     device: int
     inode: int
     published: bool = False
 
-    @property
-    def forensic_path(self) -> Path:
-        return self.requested_path.parent / self.staging_name
-
     def assert_identity(self) -> None:
         parent = os.fstat(self.parent_file_descriptor)
         current_parent = os.lstat(self.requested_path.parent)
         guardian = os.fstat(self.guardian_file_descriptor)
-        staged = os.stat(
-            self.staging_name,
-            dir_fd=self.parent_file_descriptor,
-            follow_symlinks=False,
-        )
+        expected_links = 1 if self.published else 0
         if (
             not stat.S_ISDIR(parent.st_mode)
             or stat.S_ISLNK(current_parent.st_mode)
             or not stat.S_ISDIR(current_parent.st_mode)
             or (parent.st_dev, parent.st_ino) != (current_parent.st_dev, current_parent.st_ino)
             or not stat.S_ISREG(guardian.st_mode)
-            or guardian.st_nlink != 1
+            or guardian.st_nlink != expected_links
             or (guardian.st_dev, guardian.st_ino) != (self.device, self.inode)
-            or stat.S_ISLNK(staged.st_mode)
-            or not stat.S_ISREG(staged.st_mode)
-            or (staged.st_dev, staged.st_ino) != (self.device, self.inode)
         ):
             raise SQLiteMaintenanceError("staged database identity changed")
 
@@ -105,21 +93,53 @@ class _StagedTarget:
         return result
 
     def publish(self) -> None:
-        """Publish the sealed main inode with descriptor-relative no-replace rename."""
+        """Publish the anonymous image without resolving a source pathname."""
 
         self.assert_identity()
         _assert_target_family_absent_at(
             self.parent_file_descriptor,
             self.requested_path.name,
         )
-        _rename_noreplace_at(
-            self.parent_file_descriptor,
-            self.staging_name,
+        if sys.platform.startswith("linux"):
+            _link_anonymous_at(
+                self.guardian_file_descriptor,
+                self.parent_file_descriptor,
+                self.requested_path.name,
+            )
+        elif sys.platform == "darwin":
+            self._clone_anonymous_on_macos()
+        else:
+            raise SQLiteMaintenanceError("platform cannot publish an anonymous database safely")
+        self.published = True
+        self._assert_published_identity()
+
+    def _clone_anonymous_on_macos(self) -> None:
+        """Clone an unlinked source fd into an exclusive APFS destination."""
+
+        _fclonefileat(
+            self.guardian_file_descriptor,
             self.parent_file_descriptor,
             self.requested_path.name,
         )
-        self.published = True
-        self._assert_published_identity()
+        flags = os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+        published_descriptor = os.open(
+            self.requested_path.name,
+            flags,
+            dir_fd=self.parent_file_descriptor,
+        )
+        try:
+            source_digest = _descriptor_digest(self.guardian_file_descriptor)
+            published_digest = _descriptor_digest(published_descriptor)
+            metadata = os.fstat(published_descriptor)
+            if source_digest != published_digest or not stat.S_ISREG(metadata.st_mode):
+                raise SQLiteMaintenanceError("published clone differs from anonymous source")
+        except BaseException:
+            os.close(published_descriptor)
+            raise
+        os.close(self.guardian_file_descriptor)
+        self.guardian_file_descriptor = published_descriptor
+        self.device = metadata.st_dev
+        self.inode = metadata.st_ino
         os.fsync(self.parent_file_descriptor)
         self._assert_published_identity()
 
@@ -652,47 +672,31 @@ class SQLiteMaintenanceService:
             ):
                 raise SQLiteMaintenanceError("target parent identity changed")
             _assert_target_family_absent_at(parent_file_descriptor, path.name)
-            flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
-            for _attempt in range(4):
-                staging_name = f".{path.name}.robo-trader-stage-{secrets.token_hex(16)}"
-                try:
-                    guardian = os.open(
-                        staging_name,
-                        flags,
-                        0o000,
-                        dir_fd=parent_file_descriptor,
-                    )
-                except FileExistsError:
-                    continue
-                except OSError as exc:
+            guardian = _open_anonymous_target(parent_file_descriptor, path.parent)
+            try:
+                metadata = os.fstat(guardian)
+                current_parent = os.lstat(path.parent)
+                if (
+                    not stat.S_ISREG(metadata.st_mode)
+                    or metadata.st_nlink != 0
+                    or metadata.st_dev != parent.st_dev
+                    or stat.S_ISLNK(current_parent.st_mode)
+                    or (current_parent.st_dev, current_parent.st_ino)
+                    != (parent.st_dev, parent.st_ino)
+                ):
                     raise SQLiteMaintenanceError(
-                        "private staged database cannot be created"
-                    ) from exc
-                try:
-                    metadata = os.fstat(guardian)
-                    staged = os.stat(
-                        staging_name,
-                        dir_fd=parent_file_descriptor,
-                        follow_symlinks=False,
+                        "anonymous staged database identity cannot be established"
                     )
-                    if (
-                        not stat.S_ISREG(metadata.st_mode)
-                        or metadata.st_nlink != 1
-                        or (metadata.st_dev, metadata.st_ino) != (staged.st_dev, staged.st_ino)
-                    ):
-                        raise SQLiteMaintenanceError("private staged database identity changed")
-                    return _StagedTarget(
-                        requested_path=path,
-                        parent_file_descriptor=parent_file_descriptor,
-                        staging_name=staging_name,
-                        guardian_file_descriptor=guardian,
-                        device=metadata.st_dev,
-                        inode=metadata.st_ino,
-                    )
-                except BaseException:
-                    os.close(guardian)
-                    raise
-            raise SQLiteMaintenanceError("private target staging name could not be reserved")
+                return _StagedTarget(
+                    requested_path=path,
+                    parent_file_descriptor=parent_file_descriptor,
+                    guardian_file_descriptor=guardian,
+                    device=metadata.st_dev,
+                    inode=metadata.st_ino,
+                )
+            except BaseException:
+                os.close(guardian)
+                raise
         except BaseException:
             os.close(parent_file_descriptor)
             raise
@@ -947,71 +951,67 @@ def _post_migration_authorizer(
     return _migration_authorizer(action, arg1, arg2, database, trigger)
 
 
-def _rename_noreplace_at(
-    source_directory_descriptor: int,
-    source_name: str,
-    target_directory_descriptor: int,
-    target_name: str,
-) -> None:
-    """Atomically move a pathname without replacing any destination.
+def _open_anonymous_target(parent_descriptor: int, parent_path: Path) -> int:
+    """Create an unlinked regular file on the target filesystem."""
 
-    Python does not expose the platform no-replace rename flags.  Maintenance
-    fails closed on unsupported Unix VFS platforms instead of falling back to
-    ``rename(2)``, whose overwrite behavior could destroy an interposed file.
-    """
+    if sys.platform.startswith("linux"):
+        temporary_flag = getattr(os, "O_TMPFILE", 0)
+        if not temporary_flag:
+            raise SQLiteMaintenanceError("filesystem lacks anonymous file creation")
+        flags = os.O_RDWR | temporary_flag | getattr(os, "O_CLOEXEC", 0)
+        try:
+            return os.open(".", flags, 0o600, dir_fd=parent_descriptor)
+        except OSError as exc:
+            raise SQLiteMaintenanceError(
+                "target filesystem cannot create a publishable anonymous file"
+            ) from exc
+    if sys.platform == "darwin":
+        try:
+            temporary = tempfile.TemporaryFile(mode="w+b", dir=parent_path)
+            descriptor = os.dup(temporary.fileno())
+            temporary.close()
+            return descriptor
+        except OSError as exc:
+            raise SQLiteMaintenanceError(
+                "target filesystem cannot create an anonymous file"
+            ) from exc
+    raise SQLiteMaintenanceError("platform cannot create an anonymous database safely")
+
+
+def _link_anonymous_at(source_descriptor: int, target_directory: int, target_name: str) -> None:
+    """Publish one Linux O_TMPFILE inode without resolving a source name."""
 
     libc = ctypes.CDLL(None, use_errno=True)
-    source_bytes = os.fsencode(source_name)
-    target_bytes = os.fsencode(target_name)
-    if sys.platform.startswith("linux"):
-        try:
-            rename = libc.renameat2
-        except AttributeError as exc:
-            raise SQLiteMaintenanceError(
-                "platform cannot quarantine a reservation without replacement"
-            ) from exc
-        rename.argtypes = (
-            ctypes.c_int,
-            ctypes.c_char_p,
-            ctypes.c_int,
-            ctypes.c_char_p,
-            ctypes.c_uint,
-        )
-        rename.restype = ctypes.c_int
-        result = rename(
-            source_directory_descriptor,
-            source_bytes,
-            target_directory_descriptor,
-            target_bytes,
-            1,
-        )
-    elif sys.platform == "darwin":
-        try:
-            rename = libc.renameatx_np
-        except AttributeError as exc:
-            raise SQLiteMaintenanceError(
-                "platform cannot quarantine a reservation without replacement"
-            ) from exc
-        rename.argtypes = (
-            ctypes.c_int,
-            ctypes.c_char_p,
-            ctypes.c_int,
-            ctypes.c_char_p,
-            ctypes.c_uint,
-        )
-        rename.restype = ctypes.c_int
-        result = rename(
-            source_directory_descriptor,
-            source_bytes,
-            target_directory_descriptor,
-            target_bytes,
-            0x00000004,
-        )
-    else:
-        raise SQLiteMaintenanceError("platform cannot quarantine a reservation without replacement")
-    if result != 0:
+    try:
+        link = libc.linkat
+    except AttributeError as exc:
+        raise SQLiteMaintenanceError("platform cannot publish an anonymous file") from exc
+    link.argtypes = (
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+    )
+    link.restype = ctypes.c_int
+    if link(source_descriptor, b"", target_directory, os.fsencode(target_name), 0x1000) != 0:
         error_number = ctypes.get_errno()
-        raise OSError(error_number, os.strerror(error_number), source_name)
+        raise OSError(error_number, os.strerror(error_number), target_name)
+
+
+def _fclonefileat(source_descriptor: int, target_directory: int, target_name: str) -> None:
+    """Publish a macOS clone from an unlinked source descriptor."""
+
+    libc = ctypes.CDLL(None, use_errno=True)
+    try:
+        clone = libc.fclonefileat
+    except AttributeError as exc:
+        raise SQLiteMaintenanceError("platform cannot clone an anonymous file") from exc
+    clone.argtypes = (ctypes.c_int, ctypes.c_int, ctypes.c_char_p, ctypes.c_uint)
+    clone.restype = ctypes.c_int
+    if clone(source_descriptor, target_directory, os.fsencode(target_name), 0x0001) != 0:
+        error_number = ctypes.get_errno()
+        raise OSError(error_number, os.strerror(error_number), target_name)
 
 
 def _assert_single_link(binding: SQLitePathBinding) -> None:

--- a/robo_trader/maintenance/sqlite_service.py
+++ b/robo_trader/maintenance/sqlite_service.py
@@ -348,10 +348,17 @@ class SQLiteMaintenanceService:
         self,
         source_path: Path | str,
         target_path: Path | str,
+        *,
+        manifest_reservation: _ManifestReservation | None = None,
     ) -> MaintenanceManifest:
         """Create and verify a WAL-safe snapshot at an exclusive new path."""
 
-        manifest, _ = self._online_copy(source_path, target_path, operation="backup")
+        manifest, _ = self._online_copy(
+            source_path,
+            target_path,
+            operation="backup",
+            manifest_reservation=manifest_reservation,
+        )
         return manifest
 
     def restore_clean_room(
@@ -359,6 +366,8 @@ class SQLiteMaintenanceService:
         backup_path: Path | str,
         target_path: Path | str,
         manifest: MaintenanceManifest,
+        *,
+        manifest_reservation: _ManifestReservation | None = None,
     ) -> MaintenanceManifest:
         """Restore a verified backup only into an exclusive clean-room path."""
 
@@ -369,18 +378,13 @@ class SQLiteMaintenanceService:
             target_path,
             operation="restore",
             expected_source_manifest=manifest,
+            manifest_reservation=manifest_reservation,
         )
         if restored.evidence != manifest.evidence:
             raise SQLiteMaintenanceError("clean-room restore evidence differs from backup")
-        return MaintenanceManifest(
-            manifest_version=restored.manifest_version,
-            operation="restore",
-            created_at=restored.created_at,
-            artifact_sha256=restored.artifact_sha256,
-            artifact_size=restored.artifact_size,
-            evidence=restored.evidence,
-            input_artifact_sha256=manifest.artifact_sha256,
-        )
+        if restored.input_artifact_sha256 != manifest.artifact_sha256:
+            raise SQLiteMaintenanceError("clean-room restore input digest is unavailable")
+        return restored
 
     def dry_run_migration(
         self,
@@ -621,11 +625,18 @@ class SQLiteMaintenanceService:
         operation: str,
         expected_source_manifest: MaintenanceManifest | None = None,
         target_hook: Callable[[sqlite3.Connection, DatabaseEvidence], object] | None = None,
+        manifest_reservation: _ManifestReservation | None = None,
     ) -> tuple[MaintenanceManifest, object | None]:
         source_candidate = _absolute_canonical_path(source_path)
         target_candidate = _absolute_canonical_path(target_path)
         if _sqlite_resource_family(source_candidate) & _sqlite_resource_family(target_candidate):
             raise SQLiteMaintenanceError("source and target SQLite resource families overlap")
+        if manifest_reservation is not None:
+            self.assert_report_paths_disjoint(
+                database_paths=(source_candidate, target_candidate),
+                report_paths=(manifest_reservation.requested_path,),
+            )
+            manifest_reservation.assert_identity()
         initial_source_companions = _safe_companion_identities(source_candidate)
         if expected_source_manifest is not None and initial_source_companions:
             raise SQLiteMaintenanceError(
@@ -756,7 +767,14 @@ class SQLiteMaintenanceService:
                 artifact_sha256=artifact_sha256,
                 artifact_size=artifact_size,
                 evidence=evidence,
+                input_artifact_sha256=(
+                    expected_source_manifest.artifact_sha256
+                    if operation == "restore" and expected_source_manifest is not None
+                    else None
+                ),
             )
+            if manifest_reservation is not None:
+                self.write_reserved_manifest(manifest, manifest_reservation)
             staged_target.publish()
             published_sha256, published_size = _descriptor_digest(
                 staged_target.guardian_file_descriptor

--- a/robo_trader/maintenance/sqlite_service.py
+++ b/robo_trader/maintenance/sqlite_service.py
@@ -448,9 +448,13 @@ class SQLiteMaintenanceService:
             connection.execute("BEGIN IMMEDIATE")
             connection.set_authorizer(_migration_authorizer)
             migration_started = time.monotonic()
+            migration_deadline_interrupted = False
 
             def migration_deadline_exceeded() -> bool:
-                return time.monotonic() - migration_started > self._max_migration_seconds
+                nonlocal migration_deadline_interrupted
+                if time.monotonic() - migration_started > self._max_migration_seconds:
+                    migration_deadline_interrupted = True
+                return migration_deadline_interrupted
 
             def enforce_migration_deadline() -> int:
                 return int(migration_deadline_exceeded())
@@ -480,7 +484,11 @@ class SQLiteMaintenanceService:
                 connection.set_authorizer(_migration_completion_authorizer)
                 connection.rollback()
                 outcome = "rolled_back"
-                error_code = "migration_plan_failed"
+                error_code = (
+                    "migration_deadline_exceeded"
+                    if migration_deadline_interrupted
+                    else "migration_plan_failed"
+                )
             else:
                 connection.set_authorizer(_migration_completion_authorizer)
                 connection.commit()

--- a/robo_trader/multiuser/__init__.py
+++ b/robo_trader/multiuser/__init__.py
@@ -3,18 +3,19 @@ Multi-portfolio / multiuser support for RoboTrader.
 
 This package provides:
 - PortfolioConfig: Per-portfolio configuration with risk overrides
-- Database migration: Adds portfolio_id partitioning to existing tables
+- Legacy migration inspection with mutation entrypoints quarantined
 - PortfolioScopedDB: Proxy that auto-injects portfolio_id into DB calls
 - Portfolio registry: Load/save portfolio definitions
 """
 
 from .db_proxy import PortfolioScopedDB
-from .migration import MultiuserMigration
+from .migration import LegacyMultiuserMigrationDisabled, MultiuserMigration
 from .portfolio_config import PortfolioConfig, load_portfolio_configs
 
 __all__ = [
     "PortfolioConfig",
     "load_portfolio_configs",
     "MultiuserMigration",
+    "LegacyMultiuserMigrationDisabled",
     "PortfolioScopedDB",
 ]

--- a/robo_trader/multiuser/migration.py
+++ b/robo_trader/multiuser/migration.py
@@ -1,21 +1,14 @@
-"""
-Database migration for multiuser/multi-portfolio support.
+"""Quarantined legacy multiuser/multi-portfolio migration.
 
-Adds portfolio_id column to positions, trades, account, equity_history, and signals.
-Creates new portfolios table. All existing data gets portfolio_id='default'.
-
-This migration is safe and backward-compatible:
-- Only runs once (checks migration version)
-- Creates backup before modifying tables
-- Existing single-portfolio usage continues to work unchanged
+The former migration copied only the SQLite main file, rewrote financial
+tables with foreign keys disabled, collapsed account rows, and attempted
+rollback by overwriting the authoritative database.  Read-only version
+inspection and the already-applied no-op remain available.  Every mutation,
+backup, restore, and table-rewrite entrypoint now fails closed.
 """
 
-import asyncio
-import shutil
-import sqlite3
-from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 import aiosqlite
 
@@ -23,14 +16,7 @@ from ..logger import get_logger
 
 logger = get_logger(__name__)
 
-MIGRATION_VERSION = 1  # Increment when adding new migrations
-
-
-# D-17: defense-in-depth allowlist. table_name in this module is always a
-# hardcoded literal from the call sites in _apply_migration_v1, but the DDL
-# below uses f-string interpolation — assert the value is one of the known
-# tables before any DDL executes so a future refactor that accidentally
-# threads a caller-supplied name through this path fails loudly.
+MIGRATION_VERSION = 1
 ALLOWED_MIGRATION_TABLES = frozenset(
     {
         "positions",
@@ -44,347 +30,86 @@ ALLOWED_MIGRATION_TABLES = frozenset(
     }
 )
 
+_QUARANTINE_MESSAGE = (
+    "legacy multiuser mutation is disabled: use descriptor-bound online backup, "
+    "clean-room restore, and a reviewed migration dry-run on a synthetic copy"
+)
+
+
+class LegacyMultiuserMigrationDisabled(RuntimeError):
+    """The unsafe legacy migration or overwrite restore was requested."""
+
 
 class MultiuserMigration:
-    """Handles database schema migration for multi-portfolio support."""
+    """Provide inspection and fail-closed compatibility for the old API."""
 
     def __init__(self, db_path: Path):
         self.db_path = db_path
 
     async def get_migration_version(self, conn: aiosqlite.Connection) -> int:
-        """Get current migration version from database."""
+        """Read the legacy migration version without modifying schema."""
+
         try:
             cursor = await conn.execute(
                 "SELECT version FROM schema_migrations ORDER BY version DESC LIMIT 1"
             )
             row = await cursor.fetchone()
-            return row[0] if row else 0
-        except sqlite3.OperationalError:
-            # Table doesn't exist yet
+            return int(row[0]) if row else 0
+        except aiosqlite.OperationalError:
             return 0
 
     async def needs_migration(self) -> bool:
-        """Check if the database needs the multiuser migration."""
-        async with aiosqlite.connect(self.db_path) as conn:
-            current = await self.get_migration_version(conn)
+        """Report whether the quarantined legacy schema would need migration."""
+
+        if not self.db_path.exists():
+            return True
+        async with aiosqlite.connect(self._readonly_uri(), uri=True) as connection:
+            current = await self.get_migration_version(connection)
             return current < MIGRATION_VERSION
 
-    async def _create_backup(self) -> Optional[Path]:
-        """Create a backup of the database before migration.
+    async def _create_backup(self) -> None:
+        """Reject the legacy raw-copy backup path."""
 
-        Returns:
-            Path to backup file, or None if db doesn't exist
-        """
-        if not self.db_path.exists():
-            return None
-
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        backup_path = self.db_path.with_suffix(f".backup_premultiuser_{timestamp}.db")
-        # Use asyncio.to_thread to avoid blocking the event loop
-        await asyncio.to_thread(shutil.copy2, self.db_path, backup_path)
-        logger.info(f"Created database backup at: {backup_path}")
-        return backup_path
+        raise LegacyMultiuserMigrationDisabled(_QUARANTINE_MESSAGE)
 
     async def migrate(self, default_cash: float = 100_000.0) -> bool:
-        """Run the multiuser migration.
+        """No-op if absent/applied; reject every legacy mutation request."""
 
-        Args:
-            default_cash: Starting cash for the 'default' portfolio record
-
-        Returns:
-            True if migration was applied, False if already up to date
-        """
+        del default_cash
         if not self.db_path.exists():
-            logger.info("No database found - migration will be applied on first init")
+            logger.info("No database found; quarantined migration made no changes")
             return False
-
-        migration_error = None
-        backup_path = None
-
-        async with aiosqlite.connect(self.db_path) as conn:
-            await conn.execute("PRAGMA journal_mode=WAL")
-            await conn.execute("PRAGMA busy_timeout=10000")
-            await conn.execute("PRAGMA foreign_keys=OFF")
-
-            current_version = await self.get_migration_version(conn)
+        async with aiosqlite.connect(self._readonly_uri(), uri=True) as connection:
+            current_version = await self.get_migration_version(connection)
             if current_version >= MIGRATION_VERSION:
-                logger.info(f"Database already at migration version {current_version}, skipping")
+                logger.info(
+                    "Database already at migration version %s; no changes made",
+                    current_version,
+                )
                 return False
+        raise LegacyMultiuserMigrationDisabled(_QUARANTINE_MESSAGE)
 
-            # Create backup BEFORE any changes
-            backup_path = await self._create_backup()
-            logger.info(f"Starting multiuser migration (v{current_version} → v{MIGRATION_VERSION})")
-
-            try:
-                await self._apply_migration_v1(conn, default_cash)
-                await conn.commit()
-                logger.info("Multiuser migration completed successfully")
-                return True
-
-            except (sqlite3.Error, aiosqlite.Error) as e:
-                logger.error(f"Migration failed: {e}")
-                await conn.rollback()
-                migration_error = e
-
-        # Connection is closed -- safe to restore backup by overwriting the DB file
-        if migration_error:
-            if backup_path and backup_path.exists():
-                await self._restore_from_backup(backup_path)
-            raise migration_error
+    def _readonly_uri(self) -> str:
+        path = self.db_path.expanduser()
+        if not path.is_absolute():
+            path = Path.cwd() / path
+        return path.as_uri() + "?mode=ro"
 
     async def _restore_from_backup(self, backup_path: Path) -> None:
-        """Restore database from backup after a failed migration.
+        """Reject overwrite-based rollback even when called directly."""
 
-        Verifies integrity of the restored database. If the restore itself
-        fails, raises RuntimeError with the backup path so the user can
-        recover manually.
-        """
-        try:
-            logger.info(f"Restoring database from backup: {backup_path}")
-            await asyncio.to_thread(shutil.copy2, backup_path, self.db_path)
+        del backup_path
+        raise LegacyMultiuserMigrationDisabled(_QUARANTINE_MESSAGE)
 
-            # Verify restored database integrity
-            conn = sqlite3.connect(self.db_path)
-            try:
-                cursor = conn.cursor()
-                cursor.execute("PRAGMA integrity_check")
-                result = cursor.fetchone()
-                if result[0] != "ok":
-                    raise RuntimeError(f"Restored database failed integrity check: {result[0]}")
-            finally:
-                conn.close()
+    async def _apply_migration_v1(
+        self,
+        conn: aiosqlite.Connection,
+        default_cash: float,
+    ) -> None:
+        """Reject the old table-rewrite migration even when called directly."""
 
-            logger.info("Database restored successfully from backup")
-
-        except Exception as restore_error:
-            logger.critical(
-                f"FAILED to restore database from backup: {restore_error}. "
-                f"Manual recovery required. Backup file: {backup_path}"
-            )
-            raise RuntimeError(
-                f"Migration failed AND backup restore failed. "
-                f"Manual recovery required. Copy this backup over the database: "
-                f"{backup_path}"
-            ) from restore_error
-
-    async def _apply_migration_v1(self, conn: aiosqlite.Connection, default_cash: float):
-        """Apply migration version 1: Add multi-portfolio support."""
-
-        # 1. Create schema_migrations table
-        await conn.execute("""
-            CREATE TABLE IF NOT EXISTS schema_migrations (
-                version INTEGER PRIMARY KEY,
-                description TEXT NOT NULL,
-                applied_at DATETIME DEFAULT CURRENT_TIMESTAMP
-            )
-        """)
-
-        # 2. Create portfolios table
-        await conn.execute("""
-            CREATE TABLE IF NOT EXISTS portfolios (
-                id TEXT PRIMARY KEY,
-                name TEXT NOT NULL,
-                starting_cash REAL NOT NULL DEFAULT 100000,
-                symbols TEXT NOT NULL DEFAULT '',
-                active INTEGER NOT NULL DEFAULT 1,
-                max_position_pct REAL,
-                max_daily_loss_pct REAL,
-                max_open_positions INTEGER,
-                stop_loss_pct REAL,
-                trailing_stop_pct REAL,
-                use_trailing_stop INTEGER,
-                enabled_strategies TEXT,
-                min_confidence REAL,
-                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-                updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
-            )
-        """)
-
-        # 3. Insert 'default' portfolio if not exists
-        await conn.execute(
-            """
-            INSERT OR IGNORE INTO portfolios (id, name, starting_cash)
-            VALUES ('default', 'Default Portfolio', ?)
-        """,
-            (default_cash,),
-        )
-
-        # 4. Migrate positions table: add portfolio_id, change unique constraint
-        await self._migrate_table_add_portfolio_id(
-            conn,
-            table_name="positions",
-            create_sql="""
-                CREATE TABLE positions_new (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    portfolio_id TEXT NOT NULL DEFAULT 'default',
-                    symbol TEXT NOT NULL,
-                    quantity INTEGER NOT NULL,
-                    avg_cost REAL NOT NULL,
-                    market_price REAL,
-                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
-                    UNIQUE(portfolio_id, symbol)
-                )
-            """,
-            insert_sql="""
-                INSERT INTO positions_new (id, portfolio_id, symbol, quantity, avg_cost, market_price, timestamp)
-                SELECT id, 'default', symbol, quantity, avg_cost, market_price, timestamp
-                FROM positions
-            """,
-            index_sql=[
-                "CREATE INDEX IF NOT EXISTS idx_positions_portfolio ON positions (portfolio_id)",
-            ],
-        )
-
-        # 5. Migrate trades table: add portfolio_id
-        await self._migrate_table_add_portfolio_id(
-            conn,
-            table_name="trades",
-            create_sql="""
-                CREATE TABLE trades_new (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    portfolio_id TEXT NOT NULL DEFAULT 'default',
-                    symbol TEXT NOT NULL,
-                    side TEXT NOT NULL,
-                    quantity INTEGER NOT NULL,
-                    price REAL NOT NULL,
-                    notional REAL DEFAULT 0,
-                    slippage REAL DEFAULT 0,
-                    commission REAL DEFAULT 0,
-                    pnl REAL DEFAULT NULL,
-                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
-                )
-            """,
-            insert_sql="""
-                INSERT INTO trades_new (id, portfolio_id, symbol, side, quantity, price, notional, slippage, commission, pnl, timestamp)
-                SELECT id, 'default', symbol, side, quantity, price, notional, slippage, commission, pnl, timestamp
-                FROM trades
-            """,
-            index_sql=[
-                "CREATE INDEX IF NOT EXISTS idx_trades_portfolio ON trades (portfolio_id)",
-                "CREATE INDEX IF NOT EXISTS idx_trades_portfolio_symbol ON trades (portfolio_id, symbol, timestamp DESC)",
-            ],
-        )
-
-        # 6. Migrate account table: replace id=1 with portfolio_id
-        # Account previously had an autoincrement `id`; multiple rows may have
-        # accumulated over time. We collapse to a single 'default' row, keeping
-        # the MOST RECENT row (highest id). Warn if more than one row was found
-        # so the operator knows older snapshots are not represented in the new
-        # account table (trades/equity_history retain full history regardless).
-        try:
-            cursor = await conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name='account'"
-            )
-            account_exists = await cursor.fetchone()
-            if account_exists:
-                cursor = await conn.execute("PRAGMA table_info(account)")
-                cols = [c[1] for c in await cursor.fetchall()]
-                if "portfolio_id" not in cols:
-                    cursor = await conn.execute("SELECT COUNT(*) FROM account")
-                    account_row_count = (await cursor.fetchone())[0]
-                    if account_row_count > 1:
-                        cursor = await conn.execute("SELECT MAX(id), MIN(id) FROM account")
-                        max_id, min_id = await cursor.fetchone()
-                        logger.warning(
-                            f"account table has {account_row_count} rows; "
-                            f"migration keeps only the most recent row "
-                            f"(id={max_id}; older rows id={min_id}..{max_id - 1} "
-                            f"will not appear in the new portfolio-scoped account table)."
-                        )
-        except Exception as e:
-            # Don't abort migration over a logging/diagnostic failure
-            logger.debug(f"Could not pre-check account row count: {e}")
-
-        await self._migrate_table_add_portfolio_id(
-            conn,
-            table_name="account",
-            create_sql="""
-                CREATE TABLE account_new (
-                    portfolio_id TEXT PRIMARY KEY,
-                    cash REAL NOT NULL,
-                    equity REAL NOT NULL,
-                    daily_pnl REAL DEFAULT 0,
-                    realized_pnl REAL DEFAULT 0,
-                    unrealized_pnl REAL DEFAULT 0,
-                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
-                )
-            """,
-            insert_sql="""
-                INSERT INTO account_new (portfolio_id, cash, equity, daily_pnl, realized_pnl, unrealized_pnl, timestamp)
-                SELECT 'default', cash, equity, daily_pnl, realized_pnl, unrealized_pnl, timestamp
-                FROM account
-                ORDER BY id DESC LIMIT 1
-            """,
-            index_sql=[],
-        )
-
-        # 7. Migrate equity_history table: add portfolio_id, change unique constraint
-        await self._migrate_table_add_portfolio_id(
-            conn,
-            table_name="equity_history",
-            create_sql="""
-                CREATE TABLE equity_history_new (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    portfolio_id TEXT NOT NULL DEFAULT 'default',
-                    date TEXT NOT NULL,
-                    equity REAL NOT NULL,
-                    cash REAL DEFAULT 0,
-                    positions_value REAL DEFAULT 0,
-                    realized_pnl REAL DEFAULT 0,
-                    unrealized_pnl REAL DEFAULT 0,
-                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
-                    UNIQUE(portfolio_id, date)
-                )
-            """,
-            insert_sql="""
-                INSERT INTO equity_history_new (id, portfolio_id, date, equity, cash, positions_value, realized_pnl, unrealized_pnl, timestamp)
-                SELECT id, 'default', date, equity, cash, positions_value, realized_pnl, unrealized_pnl, timestamp
-                FROM equity_history
-            """,
-            index_sql=[
-                "CREATE INDEX IF NOT EXISTS idx_equity_history_portfolio ON equity_history (portfolio_id, date)",
-            ],
-        )
-
-        # 8. Migrate signals table: add portfolio_id
-        await self._migrate_table_add_portfolio_id(
-            conn,
-            table_name="signals",
-            create_sql="""
-                CREATE TABLE signals_new (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    portfolio_id TEXT NOT NULL DEFAULT 'default',
-                    symbol TEXT NOT NULL,
-                    strategy TEXT NOT NULL,
-                    signal_type TEXT NOT NULL,
-                    strength REAL,
-                    metadata TEXT,
-                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
-                )
-            """,
-            insert_sql="""
-                INSERT INTO signals_new (id, portfolio_id, symbol, strategy, signal_type, strength, metadata, timestamp)
-                SELECT id, 'default', symbol, strategy, signal_type, strength, metadata, timestamp
-                FROM signals
-            """,
-            index_sql=[
-                "CREATE INDEX IF NOT EXISTS idx_signals_portfolio ON signals (portfolio_id)",
-            ],
-        )
-
-        # 9. Record migration
-        await conn.execute(
-            """
-            INSERT INTO schema_migrations (version, description)
-            VALUES (?, ?)
-        """,
-            (
-                MIGRATION_VERSION,
-                "Add multi-portfolio support: portfolio_id on positions, trades, account, equity_history, signals",
-            ),
-        )
-
-        logger.info("Migration v1 applied: multi-portfolio schema ready")
+        del conn, default_cash
+        raise LegacyMultiuserMigrationDisabled(_QUARANTINE_MESSAGE)
 
     async def _migrate_table_add_portfolio_id(
         self,
@@ -393,64 +118,13 @@ class MultiuserMigration:
         create_sql: str,
         insert_sql: str,
         index_sql: List[str],
-    ):
-        """Migrate a table by recreating it with portfolio_id column.
+    ) -> None:
+        """Retain validation compatibility, then reject all table rewrites."""
 
-        Uses the rename-recreate pattern since SQLite doesn't support
-        ALTER TABLE ADD CONSTRAINT.
-        """
-        # D-17: refuse any table_name outside the hardcoded allowlist before
-        # any DDL (f-string interpolated) executes. The current call sites
-        # only pass literal table names, but this guards against future
-        # regressions where caller-supplied values could thread through.
+        del conn, create_sql, insert_sql, index_sql
         if table_name not in ALLOWED_MIGRATION_TABLES:
             raise ValueError(
                 f"unexpected table_name in migration: {table_name!r}; "
                 f"must be one of {sorted(ALLOWED_MIGRATION_TABLES)}"
             )
-
-        # Check if table exists
-        cursor = await conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
-            (table_name,),
-        )
-        exists = await cursor.fetchone()
-
-        if not exists:
-            # Table doesn't exist yet - create directly with portfolio_id
-            await conn.execute(create_sql.replace(f"{table_name}_new", table_name))
-            for idx_sql in index_sql:
-                await conn.execute(idx_sql)
-            logger.info(f"Created new table: {table_name} (with portfolio_id)")
-            return
-
-        # Check if already has portfolio_id column
-        cursor = await conn.execute(f"PRAGMA table_info({table_name})")
-        columns = await cursor.fetchall()
-        column_names = [col[1] for col in columns]
-
-        if "portfolio_id" in column_names:
-            logger.info(f"Table {table_name} already has portfolio_id column, skipping")
-            return
-
-        # Count existing rows for logging
-        # nosec B608 - table_name comes from hardcoded strings in this file, not user input
-        cursor = await conn.execute(f"SELECT COUNT(*) FROM {table_name}")  # nosec B608
-        row_count = (await cursor.fetchone())[0]
-
-        # Create new table
-        await conn.execute(create_sql)
-
-        # Copy data
-        if row_count > 0:
-            await conn.execute(insert_sql)
-
-        # Drop old table and rename new one
-        await conn.execute(f"DROP TABLE {table_name}")
-        await conn.execute(f"ALTER TABLE {table_name}_new RENAME TO {table_name}")
-
-        # Create indexes
-        for idx_sql in index_sql:
-            await conn.execute(idx_sql)
-
-        logger.info(f"Migrated table {table_name}: {row_count} rows, added portfolio_id column")
+        raise LegacyMultiuserMigrationDisabled(_QUARANTINE_MESSAGE)

--- a/robo_trader/safety/sqlite_identity.py
+++ b/robo_trader/safety/sqlite_identity.py
@@ -129,6 +129,44 @@ def _sqlite_c_api():
     return api
 
 
+def sqlite_connection_serialize(connection: sqlite3.Connection) -> bytes:
+    """Return SQLite's exact in-memory main-database image.
+
+    Maintenance uses this to keep SQLite away from any filesystem target
+    namespace.  The byte buffer is allocated and released by the same SQLite
+    library that owns the CPython connection.
+    """
+
+    if type(connection) is not sqlite3.Connection:
+        raise SQLiteIdentityError("connection must be an exact sqlite3.Connection")
+    api = _sqlite_c_api()
+    try:
+        serialize = api.sqlite3_serialize
+        sqlite_free = api.sqlite3_free
+    except AttributeError as exc:
+        raise SQLiteIdentityError("active SQLite library cannot serialize databases") from exc
+    serialize.argtypes = (
+        ctypes.c_void_p,
+        ctypes.c_char_p,
+        ctypes.POINTER(ctypes.c_longlong),
+        ctypes.c_uint,
+    )
+    serialize.restype = ctypes.c_void_p
+    sqlite_free.argtypes = (ctypes.c_void_p,)
+    sqlite_free.restype = None
+    pointer = _CPythonSQLiteConnectionHead.from_address(id(connection)).db
+    if not pointer:
+        raise SQLiteIdentityError("connection has no active SQLite handle")
+    size = ctypes.c_longlong()
+    serialized = serialize(pointer, b"main", ctypes.byref(size), 0)
+    if not serialized or size.value < 0:
+        raise SQLiteIdentityError("SQLite could not serialize the database")
+    try:
+        return ctypes.string_at(serialized, size.value)
+    finally:
+        sqlite_free(serialized)
+
+
 def sqlite_connection_file_identity(
     connection: sqlite3.Connection,
 ) -> SQLiteDescriptorIdentity:

--- a/robo_trader/safety/sqlite_identity.py
+++ b/robo_trader/safety/sqlite_identity.py
@@ -14,13 +14,14 @@ import sys
 import sysconfig
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 import _sqlite3
 
 _SQLITE_FCNTL_FILE_POINTER = 7
 _SQLITE_FCNTL_VFS_POINTER = 27
 _SQLITE_OK = 0
+_SQLITE_DESERIALIZE_READONLY = 4
 _SQLITE_C_API = None
 _SQLITE_UNIX_VFS_NAMES = frozenset(
     {
@@ -165,6 +166,53 @@ def sqlite_connection_serialize(connection: sqlite3.Connection) -> bytes:
         return ctypes.string_at(serialized, size.value)
     finally:
         sqlite_free(serialized)
+
+
+def sqlite_connection_deserialize(
+    connection: sqlite3.Connection,
+    payload: bytes,
+) -> Any:
+    """Install ``payload`` as an in-memory main database and retain its buffer.
+
+    The returned ctypes buffer must remain alive until the connection is
+    closed.  Keeping ownership in Python avoids version-sensitive ownership
+    behavior in ``SQLITE_DESERIALIZE_FREEONCLOSE`` and supports CPython 3.10,
+    whose sqlite3 module does not expose ``Connection.deserialize``.
+    """
+
+    if type(connection) is not sqlite3.Connection:
+        raise SQLiteIdentityError("connection must be an exact sqlite3.Connection")
+    if not isinstance(payload, bytes) or not payload:
+        raise SQLiteIdentityError("database image must be non-empty bytes")
+    api = _sqlite_c_api()
+    try:
+        deserialize = api.sqlite3_deserialize
+    except AttributeError as exc:
+        raise SQLiteIdentityError("active SQLite library cannot deserialize databases") from exc
+    deserialize.argtypes = (
+        ctypes.c_void_p,
+        ctypes.c_char_p,
+        ctypes.c_void_p,
+        ctypes.c_longlong,
+        ctypes.c_longlong,
+        ctypes.c_uint,
+    )
+    deserialize.restype = ctypes.c_int
+    pointer = _CPythonSQLiteConnectionHead.from_address(id(connection)).db
+    if not pointer:
+        raise SQLiteIdentityError("connection has no active SQLite handle")
+    retained_buffer = ctypes.create_string_buffer(payload, len(payload))
+    result = deserialize(
+        pointer,
+        b"main",
+        ctypes.cast(retained_buffer, ctypes.c_void_p),
+        len(payload),
+        len(payload),
+        _SQLITE_DESERIALIZE_READONLY,
+    )
+    if result != _SQLITE_OK:
+        raise SQLiteIdentityError("SQLite could not deserialize the database image")
+    return retained_buffer
 
 
 def sqlite_connection_file_identity(

--- a/scripts/database_maintenance.py
+++ b/scripts/database_maintenance.py
@@ -53,8 +53,11 @@ def main(argv: list[str] | None = None) -> int:
             )
             reservation = service.reserve_manifest(args.manifest)
             try:
-                backup_manifest = service.backup(args.source, args.target)
-                service.write_reserved_manifest(backup_manifest, reservation)
+                backup_manifest = service.backup(
+                    args.source,
+                    args.target,
+                    manifest_reservation=reservation,
+                )
             finally:
                 reservation.close()
             payload = backup_manifest.to_dict()
@@ -86,8 +89,8 @@ def main(argv: list[str] | None = None) -> int:
                     args.backup,
                     args.target,
                     expected_backup,
+                    manifest_reservation=reservation,
                 )
-                service.write_reserved_manifest(restore_manifest, reservation)
             finally:
                 reservation.close()
             payload = restore_manifest.to_dict()

--- a/scripts/database_maintenance.py
+++ b/scripts/database_maintenance.py
@@ -47,10 +47,23 @@ def main(argv: list[str] | None = None) -> int:
     service = SQLiteMaintenanceService()
     try:
         if args.command == "backup":
-            backup_manifest = service.backup(args.source, args.target)
-            service.write_manifest(backup_manifest, args.manifest)
+            service.assert_report_paths_disjoint(
+                database_paths=(args.source, args.target),
+                report_paths=(args.manifest,),
+            )
+            reservation = service.reserve_manifest(args.manifest)
+            try:
+                backup_manifest = service.backup(args.source, args.target)
+                service.write_reserved_manifest(backup_manifest, reservation)
+            finally:
+                reservation.close()
             payload = backup_manifest.to_dict()
         elif args.command == "verify":
+            if args.manifest:
+                service.assert_report_paths_disjoint(
+                    database_paths=(args.database,),
+                    report_paths=(args.manifest,),
+                )
             expected_manifest = service.load_manifest(args.manifest) if args.manifest else None
             evidence = service.verify(args.database, expected_manifest)
             payload = {
@@ -62,9 +75,21 @@ def main(argv: list[str] | None = None) -> int:
                 "authorizes_startup": False,
             }
         else:
-            expected_backup = service.load_manifest(args.backup_manifest)
-            restore_manifest = service.restore_clean_room(args.backup, args.target, expected_backup)
-            service.write_manifest(restore_manifest, args.restore_manifest)
+            service.assert_report_paths_disjoint(
+                database_paths=(args.backup, args.target),
+                report_paths=(args.backup_manifest, args.restore_manifest),
+            )
+            reservation = service.reserve_manifest(args.restore_manifest)
+            try:
+                expected_backup = service.load_manifest(args.backup_manifest)
+                restore_manifest = service.restore_clean_room(
+                    args.backup,
+                    args.target,
+                    expected_backup,
+                )
+                service.write_reserved_manifest(restore_manifest, reservation)
+            finally:
+                reservation.close()
             payload = restore_manifest.to_dict()
     except SQLiteMaintenanceError as exc:
         print(

--- a/scripts/database_maintenance.py
+++ b/scripts/database_maintenance.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Dormant SQLite backup, verification, and clean-room restore CLI.
+
+Every command is local-file-only, emits ``authorizes_startup=false``, and
+refuses to replace an existing output path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from robo_trader.maintenance import SQLiteMaintenanceError, SQLiteMaintenanceService  # noqa: E402
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    backup = subparsers.add_parser("backup", help="create a verified online backup")
+    backup.add_argument("--source", type=Path, required=True)
+    backup.add_argument("--target", type=Path, required=True)
+    backup.add_argument("--manifest", type=Path, required=True)
+
+    verify = subparsers.add_parser("verify", help="verify a database and optional manifest")
+    verify.add_argument("--database", type=Path, required=True)
+    verify.add_argument("--manifest", type=Path)
+
+    restore = subparsers.add_parser(
+        "restore-clean-room", help="restore only into a new clean-room database"
+    )
+    restore.add_argument("--backup", type=Path, required=True)
+    restore.add_argument("--backup-manifest", type=Path, required=True)
+    restore.add_argument("--target", type=Path, required=True)
+    restore.add_argument("--restore-manifest", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    service = SQLiteMaintenanceService()
+    try:
+        if args.command == "backup":
+            backup_manifest = service.backup(args.source, args.target)
+            service.write_manifest(backup_manifest, args.manifest)
+            payload = backup_manifest.to_dict()
+        elif args.command == "verify":
+            expected_manifest = service.load_manifest(args.manifest) if args.manifest else None
+            evidence = service.verify(args.database, expected_manifest)
+            payload = {
+                "operation": "verify",
+                "verified": True,
+                "evidence": evidence.to_dict(),
+                "contains_secrets": False,
+                "mutated_authoritative_state": False,
+                "authorizes_startup": False,
+            }
+        else:
+            expected_backup = service.load_manifest(args.backup_manifest)
+            restore_manifest = service.restore_clean_room(args.backup, args.target, expected_backup)
+            service.write_manifest(restore_manifest, args.restore_manifest)
+            payload = restore_manifest.to_dict()
+    except SQLiteMaintenanceError as exc:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "error": str(exc),
+                    "contains_secrets": False,
+                    "mutated_authoritative_state": False,
+                    "authorizes_startup": False,
+                },
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 2
+    print(json.dumps(payload, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/maintenance/test_sqlite_service.py
+++ b/tests/maintenance/test_sqlite_service.py
@@ -939,11 +939,22 @@ def test_migration_plan_deadline_interrupts_and_rolls_back(tmp_path: Path) -> No
         ),
     )
 
-    assert time.monotonic() - started < 2.0
+    # Copying and hashing the fixture is intentionally outside the migration
+    # execution deadline and varies substantially across CI filesystems. The
+    # typed result proves that the plan itself hit the deadline; this generous
+    # ceiling only guards against a lost interrupt or hang.
+    assert time.monotonic() - started < 10.0
     assert report.outcome == "rolled_back"
-    assert report.error_code == "migration_plan_failed"
+    assert report.error_code == "migration_deadline_exceeded"
     assert report.before == report.after
     assert report.source_unchanged is True
+    with sqlite3.connect(target) as connection:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM deadline_rows WHERE value='after'"
+        ).fetchone() == (0,)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM deadline_rows WHERE value='before'"
+        ).fetchone() == (100_000,)
 
 
 def test_migration_denies_native_function_that_can_evade_vm_deadline(tmp_path: Path) -> None:

--- a/tests/maintenance/test_sqlite_service.py
+++ b/tests/maintenance/test_sqlite_service.py
@@ -7,6 +7,7 @@ import sqlite3
 import stat
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -873,6 +874,62 @@ def test_evidence_handles_without_rowid_and_shadowed_rowid_aliases(
     manifest = service.backup(source, target)
 
     assert service.verify(target) == manifest.evidence
+
+
+def test_migration_evidence_includes_persistent_planner_statistics(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "dry-run.db"
+    with sqlite3.connect(source) as connection:
+        connection.executescript("""
+            CREATE TABLE analyzed_rows (id INTEGER PRIMARY KEY, value TEXT NOT NULL);
+            CREATE INDEX idx_analyzed_rows_value ON analyzed_rows(value);
+            INSERT INTO analyzed_rows VALUES (1, 'alpha'), (2, 'beta'), (3, 'beta');
+            ANALYZE;
+            """)
+        assert connection.execute("SELECT COUNT(*) FROM sqlite_stat1").fetchone() == (1,)
+
+    report = SQLiteMaintenanceService().dry_run_migration(
+        source,
+        target,
+        plan=MigrationPlan(
+            migration_id="planner-statistics-change",
+            steps=(MigrationStep("DELETE FROM sqlite_stat1"),),
+        ),
+    )
+
+    assert report.outcome == "applied_to_synthetic_copy"
+    assert report.before != report.after
+    assert report.source_unchanged is True
+    with sqlite3.connect(target) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM sqlite_stat1").fetchone() == (0,)
+
+
+def test_migration_plan_deadline_interrupts_and_rolls_back(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "dry-run.db"
+    _create_multiportfolio_database(source).close()
+    started = time.monotonic()
+
+    report = SQLiteMaintenanceService(max_migration_seconds=0.01).dry_run_migration(
+        source,
+        target,
+        plan=MigrationPlan(
+            migration_id="bounded-recursive-query",
+            steps=(
+                MigrationStep(
+                    "WITH RECURSIVE unbounded(value) AS ("
+                    "VALUES(1) UNION ALL SELECT value+1 FROM unbounded"
+                    ") SELECT sum(value) FROM unbounded"
+                ),
+            ),
+        ),
+    )
+
+    assert time.monotonic() - started < 2.0
+    assert report.outcome == "rolled_back"
+    assert report.error_code == "migration_plan_failed"
+    assert report.before == report.after
+    assert report.source_unchanged is True
 
 
 def test_migration_uses_the_copy_connection_without_a_writable_reopen(

--- a/tests/maintenance/test_sqlite_service.py
+++ b/tests/maintenance/test_sqlite_service.py
@@ -93,6 +93,33 @@ def test_wal_active_backup_and_clean_room_restore_preserve_multiportfolio_state(
         writer.close()
 
 
+def test_wal_checkpoint_during_online_backup_is_not_treated_as_source_mutation(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "backup.db"
+    writer = _create_multiportfolio_database(source, wal=True)
+    writer.execute("INSERT INTO positions VALUES ('alpha', 'NVDA', 4)")
+    writer.commit()
+    main_before_checkpoint = source.read_bytes()
+    checkpointed = False
+
+    def checkpoint(_operation: str, _remaining: int, _total: int) -> None:
+        nonlocal checkpointed
+        if not checkpointed:
+            checkpointed = True
+            writer.execute("PRAGMA wal_checkpoint(PASSIVE)").fetchone()
+
+    try:
+        manifest = SQLiteMaintenanceService(progress_hook=checkpoint).backup(source, target)
+    finally:
+        writer.close()
+
+    assert checkpointed
+    assert source.read_bytes() != main_before_checkpoint
+    assert SQLiteMaintenanceService().verify(target) == manifest.evidence
+
+
 def test_manifest_is_secret_free_portable_and_exclusively_written(tmp_path: Path) -> None:
     source = tmp_path / "source.db"
     backup = tmp_path / "backup.db"
@@ -232,6 +259,89 @@ def test_staging_symlink_cannot_redirect_sqlite_into_attacker_directory(
 
     assert planted_wal.read_bytes() == b"irreplaceable-user-data"
     assert not target.exists()
+
+
+def test_named_staging_inode_cannot_be_opened_writable_before_sealing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "target.db"
+    _create_multiportfolio_database(source).close()
+    service = SQLiteMaintenanceService()
+    real_stage = service._stage_target
+    staged_target = None
+    attempted = False
+
+    def capture_stage(requested_path):
+        nonlocal staged_target
+        staged_target = real_stage(requested_path)
+        return staged_target
+
+    def attempt_writable_open(_operation: str, _remaining: int, _total: int) -> None:
+        nonlocal attempted
+        if not attempted:
+            attempted = True
+            assert staged_target is not None
+            with pytest.raises(PermissionError):
+                os.open(staged_target.forensic_path, os.O_RDWR)
+
+    monkeypatch.setattr(service, "_stage_target", capture_stage)
+    service._progress_hook = attempt_writable_open
+    manifest = service.backup(source, target)
+
+    assert attempted
+    assert hashlib.sha256(target.read_bytes()).hexdigest() == manifest.artifact_sha256
+
+
+def test_parent_replacement_during_publication_fsync_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source.db"
+    output_parent = tmp_path / "output"
+    parked_parent = tmp_path / "parked-output"
+    output_parent.mkdir()
+    target = output_parent / "target.db"
+    _create_multiportfolio_database(source).close()
+    service = SQLiteMaintenanceService()
+    real_stage = service._stage_target
+    real_fsync = sqlite_service_module.os.fsync
+    staged_target = None
+    replaced = False
+    replacement_payload = b"unrelated-user-file"
+
+    def capture_stage(requested_path):
+        nonlocal staged_target
+        staged_target = real_stage(requested_path)
+        return staged_target
+
+    def replace_parent_on_publication_fsync(descriptor: int) -> None:
+        nonlocal replaced
+        if staged_target is not None and descriptor == staged_target.parent_file_descriptor:
+            try:
+                os.stat(
+                    target.name,
+                    dir_fd=descriptor,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                pass
+            else:
+                if not replaced:
+                    replaced = True
+                    output_parent.rename(parked_parent)
+                    output_parent.mkdir()
+                    target.write_bytes(replacement_payload)
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(service, "_stage_target", capture_stage)
+    monkeypatch.setattr(sqlite_service_module.os, "fsync", replace_parent_on_publication_fsync)
+
+    with pytest.raises(SQLiteMaintenanceError, match="published database identity changed"):
+        service.backup(source, target)
+
+    assert replaced
+    assert target.read_bytes() == replacement_payload
+    assert (parked_parent / target.name).exists()
 
 
 def test_target_cannot_overlap_source_sqlite_companion_family(tmp_path: Path) -> None:
@@ -458,6 +568,31 @@ def test_migration_dry_run_changes_only_synthetic_copy(tmp_path: Path) -> None:
     with sqlite3.connect(source) as connection:
         columns = connection.execute("PRAGMA table_info(positions)").fetchall()
         assert "note" not in {row[1] for row in columns}
+
+
+def test_migration_dry_run_accepts_active_wal_source(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "dry-run.db"
+    writer = _create_multiportfolio_database(source, wal=True)
+    writer.execute("INSERT INTO positions VALUES ('alpha', 'NVDA', 4)")
+    writer.commit()
+    assert source.with_name(source.name + "-wal").exists()
+
+    try:
+        report = SQLiteMaintenanceService().dry_run_migration(
+            source,
+            target,
+            plan=MigrationPlan(
+                migration_id="active-wal",
+                steps=(MigrationStep("ALTER TABLE positions ADD COLUMN note TEXT"),),
+            ),
+        )
+    finally:
+        writer.close()
+
+    assert report.outcome == "applied_to_synthetic_copy"
+    assert report.source_unchanged is True
+    assert report.before != report.after
 
 
 def test_migration_uses_the_copy_connection_without_a_writable_reopen(

--- a/tests/maintenance/test_sqlite_service.py
+++ b/tests/maintenance/test_sqlite_service.py
@@ -805,6 +805,76 @@ def test_migration_dry_run_accepts_active_wal_source(tmp_path: Path) -> None:
     assert report.before != report.after
 
 
+def test_migration_detects_hidden_rowid_change_with_same_visible_values(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "dry-run.db"
+    with sqlite3.connect(source) as connection:
+        assert connection.execute("PRAGMA journal_mode=WAL").fetchone() == ("wal",)
+        connection.execute("CREATE TABLE rowid_records (value TEXT NOT NULL)")
+        connection.executemany(
+            "INSERT INTO rowid_records(value) VALUES (?)",
+            (("alpha",), ("beta",)),
+        )
+
+    changed = False
+
+    def replace_one_row(_operation: str, _remaining: int, _total: int) -> None:
+        nonlocal changed
+        if changed:
+            return
+        with sqlite3.connect(source) as writer:
+            writer.execute("DELETE FROM rowid_records WHERE rowid=1")
+            writer.execute("INSERT INTO rowid_records(value) VALUES ('alpha')")
+        changed = True
+
+    report = SQLiteMaintenanceService(progress_hook=replace_one_row).dry_run_migration(
+        source,
+        target,
+        plan=MigrationPlan(
+            migration_id="rowid-source-change",
+            steps=(MigrationStep("SELECT 1"),),
+        ),
+    )
+
+    with sqlite3.connect(source) as connection:
+        rows = connection.execute("SELECT rowid,value FROM rowid_records ORDER BY rowid").fetchall()
+    assert changed is True
+    assert rows == [(2, "beta"), (3, "alpha")]
+    assert report.before == report.after
+    assert report.source_unchanged is False
+    assert report.outcome == "source_changed_fail_closed"
+    assert report.error_code == "authoritative_source_changed"
+
+
+def test_evidence_handles_without_rowid_and_shadowed_rowid_aliases(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "backup.db"
+    with sqlite3.connect(source) as connection:
+        connection.executescript("""
+            CREATE TABLE natural_keys (
+                name TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            ) WITHOUT ROWID;
+            INSERT INTO natural_keys VALUES ('alpha', 'one');
+            CREATE TABLE shadowed_aliases (
+                rowid INTEGER NOT NULL,
+                _rowid_ INTEGER NOT NULL,
+                oid INTEGER NOT NULL,
+                value TEXT NOT NULL
+            );
+            INSERT INTO shadowed_aliases VALUES (1, 2, 3, 'visible');
+            """)
+
+    service = SQLiteMaintenanceService()
+    manifest = service.backup(source, target)
+
+    assert service.verify(target) == manifest.evidence
+
+
 def test_migration_uses_the_copy_connection_without_a_writable_reopen(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/maintenance/test_sqlite_service.py
+++ b/tests/maintenance/test_sqlite_service.py
@@ -1104,6 +1104,67 @@ def test_migration_rejects_functions_embedded_in_source_schema(tmp_path: Path) -
     assert report.source_unchanged is True
 
 
+def test_migration_screens_virtual_generated_functions_before_row_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "dry-run.db"
+    with sqlite3.connect(source) as connection:
+        connection.execute(
+            "CREATE TABLE generated_rows ("
+            "base INTEGER NOT NULL,"
+            "inflated TEXT GENERATED ALWAYS AS (hex(zeroblob(2000000))) VIRTUAL"
+            ")"
+        )
+        connection.execute("INSERT INTO generated_rows(base) VALUES (1)")
+
+    events: list[str] = []
+    original_schema_function_calls = sqlite_service_module._schema_function_calls
+    original_database_evidence = sqlite_service_module._database_evidence
+
+    def tracked_schema_function_calls(connection: sqlite3.Connection) -> tuple[str, ...]:
+        events.append("schema_screen")
+        return original_schema_function_calls(connection)
+
+    def tracked_database_evidence(
+        connection: sqlite3.Connection,
+    ) -> sqlite_service_module.DatabaseEvidence:
+        events.append("row_evidence")
+        return original_database_evidence(connection)
+
+    monkeypatch.setattr(
+        sqlite_service_module,
+        "_schema_function_calls",
+        tracked_schema_function_calls,
+    )
+    monkeypatch.setattr(
+        sqlite_service_module,
+        "_database_evidence",
+        tracked_database_evidence,
+    )
+
+    report = SQLiteMaintenanceService(max_migration_seconds=0.01).dry_run_migration(
+        source,
+        target,
+        plan=MigrationPlan(
+            migration_id="screen-before-generated-evidence",
+            steps=(
+                MigrationStep(
+                    "UPDATE generated_rows SET base=? WHERE base=?",
+                    (2, 1),
+                ),
+            ),
+        ),
+    )
+
+    assert events[:2] == ["schema_screen", "row_evidence"]
+    assert report.outcome == "rolled_back"
+    assert report.error_code == "migration_plan_failed"
+    assert report.before == report.after
+    assert report.source_unchanged is True
+
+
 @pytest.mark.parametrize("separator", ["/**/", "-- split token\n"])
 def test_migration_rejects_commented_schema_function_calls(
     tmp_path: Path,

--- a/tests/maintenance/test_sqlite_service.py
+++ b/tests/maintenance/test_sqlite_service.py
@@ -267,6 +267,96 @@ def test_manifest_is_secret_free_portable_and_exclusively_written(tmp_path: Path
         service.write_manifest(manifest, manifest_path)
 
 
+def test_restore_manifest_is_complete_before_database_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source.db"
+    backup = tmp_path / "backup.db"
+    target = tmp_path / "restore.db"
+    restore_manifest_path = tmp_path / "restore.json"
+    _create_multiportfolio_database(source).close()
+    service = SQLiteMaintenanceService()
+    backup_manifest = service.backup(source, backup)
+    reservation = service.reserve_manifest(restore_manifest_path)
+    real_publish = sqlite_service_module._StagedTarget.publish
+    inspected = False
+
+    def inspect_manifest_before_publish(staged_target) -> None:
+        nonlocal inspected
+        payload = json.loads(restore_manifest_path.read_text())
+        assert payload["operation"] == "restore"
+        assert payload["input_artifact_sha256"] == backup_manifest.artifact_sha256
+        assert stat.S_IMODE(restore_manifest_path.stat().st_mode) == 0o400
+        inspected = True
+        real_publish(staged_target)
+
+    monkeypatch.setattr(
+        sqlite_service_module._StagedTarget,
+        "publish",
+        inspect_manifest_before_publish,
+    )
+    try:
+        restore_manifest = service.restore_clean_room(
+            backup,
+            target,
+            backup_manifest,
+            manifest_reservation=reservation,
+        )
+    finally:
+        reservation.close()
+
+    assert inspected
+    assert service.load_manifest(restore_manifest_path) == restore_manifest
+    assert target.exists()
+
+
+@pytest.mark.parametrize("operation", ["backup", "restore"])
+def test_reserved_manifest_write_failure_prevents_database_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    source = tmp_path / "source.db"
+    backup = tmp_path / "backup.db"
+    target = backup
+    report_path = tmp_path / f"{operation}.json"
+    _create_multiportfolio_database(source).close()
+    service = SQLiteMaintenanceService()
+    backup_manifest = None
+    if operation == "restore":
+        backup_manifest = service.backup(source, backup)
+        target = tmp_path / "restore.db"
+    reservation = service.reserve_manifest(report_path)
+
+    def fail_manifest_write(_descriptor: int, _payload: bytes) -> None:
+        raise OSError("synthetic manifest I/O failure")
+
+    monkeypatch.setattr(sqlite_service_module, "_write_all", fail_manifest_write)
+    try:
+        with pytest.raises(SQLiteMaintenanceError, match="manifest write failed closed"):
+            if operation == "backup":
+                service.backup(
+                    source,
+                    target,
+                    manifest_reservation=reservation,
+                )
+            else:
+                assert backup_manifest is not None
+                service.restore_clean_room(
+                    backup,
+                    target,
+                    backup_manifest,
+                    manifest_reservation=reservation,
+                )
+    finally:
+        reservation.close()
+
+    assert not target.exists()
+    assert report_path.exists()
+    assert report_path.stat().st_size == 0
+
+
 @pytest.mark.parametrize("kind", ["source_symlink", "source_hardlink", "target_symlink"])
 def test_aliases_fail_closed(tmp_path: Path, kind: str) -> None:
     source = tmp_path / "source.db"

--- a/tests/maintenance/test_sqlite_service.py
+++ b/tests/maintenance/test_sqlite_service.py
@@ -841,6 +841,60 @@ def test_migration_plan_cannot_attach_or_commit(tmp_path: Path) -> None:
     assert report.source_unchanged is True
 
 
+@pytest.mark.parametrize("pragma", ["hard_heap_limit", "soft_heap_limit"])
+def test_migration_plan_cannot_change_process_global_heap_limits(
+    tmp_path: Path,
+    pragma: str,
+) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "dry-run.db"
+    _create_multiportfolio_database(source).close()
+
+    with sqlite3.connect(":memory:") as observer:
+        before_limit = observer.execute(f"PRAGMA {pragma}").fetchone()
+        report = SQLiteMaintenanceService().dry_run_migration(
+            source,
+            target,
+            plan=MigrationPlan(
+                migration_id=f"deny-{pragma.replace('_', '-')}",
+                steps=(MigrationStep(f"PRAGMA {pragma}=1048576"),),
+            ),
+        )
+        after_limit = observer.execute(f"PRAGMA {pragma}").fetchone()
+
+    assert report.outcome == "rolled_back"
+    assert report.error_code == "migration_plan_failed"
+    assert report.before == report.after
+    assert report.source_unchanged is True
+    assert after_limit == before_limit
+
+
+def test_migration_oversized_integer_parameter_rolls_back_with_report(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "dry-run.db"
+    _create_multiportfolio_database(source).close()
+
+    report = SQLiteMaintenanceService().dry_run_migration(
+        source,
+        target,
+        plan=MigrationPlan(
+            migration_id="oversized-integer",
+            steps=(
+                MigrationStep(
+                    "UPDATE positions SET quantity=? WHERE portfolio_id='alpha'",
+                    (2**100,),
+                ),
+            ),
+        ),
+    )
+
+    assert report.outcome == "rolled_back"
+    assert report.error_code == "migration_plan_failed"
+    assert report.before == report.after
+    assert report.source_unchanged is True
+    assert stat.S_IMODE(target.stat().st_mode) == 0o400
+
+
 def test_verify_rejects_companions_without_creating_or_rewriting_them(tmp_path: Path) -> None:
     source = tmp_path / "source.db"
     _create_multiportfolio_database(source).close()
@@ -943,3 +997,118 @@ def test_cli_backup_verify_and_restore_are_non_authorizing(tmp_path: Path) -> No
         )
         assert completed.returncode == 0, completed.stderr
         assert json.loads(completed.stdout)["authorizes_startup"] is False
+
+
+def test_cli_reserves_backup_manifest_before_database_publication(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    backup = tmp_path / "backup.db"
+    manifest = tmp_path / "backup.json"
+    _create_multiportfolio_database(source).close()
+    manifest.write_bytes(b"operator-owned-report")
+    script = Path(__file__).resolve().parents[2] / "scripts" / "database_maintenance.py"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "backup",
+            "--source",
+            str(source),
+            "--target",
+            str(backup),
+            "--manifest",
+            str(manifest),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+
+    assert completed.returncode == 2
+    assert not backup.exists()
+    assert manifest.read_bytes() == b"operator-owned-report"
+
+
+def test_cli_reserves_restore_manifest_before_database_publication(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    backup = tmp_path / "backup.db"
+    backup_manifest = tmp_path / "backup.json"
+    target = tmp_path / "restore.db"
+    restore_manifest = tmp_path / "restore.json"
+    _create_multiportfolio_database(source).close()
+    service = SQLiteMaintenanceService()
+    manifest = service.backup(source, backup)
+    service.write_manifest(manifest, backup_manifest)
+    restore_manifest.write_bytes(b"operator-owned-report")
+    script = Path(__file__).resolve().parents[2] / "scripts" / "database_maintenance.py"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "restore-clean-room",
+            "--backup",
+            str(backup),
+            "--backup-manifest",
+            str(backup_manifest),
+            "--target",
+            str(target),
+            "--restore-manifest",
+            str(restore_manifest),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+
+    assert completed.returncode == 2
+    assert not target.exists()
+    assert restore_manifest.read_bytes() == b"operator-owned-report"
+
+
+@pytest.mark.parametrize(
+    ("family_owner", "suffix"),
+    [
+        ("source", "-wal"),
+        ("target", ""),
+        ("target", "-journal"),
+        ("target", "-shm"),
+        ("target", "-wal"),
+    ],
+)
+def test_cli_rejects_manifest_in_database_resource_family(
+    tmp_path: Path,
+    family_owner: str,
+    suffix: str,
+) -> None:
+    source = tmp_path / "source.db"
+    backup = tmp_path / "backup.db"
+    owner = source if family_owner == "source" else backup
+    manifest = owner.with_name(owner.name + suffix)
+    _create_multiportfolio_database(source).close()
+    script = Path(__file__).resolve().parents[2] / "scripts" / "database_maintenance.py"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "backup",
+            "--source",
+            str(source),
+            "--target",
+            str(backup),
+            "--manifest",
+            str(manifest),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+
+    assert completed.returncode == 2
+    assert "report path overlaps a SQLite resource family" in completed.stderr
+    assert not backup.exists()
+    assert not manifest.exists()

--- a/tests/maintenance/test_sqlite_service.py
+++ b/tests/maintenance/test_sqlite_service.py
@@ -231,13 +231,11 @@ def test_sqlite_uses_private_namespace_and_never_unlinks_public_wal_replacement(
     assert public_wal.read_bytes() == protected_payload
     assert not target.exists()
     forensic_targets = list(tmp_path.glob(f".{target.name}.robo-trader-stage-*"))
-    assert len(forensic_targets) == 1
-    assert forensic_targets[0].is_file()
-    assert stat.S_IMODE(forensic_targets[0].stat().st_mode) == 0o400
+    assert forensic_targets == []
 
 
 def test_staging_symlink_cannot_redirect_sqlite_into_attacker_directory(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
 ) -> None:
     source = tmp_path / "source.db"
     target = tmp_path / "target.db"
@@ -245,23 +243,20 @@ def test_staging_symlink_cannot_redirect_sqlite_into_attacker_directory(
     attacker_directory.mkdir()
     planted_wal = attacker_directory / "database.db-wal"
     planted_wal.write_bytes(b"irreplaceable-user-data")
-    token = "a" * 32
-    staged_name = f".{target.name}.robo-trader-stage-{token}"
+    staged_name = f".{target.name}.robo-trader-stage-{'a' * 32}"
     (tmp_path / staged_name).symlink_to(attacker_directory, target_is_directory=True)
     writer = _create_multiportfolio_database(source, wal=True)
-    monkeypatch.setattr(sqlite_service_module.secrets, "token_hex", lambda _size: token)
 
     try:
-        with pytest.raises(SQLiteMaintenanceError, match="staging name could not be reserved"):
-            SQLiteMaintenanceService().backup(source, target)
+        manifest = SQLiteMaintenanceService().backup(source, target)
     finally:
         writer.close()
 
     assert planted_wal.read_bytes() == b"irreplaceable-user-data"
-    assert not target.exists()
+    assert SQLiteMaintenanceService().verify(target) == manifest.evidence
 
 
-def test_named_staging_inode_cannot_be_opened_writable_before_sealing(
+def test_anonymous_staging_cannot_be_located_chmodded_or_opened(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     source = tmp_path / "source.db"
@@ -271,6 +266,8 @@ def test_named_staging_inode_cannot_be_opened_writable_before_sealing(
     real_stage = service._stage_target
     staged_target = None
     attempted = False
+    located_paths: list[Path] = []
+    baseline_entries = set(tmp_path.iterdir())
 
     def capture_stage(requested_path):
         nonlocal staged_target
@@ -282,14 +279,19 @@ def test_named_staging_inode_cannot_be_opened_writable_before_sealing(
         if not attempted:
             attempted = True
             assert staged_target is not None
-            with pytest.raises(PermissionError):
-                os.open(staged_target.forensic_path, os.O_RDWR)
+            assert os.fstat(staged_target.guardian_file_descriptor).st_nlink == 0
+            located_paths.extend(set(tmp_path.iterdir()) - baseline_entries)
+            for path in located_paths:
+                path.chmod(0o600)
+                descriptor = os.open(path, os.O_RDWR)
+                os.close(descriptor)
 
     monkeypatch.setattr(service, "_stage_target", capture_stage)
     service._progress_hook = attempt_writable_open
     manifest = service.backup(source, target)
 
     assert attempted
+    assert located_paths == []
     assert hashlib.sha256(target.read_bytes()).hexdigest() == manifest.artifact_sha256
 
 
@@ -442,8 +444,7 @@ def test_interrupted_backup_preserves_source_and_seals_forensic_target(tmp_path:
     assert source.read_bytes() == before
     assert not target.exists()
     forensic_targets = list(tmp_path.glob(f".{target.name}.robo-trader-stage-*"))
-    assert len(forensic_targets) == 1
-    assert stat.S_IMODE(forensic_targets[0].stat().st_mode) == 0o400
+    assert forensic_targets == []
 
 
 def test_manifest_with_unknown_field_is_rejected(tmp_path: Path) -> None:
@@ -480,38 +481,35 @@ def test_target_substitution_during_backup_fails_descriptor_check(tmp_path: Path
     assert target.is_symlink()
 
 
-def test_hardlink_race_during_backup_fails_closed(
+def test_anonymous_staging_has_no_path_for_hardlink_race(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     source = tmp_path / "source.db"
     target = tmp_path / "target.db"
-    alias = tmp_path / "target-alias.db"
     _create_multiportfolio_database(source).close()
     service = SQLiteMaintenanceService()
     real_stage = service._stage_target
-    staged_path: Path | None = None
+    staged_target = None
     invoked = False
 
     def capture_stage(requested_path):
-        nonlocal staged_path
-        staged = real_stage(requested_path)
-        staged_path = staged.forensic_path
-        return staged
+        nonlocal staged_target
+        staged_target = real_stage(requested_path)
+        return staged_target
 
-    def add_link(_operation: str, _remaining: int, _total: int) -> None:
+    def attempt_link(_operation: str, _remaining: int, _total: int) -> None:
         nonlocal invoked
         if not invoked:
             invoked = True
-            assert staged_path is not None
-            os.link(staged_path, alias)
+            assert staged_target is not None
+            assert os.fstat(staged_target.guardian_file_descriptor).st_nlink == 0
+            assert list(tmp_path.glob(f".{target.name}.robo-trader-stage-*")) == []
 
     monkeypatch.setattr(service, "_stage_target", capture_stage)
-    with pytest.raises(SQLiteMaintenanceError, match="staged database identity changed"):
-        service._progress_hook = add_link
-        service.backup(source, target)
+    service._progress_hook = attempt_link
+    service.backup(source, target)
     assert source.exists()
-    assert not target.exists()
-    assert alias.exists()
+    assert target.exists()
 
 
 def test_interrupted_restore_preserves_backup_and_seals_target(tmp_path: Path) -> None:
@@ -533,8 +531,7 @@ def test_interrupted_restore_preserves_backup_and_seals_target(tmp_path: Path) -
     assert backup.read_bytes() == backup_before
     assert not target.exists()
     forensic_targets = list(tmp_path.glob(f".{target.name}.robo-trader-stage-*"))
-    assert len(forensic_targets) == 1
-    assert stat.S_IMODE(forensic_targets[0].stat().st_mode) == 0o400
+    assert forensic_targets == []
 
 
 def test_migration_dry_run_changes_only_synthetic_copy(tmp_path: Path) -> None:

--- a/tests/maintenance/test_sqlite_service.py
+++ b/tests/maintenance/test_sqlite_service.py
@@ -120,6 +120,34 @@ def test_wal_checkpoint_during_online_backup_is_not_treated_as_source_mutation(
     assert SQLiteMaintenanceService().verify(target) == manifest.evidence
 
 
+def test_cleanly_closed_wal_source_does_not_create_service_sidecars(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.db"
+    backup = tmp_path / "backup.db"
+    synthetic = tmp_path / "synthetic.db"
+    writer = _create_multiportfolio_database(source, wal=True)
+    writer.close()
+    companions = tuple(source.with_name(source.name + suffix) for suffix in ("-wal", "-shm"))
+    assert not any(path.exists() for path in companions)
+
+    service = SQLiteMaintenanceService()
+    manifest = service.backup(source, backup)
+    report = service.dry_run_migration(
+        source,
+        synthetic,
+        plan=MigrationPlan(
+            migration_id="clean-wal-noop",
+            steps=(MigrationStep(sql="SELECT 1"),),
+        ),
+    )
+
+    assert service.verify(backup) == manifest.evidence
+    assert report.source_unchanged is True
+    assert report.outcome == "applied_to_synthetic_copy"
+    assert not any(path.exists() for path in companions)
+
+
 def test_manifest_is_secret_free_portable_and_exclusively_written(tmp_path: Path) -> None:
     source = tmp_path / "source.db"
     backup = tmp_path / "backup.db"
@@ -256,7 +284,7 @@ def test_staging_symlink_cannot_redirect_sqlite_into_attacker_directory(
     assert SQLiteMaintenanceService().verify(target) == manifest.evidence
 
 
-def test_anonymous_staging_cannot_be_located_chmodded_or_opened(
+def test_no_persistent_staging_path_is_exposed_during_copy(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     source = tmp_path / "source.db"

--- a/tests/maintenance/test_sqlite_service.py
+++ b/tests/maintenance/test_sqlite_service.py
@@ -614,6 +614,7 @@ def test_restore_verifies_and_copies_through_one_bound_source_open(
     _create_multiportfolio_database(replacement).close()
     with sqlite3.connect(replacement) as connection:
         connection.execute("VACUUM")
+        connection.execute(f"PRAGMA schema_version={manifest.evidence.schema_version}")
     assert replacement.read_bytes() != backup.read_bytes()
     assert service.verify(replacement) == manifest.evidence
 
@@ -932,6 +933,55 @@ def test_migration_plan_deadline_interrupts_and_rolls_back(tmp_path: Path) -> No
     assert report.source_unchanged is True
 
 
+def test_migration_denies_native_function_that_can_evade_vm_deadline(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "dry-run.db"
+    _create_multiportfolio_database(source).close()
+
+    report = SQLiteMaintenanceService(max_migration_seconds=0.01).dry_run_migration(
+        source,
+        target,
+        plan=MigrationPlan(
+            migration_id="deny-native-allocation",
+            steps=(
+                MigrationStep("CREATE TABLE oversized_payload (value BLOB NOT NULL)"),
+                MigrationStep("INSERT INTO oversized_payload VALUES (randomblob(50000000))"),
+            ),
+        ),
+    )
+
+    assert report.outcome == "rolled_back"
+    assert report.error_code == "migration_plan_failed"
+    assert report.before == report.after
+    assert report.source_unchanged is True
+    assert target.stat().st_size < 50_000_000
+
+
+def test_migration_growth_is_capped_by_synthetic_database_page_limit(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "dry-run.db"
+    _create_multiportfolio_database(source).close()
+    payload = b"x" * 700_000
+
+    report = SQLiteMaintenanceService(max_migration_growth_bytes=1024 * 1024).dry_run_migration(
+        source,
+        target,
+        plan=MigrationPlan(
+            migration_id="bounded-synthetic-growth",
+            steps=(
+                MigrationStep("CREATE TABLE bounded_payload (value BLOB NOT NULL)"),
+                MigrationStep("INSERT INTO bounded_payload VALUES (?)", (payload,)),
+                MigrationStep("INSERT INTO bounded_payload VALUES (?)", (payload,)),
+            ),
+        ),
+    )
+
+    assert report.outcome == "rolled_back"
+    assert report.error_code == "migration_plan_failed"
+    assert report.before == report.after
+    assert report.source_unchanged is True
+
+
 def test_migration_authorizer_denies_native_pointer_and_virtual_table_actions(
     tmp_path: Path,
 ) -> None:
@@ -943,6 +993,9 @@ def test_migration_authorizer_denies_native_pointer_and_virtual_table_actions(
     assert (
         authorizer(sqlite3.SQLITE_FUNCTION, None, "load_extension", None, None)
         == sqlite3.SQLITE_DENY
+    )
+    assert (
+        authorizer(sqlite3.SQLITE_FUNCTION, None, "randomblob", None, None) == sqlite3.SQLITE_DENY
     )
     assert (
         authorizer(sqlite3.SQLITE_CREATE_VTABLE, "docs", "fts3", "main", None)
@@ -1005,6 +1058,56 @@ def test_migration_plan_cannot_change_untracked_schema_cookie(tmp_path: Path) ->
     assert report.source_unchanged is True
     with sqlite3.connect(target) as connection:
         assert connection.execute("PRAGMA schema_version").fetchone() != (999,)
+
+
+def test_migration_evidence_tracks_schema_cookie_after_transient_ddl(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "dry-run.db"
+    _create_multiportfolio_database(source).close()
+
+    report = SQLiteMaintenanceService().dry_run_migration(
+        source,
+        target,
+        plan=MigrationPlan(
+            migration_id="transient-ddl-schema-cookie",
+            steps=(
+                MigrationStep("CREATE TABLE transient_table (id INTEGER PRIMARY KEY)"),
+                MigrationStep("DROP TABLE transient_table"),
+            ),
+        ),
+    )
+
+    assert report.outcome == "applied_to_synthetic_copy"
+    assert report.before.schema_sha256 == report.after.schema_sha256
+    assert report.after.schema_version > report.before.schema_version
+    assert report.before != report.after
+
+
+def test_final_source_evidence_failure_prevents_synthetic_publication(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "dry-run.db"
+    _create_multiportfolio_database(source).close()
+    service = SQLiteMaintenanceService()
+
+    def fail_final_evidence(_source_path: Path | str):
+        raise SQLiteMaintenanceError("injected final evidence failure")
+
+    monkeypatch.setattr(service, "_live_source_evidence", fail_final_evidence)
+
+    with pytest.raises(SQLiteMaintenanceError, match="final evidence failure"):
+        service.dry_run_migration(
+            source,
+            target,
+            plan=MigrationPlan(
+                migration_id="final-evidence-failure",
+                steps=(MigrationStep("ALTER TABLE positions ADD COLUMN note TEXT"),),
+            ),
+        )
+
+    assert not target.exists()
+    assert list(tmp_path.glob(f".{target.name}.robo-trader-stage-*")) == []
 
 
 def test_migration_uses_the_copy_connection_without_a_writable_reopen(

--- a/tests/maintenance/test_sqlite_service.py
+++ b/tests/maintenance/test_sqlite_service.py
@@ -179,40 +179,58 @@ def test_preexisting_target_sidecar_is_preserved_without_main_creation(
 
 
 def test_sqlite_uses_private_namespace_and_never_unlinks_public_wal_replacement(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
 ) -> None:
     source = tmp_path / "source.db"
     target = tmp_path / "target.db"
     public_wal = target.with_name(target.name + "-wal")
     protected_payload = b"irreplaceable-user-evidence"
     writer = _create_multiportfolio_database(source, wal=True)
-    service = SQLiteMaintenanceService()
-    real_connect = service._connect_bound
-    writable_paths: list[Path] = []
+    invoked = False
 
-    def observe_connect(binding, *, readonly, journal_off=False, immutable_readonly=False):
-        if not readonly:
-            writable_paths.append(binding.path)
+    def inject_public_sidecar(_operation: str, _remaining: int, _total: int) -> None:
+        nonlocal invoked
+        if not invoked:
+            invoked = True
             public_wal.write_bytes(protected_payload)
-        return real_connect(
-            binding,
-            readonly=readonly,
-            journal_off=journal_off,
-            immutable_readonly=immutable_readonly,
-        )
 
-    monkeypatch.setattr(service, "_connect_bound", observe_connect)
     try:
         with pytest.raises(SQLiteMaintenanceError, match="new exclusively-created SQLite family"):
-            service.backup(source, target)
+            SQLiteMaintenanceService(progress_hook=inject_public_sidecar).backup(source, target)
     finally:
         writer.close()
 
-    assert writable_paths
-    assert all(path != target and path.parent != target.parent for path in writable_paths)
-    assert stat.S_IMODE(writable_paths[0].parent.stat().st_mode) == 0o700
-    assert writable_paths[0].parent.name.startswith(f".{target.name}.robo-trader-stage-")
+    assert invoked
     assert public_wal.read_bytes() == protected_payload
+    assert not target.exists()
+    forensic_targets = list(tmp_path.glob(f".{target.name}.robo-trader-stage-*"))
+    assert len(forensic_targets) == 1
+    assert forensic_targets[0].is_file()
+    assert stat.S_IMODE(forensic_targets[0].stat().st_mode) == 0o400
+
+
+def test_staging_symlink_cannot_redirect_sqlite_into_attacker_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "target.db"
+    attacker_directory = tmp_path / "attacker"
+    attacker_directory.mkdir()
+    planted_wal = attacker_directory / "database.db-wal"
+    planted_wal.write_bytes(b"irreplaceable-user-data")
+    token = "a" * 32
+    staged_name = f".{target.name}.robo-trader-stage-{token}"
+    (tmp_path / staged_name).symlink_to(attacker_directory, target_is_directory=True)
+    writer = _create_multiportfolio_database(source, wal=True)
+    monkeypatch.setattr(sqlite_service_module.secrets, "token_hex", lambda _size: token)
+
+    try:
+        with pytest.raises(SQLiteMaintenanceError, match="staging name could not be reserved"):
+            SQLiteMaintenanceService().backup(source, target)
+    finally:
+        writer.close()
+
+    assert planted_wal.read_bytes() == b"irreplaceable-user-data"
     assert not target.exists()
 
 
@@ -313,7 +331,7 @@ def test_interrupted_backup_preserves_source_and_seals_forensic_target(tmp_path:
 
     assert source.read_bytes() == before
     assert not target.exists()
-    forensic_targets = list(tmp_path.glob(f".{target.name}.robo-trader-stage-*/database.db"))
+    forensic_targets = list(tmp_path.glob(f".{target.name}.robo-trader-stage-*"))
     assert len(forensic_targets) == 1
     assert stat.S_IMODE(forensic_targets[0].stat().st_mode) == 0o400
 
@@ -367,7 +385,7 @@ def test_hardlink_race_during_backup_fails_closed(
     def capture_stage(requested_path):
         nonlocal staged_path
         staged = real_stage(requested_path)
-        staged_path = staged.binding.path
+        staged_path = staged.forensic_path
         return staged
 
     def add_link(_operation: str, _remaining: int, _total: int) -> None:
@@ -378,7 +396,7 @@ def test_hardlink_race_during_backup_fails_closed(
             os.link(staged_path, alias)
 
     monkeypatch.setattr(service, "_stage_target", capture_stage)
-    with pytest.raises(SQLiteMaintenanceError, match="another filesystem link"):
+    with pytest.raises(SQLiteMaintenanceError, match="staged database identity changed"):
         service._progress_hook = add_link
         service.backup(source, target)
     assert source.exists()
@@ -404,7 +422,7 @@ def test_interrupted_restore_preserves_backup_and_seals_target(tmp_path: Path) -
         )
     assert backup.read_bytes() == backup_before
     assert not target.exists()
-    forensic_targets = list(tmp_path.glob(f".{target.name}.robo-trader-stage-*/database.db"))
+    forensic_targets = list(tmp_path.glob(f".{target.name}.robo-trader-stage-*"))
     assert len(forensic_targets) == 1
     assert stat.S_IMODE(forensic_targets[0].stat().st_mode) == 0o400
 
@@ -475,9 +493,7 @@ def test_migration_uses_the_copy_connection_without_a_writable_reopen(
     )
 
     assert report.outcome == "applied_to_synthetic_copy"
-    assert len(writable_paths) == 1
-    assert writable_paths[0] != target
-    assert writable_paths[0].parent != target.parent
+    assert writable_paths == []
     assert target not in all_opened_paths
 
 

--- a/tests/maintenance/test_sqlite_service.py
+++ b/tests/maintenance/test_sqlite_service.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import pytest
 
 from robo_trader.maintenance import (
+    MigrationPlan,
+    MigrationStep,
     SQLiteMaintenanceError,
     SQLiteMaintenanceService,
 )
@@ -71,6 +73,11 @@ def test_wal_active_backup_and_clean_room_restore_preserve_multiportfolio_state(
         assert manifest.authorizes_startup is False
         assert stat.S_IMODE(backup.stat().st_mode) == 0o400
         assert stat.S_IMODE(restored.stat().st_mode) == 0o400
+        for database in (backup, restored):
+            assert not any(
+                database.with_name(database.name + suffix).exists()
+                for suffix in ("-journal", "-shm", "-wal")
+            )
         with sqlite3.connect(restored) as connection:
             assert connection.execute(
                 "SELECT portfolio_id,symbol,quantity FROM positions " "ORDER BY portfolio_id,symbol"
@@ -98,6 +105,8 @@ def test_manifest_is_secret_free_portable_and_exclusively_written(tmp_path: Path
     assert str(tmp_path) not in serialized
     assert "credential" not in serialized.lower()
     assert "account" not in serialized.lower()
+    assert "positions" not in serialized.lower()
+    assert "portfolios" not in serialized.lower()
     assert payload["contains_secrets"] is False
     assert payload["mutated_authoritative_state"] is False
     assert payload["authorizes_startup"] is False
@@ -150,6 +159,23 @@ def test_existing_restore_target_is_never_replaced(tmp_path: Path) -> None:
     assert target.read_bytes() == b"do-not-replace"
 
 
+@pytest.mark.parametrize("suffix", ["-journal", "-shm", "-wal"])
+def test_preexisting_target_sidecar_is_preserved_without_main_creation(
+    tmp_path: Path, suffix: str
+) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "target.db"
+    sidecar = target.with_name(target.name + suffix)
+    _create_multiportfolio_database(source).close()
+    sidecar.write_bytes(b"operator-evidence")
+
+    with pytest.raises(SQLiteMaintenanceError, match="new exclusively-created SQLite family"):
+        SQLiteMaintenanceService().backup(source, target)
+
+    assert not target.exists()
+    assert sidecar.read_bytes() == b"operator-evidence"
+
+
 def test_target_cannot_overlap_source_sqlite_companion_family(tmp_path: Path) -> None:
     source = tmp_path / "source.db"
     _create_multiportfolio_database(source).close()
@@ -186,6 +212,51 @@ def test_manifest_detects_backup_corruption_before_clean_room_creation(tmp_path:
     with pytest.raises(SQLiteMaintenanceError):
         service.restore_clean_room(backup, target, manifest)
     assert not target.exists()
+
+
+def test_restore_verifies_and_copies_through_one_bound_source_open(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source.db"
+    backup = tmp_path / "backup.db"
+    replacement = tmp_path / "replacement.db"
+    parked = tmp_path / "parked.db"
+    target = tmp_path / "restore.db"
+    _create_multiportfolio_database(source).close()
+    service = SQLiteMaintenanceService()
+    manifest = service.backup(source, backup)
+    with sqlite3.connect(replacement) as connection:
+        connection.execute("PRAGMA page_size=8192")
+    _create_multiportfolio_database(replacement).close()
+    with sqlite3.connect(replacement) as connection:
+        connection.execute("VACUUM")
+    assert replacement.read_bytes() != backup.read_bytes()
+    assert service.verify(replacement) == manifest.evidence
+
+    real_connect = service._connect_bound
+    readonly_backup_opens = 0
+
+    def observe_connect(binding, *, readonly, journal_off=False, immutable_readonly=False):
+        nonlocal readonly_backup_opens
+        if readonly and binding.path == backup:
+            readonly_backup_opens += 1
+            if readonly_backup_opens == 2:
+                backup.rename(parked)
+                replacement.rename(backup)
+        return real_connect(
+            binding,
+            readonly=readonly,
+            journal_off=journal_off,
+            immutable_readonly=immutable_readonly,
+        )
+
+    monkeypatch.setattr(service, "_connect_bound", observe_connect)
+    restored = service.restore_clean_room(backup, target, manifest)
+
+    assert readonly_backup_opens == 1
+    assert restored.input_artifact_sha256 == manifest.artifact_sha256
+    assert not parked.exists()
+    assert replacement.exists()
 
 
 def test_interrupted_backup_preserves_source_and_seals_forensic_target(tmp_path: Path) -> None:
@@ -288,16 +359,20 @@ def test_migration_dry_run_changes_only_synthetic_copy(tmp_path: Path) -> None:
     _create_multiportfolio_database(source).close()
     before_bytes = source.read_bytes()
 
-    def migration(connection: sqlite3.Connection) -> None:
-        connection.execute("ALTER TABLE positions ADD COLUMN note TEXT")
-        connection.execute("UPDATE positions SET note='synthetic-only' WHERE portfolio_id='alpha'")
-        connection.execute("PRAGMA user_version=8")
-
     report = SQLiteMaintenanceService().dry_run_migration(
         source,
         target,
-        migration_id="synthetic-v8",
-        migration=migration,
+        plan=MigrationPlan(
+            migration_id="synthetic-v8",
+            steps=(
+                MigrationStep("ALTER TABLE positions ADD COLUMN note TEXT"),
+                MigrationStep(
+                    "UPDATE positions SET note=? WHERE portfolio_id=?",
+                    ("synthetic-only", "alpha"),
+                ),
+            ),
+            target_user_version=8,
+        ),
     )
 
     assert report.outcome == "applied_to_synthetic_copy"
@@ -316,40 +391,54 @@ def test_interrupted_migration_rolls_back_copy_and_preserves_source(tmp_path: Pa
     target = tmp_path / "dry-run.db"
     _create_multiportfolio_database(source).close()
 
-    def migration(connection: sqlite3.Connection) -> None:
-        connection.execute("DELETE FROM positions")
-        raise RuntimeError("simulated interruption")
-
     report = SQLiteMaintenanceService().dry_run_migration(
         source,
         target,
-        migration_id="synthetic-interruption",
-        migration=migration,
+        plan=MigrationPlan(
+            migration_id="synthetic-interruption",
+            steps=(
+                MigrationStep("DELETE FROM positions"),
+                MigrationStep("THIS IS NOT VALID SQL"),
+            ),
+        ),
     )
 
     assert report.outcome == "rolled_back"
-    assert report.error_code == "migration_callback_failed"
+    assert report.error_code == "migration_plan_failed"
     assert report.before == report.after
     assert report.source_unchanged is True
     assert stat.S_IMODE(target.stat().st_mode) == 0o400
 
 
-def test_migration_callback_cannot_attach_or_commit(tmp_path: Path) -> None:
+def test_migration_plan_cannot_attach_or_commit(tmp_path: Path) -> None:
     source = tmp_path / "source.db"
     target = tmp_path / "dry-run.db"
     _create_multiportfolio_database(source).close()
 
-    def migration(connection: sqlite3.Connection) -> None:
-        connection.execute("ATTACH DATABASE ':memory:' AS escaped")
-
     report = SQLiteMaintenanceService().dry_run_migration(
         source,
         target,
-        migration_id="synthetic-attach",
-        migration=migration,
+        plan=MigrationPlan(
+            migration_id="synthetic-attach",
+            steps=(MigrationStep("ATTACH DATABASE ? AS escaped", (str(source),)),),
+        ),
     )
     assert report.outcome == "rolled_back"
     assert report.before == report.after
+    assert report.source_unchanged is True
+
+
+def test_verify_rejects_companions_without_creating_or_rewriting_them(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    _create_multiportfolio_database(source).close()
+    wal = source.with_name(source.name + "-wal")
+    wal.write_bytes(b"preserve-this-evidence")
+    before = {path.name: path.read_bytes() for path in tmp_path.iterdir()}
+
+    with pytest.raises(SQLiteMaintenanceError, match="sealed database"):
+        SQLiteMaintenanceService().verify(source)
+
+    assert {path.name: path.read_bytes() for path in tmp_path.iterdir()} == before
 
 
 @pytest.mark.asyncio

--- a/tests/maintenance/test_sqlite_service.py
+++ b/tests/maintenance/test_sqlite_service.py
@@ -1134,6 +1134,32 @@ def test_migration_rejects_commented_schema_function_calls(
     assert report.source_unchanged is True
 
 
+def test_schema_line_comment_continues_through_carriage_return(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "dry-run.db"
+    with sqlite3.connect(source) as connection:
+        connection.execute(
+            "CREATE TABLE guarded ("
+            "value INTEGER NOT NULL CHECK(1 -- note\rrandomblob/**/(50000000)\n)"
+            ")"
+        )
+        assert sqlite_service_module._schema_function_calls(connection) == ()
+
+    report = SQLiteMaintenanceService(max_migration_seconds=1).dry_run_migration(
+        source,
+        target,
+        plan=MigrationPlan(
+            migration_id="accept-function-name-inside-line-comment",
+            steps=(MigrationStep("INSERT INTO guarded(value) VALUES (?)", (1,)),),
+        ),
+    )
+
+    assert report.outcome == "applied_to_synthetic_copy"
+    assert report.error_code is None
+    assert report.before != report.after
+    assert report.source_unchanged is True
+
+
 def test_migration_authorizer_denies_native_pointer_and_virtual_table_actions(
     tmp_path: Path,
 ) -> None:

--- a/tests/maintenance/test_sqlite_service.py
+++ b/tests/maintenance/test_sqlite_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import sqlite3
@@ -177,62 +178,42 @@ def test_preexisting_target_sidecar_is_preserved_without_main_creation(
     assert sidecar.read_bytes() == b"operator-evidence"
 
 
-def test_release_accepts_only_sqlite_consumed_sidecar_reservations(tmp_path: Path) -> None:
-    target = tmp_path / "target.db"
-    reservation = SQLiteMaintenanceService._reserve_target(target)
-    consumed = target.with_name(target.name + "-wal")
-    try:
-        # Model SQLite's Linux WAL close behavior: it removes its own empty
-        # reservation while the maintenance service still holds the descriptor.
-        os.unlink(consumed)
-        reservation.release()
-    finally:
-        reservation.binding.close()
-
-    assert not consumed.exists()
-    assert not any(
-        target.with_name(target.name + suffix).exists() for suffix in ("-journal", "-shm", "-wal")
-    )
-
-
-def test_release_never_deletes_sidecar_substituted_after_check(
+def test_sqlite_uses_private_namespace_and_never_unlinks_public_wal_replacement(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    source = tmp_path / "source.db"
     target = tmp_path / "target.db"
-    displaced = tmp_path / "original-reservation"
+    public_wal = target.with_name(target.name + "-wal")
     protected_payload = b"irreplaceable-user-evidence"
-    reservation = SQLiteMaintenanceService._reserve_target(target)
-    raced_path = target.with_name(target.name + "-journal")
-    real_rename_noreplace = sqlite_service_module._rename_noreplace
-    raced = False
+    writer = _create_multiportfolio_database(source, wal=True)
+    service = SQLiteMaintenanceService()
+    real_connect = service._connect_bound
+    writable_paths: list[Path] = []
 
-    def substitute_before_atomic_claim(source: Path, destination: Path) -> None:
-        nonlocal raced
-        if source == raced_path and not raced:
-            raced = True
-            source.rename(displaced)
-            source.write_bytes(protected_payload)
-        real_rename_noreplace(source, destination)
+    def observe_connect(binding, *, readonly, journal_off=False, immutable_readonly=False):
+        if not readonly:
+            writable_paths.append(binding.path)
+            public_wal.write_bytes(protected_payload)
+        return real_connect(
+            binding,
+            readonly=readonly,
+            journal_off=journal_off,
+            immutable_readonly=immutable_readonly,
+        )
 
-    monkeypatch.setattr(
-        sqlite_service_module,
-        "_rename_noreplace",
-        substitute_before_atomic_claim,
-    )
+    monkeypatch.setattr(service, "_connect_bound", observe_connect)
     try:
-        with pytest.raises(SQLiteMaintenanceError, match="could not be released safely"):
-            reservation.release()
+        with pytest.raises(SQLiteMaintenanceError, match="new exclusively-created SQLite family"):
+            service.backup(source, target)
     finally:
-        reservation.binding.close()
+        writer.close()
 
-    preserved = [
-        path
-        for path in tmp_path.rglob("*")
-        if path.is_file() and path.read_bytes() == protected_payload
-    ]
-    assert preserved, "the substituted user file must be preserved, never unlinked"
-    assert raced_path.read_bytes() == protected_payload
-    assert displaced.exists()
+    assert writable_paths
+    assert all(path != target and path.parent != target.parent for path in writable_paths)
+    assert stat.S_IMODE(writable_paths[0].parent.stat().st_mode) == 0o700
+    assert writable_paths[0].parent.name.startswith(f".{target.name}.robo-trader-stage-")
+    assert public_wal.read_bytes() == protected_payload
+    assert not target.exists()
 
 
 def test_target_cannot_overlap_source_sqlite_companion_family(tmp_path: Path) -> None:
@@ -331,8 +312,10 @@ def test_interrupted_backup_preserves_source_and_seals_forensic_target(tmp_path:
         SQLiteMaintenanceService(progress_hook=interrupt).backup(source, target)
 
     assert source.read_bytes() == before
-    assert target.exists()
-    assert stat.S_IMODE(target.stat().st_mode) == 0o400
+    assert not target.exists()
+    forensic_targets = list(tmp_path.glob(f".{target.name}.robo-trader-stage-*/database.db"))
+    assert len(forensic_targets) == 1
+    assert stat.S_IMODE(forensic_targets[0].stat().st_mode) == 0o400
 
 
 def test_manifest_with_unknown_field_is_rejected(tmp_path: Path) -> None:
@@ -353,7 +336,6 @@ def test_manifest_with_unknown_field_is_rejected(tmp_path: Path) -> None:
 def test_target_substitution_during_backup_fails_descriptor_check(tmp_path: Path) -> None:
     source = tmp_path / "source.db"
     target = tmp_path / "target.db"
-    displaced = tmp_path / "displaced.db"
     _create_multiportfolio_database(source).close()
     invoked = False
 
@@ -362,32 +344,45 @@ def test_target_substitution_during_backup_fails_descriptor_check(tmp_path: Path
         if invoked:
             return
         invoked = True
-        target.rename(displaced)
         target.symlink_to(source)
 
-    with pytest.raises(SQLiteMaintenanceError, match="failed closed"):
+    with pytest.raises(SQLiteMaintenanceError, match="new exclusively-created"):
         SQLiteMaintenanceService(progress_hook=replace_target).backup(source, target)
     assert source.exists()
-    assert displaced.exists()
+    assert target.is_symlink()
 
 
-def test_hardlink_race_during_backup_fails_closed(tmp_path: Path) -> None:
+def test_hardlink_race_during_backup_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     source = tmp_path / "source.db"
     target = tmp_path / "target.db"
     alias = tmp_path / "target-alias.db"
     _create_multiportfolio_database(source).close()
+    service = SQLiteMaintenanceService()
+    real_stage = service._stage_target
+    staged_path: Path | None = None
     invoked = False
+
+    def capture_stage(requested_path):
+        nonlocal staged_path
+        staged = real_stage(requested_path)
+        staged_path = staged.binding.path
+        return staged
 
     def add_link(_operation: str, _remaining: int, _total: int) -> None:
         nonlocal invoked
         if not invoked:
             invoked = True
-            os.link(target, alias)
+            assert staged_path is not None
+            os.link(staged_path, alias)
 
+    monkeypatch.setattr(service, "_stage_target", capture_stage)
     with pytest.raises(SQLiteMaintenanceError, match="another filesystem link"):
-        SQLiteMaintenanceService(progress_hook=add_link).backup(source, target)
+        service._progress_hook = add_link
+        service.backup(source, target)
     assert source.exists()
-    assert target.exists()
+    assert not target.exists()
     assert alias.exists()
 
 
@@ -408,8 +403,10 @@ def test_interrupted_restore_preserves_backup_and_seals_target(tmp_path: Path) -
             backup, target, manifest
         )
     assert backup.read_bytes() == backup_before
-    assert target.exists()
-    assert stat.S_IMODE(target.stat().st_mode) == 0o400
+    assert not target.exists()
+    forensic_targets = list(tmp_path.glob(f".{target.name}.robo-trader-stage-*/database.db"))
+    assert len(forensic_targets) == 1
+    assert stat.S_IMODE(forensic_targets[0].stat().st_mode) == 0o400
 
 
 def test_migration_dry_run_changes_only_synthetic_copy(tmp_path: Path) -> None:
@@ -453,12 +450,13 @@ def test_migration_uses_the_copy_connection_without_a_writable_reopen(
     _create_multiportfolio_database(source).close()
     service = SQLiteMaintenanceService()
     real_connect = service._connect_bound
-    writable_target_opens = 0
+    writable_paths: list[Path] = []
+    all_opened_paths: list[Path] = []
 
     def count_connect(binding, *, readonly, journal_off=False, immutable_readonly=False):
-        nonlocal writable_target_opens
-        if binding.path == target and not readonly:
-            writable_target_opens += 1
+        all_opened_paths.append(binding.path)
+        if not readonly:
+            writable_paths.append(binding.path)
         return real_connect(
             binding,
             readonly=readonly,
@@ -477,7 +475,51 @@ def test_migration_uses_the_copy_connection_without_a_writable_reopen(
     )
 
     assert report.outcome == "applied_to_synthetic_copy"
-    assert writable_target_opens == 1
+    assert len(writable_paths) == 1
+    assert writable_paths[0] != target
+    assert writable_paths[0].parent != target.parent
+    assert target not in all_opened_paths
+
+
+def test_migration_report_remains_bound_to_manifest_after_target_substitution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "dry-run.db"
+    parked = tmp_path / "bound-copy.db"
+    replacement = tmp_path / "replacement.db"
+    _create_multiportfolio_database(source).close()
+    replacement_connection = _create_multiportfolio_database(replacement)
+    replacement_connection.execute("INSERT INTO positions VALUES ('alpha', 'TSLA', 99)")
+    replacement_connection.commit()
+    replacement_connection.close()
+    service = SQLiteMaintenanceService()
+    real_online_copy = service._online_copy
+    captured_manifest = None
+
+    def substitute_after_bound_copy(*args, **kwargs):
+        nonlocal captured_manifest
+        manifest, result = real_online_copy(*args, **kwargs)
+        captured_manifest = manifest
+        target.rename(parked)
+        replacement.rename(target)
+        return manifest, result
+
+    monkeypatch.setattr(service, "_online_copy", substitute_after_bound_copy)
+    report = service.dry_run_migration(
+        source,
+        target,
+        plan=MigrationPlan(
+            migration_id="bound-final-report",
+            steps=(MigrationStep("ALTER TABLE positions ADD COLUMN note TEXT"),),
+        ),
+    )
+
+    assert captured_manifest is not None
+    assert report.after == captured_manifest.evidence
+    assert report.target_artifact_sha256 == captured_manifest.artifact_sha256
+    assert report.target_artifact_sha256 == hashlib.sha256(parked.read_bytes()).hexdigest()
+    assert report.target_artifact_sha256 != hashlib.sha256(target.read_bytes()).hexdigest()
 
 
 def test_service_transaction_completion_policy_is_python310_compatible() -> None:

--- a/tests/maintenance/test_sqlite_service.py
+++ b/tests/maintenance/test_sqlite_service.py
@@ -121,6 +121,35 @@ def test_wal_checkpoint_during_online_backup_is_not_treated_as_source_mutation(
     assert SQLiteMaintenanceService().verify(target) == manifest.evidence
 
 
+def test_online_copy_rejects_oversized_source_before_materializing_target(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "oversized.db"
+    target = tmp_path / "backup.db"
+    progress_events: list[tuple[str, int, int]] = []
+    with sqlite3.connect(source) as connection:
+        connection.execute("CREATE TABLE payloads (value BLOB NOT NULL)")
+        connection.execute("INSERT INTO payloads(value) VALUES (zeroblob(2000000))")
+
+    with pytest.raises(SQLiteMaintenanceError, match="artifact size limit"):
+        SQLiteMaintenanceService(
+            max_source_bytes=1024 * 1024,
+            progress_hook=lambda *event: progress_events.append(event),
+        ).backup(source, target)
+
+    assert progress_events == []
+    assert not target.exists()
+
+
+@pytest.mark.parametrize(
+    "invalid_limit",
+    [True, 1024 * 1024 - 1, 1024 * 1024 * 1024 + 1],
+)
+def test_online_copy_source_size_limit_is_bounded(invalid_limit: object) -> None:
+    with pytest.raises(ValueError, match="max_source_bytes"):
+        SQLiteMaintenanceService(max_source_bytes=invalid_limit)  # type: ignore[arg-type]
+
+
 def test_cleanly_closed_wal_source_accounts_for_connection_sidecars(
     tmp_path: Path,
 ) -> None:
@@ -923,32 +952,48 @@ def test_migration_plan_deadline_interrupts_and_rolls_back(tmp_path: Path) -> No
             "INSERT INTO deadline_rows(id, marker, value) VALUES (?, 1, 'before')",
             ((row_id,) for row_id in range(100_000)),
         )
-    started = time.monotonic()
-
-    report = SQLiteMaintenanceService(max_migration_seconds=0.01).dry_run_migration(
-        source,
-        target,
-        plan=MigrationPlan(
-            migration_id="bounded-bulk-update",
-            steps=(
-                MigrationStep(
-                    "UPDATE deadline_rows SET value=? WHERE marker=?",
-                    ("after", 1),
-                ),
+    child = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "\n".join(
+                (
+                    "import sys",
+                    "from robo_trader.maintenance import MigrationPlan, MigrationStep, SQLiteMaintenanceService",
+                    "report = SQLiteMaintenanceService(max_migration_seconds=0.01).dry_run_migration(",
+                    "    sys.argv[1], sys.argv[2],",
+                    "    plan=MigrationPlan(migration_id='bounded-bulk-update', steps=(",
+                    "        MigrationStep('UPDATE deadline_rows SET value=? WHERE marker=?', ('after', 1)),",
+                    "    )),",
+                    ")",
+                    "print(report.outcome)",
+                    "print(report.error_code)",
+                )
             ),
-        ),
+            str(source),
+            str(target),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
     )
 
-    # Copying and hashing the fixture is intentionally outside the migration
-    # execution deadline and varies substantially across CI filesystems. The
-    # typed result proves that the plan itself hit the deadline; this generous
-    # ceiling only guards against a lost interrupt or hang.
-    assert time.monotonic() - started < 10.0
-    assert report.outcome == "rolled_back"
-    assert report.error_code == "migration_deadline_exceeded"
-    assert report.before == report.after
-    assert report.source_unchanged is True
+    # The child process is a hard outer boundary: a lost SQLite interrupt
+    # cannot hang the test runner. The progress-specific result proves that
+    # SQLite's VM handler, rather than only a post-statement check, stopped it.
+    assert child.stdout.strip().splitlines()[-2:] == [
+        "rolled_back",
+        "migration_progress_deadline_exceeded",
+    ]
     with sqlite3.connect(target) as connection:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM deadline_rows WHERE value='after'"
+        ).fetchone() == (0,)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM deadline_rows WHERE value='before'"
+        ).fetchone() == (100_000,)
+    with sqlite3.connect(source) as connection:
         assert connection.execute(
             "SELECT COUNT(*) FROM deadline_rows WHERE value='after'"
         ).fetchone() == (0,)
@@ -1088,20 +1133,18 @@ def test_migration_rejects_functions_embedded_in_source_schema(tmp_path: Path) -
         )
     started = time.monotonic()
 
-    report = SQLiteMaintenanceService(max_migration_seconds=0.01).dry_run_migration(
-        source,
-        target,
-        plan=MigrationPlan(
-            migration_id="reject-schema-function",
-            steps=(MigrationStep("INSERT INTO guarded(value) VALUES (?)", (1,)),),
-        ),
-    )
+    with pytest.raises(SQLiteMaintenanceError, match="source schema"):
+        SQLiteMaintenanceService(max_migration_seconds=0.01).dry_run_migration(
+            source,
+            target,
+            plan=MigrationPlan(
+                migration_id="reject-schema-function",
+                steps=(MigrationStep("INSERT INTO guarded(value) VALUES (?)", (1,)),),
+            ),
+        )
 
     assert time.monotonic() - started < 2.0
-    assert report.outcome == "rolled_back"
-    assert report.error_code == "migration_plan_failed"
-    assert report.before == report.after
-    assert report.source_unchanged is True
+    assert not target.exists()
 
 
 def test_migration_screens_virtual_generated_functions_before_row_evidence(
@@ -1144,55 +1187,59 @@ def test_migration_screens_virtual_generated_functions_before_row_evidence(
         tracked_database_evidence,
     )
 
-    report = SQLiteMaintenanceService(max_migration_seconds=0.01).dry_run_migration(
-        source,
-        target,
-        plan=MigrationPlan(
-            migration_id="screen-before-generated-evidence",
-            steps=(
-                MigrationStep(
-                    "UPDATE generated_rows SET base=? WHERE base=?",
-                    (2, 1),
+    with pytest.raises(SQLiteMaintenanceError, match="source schema"):
+        SQLiteMaintenanceService(max_migration_seconds=0.01).dry_run_migration(
+            source,
+            target,
+            plan=MigrationPlan(
+                migration_id="screen-before-generated-evidence",
+                steps=(
+                    MigrationStep(
+                        "UPDATE generated_rows SET base=? WHERE base=?",
+                        (2, 1),
+                    ),
                 ),
             ),
-        ),
-    )
+        )
 
-    assert events[:2] == ["schema_screen", "row_evidence"]
-    assert report.outcome == "rolled_back"
-    assert report.error_code == "migration_plan_failed"
-    assert report.before == report.after
-    assert report.source_unchanged is True
+    assert events == ["schema_screen"]
+    assert not target.exists()
 
 
-@pytest.mark.parametrize("separator", ["/**/", "-- split token\n"])
+@pytest.mark.parametrize(
+    "schema_expression",
+    [
+        "randomblob/**/(50000000)",
+        "randomblob-- split token\n(50000000)",
+        "/**/randomblob(50000000)",
+        "-- prefix comment\nrandomblob(50000000)",
+    ],
+)
 def test_migration_rejects_commented_schema_function_calls(
     tmp_path: Path,
-    separator: str,
+    schema_expression: str,
 ) -> None:
     source = tmp_path / "source.db"
     target = tmp_path / "dry-run.db"
     with sqlite3.connect(source) as connection:
         connection.execute(
             "CREATE TABLE guarded ("
-            f"value INTEGER NOT NULL CHECK(randomblob{separator}(50000000) IS NOT NULL)"
+            f"value INTEGER NOT NULL CHECK({schema_expression} IS NOT NULL)"
             ")"
         )
         assert sqlite_service_module._schema_function_calls(connection) == ("randomblob",)
 
-    report = SQLiteMaintenanceService(max_migration_seconds=0.01).dry_run_migration(
-        source,
-        target,
-        plan=MigrationPlan(
-            migration_id="reject-commented-schema-function",
-            steps=(MigrationStep("INSERT INTO guarded(value) VALUES (?)", (1,)),),
-        ),
-    )
+    with pytest.raises(SQLiteMaintenanceError, match="source schema"):
+        SQLiteMaintenanceService(max_migration_seconds=0.01).dry_run_migration(
+            source,
+            target,
+            plan=MigrationPlan(
+                migration_id="reject-commented-schema-function",
+                steps=(MigrationStep("INSERT INTO guarded(value) VALUES (?)", (1,)),),
+            ),
+        )
 
-    assert report.outcome == "rolled_back"
-    assert report.error_code == "migration_plan_failed"
-    assert report.before == report.after
-    assert report.source_unchanged is True
+    assert not target.exists()
 
 
 def test_schema_line_comment_continues_through_carriage_return(tmp_path: Path) -> None:

--- a/tests/maintenance/test_sqlite_service.py
+++ b/tests/maintenance/test_sqlite_service.py
@@ -120,7 +120,7 @@ def test_wal_checkpoint_during_online_backup_is_not_treated_as_source_mutation(
     assert SQLiteMaintenanceService().verify(target) == manifest.evidence
 
 
-def test_cleanly_closed_wal_source_does_not_create_service_sidecars(
+def test_cleanly_closed_wal_source_accounts_for_connection_sidecars(
     tmp_path: Path,
 ) -> None:
     source = tmp_path / "source.db"
@@ -145,7 +145,102 @@ def test_cleanly_closed_wal_source_does_not_create_service_sidecars(
     assert service.verify(backup) == manifest.evidence
     assert report.source_unchanged is True
     assert report.outcome == "applied_to_synthetic_copy"
-    assert not any(path.exists() for path in companions)
+    for companion in companions:
+        if companion.exists():
+            metadata = companion.lstat()
+            assert stat.S_ISREG(metadata.st_mode)
+            assert metadata.st_nlink == 1
+
+
+def test_companion_free_wal_backup_is_one_atomic_committed_state(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.db"
+    backup = tmp_path / "backup.db"
+    writer = _create_multiportfolio_database(source, wal=True)
+    writer.execute("CREATE TABLE atomic_rows (id INTEGER PRIMARY KEY, value INTEGER NOT NULL)")
+    writer.executemany(
+        "INSERT INTO atomic_rows(id, value) VALUES (?, 0)",
+        ((row_id,) for row_id in range(30_000)),
+    )
+    writer.commit()
+    writer.close()
+    assert not source.with_name(source.name + "-wal").exists()
+    update_committed = False
+
+    def commit_atomic_update(_operation: str, _remaining: int, _total: int) -> None:
+        nonlocal update_committed
+        if update_committed:
+            return
+        concurrent = sqlite3.connect(source, timeout=10.0)
+        try:
+            concurrent.execute("BEGIN IMMEDIATE")
+            concurrent.execute("UPDATE atomic_rows SET value = 1")
+            concurrent.commit()
+            concurrent.execute("PRAGMA wal_checkpoint(PASSIVE)").fetchone()
+            update_committed = True
+        finally:
+            concurrent.close()
+
+    manifest = SQLiteMaintenanceService(progress_hook=commit_atomic_update).backup(source, backup)
+
+    assert update_committed
+    with sqlite3.connect(backup) as connection:
+        committed_states = connection.execute(
+            "SELECT value, COUNT(*) FROM atomic_rows GROUP BY value ORDER BY value"
+        ).fetchall()
+    assert committed_states in ([(0, 30_000)], [(1, 30_000)])
+    assert SQLiteMaintenanceService().verify(backup) == manifest.evidence
+
+
+def test_descriptor_byte_corruption_fails_before_publication(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "backup.db"
+    alternate = tmp_path / "alternate.db"
+    _create_multiportfolio_database(source).close()
+    alternate_connection = _create_multiportfolio_database(alternate)
+    alternate_connection.execute(
+        "UPDATE positions SET quantity = 999 WHERE portfolio_id = 'alpha' AND symbol = 'AAPL'"
+    )
+    alternate_connection.commit()
+    alternate_connection.close()
+    alternate_image = alternate.read_bytes()
+    retained_descriptor: int | None = None
+    service = SQLiteMaintenanceService()
+    real_stage = service._stage_target
+    real_seal = sqlite_service_module._StagedTarget.seal_readonly
+
+    def capture_stage(requested_path):
+        nonlocal retained_descriptor
+        staged = real_stage(requested_path)
+        retained_descriptor = os.dup(staged.guardian_file_descriptor)
+        return staged
+
+    def corrupt_after_seal(staged) -> None:
+        real_seal(staged)
+        assert retained_descriptor is not None
+        os.ftruncate(retained_descriptor, len(alternate_image))
+        os.pwrite(retained_descriptor, alternate_image, 0)
+
+    monkeypatch.setattr(service, "_stage_target", capture_stage)
+    monkeypatch.setattr(
+        sqlite_service_module._StagedTarget,
+        "seal_readonly",
+        corrupt_after_seal,
+    )
+    try:
+        with pytest.raises(
+            SQLiteMaintenanceError,
+            match="descriptor-bound artifact evidence differs",
+        ):
+            service.backup(source, target)
+    finally:
+        if retained_descriptor is not None:
+            os.close(retained_descriptor)
+
+    assert not target.exists()
 
 
 def test_manifest_is_secret_free_portable_and_exclusively_written(tmp_path: Path) -> None:

--- a/tests/maintenance/test_sqlite_service.py
+++ b/tests/maintenance/test_sqlite_service.py
@@ -1104,6 +1104,36 @@ def test_migration_rejects_functions_embedded_in_source_schema(tmp_path: Path) -
     assert report.source_unchanged is True
 
 
+@pytest.mark.parametrize("separator", ["/**/", "-- split token\n"])
+def test_migration_rejects_commented_schema_function_calls(
+    tmp_path: Path,
+    separator: str,
+) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "dry-run.db"
+    with sqlite3.connect(source) as connection:
+        connection.execute(
+            "CREATE TABLE guarded ("
+            f"value INTEGER NOT NULL CHECK(randomblob{separator}(50000000) IS NOT NULL)"
+            ")"
+        )
+        assert sqlite_service_module._schema_function_calls(connection) == ("randomblob",)
+
+    report = SQLiteMaintenanceService(max_migration_seconds=0.01).dry_run_migration(
+        source,
+        target,
+        plan=MigrationPlan(
+            migration_id="reject-commented-schema-function",
+            steps=(MigrationStep("INSERT INTO guarded(value) VALUES (?)", (1,)),),
+        ),
+    )
+
+    assert report.outcome == "rolled_back"
+    assert report.error_code == "migration_plan_failed"
+    assert report.before == report.after
+    assert report.source_unchanged is True
+
+
 def test_migration_authorizer_denies_native_pointer_and_virtual_table_actions(
     tmp_path: Path,
 ) -> None:

--- a/tests/maintenance/test_sqlite_service.py
+++ b/tests/maintenance/test_sqlite_service.py
@@ -16,6 +16,7 @@ from robo_trader.maintenance import (
     SQLiteMaintenanceError,
     SQLiteMaintenanceService,
 )
+from robo_trader.maintenance import sqlite_service as sqlite_service_module
 from robo_trader.multiuser.migration import (
     LegacyMultiuserMigrationDisabled,
     MultiuserMigration,
@@ -174,6 +175,64 @@ def test_preexisting_target_sidecar_is_preserved_without_main_creation(
 
     assert not target.exists()
     assert sidecar.read_bytes() == b"operator-evidence"
+
+
+def test_release_accepts_only_sqlite_consumed_sidecar_reservations(tmp_path: Path) -> None:
+    target = tmp_path / "target.db"
+    reservation = SQLiteMaintenanceService._reserve_target(target)
+    consumed = target.with_name(target.name + "-wal")
+    try:
+        # Model SQLite's Linux WAL close behavior: it removes its own empty
+        # reservation while the maintenance service still holds the descriptor.
+        os.unlink(consumed)
+        reservation.release()
+    finally:
+        reservation.binding.close()
+
+    assert not consumed.exists()
+    assert not any(
+        target.with_name(target.name + suffix).exists() for suffix in ("-journal", "-shm", "-wal")
+    )
+
+
+def test_release_never_deletes_sidecar_substituted_after_check(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "target.db"
+    displaced = tmp_path / "original-reservation"
+    protected_payload = b"irreplaceable-user-evidence"
+    reservation = SQLiteMaintenanceService._reserve_target(target)
+    raced_path = target.with_name(target.name + "-journal")
+    real_rename_noreplace = sqlite_service_module._rename_noreplace
+    raced = False
+
+    def substitute_before_atomic_claim(source: Path, destination: Path) -> None:
+        nonlocal raced
+        if source == raced_path and not raced:
+            raced = True
+            source.rename(displaced)
+            source.write_bytes(protected_payload)
+        real_rename_noreplace(source, destination)
+
+    monkeypatch.setattr(
+        sqlite_service_module,
+        "_rename_noreplace",
+        substitute_before_atomic_claim,
+    )
+    try:
+        with pytest.raises(SQLiteMaintenanceError, match="could not be released safely"):
+            reservation.release()
+    finally:
+        reservation.binding.close()
+
+    preserved = [
+        path
+        for path in tmp_path.rglob("*")
+        if path.is_file() and path.read_bytes() == protected_payload
+    ]
+    assert preserved, "the substituted user file must be preserved, never unlinked"
+    assert raced_path.read_bytes() == protected_payload
+    assert displaced.exists()
 
 
 def test_target_cannot_overlap_source_sqlite_companion_family(tmp_path: Path) -> None:
@@ -384,6 +443,47 @@ def test_migration_dry_run_changes_only_synthetic_copy(tmp_path: Path) -> None:
     with sqlite3.connect(source) as connection:
         columns = connection.execute("PRAGMA table_info(positions)").fetchall()
         assert "note" not in {row[1] for row in columns}
+
+
+def test_migration_uses_the_copy_connection_without_a_writable_reopen(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "dry-run.db"
+    _create_multiportfolio_database(source).close()
+    service = SQLiteMaintenanceService()
+    real_connect = service._connect_bound
+    writable_target_opens = 0
+
+    def count_connect(binding, *, readonly, journal_off=False, immutable_readonly=False):
+        nonlocal writable_target_opens
+        if binding.path == target and not readonly:
+            writable_target_opens += 1
+        return real_connect(
+            binding,
+            readonly=readonly,
+            journal_off=journal_off,
+            immutable_readonly=immutable_readonly,
+        )
+
+    monkeypatch.setattr(service, "_connect_bound", count_connect)
+    report = service.dry_run_migration(
+        source,
+        target,
+        plan=MigrationPlan(
+            migration_id="single-bound-target",
+            steps=(MigrationStep("ALTER TABLE positions ADD COLUMN note TEXT"),),
+        ),
+    )
+
+    assert report.outcome == "applied_to_synthetic_copy"
+    assert writable_target_opens == 1
+
+
+def test_service_transaction_completion_policy_is_python310_compatible() -> None:
+    arguments = (sqlite3.SQLITE_TRANSACTION, "COMMIT", None, None, None)
+    assert sqlite_service_module._migration_authorizer(*arguments) == sqlite3.SQLITE_DENY
+    assert sqlite_service_module._migration_completion_authorizer(*arguments) == sqlite3.SQLITE_OK
 
 
 def test_interrupted_migration_rolls_back_copy_and_preserves_source(tmp_path: Path) -> None:

--- a/tests/maintenance/test_sqlite_service.py
+++ b/tests/maintenance/test_sqlite_service.py
@@ -894,7 +894,12 @@ def test_migration_evidence_includes_persistent_planner_statistics(tmp_path: Pat
         target,
         plan=MigrationPlan(
             migration_id="planner-statistics-change",
-            steps=(MigrationStep("DELETE FROM sqlite_stat1"),),
+            steps=(
+                MigrationStep(
+                    "UPDATE sqlite_stat1 SET stat=? WHERE tbl=?",
+                    ("999 1", "analyzed_rows"),
+                ),
+            ),
         ),
     )
 
@@ -902,25 +907,33 @@ def test_migration_evidence_includes_persistent_planner_statistics(tmp_path: Pat
     assert report.before != report.after
     assert report.source_unchanged is True
     with sqlite3.connect(target) as connection:
-        assert connection.execute("SELECT COUNT(*) FROM sqlite_stat1").fetchone() == (0,)
+        assert connection.execute(
+            "SELECT stat FROM sqlite_stat1 WHERE tbl='analyzed_rows'"
+        ).fetchone() == ("999 1",)
 
 
 def test_migration_plan_deadline_interrupts_and_rolls_back(tmp_path: Path) -> None:
     source = tmp_path / "source.db"
     target = tmp_path / "dry-run.db"
-    _create_multiportfolio_database(source).close()
+    with sqlite3.connect(source) as connection:
+        connection.execute(
+            "CREATE TABLE deadline_rows (id INTEGER PRIMARY KEY, marker INTEGER, value TEXT)"
+        )
+        connection.executemany(
+            "INSERT INTO deadline_rows(id, marker, value) VALUES (?, 1, 'before')",
+            ((row_id,) for row_id in range(100_000)),
+        )
     started = time.monotonic()
 
     report = SQLiteMaintenanceService(max_migration_seconds=0.01).dry_run_migration(
         source,
         target,
         plan=MigrationPlan(
-            migration_id="bounded-recursive-query",
+            migration_id="bounded-bulk-update",
             steps=(
                 MigrationStep(
-                    "WITH RECURSIVE unbounded(value) AS ("
-                    "VALUES(1) UNION ALL SELECT value+1 FROM unbounded"
-                    ") SELECT sum(value) FROM unbounded"
+                    "UPDATE deadline_rows SET value=? WHERE marker=?",
+                    ("after", 1),
                 ),
             ),
         ),
@@ -938,23 +951,72 @@ def test_migration_denies_native_function_that_can_evade_vm_deadline(tmp_path: P
     target = tmp_path / "dry-run.db"
     _create_multiportfolio_database(source).close()
 
-    report = SQLiteMaintenanceService(max_migration_seconds=0.01).dry_run_migration(
-        source,
-        target,
-        plan=MigrationPlan(
-            migration_id="deny-native-allocation",
-            steps=(
-                MigrationStep("CREATE TABLE oversized_payload (value BLOB NOT NULL)"),
-                MigrationStep("INSERT INTO oversized_payload VALUES (randomblob(50000000))"),
+    with pytest.raises(SQLiteMaintenanceError, match="supported grammar"):
+        SQLiteMaintenanceService(max_migration_seconds=0.01).dry_run_migration(
+            source,
+            target,
+            plan=MigrationPlan(
+                migration_id="deny-native-allocation",
+                steps=(
+                    MigrationStep("CREATE TABLE oversized_payload (value BLOB NOT NULL)"),
+                    MigrationStep(
+                        "INSERT INTO oversized_payload(value) VALUES (randomblob(50000000))"
+                    ),
+                ),
             ),
-        ),
+        )
+
+    assert not target.exists()
+
+
+def test_migration_grammar_rejects_unreviewed_sql_shapes_before_copy(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    _create_multiportfolio_database(source).close()
+    unsupported = (
+        "UPDATE positions SET quantity=?",
+        "INSERT INTO positions(portfolio_id,symbol,quantity) SELECT ?,?,?",
+        "CREATE TABLE escaped (value TEXT CHECK(value <> ''))",
+        'ALTER TABLE "positions" ADD COLUMN note TEXT',
+        "SELECT 1 -- comment",
+        "DELETE FROM positions WHERE portfolio_id='alpha'",
+        "BEGIN",
     )
 
-    assert report.outcome == "rolled_back"
-    assert report.error_code == "migration_plan_failed"
-    assert report.before == report.after
-    assert report.source_unchanged is True
-    assert target.stat().st_size < 50_000_000
+    for index, sql in enumerate(unsupported):
+        target = tmp_path / f"rejected-{index}.db"
+        parameters = tuple(1 for _ in range(sql.count("?")))
+        with pytest.raises(SQLiteMaintenanceError, match="supported grammar"):
+            SQLiteMaintenanceService().dry_run_migration(
+                source,
+                target,
+                plan=MigrationPlan(
+                    migration_id=f"rejected-shape-{index}",
+                    steps=(MigrationStep(sql, parameters),),
+                ),
+            )
+        assert not target.exists()
+
+
+def test_migration_deadline_checks_every_vm_opcode_between_allocations(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "dry-run.db"
+    _create_multiportfolio_database(source).close()
+    payload = b"x" * (1024 * 1024)
+    expression = "||".join("?1" for _ in range(40))
+    started = time.monotonic()
+
+    with pytest.raises(SQLiteMaintenanceError, match="supported grammar"):
+        SQLiteMaintenanceService(max_migration_seconds=0.01).dry_run_migration(
+            source,
+            target,
+            plan=MigrationPlan(
+                migration_id="bounded-between-opcodes",
+                steps=(MigrationStep(f"SELECT {expression}", (payload,)),),
+            ),
+        )
+
+    assert time.monotonic() - started < 2.0
+    assert not target.exists()
 
 
 def test_migration_growth_is_capped_by_synthetic_database_page_limit(tmp_path: Path) -> None:
@@ -970,12 +1032,61 @@ def test_migration_growth_is_capped_by_synthetic_database_page_limit(tmp_path: P
             migration_id="bounded-synthetic-growth",
             steps=(
                 MigrationStep("CREATE TABLE bounded_payload (value BLOB NOT NULL)"),
-                MigrationStep("INSERT INTO bounded_payload VALUES (?)", (payload,)),
-                MigrationStep("INSERT INTO bounded_payload VALUES (?)", (payload,)),
+                MigrationStep("INSERT INTO bounded_payload(value) VALUES (?)", (payload,)),
+                MigrationStep("INSERT INTO bounded_payload(value) VALUES (?)", (payload,)),
             ),
         ),
     )
 
+    assert report.outcome == "rolled_back"
+    assert report.error_code == "migration_plan_failed"
+    assert report.before == report.after
+    assert report.source_unchanged is True
+
+
+def test_migration_temp_schema_writes_are_denied_and_capped(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "dry-run.db"
+    _create_multiportfolio_database(source).close()
+    payload = b"x" * (3 * 1024 * 1024)
+
+    with pytest.raises(SQLiteMaintenanceError, match="supported grammar"):
+        SQLiteMaintenanceService(max_migration_growth_bytes=1024 * 1024).dry_run_migration(
+            source,
+            target,
+            plan=MigrationPlan(
+                migration_id="deny-temp-growth",
+                steps=(
+                    MigrationStep("CREATE TEMP TABLE escaped_growth (value BLOB NOT NULL)"),
+                    MigrationStep("INSERT INTO escaped_growth(value) VALUES (?)", (payload,)),
+                ),
+            ),
+        )
+
+    assert not target.exists()
+
+
+def test_migration_rejects_functions_embedded_in_source_schema(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "dry-run.db"
+    with sqlite3.connect(source) as connection:
+        connection.execute(
+            "CREATE TABLE guarded ("
+            "value INTEGER NOT NULL CHECK(length(randomblob(50000000)) > 0)"
+            ")"
+        )
+    started = time.monotonic()
+
+    report = SQLiteMaintenanceService(max_migration_seconds=0.01).dry_run_migration(
+        source,
+        target,
+        plan=MigrationPlan(
+            migration_id="reject-schema-function",
+            steps=(MigrationStep("INSERT INTO guarded(value) VALUES (?)", (1,)),),
+        ),
+    )
+
+    assert time.monotonic() - started < 2.0
     assert report.outcome == "rolled_back"
     assert report.error_code == "migration_plan_failed"
     assert report.before == report.after
@@ -1008,24 +1119,22 @@ def test_migration_authorizer_denies_native_pointer_and_virtual_table_actions(
     source = tmp_path / "source.db"
     target = tmp_path / "dry-run.db"
     _create_multiportfolio_database(source).close()
-    report = SQLiteMaintenanceService().dry_run_migration(
-        source,
-        target,
-        plan=MigrationPlan(
-            migration_id="deny-native-pointer-function",
-            steps=(
-                MigrationStep(
-                    "SELECT fts3_tokenizer('unsafe', ?)",
-                    (b"\x42" * 8,),
+    with pytest.raises(SQLiteMaintenanceError, match="supported grammar"):
+        SQLiteMaintenanceService().dry_run_migration(
+            source,
+            target,
+            plan=MigrationPlan(
+                migration_id="deny-native-pointer-function",
+                steps=(
+                    MigrationStep(
+                        "SELECT fts3_tokenizer('unsafe', ?)",
+                        (b"\x42" * 8,),
+                    ),
                 ),
             ),
-        ),
-    )
+        )
 
-    assert report.outcome == "rolled_back"
-    assert report.error_code == "migration_plan_failed"
-    assert report.before == report.after
-    assert report.source_unchanged is True
+    assert not target.exists()
 
 
 def test_migration_plan_cannot_change_untracked_schema_cookie(tmp_path: Path) -> None:
@@ -1043,21 +1152,17 @@ def test_migration_plan_cannot_change_untracked_schema_cookie(tmp_path: Path) ->
         == sqlite3.SQLITE_DENY
     )
 
-    report = SQLiteMaintenanceService().dry_run_migration(
-        source,
-        target,
-        plan=MigrationPlan(
-            migration_id="deny-schema-cookie",
-            steps=(MigrationStep("PRAGMA schema_version=999"),),
-        ),
-    )
+    with pytest.raises(SQLiteMaintenanceError, match="supported grammar"):
+        SQLiteMaintenanceService().dry_run_migration(
+            source,
+            target,
+            plan=MigrationPlan(
+                migration_id="deny-schema-cookie",
+                steps=(MigrationStep("PRAGMA schema_version=999"),),
+            ),
+        )
 
-    assert report.outcome == "rolled_back"
-    assert report.error_code == "migration_plan_failed"
-    assert report.before == report.after
-    assert report.source_unchanged is True
-    with sqlite3.connect(target) as connection:
-        assert connection.execute("PRAGMA schema_version").fetchone() != (999,)
+    assert not target.exists()
 
 
 def test_migration_evidence_tracks_schema_cookie_after_transient_ddl(tmp_path: Path) -> None:
@@ -1205,8 +1310,14 @@ def test_interrupted_migration_rolls_back_copy_and_preserves_source(tmp_path: Pa
         plan=MigrationPlan(
             migration_id="synthetic-interruption",
             steps=(
-                MigrationStep("DELETE FROM positions"),
-                MigrationStep("THIS IS NOT VALID SQL"),
+                MigrationStep(
+                    "UPDATE positions SET quantity=? WHERE portfolio_id=?",
+                    (99, "alpha"),
+                ),
+                MigrationStep(
+                    "UPDATE missing_table SET value=? WHERE id=?",
+                    ("unreachable", 1),
+                ),
             ),
         ),
     )
@@ -1223,17 +1334,16 @@ def test_migration_plan_cannot_attach_or_commit(tmp_path: Path) -> None:
     target = tmp_path / "dry-run.db"
     _create_multiportfolio_database(source).close()
 
-    report = SQLiteMaintenanceService().dry_run_migration(
-        source,
-        target,
-        plan=MigrationPlan(
-            migration_id="synthetic-attach",
-            steps=(MigrationStep("ATTACH DATABASE ? AS escaped", (str(source),)),),
-        ),
-    )
-    assert report.outcome == "rolled_back"
-    assert report.before == report.after
-    assert report.source_unchanged is True
+    with pytest.raises(SQLiteMaintenanceError, match="supported grammar"):
+        SQLiteMaintenanceService().dry_run_migration(
+            source,
+            target,
+            plan=MigrationPlan(
+                migration_id="synthetic-attach",
+                steps=(MigrationStep("ATTACH DATABASE ? AS escaped", (str(source),)),),
+            ),
+        )
+    assert not target.exists()
 
 
 @pytest.mark.parametrize("pragma", ["hard_heap_limit", "soft_heap_limit"])
@@ -1247,21 +1357,19 @@ def test_migration_plan_cannot_change_process_global_heap_limits(
 
     with sqlite3.connect(":memory:") as observer:
         before_limit = observer.execute(f"PRAGMA {pragma}").fetchone()
-        report = SQLiteMaintenanceService().dry_run_migration(
-            source,
-            target,
-            plan=MigrationPlan(
-                migration_id=f"deny-{pragma.replace('_', '-')}",
-                steps=(MigrationStep(f"PRAGMA {pragma}=1048576"),),
-            ),
-        )
+        with pytest.raises(SQLiteMaintenanceError, match="supported grammar"):
+            SQLiteMaintenanceService().dry_run_migration(
+                source,
+                target,
+                plan=MigrationPlan(
+                    migration_id=f"deny-{pragma.replace('_', '-')}",
+                    steps=(MigrationStep(f"PRAGMA {pragma}=1048576"),),
+                ),
+            )
         after_limit = observer.execute(f"PRAGMA {pragma}").fetchone()
 
-    assert report.outcome == "rolled_back"
-    assert report.error_code == "migration_plan_failed"
-    assert report.before == report.after
-    assert report.source_unchanged is True
     assert after_limit == before_limit
+    assert not target.exists()
 
 
 def test_migration_oversized_integer_parameter_rolls_back_with_report(tmp_path: Path) -> None:
@@ -1276,8 +1384,8 @@ def test_migration_oversized_integer_parameter_rolls_back_with_report(tmp_path: 
             migration_id="oversized-integer",
             steps=(
                 MigrationStep(
-                    "UPDATE positions SET quantity=? WHERE portfolio_id='alpha'",
-                    (2**100,),
+                    "UPDATE positions SET quantity=? WHERE portfolio_id=?",
+                    (2**100, "alpha"),
                 ),
             ),
         ),

--- a/tests/maintenance/test_sqlite_service.py
+++ b/tests/maintenance/test_sqlite_service.py
@@ -932,6 +932,81 @@ def test_migration_plan_deadline_interrupts_and_rolls_back(tmp_path: Path) -> No
     assert report.source_unchanged is True
 
 
+def test_migration_authorizer_denies_native_pointer_and_virtual_table_actions(
+    tmp_path: Path,
+) -> None:
+    authorizer = sqlite_service_module._migration_authorizer
+    assert (
+        authorizer(sqlite3.SQLITE_FUNCTION, None, "fts3_tokenizer", None, None)
+        == sqlite3.SQLITE_DENY
+    )
+    assert (
+        authorizer(sqlite3.SQLITE_FUNCTION, None, "load_extension", None, None)
+        == sqlite3.SQLITE_DENY
+    )
+    assert (
+        authorizer(sqlite3.SQLITE_CREATE_VTABLE, "docs", "fts3", "main", None)
+        == sqlite3.SQLITE_DENY
+    )
+    assert (
+        authorizer(sqlite3.SQLITE_DROP_VTABLE, "docs", "fts3", "main", None) == sqlite3.SQLITE_DENY
+    )
+
+    source = tmp_path / "source.db"
+    target = tmp_path / "dry-run.db"
+    _create_multiportfolio_database(source).close()
+    report = SQLiteMaintenanceService().dry_run_migration(
+        source,
+        target,
+        plan=MigrationPlan(
+            migration_id="deny-native-pointer-function",
+            steps=(
+                MigrationStep(
+                    "SELECT fts3_tokenizer('unsafe', ?)",
+                    (b"\x42" * 8,),
+                ),
+            ),
+        ),
+    )
+
+    assert report.outcome == "rolled_back"
+    assert report.error_code == "migration_plan_failed"
+    assert report.before == report.after
+    assert report.source_unchanged is True
+
+
+def test_migration_plan_cannot_change_untracked_schema_cookie(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "dry-run.db"
+    _create_multiportfolio_database(source).close()
+    assert (
+        sqlite_service_module._migration_authorizer(
+            sqlite3.SQLITE_PRAGMA,
+            "schema_version",
+            "999",
+            "main",
+            None,
+        )
+        == sqlite3.SQLITE_DENY
+    )
+
+    report = SQLiteMaintenanceService().dry_run_migration(
+        source,
+        target,
+        plan=MigrationPlan(
+            migration_id="deny-schema-cookie",
+            steps=(MigrationStep("PRAGMA schema_version=999"),),
+        ),
+    )
+
+    assert report.outcome == "rolled_back"
+    assert report.error_code == "migration_plan_failed"
+    assert report.before == report.after
+    assert report.source_unchanged is True
+    with sqlite3.connect(target) as connection:
+        assert connection.execute("PRAGMA schema_version").fetchone() != (999,)
+
+
 def test_migration_uses_the_copy_connection_without_a_writable_reopen(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/maintenance/test_sqlite_service.py
+++ b/tests/maintenance/test_sqlite_service.py
@@ -1,0 +1,443 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from robo_trader.maintenance import (
+    SQLiteMaintenanceError,
+    SQLiteMaintenanceService,
+)
+from robo_trader.multiuser.migration import (
+    LegacyMultiuserMigrationDisabled,
+    MultiuserMigration,
+)
+
+
+def _create_multiportfolio_database(path: Path, *, wal: bool = False) -> sqlite3.Connection:
+    connection = sqlite3.connect(path)
+    if wal:
+        assert connection.execute("PRAGMA journal_mode=WAL").fetchone() == ("wal",)
+        connection.execute("PRAGMA wal_autocheckpoint=0")
+    connection.executescript("""
+        PRAGMA foreign_keys=ON;
+        CREATE TABLE portfolios (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL
+        );
+        CREATE TABLE positions (
+            portfolio_id TEXT NOT NULL REFERENCES portfolios(id),
+            symbol TEXT NOT NULL,
+            quantity INTEGER NOT NULL,
+            PRIMARY KEY (portfolio_id, symbol)
+        );
+        INSERT INTO portfolios VALUES ('alpha', 'Alpha'), ('beta', 'Beta');
+        INSERT INTO positions VALUES
+            ('alpha', 'AAPL', 3),
+            ('beta', 'AAPL', 7),
+            ('beta', 'MSFT', 2);
+        PRAGMA user_version=7;
+        """)
+    connection.commit()
+    return connection
+
+
+def test_wal_active_backup_and_clean_room_restore_preserve_multiportfolio_state(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "synthetic-source.db"
+    backup = tmp_path / "new-backup.db"
+    restored = tmp_path / "new-restore.db"
+    writer = _create_multiportfolio_database(source, wal=True)
+    try:
+        writer.execute("INSERT INTO positions VALUES ('alpha', 'NVDA', 4)")
+        writer.commit()
+        assert source.with_name(source.name + "-wal").stat().st_size > 0
+
+        service = SQLiteMaintenanceService()
+        manifest = service.backup(source, backup)
+        restore_manifest = service.restore_clean_room(backup, restored, manifest)
+
+        assert manifest.operation == "backup"
+        assert restore_manifest.operation == "restore"
+        assert restore_manifest.input_artifact_sha256 == manifest.artifact_sha256
+        assert manifest.evidence == restore_manifest.evidence
+        assert manifest.authorizes_startup is False
+        assert stat.S_IMODE(backup.stat().st_mode) == 0o400
+        assert stat.S_IMODE(restored.stat().st_mode) == 0o400
+        with sqlite3.connect(restored) as connection:
+            assert connection.execute(
+                "SELECT portfolio_id,symbol,quantity FROM positions " "ORDER BY portfolio_id,symbol"
+            ).fetchall() == [
+                ("alpha", "AAPL", 3),
+                ("alpha", "NVDA", 4),
+                ("beta", "AAPL", 7),
+                ("beta", "MSFT", 2),
+            ]
+    finally:
+        writer.close()
+
+
+def test_manifest_is_secret_free_portable_and_exclusively_written(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    backup = tmp_path / "backup.db"
+    manifest_path = tmp_path / "manifest.json"
+    _create_multiportfolio_database(source).close()
+    service = SQLiteMaintenanceService()
+    manifest = service.backup(source, backup)
+    service.write_manifest(manifest, manifest_path)
+    payload = json.loads(manifest_path.read_text())
+
+    serialized = json.dumps(payload, sort_keys=True)
+    assert str(tmp_path) not in serialized
+    assert "credential" not in serialized.lower()
+    assert "account" not in serialized.lower()
+    assert payload["contains_secrets"] is False
+    assert payload["mutated_authoritative_state"] is False
+    assert payload["authorizes_startup"] is False
+    assert service.load_manifest(manifest_path) == manifest
+    with pytest.raises(SQLiteMaintenanceError, match="new exclusive"):
+        service.write_manifest(manifest, manifest_path)
+
+
+@pytest.mark.parametrize("kind", ["source_symlink", "source_hardlink", "target_symlink"])
+def test_aliases_fail_closed(tmp_path: Path, kind: str) -> None:
+    source = tmp_path / "source.db"
+    _create_multiportfolio_database(source).close()
+    candidate_source = source
+    target = tmp_path / "target.db"
+    if kind == "source_symlink":
+        candidate_source = tmp_path / "source-link.db"
+        candidate_source.symlink_to(source)
+    elif kind == "source_hardlink":
+        candidate_source = tmp_path / "source-hardlink.db"
+        os.link(source, candidate_source)
+    else:
+        target.symlink_to(source)
+
+    with pytest.raises(SQLiteMaintenanceError):
+        SQLiteMaintenanceService().backup(candidate_source, target)
+
+
+def test_symlinked_wal_companion_is_rejected_before_sqlite_open(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "target.db"
+    _create_multiportfolio_database(source).close()
+    source.with_name(source.name + "-wal").symlink_to(source)
+
+    with pytest.raises(SQLiteMaintenanceError, match="SQLite companions"):
+        SQLiteMaintenanceService().backup(source, target)
+    assert not target.exists()
+
+
+def test_existing_restore_target_is_never_replaced(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    backup = tmp_path / "backup.db"
+    target = tmp_path / "authoritative-looking.db"
+    _create_multiportfolio_database(source).close()
+    target.write_bytes(b"do-not-replace")
+    service = SQLiteMaintenanceService()
+    manifest = service.backup(source, backup)
+
+    with pytest.raises(SQLiteMaintenanceError, match="new exclusively-created"):
+        service.restore_clean_room(backup, target, manifest)
+    assert target.read_bytes() == b"do-not-replace"
+
+
+def test_target_cannot_overlap_source_sqlite_companion_family(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    _create_multiportfolio_database(source).close()
+    target = source.with_name(source.name + "-journal")
+
+    with pytest.raises(SQLiteMaintenanceError, match="resource families overlap"):
+        SQLiteMaintenanceService().backup(source, target)
+    assert not target.exists()
+
+
+def test_corrupt_backup_is_rejected_before_restore_target_creation(tmp_path: Path) -> None:
+    corrupt = tmp_path / "corrupt.db"
+    target = tmp_path / "restore.db"
+    corrupt.write_bytes(b"not a sqlite database")
+
+    with pytest.raises(SQLiteMaintenanceError):
+        SQLiteMaintenanceService().verify(corrupt)
+    assert not target.exists()
+
+
+def test_manifest_detects_backup_corruption_before_clean_room_creation(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    backup = tmp_path / "backup.db"
+    target = tmp_path / "restore.db"
+    _create_multiportfolio_database(source).close()
+    service = SQLiteMaintenanceService()
+    manifest = service.backup(source, backup)
+    backup.chmod(0o600)
+    with backup.open("r+b") as stream:
+        stream.seek(100)
+        stream.write(b"tampered")
+    backup.chmod(0o400)
+
+    with pytest.raises(SQLiteMaintenanceError):
+        service.restore_clean_room(backup, target, manifest)
+    assert not target.exists()
+
+
+def test_interrupted_backup_preserves_source_and_seals_forensic_target(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "partial.db"
+    _create_multiportfolio_database(source).close()
+    before = source.read_bytes()
+
+    def interrupt(_operation: str, _remaining: int, _total: int) -> None:
+        raise RuntimeError("synthetic interruption")
+
+    with pytest.raises(RuntimeError, match="synthetic interruption"):
+        SQLiteMaintenanceService(progress_hook=interrupt).backup(source, target)
+
+    assert source.read_bytes() == before
+    assert target.exists()
+    assert stat.S_IMODE(target.stat().st_mode) == 0o400
+
+
+def test_manifest_with_unknown_field_is_rejected(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    backup = tmp_path / "backup.db"
+    manifest_path = tmp_path / "manifest.json"
+    _create_multiportfolio_database(source).close()
+    service = SQLiteMaintenanceService()
+    manifest = service.backup(source, backup)
+    payload = manifest.to_dict()
+    payload["broker_token"] = "must-not-be-accepted"
+    manifest_path.write_text(json.dumps(payload))
+
+    with pytest.raises(SQLiteMaintenanceError, match="manifest is invalid"):
+        service.load_manifest(manifest_path)
+
+
+def test_target_substitution_during_backup_fails_descriptor_check(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "target.db"
+    displaced = tmp_path / "displaced.db"
+    _create_multiportfolio_database(source).close()
+    invoked = False
+
+    def replace_target(_operation: str, _remaining: int, _total: int) -> None:
+        nonlocal invoked
+        if invoked:
+            return
+        invoked = True
+        target.rename(displaced)
+        target.symlink_to(source)
+
+    with pytest.raises(SQLiteMaintenanceError, match="failed closed"):
+        SQLiteMaintenanceService(progress_hook=replace_target).backup(source, target)
+    assert source.exists()
+    assert displaced.exists()
+
+
+def test_hardlink_race_during_backup_fails_closed(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "target.db"
+    alias = tmp_path / "target-alias.db"
+    _create_multiportfolio_database(source).close()
+    invoked = False
+
+    def add_link(_operation: str, _remaining: int, _total: int) -> None:
+        nonlocal invoked
+        if not invoked:
+            invoked = True
+            os.link(target, alias)
+
+    with pytest.raises(SQLiteMaintenanceError, match="another filesystem link"):
+        SQLiteMaintenanceService(progress_hook=add_link).backup(source, target)
+    assert source.exists()
+    assert target.exists()
+    assert alias.exists()
+
+
+def test_interrupted_restore_preserves_backup_and_seals_target(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    backup = tmp_path / "backup.db"
+    target = tmp_path / "partial-restore.db"
+    _create_multiportfolio_database(source).close()
+    manifest = SQLiteMaintenanceService().backup(source, backup)
+    backup_before = backup.read_bytes()
+
+    def interrupt(operation: str, _remaining: int, _total: int) -> None:
+        if operation == "restore":
+            raise RuntimeError("synthetic restore interruption")
+
+    with pytest.raises(RuntimeError, match="restore interruption"):
+        SQLiteMaintenanceService(progress_hook=interrupt).restore_clean_room(
+            backup, target, manifest
+        )
+    assert backup.read_bytes() == backup_before
+    assert target.exists()
+    assert stat.S_IMODE(target.stat().st_mode) == 0o400
+
+
+def test_migration_dry_run_changes_only_synthetic_copy(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "dry-run.db"
+    _create_multiportfolio_database(source).close()
+    before_bytes = source.read_bytes()
+
+    def migration(connection: sqlite3.Connection) -> None:
+        connection.execute("ALTER TABLE positions ADD COLUMN note TEXT")
+        connection.execute("UPDATE positions SET note='synthetic-only' WHERE portfolio_id='alpha'")
+        connection.execute("PRAGMA user_version=8")
+
+    report = SQLiteMaintenanceService().dry_run_migration(
+        source,
+        target,
+        migration_id="synthetic-v8",
+        migration=migration,
+    )
+
+    assert report.outcome == "applied_to_synthetic_copy"
+    assert report.source_unchanged is True
+    assert report.before != report.after
+    assert report.after.user_version == 8
+    assert report.authorizes_startup is False
+    assert source.read_bytes() == before_bytes
+    with sqlite3.connect(source) as connection:
+        columns = connection.execute("PRAGMA table_info(positions)").fetchall()
+        assert "note" not in {row[1] for row in columns}
+
+
+def test_interrupted_migration_rolls_back_copy_and_preserves_source(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "dry-run.db"
+    _create_multiportfolio_database(source).close()
+
+    def migration(connection: sqlite3.Connection) -> None:
+        connection.execute("DELETE FROM positions")
+        raise RuntimeError("simulated interruption")
+
+    report = SQLiteMaintenanceService().dry_run_migration(
+        source,
+        target,
+        migration_id="synthetic-interruption",
+        migration=migration,
+    )
+
+    assert report.outcome == "rolled_back"
+    assert report.error_code == "migration_callback_failed"
+    assert report.before == report.after
+    assert report.source_unchanged is True
+    assert stat.S_IMODE(target.stat().st_mode) == 0o400
+
+
+def test_migration_callback_cannot_attach_or_commit(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    target = tmp_path / "dry-run.db"
+    _create_multiportfolio_database(source).close()
+
+    def migration(connection: sqlite3.Connection) -> None:
+        connection.execute("ATTACH DATABASE ':memory:' AS escaped")
+
+    report = SQLiteMaintenanceService().dry_run_migration(
+        source,
+        target,
+        migration_id="synthetic-attach",
+        migration=migration,
+    )
+    assert report.outcome == "rolled_back"
+    assert report.before == report.after
+
+
+@pytest.mark.asyncio
+async def test_legacy_multiuser_migration_preserves_inspection_and_noop(tmp_path: Path) -> None:
+    missing = MultiuserMigration(tmp_path / "missing.db")
+    assert await missing.needs_migration() is True
+    assert await missing.migrate() is False
+
+    applied_path = tmp_path / "applied.db"
+    with sqlite3.connect(applied_path) as connection:
+        connection.execute(
+            "CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, description TEXT)"
+        )
+        connection.execute("INSERT INTO schema_migrations VALUES (1, 'already applied')")
+    applied = MultiuserMigration(applied_path)
+    assert await applied.needs_migration() is False
+    assert await applied.migrate() is False
+
+
+@pytest.mark.asyncio
+async def test_legacy_multiuser_mutation_entrypoints_are_quarantined(tmp_path: Path) -> None:
+    source = tmp_path / "legacy.db"
+    with sqlite3.connect(source) as connection:
+        connection.execute("CREATE TABLE positions (symbol TEXT)")
+        connection.execute("INSERT INTO positions VALUES ('AAPL')")
+        connection.execute("CREATE TABLE account (id INTEGER PRIMARY KEY, cash REAL)")
+        connection.execute("INSERT INTO account VALUES (1, 1000.0), (2, 1250.0)")
+    before = source.read_bytes()
+    migration = MultiuserMigration(source)
+
+    with pytest.raises(LegacyMultiuserMigrationDisabled):
+        await migration.migrate()
+    with pytest.raises(LegacyMultiuserMigrationDisabled):
+        await migration._create_backup()
+    with pytest.raises(LegacyMultiuserMigrationDisabled):
+        await migration._restore_from_backup(tmp_path / "backup.db")
+    assert source.read_bytes() == before
+    with sqlite3.connect(source) as connection:
+        assert connection.execute("SELECT id,cash FROM account ORDER BY id").fetchall() == [
+            (1, 1000.0),
+            (2, 1250.0),
+        ]
+
+
+def test_cli_backup_verify_and_restore_are_non_authorizing(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    backup = tmp_path / "backup.db"
+    backup_manifest = tmp_path / "backup.json"
+    restore = tmp_path / "restore.db"
+    restore_manifest = tmp_path / "restore.json"
+    _create_multiportfolio_database(source).close()
+    script = Path(__file__).resolve().parents[2] / "scripts" / "database_maintenance.py"
+
+    for arguments in (
+        [
+            "backup",
+            "--source",
+            str(source),
+            "--target",
+            str(backup),
+            "--manifest",
+            str(backup_manifest),
+        ],
+        [
+            "verify",
+            "--database",
+            str(backup),
+            "--manifest",
+            str(backup_manifest),
+        ],
+        [
+            "restore-clean-room",
+            "--backup",
+            str(backup),
+            "--backup-manifest",
+            str(backup_manifest),
+            "--target",
+            str(restore),
+            "--restore-manifest",
+            str(restore_manifest),
+        ],
+    ):
+        completed = subprocess.run(
+            [sys.executable, str(script), *arguments],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        assert completed.returncode == 0, completed.stderr
+        assert json.loads(completed.stdout)["authorizes_startup"] is False

--- a/tests/test_multiuser.py
+++ b/tests/test_multiuser.py
@@ -12,7 +12,10 @@ import pytest
 from robo_trader.database_async import AsyncTradingDatabase
 from robo_trader.database_validator import DatabaseValidator, ValidationError
 from robo_trader.multiuser.db_proxy import PortfolioScopedDB
-from robo_trader.multiuser.migration import MultiuserMigration
+from robo_trader.multiuser.migration import (
+    LegacyMultiuserMigrationDisabled,
+    MultiuserMigration,
+)
 from robo_trader.multiuser.portfolio_config import PortfolioConfig, load_portfolio_configs
 
 # ──────────────────────────────────────────────
@@ -267,181 +270,30 @@ async def create_legacy_schema(db_path: Path):
 
 class TestMultiuserMigration:
     @pytest.mark.asyncio
-    async def test_migration_on_legacy_db(self, temp_db):
-        """Test that migration correctly adds portfolio_id to all tables."""
-        import aiosqlite
-
-        # Create legacy schema with data
+    async def test_unmigrated_legacy_db_is_quarantined_without_changes(self, temp_db):
         await create_legacy_schema(temp_db)
-
-        # Run migration
+        before = temp_db.read_bytes()
         migration = MultiuserMigration(temp_db)
+
         assert await migration.needs_migration() is True
-        result = await migration.migrate(default_cash=100000)
-        assert result is True
+        with pytest.raises(LegacyMultiuserMigrationDisabled, match="legacy multiuser"):
+            await migration.migrate(default_cash=100000)
+        assert temp_db.read_bytes() == before
+        assert list(temp_db.parent.glob(f"{temp_db.stem}.backup_premultiuser_*")) == []
 
-        # Verify migration applied
+    @pytest.mark.asyncio
+    async def test_already_applied_migration_remains_a_noop(self, temp_db):
+        import aiosqlite
+
+        async with aiosqlite.connect(temp_db) as connection:
+            await connection.execute(
+                "CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, description TEXT)"
+            )
+            await connection.execute("INSERT INTO schema_migrations VALUES (1, 'applied')")
+            await connection.commit()
+        migration = MultiuserMigration(temp_db)
         assert await migration.needs_migration() is False
-
-        # Verify data integrity
-        async with aiosqlite.connect(temp_db) as conn:
-            # Check portfolios table exists with default entry
-            cursor = await conn.execute("SELECT id, name, starting_cash FROM portfolios")
-            rows = await cursor.fetchall()
-            assert len(rows) == 1
-            assert rows[0][0] == "default"
-
-            # Check positions have portfolio_id
-            cursor = await conn.execute("SELECT portfolio_id, symbol, quantity FROM positions")
-            rows = await cursor.fetchall()
-            assert len(rows) == 2
-            assert all(row[0] == "default" for row in rows)
-
-            # Check trades have portfolio_id
-            cursor = await conn.execute("SELECT portfolio_id, symbol, side FROM trades")
-            rows = await cursor.fetchall()
-            assert len(rows) == 1
-            assert rows[0][0] == "default"
-
-            # Check account uses portfolio_id instead of id=1
-            cursor = await conn.execute("SELECT portfolio_id, cash, equity FROM account")
-            rows = await cursor.fetchall()
-            assert len(rows) == 1
-            assert rows[0][0] == "default"
-            assert rows[0][1] == 80000  # cash preserved
-
-            # Check equity_history has portfolio_id
-            cursor = await conn.execute("SELECT portfolio_id, date, equity FROM equity_history")
-            rows = await cursor.fetchall()
-            assert len(rows) == 1
-            assert rows[0][0] == "default"
-
-            # Check signals have portfolio_id
-            cursor = await conn.execute("SELECT portfolio_id, symbol, strategy FROM signals")
-            rows = await cursor.fetchall()
-            assert len(rows) == 1
-            assert rows[0][0] == "default"
-
-    @pytest.mark.asyncio
-    async def test_migration_is_idempotent(self, temp_db):
-        """Running migration twice should be safe."""
-        await create_legacy_schema(temp_db)
-
-        migration = MultiuserMigration(temp_db)
-        result1 = await migration.migrate()
-        assert result1 is True
-
-        result2 = await migration.migrate()
-        assert result2 is False  # Already applied
-
-    @pytest.mark.asyncio
-    async def test_migration_creates_backup(self, temp_db):
-        """Migration should create a backup file."""
-        await create_legacy_schema(temp_db)
-
-        migration = MultiuserMigration(temp_db)
-        await migration.migrate()
-
-        backups = list(temp_db.parent.glob(f"{temp_db.stem}.backup_premultiuser_*"))
-        assert len(backups) >= 1
-
-    @pytest.mark.asyncio
-    async def test_migration_on_empty_db(self, temp_db):
-        """Migration on a fresh/empty database should work."""
-        import aiosqlite
-
-        # Create empty DB with just the tables (no data)
-        async with aiosqlite.connect(temp_db) as conn:
-            await conn.execute("""
-                CREATE TABLE positions (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    symbol TEXT NOT NULL,
-                    quantity INTEGER NOT NULL,
-                    avg_cost REAL NOT NULL,
-                    market_price REAL,
-                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
-                    UNIQUE(symbol)
-                )
-            """)
-            await conn.execute("""
-                CREATE TABLE trades (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    symbol TEXT NOT NULL,
-                    side TEXT NOT NULL,
-                    quantity INTEGER NOT NULL,
-                    price REAL NOT NULL,
-                    notional REAL DEFAULT 0,
-                    slippage REAL DEFAULT 0,
-                    commission REAL DEFAULT 0,
-                    pnl REAL DEFAULT NULL,
-                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
-                )
-            """)
-            await conn.execute("""
-                CREATE TABLE account (
-                    id INTEGER PRIMARY KEY,
-                    cash REAL NOT NULL,
-                    equity REAL NOT NULL,
-                    daily_pnl REAL DEFAULT 0,
-                    realized_pnl REAL DEFAULT 0,
-                    unrealized_pnl REAL DEFAULT 0,
-                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
-                )
-            """)
-            await conn.execute("""
-                CREATE TABLE equity_history (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    date TEXT NOT NULL UNIQUE,
-                    equity REAL NOT NULL,
-                    cash REAL DEFAULT 0,
-                    positions_value REAL DEFAULT 0,
-                    realized_pnl REAL DEFAULT 0,
-                    unrealized_pnl REAL DEFAULT 0,
-                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
-                )
-            """)
-            await conn.execute("""
-                CREATE TABLE signals (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    symbol TEXT NOT NULL,
-                    strategy TEXT NOT NULL,
-                    signal_type TEXT NOT NULL,
-                    strength REAL,
-                    metadata TEXT,
-                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
-                )
-            """)
-            await conn.commit()
-
-        migration = MultiuserMigration(temp_db)
-        result = await migration.migrate()
-        assert result is True
-
-    @pytest.mark.asyncio
-    async def test_unique_constraint_portfolio_symbol(self, temp_db):
-        """Two portfolios can hold the same symbol independently."""
-        import aiosqlite
-
-        await create_legacy_schema(temp_db)
-        migration = MultiuserMigration(temp_db)
-        await migration.migrate()
-
-        async with aiosqlite.connect(temp_db) as conn:
-            # Portfolio A has AAPL (from migration, portfolio_id='default')
-            # Portfolio B can also have AAPL
-            await conn.execute(
-                "INSERT INTO positions (portfolio_id, symbol, quantity, avg_cost) VALUES (?, ?, ?, ?)",
-                ("portfolio_b", "AAPL", 50, 190.00),
-            )
-            await conn.commit()
-
-            cursor = await conn.execute(
-                "SELECT portfolio_id, symbol, quantity FROM positions WHERE symbol = 'AAPL'"
-            )
-            rows = await cursor.fetchall()
-            assert len(rows) == 2
-            portfolios = {row[0] for row in rows}
-            assert portfolios == {"default", "portfolio_b"}
+        assert await migration.migrate() is False
 
     @pytest.mark.asyncio
     async def test_no_db_file_returns_false(self, temp_db):
@@ -1361,100 +1213,22 @@ class TestUpsertPortfolio:
 
 
 class TestMigrationEdgeCases:
-    """Additional migration edge cases."""
+    """The legacy mutation path cannot run even on unusual fixture content."""
 
     @pytest.mark.asyncio
-    async def test_migration_version_recorded_correctly(self, temp_db):
-        """Migration version is recorded in schema_migrations table."""
+    async def test_quarantine_preserves_null_prices_pnl_and_many_rows(self, temp_db):
         import aiosqlite
 
         await create_legacy_schema(temp_db)
-        migration = MultiuserMigration(temp_db)
-        await migration.migrate()
-
-        async with aiosqlite.connect(temp_db) as conn:
-            cursor = await conn.execute("SELECT version, description FROM schema_migrations")
-            rows = await cursor.fetchall()
-            assert len(rows) == 1
-            assert rows[0][0] == 1  # Version 1
-            assert "multi-portfolio" in rows[0][1].lower()
-
-    @pytest.mark.asyncio
-    async def test_migration_preserves_null_market_price(self, temp_db):
-        """Migration preserves NULL market_price values."""
-        import aiosqlite
-
-        await create_legacy_schema(temp_db)
-
-        # Add a position with NULL market_price
         async with aiosqlite.connect(temp_db) as conn:
             await conn.execute(
                 "INSERT INTO positions (symbol, quantity, avg_cost) VALUES (?, ?, ?)",
                 ("TSLA", 30, 250.00),
             )
-            await conn.commit()
-
-        migration = MultiuserMigration(temp_db)
-        await migration.migrate()
-
-        async with aiosqlite.connect(temp_db) as conn:
-            cursor = await conn.execute(
-                "SELECT symbol, market_price FROM positions WHERE symbol = 'TSLA'"
-            )
-            row = await cursor.fetchone()
-            assert row[0] == "TSLA"
-            assert row[1] is None  # NULL preserved
-
-    @pytest.mark.asyncio
-    async def test_migration_preserves_trade_pnl(self, temp_db):
-        """Migration preserves PnL values on trades."""
-        import aiosqlite
-
-        await create_legacy_schema(temp_db)
-
-        async with aiosqlite.connect(temp_db) as conn:
             await conn.execute(
                 "INSERT INTO trades (symbol, side, quantity, price, notional, pnl) VALUES (?, ?, ?, ?, ?, ?)",
                 ("AAPL", "SELL", 50, 195.0, 9750.0, 750.0),
             )
-            await conn.commit()
-
-        migration = MultiuserMigration(temp_db)
-        await migration.migrate()
-
-        async with aiosqlite.connect(temp_db) as conn:
-            cursor = await conn.execute("SELECT symbol, side, pnl FROM trades WHERE side = 'SELL'")
-            row = await cursor.fetchone()
-            assert row[0] == "AAPL"
-            assert row[2] == 750.0  # PnL preserved
-
-    @pytest.mark.asyncio
-    async def test_migration_backup_is_valid_sqlite(self, temp_db):
-        """Backup file created by migration is a valid SQLite database."""
-        import aiosqlite
-
-        await create_legacy_schema(temp_db)
-        migration = MultiuserMigration(temp_db)
-        await migration.migrate()
-
-        backups = list(temp_db.parent.glob(f"{temp_db.stem}.backup_premultiuser_*"))
-        assert len(backups) >= 1
-
-        # Verify backup is valid SQLite
-        async with aiosqlite.connect(backups[0]) as conn:
-            cursor = await conn.execute("SELECT COUNT(*) FROM positions")
-            count = (await cursor.fetchone())[0]
-            assert count == 2  # Original 2 positions
-
-    @pytest.mark.asyncio
-    async def test_migration_with_many_trades(self, temp_db):
-        """Migration handles a moderate number of trades correctly."""
-        import aiosqlite
-
-        await create_legacy_schema(temp_db)
-
-        # Insert 500 additional trades
-        async with aiosqlite.connect(temp_db) as conn:
             for i in range(500):
                 symbol = ["AAPL", "NVDA", "MSFT", "TSLA", "GOOG"][i % 5]
                 side = "BUY" if i % 3 != 0 else "SELL"
@@ -1466,19 +1240,20 @@ class TestMigrationEdgeCases:
             await conn.commit()
 
         migration = MultiuserMigration(temp_db)
-        await migration.migrate()
+        with pytest.raises(LegacyMultiuserMigrationDisabled):
+            await migration.migrate()
 
         async with aiosqlite.connect(temp_db) as conn:
-            cursor = await conn.execute("SELECT COUNT(*) FROM trades")
-            count = (await cursor.fetchone())[0]
-            assert count == 501  # 1 original + 500 added
-
-            # All should have portfolio_id='default'
-            cursor = await conn.execute(
-                "SELECT COUNT(*) FROM trades WHERE portfolio_id = 'default'"
-            )
-            default_count = (await cursor.fetchone())[0]
-            assert default_count == 501
+            assert await (
+                await conn.execute("SELECT market_price FROM positions WHERE symbol='TSLA'")
+            ).fetchone() == (None,)
+            assert await (
+                await conn.execute("SELECT pnl FROM trades WHERE side='SELL' AND pnl=750.0")
+            ).fetchone() == (750.0,)
+            count = await (await conn.execute("SELECT COUNT(*) FROM trades")).fetchone()
+            assert count == (502,)
+            columns = await (await conn.execute("PRAGMA table_info(trades)")).fetchall()
+            assert "portfolio_id" not in {column[1] for column in columns}
 
 
 # ──────────────────────────────────────────────
@@ -1860,94 +1635,20 @@ class TestScopeLeakDetection:
 
 
 class TestMigrationRestoreErrorHandling:
-    """Test that migration backup restore handles failures safely."""
+    """Legacy backup/restore entrypoints fail before touching either file."""
 
     @pytest.mark.asyncio
-    async def test_restore_verifies_integrity(self, temp_db):
-        """After restoring from backup, the database integrity is verified."""
+    async def test_backup_and_restore_are_quarantined(self, temp_db):
         await create_legacy_schema(temp_db)
         migration = MultiuserMigration(temp_db)
+        before = temp_db.read_bytes()
 
-        # Create backup manually and verify _restore_from_backup works
-        backup_path = await migration._create_backup()
-        assert backup_path.exists()
-
-        # Corrupt the main DB
-        temp_db.write_bytes(b"not a database")
-
-        # Restore should succeed and fix the DB
-        await migration._restore_from_backup(backup_path)
-
-        # Verify restored DB is valid
-        import aiosqlite
-
-        async with aiosqlite.connect(temp_db) as conn:
-            cursor = await conn.execute("SELECT COUNT(*) FROM positions")
-            count = (await cursor.fetchone())[0]
-            assert count == 2  # Original test data
-
-    @pytest.mark.asyncio
-    async def test_restore_raises_on_missing_backup(self, temp_db):
-        """Restore raises RuntimeError when backup file doesn't exist."""
-        await create_legacy_schema(temp_db)
-        migration = MultiuserMigration(temp_db)
-
-        fake_backup = temp_db.with_suffix(".fake_backup.db")
-        with pytest.raises(RuntimeError, match="backup restore failed"):
-            await migration._restore_from_backup(fake_backup)
-
-    @pytest.mark.asyncio
-    async def test_restore_raises_on_corrupted_backup(self, temp_db):
-        """Restore raises RuntimeError when backup is corrupted."""
-        await create_legacy_schema(temp_db)
-        migration = MultiuserMigration(temp_db)
-
-        # Create a fake corrupted backup
-        corrupted_backup = temp_db.with_suffix(".corrupted.db")
-        corrupted_backup.write_bytes(b"corrupted data that is not sqlite")
-
-        with pytest.raises(RuntimeError, match="backup restore failed"):
-            await migration._restore_from_backup(corrupted_backup)
-
-        corrupted_backup.unlink(missing_ok=True)
-
-    @pytest.mark.asyncio
-    async def test_failed_migration_triggers_restore(self, temp_db):
-        """When migration fails, it automatically restores from backup."""
-        import aiosqlite
-
-        await create_legacy_schema(temp_db)
-        migration = MultiuserMigration(temp_db)
-
-        # Patch _apply_migration_v1 to raise an error mid-migration
-        original_apply = migration._apply_migration_v1
-
-        async def failing_apply(conn, default_cash):
-            # Create the schema_migrations table so it looks like we started
-            await conn.execute("""
-                CREATE TABLE IF NOT EXISTS schema_migrations (
-                    version INTEGER PRIMARY KEY,
-                    description TEXT NOT NULL,
-                    applied_at DATETIME DEFAULT CURRENT_TIMESTAMP
-                )
-            """)
-            raise aiosqlite.Error("Simulated migration failure")
-
-        migration._apply_migration_v1 = failing_apply
-
-        with pytest.raises(aiosqlite.Error, match="Simulated migration failure"):
-            await migration.migrate()
-
-        # Verify the DB was restored to pre-migration state (no portfolio_id column)
-        async with aiosqlite.connect(temp_db) as conn:
-            cursor = await conn.execute("PRAGMA table_info(positions)")
-            columns = [col[1] for col in await cursor.fetchall()]
-            assert "portfolio_id" not in columns  # Restored to legacy schema
-
-            # Data should be intact
-            cursor = await conn.execute("SELECT COUNT(*) FROM positions")
-            count = (await cursor.fetchone())[0]
-            assert count == 2
+        with pytest.raises(LegacyMultiuserMigrationDisabled):
+            await migration._create_backup()
+        with pytest.raises(LegacyMultiuserMigrationDisabled):
+            await migration._restore_from_backup(temp_db.with_suffix(".backup.db"))
+        assert temp_db.read_bytes() == before
+        assert not temp_db.with_suffix(".backup.db").exists()
 
 
 # ──────────────────────────────────────────────

--- a/tests/test_pr2b3_terminal_settlement_persistence.py
+++ b/tests/test_pr2b3_terminal_settlement_persistence.py
@@ -24,7 +24,6 @@ from robo_trader.accounting.fifo_runtime import (
 from robo_trader.config import RuntimeContract
 from robo_trader.database_async import AsyncTradingDatabase
 from robo_trader.database_validator import ValidationError as DatabaseValidationError
-from robo_trader.multiuser.migration import MultiuserMigration
 from robo_trader.paper_terminal_settlement import (
     PaperAccountSettlementState,
     PaperTerminalSettlementConflict,
@@ -50,9 +49,118 @@ from robo_trader.safety.models import (
 )
 from tests.fifo_runtime_test_support import install_synthetic_fifo_epoch
 from tests.safety.conftest import make_case
-from tests.test_multiuser import create_legacy_schema
 
 ACCOUNT_SCOPE = "acct_v1_0123456789abcdef0123456789abcdef" "fedcba9876543210fedcba9876543210"
+
+
+def _create_supported_multiuser_v1_schema(path: Path, *, with_legacy_rows: bool) -> None:
+    """Install the historical v1 result without invoking its quarantined migrator."""
+
+    with sqlite3.connect(path) as connection:
+        connection.executescript("""
+            CREATE TABLE schema_migrations (
+                version INTEGER PRIMARY KEY,
+                description TEXT NOT NULL,
+                applied_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE portfolios (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                starting_cash REAL NOT NULL DEFAULT 100000,
+                symbols TEXT NOT NULL DEFAULT '',
+                active INTEGER NOT NULL DEFAULT 1,
+                max_position_pct REAL,
+                max_daily_loss_pct REAL,
+                max_open_positions INTEGER,
+                stop_loss_pct REAL,
+                trailing_stop_pct REAL,
+                use_trailing_stop INTEGER,
+                enabled_strategies TEXT,
+                min_confidence REAL,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE positions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                portfolio_id TEXT NOT NULL DEFAULT 'default',
+                symbol TEXT NOT NULL,
+                quantity INTEGER NOT NULL,
+                avg_cost REAL NOT NULL,
+                market_price REAL,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(portfolio_id, symbol)
+            );
+            CREATE INDEX idx_positions_portfolio ON positions (portfolio_id);
+            CREATE TABLE trades (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                portfolio_id TEXT NOT NULL DEFAULT 'default',
+                symbol TEXT NOT NULL,
+                side TEXT NOT NULL,
+                quantity INTEGER NOT NULL,
+                price REAL NOT NULL,
+                notional REAL DEFAULT 0,
+                slippage REAL DEFAULT 0,
+                commission REAL DEFAULT 0,
+                pnl REAL DEFAULT NULL,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE INDEX idx_trades_portfolio ON trades (portfolio_id);
+            CREATE INDEX idx_trades_portfolio_symbol
+                ON trades (portfolio_id, symbol, timestamp DESC);
+            CREATE TABLE account (
+                portfolio_id TEXT PRIMARY KEY,
+                cash REAL NOT NULL,
+                equity REAL NOT NULL,
+                daily_pnl REAL DEFAULT 0,
+                realized_pnl REAL DEFAULT 0,
+                unrealized_pnl REAL DEFAULT 0,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE equity_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                portfolio_id TEXT NOT NULL DEFAULT 'default',
+                date TEXT NOT NULL,
+                equity REAL NOT NULL,
+                cash REAL DEFAULT 0,
+                positions_value REAL DEFAULT 0,
+                realized_pnl REAL DEFAULT 0,
+                unrealized_pnl REAL DEFAULT 0,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(portfolio_id, date)
+            );
+            CREATE INDEX idx_equity_history_portfolio
+                ON equity_history (portfolio_id, date);
+            CREATE TABLE signals (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                portfolio_id TEXT NOT NULL DEFAULT 'default',
+                symbol TEXT NOT NULL,
+                strategy TEXT NOT NULL,
+                signal_type TEXT NOT NULL,
+                strength REAL,
+                metadata TEXT,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE INDEX idx_signals_portfolio ON signals (portfolio_id);
+            INSERT INTO schema_migrations(version, description)
+                VALUES (1, 'synthetic test fixture for historical multiuser v1');
+            INSERT INTO portfolios(id, name, starting_cash)
+                VALUES ('default', 'Default Portfolio', 100000);
+            """)
+        if with_legacy_rows:
+            connection.executescript("""
+                INSERT INTO positions(portfolio_id,symbol,quantity,avg_cost,market_price)
+                    VALUES ('default','AAPL',100,180.50,185.00),
+                           ('default','NVDA',50,450.00,470.00);
+                INSERT INTO trades(portfolio_id,symbol,side,quantity,price,notional)
+                    VALUES ('default','AAPL','BUY',100,180.50,18050.0);
+                INSERT INTO account(portfolio_id,cash,equity)
+                    VALUES ('default',80000,100000);
+                INSERT INTO equity_history(
+                    portfolio_id,date,equity,cash,positions_value
+                ) VALUES ('default','2026-02-05',100000,80000,20000);
+                INSERT INTO signals(portfolio_id,symbol,strategy,signal_type,strength)
+                    VALUES ('default','AAPL','momentum','BUY',0.8);
+                """)
 
 
 @pytest.mark.parametrize(
@@ -1025,8 +1133,7 @@ async def test_quoted_literal_case_change_fails_before_mutation(tmp_path: Path):
 async def test_supported_multiuser_v1_hot_schema_can_settle(tmp_path: Path):
     contract = _runtime_contract(tmp_path)
     database_path = Path(contract.database_path)
-    await create_legacy_schema(database_path)
-    assert await MultiuserMigration(database_path).migrate() is True
+    _create_supported_multiuser_v1_schema(database_path, with_legacy_rows=True)
 
     database = AsyncTradingDatabase(database_path, pool_size=1)
     await database.initialize()
@@ -1056,9 +1163,7 @@ async def test_supported_multiuser_v1_hot_schema_can_settle(tmp_path: Path):
 async def test_supported_multiuser_v1_direct_create_schema_can_settle(tmp_path: Path):
     contract = _runtime_contract(tmp_path)
     database_path = Path(contract.database_path)
-    with sqlite3.connect(database_path):
-        pass
-    assert await MultiuserMigration(database_path).migrate() is True
+    _create_supported_multiuser_v1_schema(database_path, with_legacy_rows=False)
 
     database = AsyncTradingDatabase(database_path, pool_size=1)
     await database.initialize()


### PR DESCRIPTION
# PR 4D local review evidence

Date: 2026-07-28

Base: `101beb94921c884c050580973a084e8a8380be8d`

Branch: `codex/pr4d-backup-restore`

## Scope and safety result

- Added dormant, descriptor-bound SQLite backup, verification, clean-room
  restore, and synthetic migration dry-run tooling.
- Every output uses an exclusive new path. No operation deletes, renames over,
  restores over, or automatically replaces an authoritative database.
- Manifests contain no paths, row values, environment values, credentials, or
  broker/account configuration and always report
  `authorizes_startup=false`.
- Removed the callable raw-copy, overwrite-restore, foreign-key-disabled, and
  account-row-collapsing legacy multiuser implementation. Read-only inspection,
  missing-database no-op, and already-applied no-op behavior remain.
- Repository call-graph search found no non-test caller of
  `MultiuserMigration`; no sanctioned startup path was changed.
- All backup, corruption, restore, migration, WAL, alias, and interruption
  exercises used pytest temporary databases. No authoritative/user database,
  broker, runtime process, listener, or service was accessed or modified.
- This work does not authorize startup and does not advance Gate A.

## Verification

Focused maintenance, legacy migration, and database-isolation matrix:

```text
python -m pytest tests/maintenance/test_sqlite_service.py \
  tests/test_multiuser.py tests/security/test_db_isolation.py -q --tb=short
188 passed
```

The new PR 4D maintenance module has 21 direct tests covering active WAL state,
multiportfolio preservation, backup/restore manifests, clean-room equivalence,
corruption, preexisting targets, symlinks, hardlinks, companion files,
substitution races, backup/restore interruption, migration rollback, callback
containment, CLI output, and legacy quarantine.

Final full repository regression:

```text
python -m pytest tests/ -q --tb=short
2854 passed, 5 skipped, 20 known warnings in 189.19s
```

Static checks:

```text
python -m black --check <changed Python paths>
python -m isort --check-only <changed Python paths>
python -m flake8 <changed Python paths>
python -m bandit -q -r robo_trader/maintenance \
  scripts/database_maintenance.py robo_trader/multiuser/migration.py
python -m mypy --follow-imports=skip --ignore-missing-imports \
  robo_trader/maintenance/models.py \
  robo_trader/maintenance/sqlite_service.py \
  scripts/database_maintenance.py robo_trader/multiuser/migration.py
git diff --check
```

All listed static checks passed. The focused mypy invocation intentionally
isolates changed modules because the repository retains unrelated, documented
type debt.

## Review notes

- The service reuses the reviewed SQLite-owned-descriptor proof from
  `robo_trader.safety.sqlite_identity` and independently holds an
  `O_NOFOLLOW` guardian.
- Main database and `-wal`/`-shm`/`-journal` identities are checked throughout
  online copy progress. Backup and restore artifacts are integrity-checked,
  foreign-key-checked, logically hashed, raw-file hashed, fsynced, and sealed
  read-only.
- Failed or interrupted outputs are retained read-only for forensic inspection
  and have no successful manifest. They are never promoted or reused.
- Migration callbacks run only against the new synthetic copy in a
  service-owned transaction. Transaction control, `ATTACH`, `DETACH`, and
  dangerous path/schema pragmas are denied; failures roll back and return a
  secret-free report.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new filesystem and SQLite safety surface for ledger data, but tooling is dormant, non-authorizing, and extensively tested; legacy in-place migration is disabled rather than left callable.
> 
> **Overview**
> Introduces **dormant** SQLite maintenance: WAL-aware online backup, manifest-backed verify, clean-room restore to new paths only, and bounded **migration dry-runs** on synthetic copies. Outputs are secret-free JSON with `authorizes_startup=false`; nothing overwrites or promotes an authoritative DB.
> 
> **`SQLiteMaintenanceService`** copies via in-memory SQLite, then publishes a verified image from an unlinked inode (`O_TMPFILE` / `linkat` on Linux, `fclonefileat` on macOS) with descriptor identity checks, companion `-wal`/`-shm`/`-journal` monitoring, and read-back verification before link. Migration plans are a narrow DDL/DML grammar plus authorizer, deadlines, and page limits—not arbitrary SQL.
> 
> **Legacy `MultiuserMigration`** in-place copy/rewrite/overwrite rollback is removed and replaced with read-only inspection and `LegacyMultiuserMigrationDisabled` on mutation. **`sqlite_identity`** gains serialize/deserialize for maintenance; **`scripts/database_maintenance.py`** exposes backup/verify/restore CLI. Runbook and review evidence docs added; large `tests/maintenance/test_sqlite_service.py` suite covers WAL, races, and quarantine.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cea3074ec4cec34b8f407d38c24419ab5a9a28b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->