### PR TITLE
feat(accounting): bind legacy bootstrap to FIFO epoch

### DIFF
--- a/docs/design/PR4B_FIFO_LEGACY_BOOTSTRAP.md
+++ b/docs/design/PR4B_FIFO_LEGACY_BOOTSTRAP.md
@@ -1,0 +1,75 @@
+# PR4B FIFO legacy bootstrap
+
+## Status and authority boundary
+
+This slice binds the already reviewed exact-state bootstrap to the dormant FIFO
+accounting foundation. It remains an offline operator tool. It does not run at
+startup, connect to a broker, start any service, authorize an order, or open
+Gate A. Every preview and apply result continues to report
+`authorizes_startup=false`.
+
+The only apply path remains `scripts/bootstrap_exact_paper_state.py apply`. It
+requires the existing lifecycle lock, proof that the runner, dashboard,
+WebSocket server, and Gateway are stopped, exact destination-bound operator
+confirmation, a specific reason, authenticated reconciliation and protective
+mark artifacts, and a new descriptor-verified SQLite online backup. No
+authoritative database is changed automatically.
+
+## Truthful legacy epoch boundary
+
+Each reviewed portfolio receives one append-only FIFO epoch whose
+`origin_kind` is `LEGACY_AGGREGATE_OPENING_BALANCE`. Its source fingerprint is
+the full candidate fingerprint. A separate lineage record binds the epoch to:
+
+- the exact-state bootstrap ID and candidate fingerprint;
+- the reconciliation snapshot and authenticated report hash;
+- the authenticated read-only broker snapshot hash;
+- the complete reviewed legacy-ledger snapshot hash; and
+- the administrator action recorded by the same transaction.
+
+Every nonzero legacy position becomes one `fifo_opening_balances` row and one
+corresponding open lot. The signed legacy quantity determines `LONG` or
+`SHORT`; the lot quantity is its absolute magnitude; and its price is the
+reviewed aggregate legacy cost basis. The positive IBKR contract ID is copied
+from the authenticated protective-mark artifact and must match the candidate
+exactly.
+
+No `fifo_fills`, `fifo_commissions`, execution IDs, or position snapshots are
+created at bootstrap. The opening lot records `opening_commission_minor=0` only
+to define prospective epoch accounting: it means pre-epoch commission history
+is unknown and not reconstructed. It is not a claim that historical broker
+fees were zero. Later fills consume these aggregate opening lots through the
+ordinary deterministic FIFO projector.
+
+## Pre-epoch account baseline
+
+One append-only baseline record preserves the candidate's exact cash, realized
+P&L, daily P&L, daily P&L baseline, and baseline date. Post-epoch FIFO realized
+P&L therefore starts at zero without erasing or relabeling pre-epoch economics.
+
+## Atomicity and rollback
+
+Schema preparation, the administrator action, exact-state bootstrap records,
+evidence-consumption receipts, exact account/position adoption, FIFO epoch,
+lineage, baseline, opening balances, and opening lots are appended inside the
+same existing `BEGIN IMMEDIATE` transaction. The source descriptor, safety
+journal, candidate, evidence, and sealed backup are revalidated at the existing
+boundaries. Any exception before commit rolls back the complete schema and data
+change. The verified backup remains the rollback artifact; PR4D owns the
+operational clean-room restore drill.
+
+## Read-only candidate report
+
+`preview` reports the deterministic epoch ID, candidate fingerprint, exact
+pre-epoch baseline, each contract-bound opening balance and lot, zero synthetic
+fills, and `pre_epoch_history_reconstructed=false`. Preview only reads and
+revalidates the candidate, evidence, ledger, and safety journal; it does not
+create FIFO schema or rows.
+
+## Non-goals
+
+- No runtime settlement integration (PR4C).
+- No automated or operational migration/restore execution (PR4D).
+- No broker write capability or live-trading behavior.
+- No reconstruction of historical lots, fills, executions, or commissions.
+- No mutation of legacy account, position, trade, or equity-history rows.

--- a/docs/reviews/PR4B_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
+++ b/docs/reviews/PR4B_LOCAL_REVIEW_EVIDENCE_2026-07-28.md
@@ -1,0 +1,75 @@
+# PR4B local review evidence — 2026-07-28
+
+## Reviewed scope
+
+Branch `codex/pr4b-fifo-bootstrap` was created from exact PR4A head
+`101beb94921c884c050580973a084e8a8380be8d` in the dedicated worktree
+`/private/tmp/robo-pr4b-fifo-bootstrap`.
+
+The review covered only the PR4B bridge from the PR112 exact-state bootstrap to
+the PR4A FIFO ledger:
+
+- authenticated positive `con_id` binding for every nonzero candidate position;
+- deterministic `LEGACY_AGGREGATE_OPENING_BALANCE` epoch identity;
+- append-only candidate, reconciliation, broker, legacy-ledger, administrator,
+  and exact-state bootstrap lineage;
+- exact pre-epoch account baseline;
+- explicit long/short opening balances and opening lots with no synthetic fill,
+  execution, commission event, or position snapshot;
+- read-only non-authorizing candidate preview; and
+- one atomic offline schema/bootstrap transaction under the existing lifecycle,
+  confirmation, evidence, safety-journal, descriptor, and verified-backup gates.
+
+PR4C runtime settlement wiring and PR4D operational migration/restore drills
+were not added. No startup, broker, runtime, service, authoritative database, or
+user data was accessed or mutated.
+
+## Adversarial evidence
+
+Synthetic tests prove:
+
+- candidate omission, duplication, or mismatch of authenticated contract IDs
+  fails closed;
+- long and short legacy quantities become aggregate opening balances rather
+  than BUY/SELL fills;
+- FIFO fill and commission tables remain empty at bootstrap;
+- zero opening commission is explicitly reported as unknown pre-epoch history,
+  not reconstructed fee evidence;
+- the candidate fingerprint binds the FIFO epoch and exact-state lineage;
+- a conflicting epoch for the same account/portfolio scope blocks the complete
+  exact-state bootstrap;
+- a fault after FIFO append rolls back schema and every bootstrap row to the
+  byte-identical raw fixture database;
+- preview leaves the fixture byte-identical and creates no FIFO objects;
+- the pre-epoch cash, realized P&L, daily P&L, baseline, and date are preserved;
+- a prospective post-epoch fill consumes the aggregate opening lot by strict
+  FIFO with exact realized P&L; and
+- existing stopped-runtime, evidence-replay, journal, backup, path, inode,
+  hard-link, and post-commit backup checks remain green.
+
+## Verification results
+
+All commands used the repository virtual environment at
+`/Users/oliver/Projects/robo_trader/.venv/bin/python3` and synthetic per-test
+databases.
+
+- Focused FIFO/exact-bootstrap/CLI suite: `124 passed`.
+- Broader accounting/bootstrap/database/reconciliation/settlement matrix:
+  `517 passed`.
+- Full repository suite: `2849 passed, 5 skipped, 20 warnings` in 167.09s.
+  Skips and warnings are the existing environment/test warnings reported by the
+  suite; no test failed.
+- Black, isort, Flake8, compilation, and `git diff --check`: passed for every
+  changed Python file.
+- Targeted mypy for FIFO/bootstrap sources: passed with no issues.
+- Targeted Bandit: no medium or high findings. Three existing low findings are
+  the bootstrap CLI's fixed-argv `subprocess` import/calls used for stopped-state
+  checks.
+- Scope/secret checks: no runner, launcher, or terminal-settlement file changed;
+  no startup-authorizing value or private-key/access-key pattern was added.
+
+## Review conclusion
+
+No local correctness, data-integrity, trading-safety, security, or scope blocker
+remains. This is code/test evidence only. It is not operational restore
+evidence, broker evidence, startup approval, or Gate A approval.

--- a/robo_trader/accounting/__init__.py
+++ b/robo_trader/accounting/__init__.py
@@ -1,8 +1,9 @@
 """Dormant exact-accounting foundations.
 
 Nothing in this package is connected to the trading runtime.  PR4A exposes a
-fixture-only schema migration and a deterministic FIFO projector so the ledger
-contract can be reviewed before any operational database is eligible to use it.
+fixture-only schema migration and a deterministic FIFO projector. PR4B adds a
+separately guarded offline legacy-opening bridge; no runtime path imports this
+package to authorize startup or an order.
 """
 
 from .fifo import (

--- a/robo_trader/accounting/fifo.py
+++ b/robo_trader/accounting/fifo.py
@@ -406,6 +406,7 @@ class FifoLedger:
             allow_other_objects=allow_other_objects,
         )
         self._connection = connection
+        self._allow_other_objects = allow_other_objects
 
     def create_epoch(self, epoch: AccountingEpoch) -> AccountingEpoch:
         _assert_no_temp_fifo_objects(self._connection)
@@ -415,6 +416,10 @@ class FifoLedger:
             raise FifoAccountingError("epoch creation requires an idle connection")
         try:
             self._connection.execute("BEGIN IMMEDIATE")
+            assert_fifo_accounting_schema(
+                self._connection,
+                allow_other_objects=self._allow_other_objects,
+            )
             by_id = self._connection.execute(
                 "SELECT * FROM fifo_accounting_epochs WHERE epoch_id = ?",
                 (epoch.epoch_id,),
@@ -486,6 +491,10 @@ class FifoLedger:
             raise FifoAccountingError("fill recording requires an idle connection")
         try:
             self._connection.execute("BEGIN IMMEDIATE")
+            assert_fifo_accounting_schema(
+                self._connection,
+                allow_other_objects=self._allow_other_objects,
+            )
             effective_at = self._require_epoch(event.epoch_id)
             if event.occurred_at < effective_at:
                 raise FifoAccountingOrderingError("fill event time precedes epoch effective_at")

--- a/robo_trader/accounting/fifo.py
+++ b/robo_trader/accounting/fifo.py
@@ -17,7 +17,11 @@ from decimal import Decimal, InvalidOperation, localcontext
 from enum import Enum
 from typing import Optional, Sequence
 
-from .fifo_fixture_migration import _assert_no_temp_fifo_objects, assert_fifo_accounting_schema
+from .fifo_fixture_migration import (
+    _assert_no_temp_fifo_objects,
+    _legacy_opening_manifest_hash,
+    assert_fifo_accounting_schema,
+)
 
 _ID_PATTERNS = {
     "epoch_id": re.compile(r"^fepoch-[0-9a-f]{32}$"),
@@ -974,7 +978,8 @@ class FifoLedger:
     def _verify_legacy_epoch_shape(self, epoch_id: str) -> None:
         lineage_rows = self._connection.execute(
             """
-            SELECT e.source_fingerprint,l.candidate_fingerprint,e.effective_at
+            SELECT e.source_fingerprint,l.candidate_fingerprint,e.effective_at,
+                   l.opening_manifest_count,l.opening_manifest_hash
             FROM fifo_accounting_epochs e
             JOIN fifo_legacy_bootstrap_lineage l ON l.epoch_id=e.epoch_id
             WHERE e.epoch_id=?
@@ -994,13 +999,18 @@ class FifoLedger:
                 "legacy epoch lacks one sealed lineage and account baseline"
             )
         effective_at = _parse_utc(lineage_rows[0][2], "legacy epoch effective_at")
+        manifest_count = _stored_int(lineage_rows[0][3], "legacy opening manifest count")
+        manifest_hash = str(lineage_rows[0][4])
+        if manifest_count < 0 or _HASH.fullmatch(manifest_hash) is None:
+            raise FifoAccountingValidationError("legacy opening manifest is malformed")
         balances = self._connection.execute(
             """
-            SELECT b.opening_balance_id,b.con_id,b.symbol,b.direction,
-                   b.opened_quantity_text,b.cost_basis_text,l.opening_balance_id,
-                   l.con_id,l.symbol,l.direction,l.opened_quantity_text,l.open_price_text,
+            SELECT b.opening_balance_id,l.lot_id,b.con_id,b.symbol,b.direction,
+                   b.opened_quantity_text,b.cost_basis_text,b.mark_price_text,
+                   b.mark_observed_at,b.mark_evidence_fingerprint,
                    l.opening_commission_minor,l.opened_sequence,l.opened_at,
-                   b.mark_observed_at
+                   l.opening_balance_id,l.con_id,l.symbol,l.direction,
+                   l.opened_quantity_text,l.open_price_text
             FROM fifo_opening_balances b
             LEFT JOIN fifo_lot_openings l
               ON l.epoch_id=b.epoch_id AND l.opening_balance_id=b.opening_balance_id
@@ -1019,16 +1029,25 @@ class FifoLedger:
             raise FifoAccountingValidationError(
                 "legacy opening balances do not map one-to-one to opening lots"
             )
+        if len(balances) != manifest_count:
+            raise FifoAccountingValidationError(
+                "legacy opening rows do not match the sealed candidate manifest"
+            )
+        manifest_rows = [tuple(row[:13]) for row in balances]
+        if _legacy_opening_manifest_hash(manifest_rows) != manifest_hash:
+            raise FifoAccountingValidationError(
+                "legacy opening rows do not match the sealed candidate manifest"
+            )
         for row in balances:
-            if row[6] is None or tuple(row[1:6]) != tuple(row[7:12]):
+            if row[13] is None or tuple(row[2:7]) != tuple(row[14:19]):
                 raise FifoAccountingValidationError(
                     "legacy opening balance differs from its exact opening lot"
                 )
             if (
-                _stored_int(row[12], "legacy opening commission") != 0
-                or _stored_int(row[13], "legacy opened_sequence") != 0
-                or _parse_utc(row[14], "legacy opened_at") != effective_at
-                or _parse_utc(row[15], "legacy mark_observed_at") > effective_at
+                _stored_int(row[10], "legacy opening commission") != 0
+                or _stored_int(row[11], "legacy opened_sequence") != 0
+                or _parse_utc(row[12], "legacy opened_at") != effective_at
+                or _parse_utc(row[8], "legacy mark_observed_at") > effective_at
             ):
                 raise FifoAccountingValidationError(
                     "legacy opening lot must not reconstruct pre-epoch commissions"

--- a/robo_trader/accounting/fifo.py
+++ b/robo_trader/accounting/fifo.py
@@ -1,4 +1,4 @@
-"""Deterministic, exact FIFO projection for the dormant PR4A ledger.
+"""Deterministic, exact FIFO projection for the dormant PR4 ledger.
 
 The projector records one complete fill, its commission, derived lot openings
 and matches, and a chained position snapshot in one SQLite transaction.  It
@@ -387,12 +387,20 @@ class _ProjectionLot:
 
 
 class FifoLedger:
-    """Append exact fill events to a previously migrated fixture ledger."""
+    """Append exact fill events to a previously verified FIFO ledger."""
 
-    def __init__(self, connection: sqlite3.Connection) -> None:
+    def __init__(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        allow_other_objects: bool = False,
+    ) -> None:
         if type(connection) is not sqlite3.Connection:
             raise TypeError("connection must be sqlite3.Connection")
-        assert_fifo_accounting_schema(connection)
+        assert_fifo_accounting_schema(
+            connection,
+            allow_other_objects=allow_other_objects,
+        )
         self._connection = connection
 
     def create_epoch(self, epoch: AccountingEpoch) -> AccountingEpoch:
@@ -843,6 +851,30 @@ class FifoLedger:
 
     def _verify_fifo_projection_structure(self, events: Sequence[FillEvent]) -> None:
         active_by_asset: dict[tuple[int, str], list[_ProjectionLot]] = {}
+        if events:
+            epoch_id = events[0].epoch_id
+            opening_rows = self._connection.execute(
+                """
+                SELECT lot_id, con_id, symbol, direction, opened_quantity_text,
+                       open_price_text
+                FROM fifo_lot_openings
+                WHERE epoch_id = ? AND opening_balance_id IS NOT NULL
+                ORDER BY con_id, symbol, lot_id
+                """,
+                (epoch_id,),
+            ).fetchall()
+            for row in opening_rows:
+                asset = (_stored_int(row[1], "opening con_id"), str(row[2]))
+                active_by_asset.setdefault(asset, []).append(
+                    _ProjectionLot(
+                        lot_id=str(row[0]),
+                        direction=str(row[3]),
+                        remaining_quantity=_parse_decimal(
+                            row[4], "opening quantity", positive=True
+                        ),
+                        open_price=_parse_decimal(row[5], "opening price", positive=True),
+                    )
+                )
         for event in events:
             asset = (event.con_id, event.symbol)
             active = active_by_asset.setdefault(asset, [])
@@ -933,11 +965,74 @@ class FifoLedger:
         ).fetchone()
         if row is None:
             raise FifoAccountingValidationError("unknown accounting epoch")
-        if row[0] != "EMPTY_LEDGER":
-            raise FifoAccountingValidationError(
-                "PR4A cannot project an adopted legacy accounting epoch"
-            )
+        if row[0] == "LEGACY_AGGREGATE_OPENING_BALANCE":
+            self._verify_legacy_epoch_shape(epoch_id)
+        elif row[0] != "EMPTY_LEDGER":
+            raise FifoAccountingValidationError("accounting epoch origin is unsupported")
         return _parse_utc(row[1], "epoch effective_at")
+
+    def _verify_legacy_epoch_shape(self, epoch_id: str) -> None:
+        lineage_rows = self._connection.execute(
+            """
+            SELECT e.source_fingerprint,l.candidate_fingerprint,e.effective_at
+            FROM fifo_accounting_epochs e
+            JOIN fifo_legacy_bootstrap_lineage l ON l.epoch_id=e.epoch_id
+            WHERE e.epoch_id=?
+            """,
+            (epoch_id,),
+        ).fetchall()
+        baseline_count = self._connection.execute(
+            "SELECT COUNT(*) FROM fifo_epoch_account_baselines WHERE epoch_id = ?",
+            (epoch_id,),
+        ).fetchone()
+        if (
+            len(lineage_rows) != 1
+            or lineage_rows[0][0] != lineage_rows[0][1]
+            or baseline_count != (1,)
+        ):
+            raise FifoAccountingValidationError(
+                "legacy epoch lacks one sealed lineage and account baseline"
+            )
+        effective_at = _parse_utc(lineage_rows[0][2], "legacy epoch effective_at")
+        balances = self._connection.execute(
+            """
+            SELECT b.opening_balance_id,b.con_id,b.symbol,b.direction,
+                   b.opened_quantity_text,b.cost_basis_text,l.opening_balance_id,
+                   l.con_id,l.symbol,l.direction,l.opened_quantity_text,l.open_price_text,
+                   l.opening_commission_minor,l.opened_sequence,l.opened_at,
+                   b.mark_observed_at
+            FROM fifo_opening_balances b
+            LEFT JOIN fifo_lot_openings l
+              ON l.epoch_id=b.epoch_id AND l.opening_balance_id=b.opening_balance_id
+            WHERE b.epoch_id=? ORDER BY b.symbol
+            """,
+            (epoch_id,),
+        ).fetchall()
+        lot_count = self._connection.execute(
+            """
+            SELECT COUNT(*) FROM fifo_lot_openings
+            WHERE epoch_id=? AND opening_balance_id IS NOT NULL
+            """,
+            (epoch_id,),
+        ).fetchone()
+        if lot_count != (len(balances),):
+            raise FifoAccountingValidationError(
+                "legacy opening balances do not map one-to-one to opening lots"
+            )
+        for row in balances:
+            if row[6] is None or tuple(row[1:6]) != tuple(row[7:12]):
+                raise FifoAccountingValidationError(
+                    "legacy opening balance differs from its exact opening lot"
+                )
+            if (
+                _stored_int(row[12], "legacy opening commission") != 0
+                or _stored_int(row[13], "legacy opened_sequence") != 0
+                or _parse_utc(row[14], "legacy opened_at") != effective_at
+                or _parse_utc(row[15], "legacy mark_observed_at") > effective_at
+            ):
+                raise FifoAccountingValidationError(
+                    "legacy opening lot must not reconstruct pre-epoch commissions"
+                )
 
     def _existing_fill(self, event: FillEvent) -> Optional[FillResult]:
         rows = self._connection.execute(
@@ -1017,10 +1112,20 @@ class FifoLedger:
     def _assert_instrument_identity(self, event: FillEvent) -> None:
         rows = self._connection.execute(
             """
-            SELECT DISTINCT con_id, symbol FROM fifo_fills
+            SELECT con_id,symbol FROM fifo_fills
+            WHERE epoch_id = ? AND (con_id = ? OR symbol = ?)
+            UNION
+            SELECT con_id,symbol FROM fifo_opening_balances
             WHERE epoch_id = ? AND (con_id = ? OR symbol = ?)
             """,
-            (event.epoch_id, event.con_id, event.symbol),
+            (
+                event.epoch_id,
+                event.con_id,
+                event.symbol,
+                event.epoch_id,
+                event.con_id,
+                event.symbol,
+            ),
         ).fetchall()
         if any(
             (_stored_int(row[0], "fill con_id"), str(row[1])) != (event.con_id, event.symbol)
@@ -1201,10 +1306,11 @@ class FifoLedger:
             self._connection.execute(
                 """
                 INSERT INTO fifo_lot_openings(
-                    lot_id, epoch_id, opening_fill_id, lot_ordinal, con_id, symbol,
+                    lot_id, epoch_id, opening_fill_id, opening_balance_id,
+                    lot_ordinal, con_id, symbol,
                     direction, opened_quantity_text, open_price_text,
                     opening_commission_minor, opened_sequence, opened_at
-                ) VALUES (?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, NULL, 0, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     opened_lot_id,

--- a/robo_trader/accounting/fifo_bootstrap.py
+++ b/robo_trader/accounting/fifo_bootstrap.py
@@ -1,0 +1,474 @@
+"""Sealed PR4B bridge from reviewed legacy state into an exact FIFO epoch.
+
+The bridge records prospective opening balances.  It deliberately does not
+invent historical fills, executions, or commissions.  A zero opening
+commission means that pre-epoch fee history is outside this epoch, not that the
+historical broker commission was zero.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Sequence
+
+import aiosqlite
+
+from .fifo_fixture_migration import (
+    _TABLE_SQL,
+    _TRIGGER_SQL,
+    FIFO_ACCOUNTING_COMPONENT,
+    FIFO_ACCOUNTING_MIGRATIONS,
+    _normalize_sql,
+)
+
+
+class FifoBootstrapError(RuntimeError):
+    """A reviewed legacy candidate cannot be appended as a FIFO epoch."""
+
+
+def _derived_id(prefix: str, *parts: object) -> str:
+    material = "\x1f".join(str(part) for part in parts)
+    return f"{prefix}-{hashlib.sha256(material.encode('utf-8')).hexdigest()[:32]}"
+
+
+@dataclass(frozen=True, slots=True)
+class LegacyOpeningBalance:
+    opening_balance_id: str
+    lot_id: str
+    con_id: int
+    symbol: str
+    direction: str
+    opened_quantity_text: str
+    cost_basis_text: str
+    mark_price_text: str
+    mark_observed_at: str
+    mark_evidence_fingerprint: str
+
+    def public_dict(self) -> dict[str, object]:
+        return {
+            "con_id": self.con_id,
+            "cost_basis_text": self.cost_basis_text,
+            "direction": self.direction,
+            "lot_id": self.lot_id,
+            "mark_evidence_fingerprint": self.mark_evidence_fingerprint,
+            "mark_observed_at": self.mark_observed_at,
+            "mark_price_text": self.mark_price_text,
+            "opened_quantity_text": self.opened_quantity_text,
+            "opening_balance_id": self.opening_balance_id,
+            "opening_commission_minor": 0,
+            "symbol": self.symbol,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class LegacyFifoBootstrapPlan:
+    epoch_id: str
+    bootstrap_id: str
+    candidate_fingerprint: str
+    execution_domain_scope: str
+    account_scope: str
+    portfolio_id: str
+    effective_at: str
+    reconciliation_snapshot_id: str
+    reconciliation_report_hash: str
+    broker_snapshot_hash: str
+    legacy_snapshot_hash: str
+    cash_text: str
+    realized_pnl_text: str
+    daily_pnl_text: str
+    daily_pnl_baseline_text: str
+    daily_pnl_date: str
+    opening_balances: tuple[LegacyOpeningBalance, ...]
+
+    def public_dict(self) -> dict[str, object]:
+        return {
+            "account_baseline": {
+                "cash_text": self.cash_text,
+                "daily_pnl_baseline_text": self.daily_pnl_baseline_text,
+                "daily_pnl_date": self.daily_pnl_date,
+                "daily_pnl_text": self.daily_pnl_text,
+                "realized_pnl_text": self.realized_pnl_text,
+            },
+            "bootstrap_id": self.bootstrap_id,
+            "candidate_fingerprint": self.candidate_fingerprint,
+            "epoch_id": self.epoch_id,
+            "authorizes_startup": False,
+            "opening_balances": [value.public_dict() for value in self.opening_balances],
+            "opening_commission_semantics": "UNKNOWN_PRE_EPOCH_HISTORY_NOT_RECONSTRUCTED",
+            "origin_kind": "LEGACY_AGGREGATE_OPENING_BALANCE",
+            "pre_epoch_history_reconstructed": False,
+            "synthetic_fill_count": 0,
+        }
+
+
+def build_legacy_fifo_bootstrap_plan(
+    *,
+    bootstrap_id: str,
+    candidate_fingerprint: str,
+    execution_domain_scope: str,
+    account_scope: str,
+    portfolio_id: str,
+    effective_at: str,
+    reconciliation_snapshot_id: str,
+    reconciliation_report_hash: str,
+    broker_snapshot_hash: str,
+    legacy_snapshot_hash: str,
+    cash_text: str,
+    realized_pnl_text: str,
+    daily_pnl_text: str,
+    daily_pnl_baseline_text: str,
+    daily_pnl_date: str,
+    positions: Sequence[dict[str, object]],
+) -> LegacyFifoBootstrapPlan:
+    """Derive deterministic epoch/opening identities from one sealed candidate."""
+
+    epoch_id = _derived_id("fepoch", "legacy-bootstrap", candidate_fingerprint)
+    openings: list[LegacyOpeningBalance] = []
+    seen_contracts: set[int] = set()
+    seen_symbols: set[str] = set()
+    for position in positions:
+        con_id = position.get("con_id")
+        symbol = position.get("symbol")
+        quantity = position.get("quantity")
+        if type(con_id) is not int or con_id <= 0:
+            raise FifoBootstrapError("every legacy opening balance requires a positive con_id")
+        if type(symbol) is not str or not symbol or type(quantity) is not int or quantity == 0:
+            raise FifoBootstrapError("legacy opening balance identity is malformed")
+        if con_id in seen_contracts or symbol in seen_symbols:
+            raise FifoBootstrapError("legacy opening balance identities are not unique")
+        seen_contracts.add(con_id)
+        seen_symbols.add(symbol)
+        opening_balance_id = _derived_id("fobal", epoch_id, con_id, symbol, candidate_fingerprint)
+        openings.append(
+            LegacyOpeningBalance(
+                opening_balance_id=opening_balance_id,
+                lot_id=_derived_id("flot", epoch_id, opening_balance_id),
+                con_id=con_id,
+                symbol=symbol,
+                direction="LONG" if quantity > 0 else "SHORT",
+                opened_quantity_text=str(abs(quantity)),
+                cost_basis_text=str(position["cost_basis_text"]),
+                mark_price_text=str(position["mark_price_text"]),
+                mark_observed_at=str(position["mark_observed_at"]),
+                mark_evidence_fingerprint=str(position["mark_evidence_fingerprint"]),
+            )
+        )
+    if [opening.symbol for opening in openings] != sorted(seen_symbols):
+        raise FifoBootstrapError("legacy opening balances must be sorted by symbol")
+    return LegacyFifoBootstrapPlan(
+        epoch_id=epoch_id,
+        bootstrap_id=bootstrap_id,
+        candidate_fingerprint=candidate_fingerprint,
+        execution_domain_scope=execution_domain_scope,
+        account_scope=account_scope,
+        portfolio_id=portfolio_id,
+        effective_at=effective_at,
+        reconciliation_snapshot_id=reconciliation_snapshot_id,
+        reconciliation_report_hash=reconciliation_report_hash,
+        broker_snapshot_hash=broker_snapshot_hash,
+        legacy_snapshot_hash=legacy_snapshot_hash,
+        cash_text=cash_text,
+        realized_pnl_text=realized_pnl_text,
+        daily_pnl_text=daily_pnl_text,
+        daily_pnl_baseline_text=daily_pnl_baseline_text,
+        daily_pnl_date=daily_pnl_date,
+        opening_balances=tuple(openings),
+    )
+
+
+async def _assert_fifo_schema(connection: aiosqlite.Connection) -> None:
+    foreign_keys = await connection.execute("PRAGMA foreign_keys")
+    if await foreign_keys.fetchone() != (1,):
+        raise FifoBootstrapError("FIFO accounting requires foreign-key enforcement")
+    temporary = await connection.execute(
+        "SELECT type,name FROM temp.sqlite_master WHERE name LIKE 'fifo_%' ORDER BY type,name"
+    )
+    if await temporary.fetchone() is not None:
+        raise FifoBootstrapError("temporary FIFO objects cannot shadow durable state")
+    tables = await connection.execute(
+        "SELECT name,sql FROM main.sqlite_master "
+        "WHERE type='table' AND name LIKE 'fifo_%' ORDER BY name"
+    )
+    actual_tables = {str(name): _normalize_sql(sql) for name, sql in await tables.fetchall()}
+    if set(actual_tables) != set(_TABLE_SQL):
+        raise FifoBootstrapError("FIFO accounting table set is incomplete or unknown")
+    for name, statement in _TABLE_SQL.items():
+        if actual_tables[name] != _normalize_sql(statement):
+            raise FifoBootstrapError(f"FIFO accounting table {name} is malformed")
+    triggers = await connection.execute(
+        "SELECT name,sql FROM main.sqlite_master "
+        "WHERE type='trigger' AND name LIKE 'fifo_%' ORDER BY name"
+    )
+    actual_triggers = {str(name): _normalize_sql(sql) for name, sql in await triggers.fetchall()}
+    if set(actual_triggers) != set(_TRIGGER_SQL):
+        raise FifoBootstrapError("FIFO accounting trigger set is incomplete or unknown")
+    for name, statement in _TRIGGER_SQL.items():
+        if actual_triggers[name] != _normalize_sql(statement):
+            raise FifoBootstrapError(f"FIFO accounting trigger {name} is malformed")
+    versions = await connection.execute(
+        "SELECT version,description FROM fifo_schema_migrations "
+        "WHERE component=? ORDER BY version",
+        (FIFO_ACCOUNTING_COMPONENT,),
+    )
+    if await versions.fetchall() != list(FIFO_ACCOUNTING_MIGRATIONS):
+        raise FifoBootstrapError("FIFO accounting migration evidence is incomplete")
+    foreign_key_check = await connection.execute("PRAGMA main.foreign_key_check")
+    if await foreign_key_check.fetchone() is not None:
+        raise FifoBootstrapError("FIFO accounting schema has foreign-key violations")
+
+
+async def prepare_fifo_accounting_schema_in_transaction(
+    connection: aiosqlite.Connection,
+    *,
+    applied_at: str,
+) -> None:
+    """Create the FIFO schema only inside the caller's already-held transaction."""
+
+    if not connection.in_transaction:
+        raise FifoBootstrapError("FIFO schema preparation requires an active transaction")
+    objects = await connection.execute(
+        "SELECT type,name FROM main.sqlite_master " "WHERE name LIKE 'fifo_%' ORDER BY type,name"
+    )
+    existing = await objects.fetchall()
+    if existing:
+        await _assert_fifo_schema(connection)
+        return
+    for statement in _TABLE_SQL.values():
+        await connection.execute(statement)
+    await connection.executemany(
+        """
+        INSERT INTO fifo_schema_migrations(component,version,description,applied_at)
+        VALUES (?,?,?,?)
+        """,
+        tuple(
+            (FIFO_ACCOUNTING_COMPONENT, version, description, applied_at)
+            for version, description in FIFO_ACCOUNTING_MIGRATIONS
+        ),
+    )
+    for statement in _TRIGGER_SQL.values():
+        await connection.execute(statement)
+    await _assert_fifo_schema(connection)
+
+
+async def append_legacy_fifo_bootstrap_in_transaction(
+    connection: aiosqlite.Connection,
+    *,
+    plan: LegacyFifoBootstrapPlan,
+    operator_action_id: str,
+    recorded_at: str,
+) -> None:
+    """Append a legacy epoch and its explicit non-fill opening records."""
+
+    if not connection.in_transaction:
+        raise FifoBootstrapError("legacy FIFO bootstrap requires an active transaction")
+    if type(plan) is not LegacyFifoBootstrapPlan:
+        raise FifoBootstrapError("legacy FIFO bootstrap plan has the wrong type")
+    if type(operator_action_id) is not str or not operator_action_id:
+        raise FifoBootstrapError("legacy FIFO bootstrap requires an administrator action")
+    await _assert_fifo_schema(connection)
+    existing = await connection.execute(
+        """
+        SELECT epoch_id FROM fifo_accounting_epochs
+        WHERE epoch_id=? OR source_fingerprint=? OR (
+            execution_domain_scope=? AND account_scope=? AND portfolio_id=?
+        )
+        """,
+        (
+            plan.epoch_id,
+            plan.candidate_fingerprint,
+            plan.execution_domain_scope,
+            plan.account_scope,
+            plan.portfolio_id,
+        ),
+    )
+    if await existing.fetchone() is not None:
+        raise FifoBootstrapError("FIFO accounting scope already has a sealed epoch")
+    await connection.execute(
+        """
+        INSERT INTO fifo_accounting_epochs(
+            epoch_id,schema_version,execution_domain_scope,account_scope,portfolio_id,
+            origin_kind,source_fingerprint,effective_at,created_at
+        ) VALUES (?,?,?,?,?,'LEGACY_AGGREGATE_OPENING_BALANCE',?,?,?)
+        """,
+        (
+            plan.epoch_id,
+            1,
+            plan.execution_domain_scope,
+            plan.account_scope,
+            plan.portfolio_id,
+            plan.candidate_fingerprint,
+            plan.effective_at,
+            recorded_at,
+        ),
+    )
+    await connection.execute(
+        """
+        INSERT INTO fifo_legacy_bootstrap_lineage(
+            epoch_id,bootstrap_id,candidate_fingerprint,reconciliation_snapshot_id,
+            reconciliation_report_hash,broker_snapshot_hash,legacy_snapshot_hash,
+            operator_action_id,recorded_at
+        ) VALUES (?,?,?,?,?,?,?,?,?)
+        """,
+        (
+            plan.epoch_id,
+            plan.bootstrap_id,
+            plan.candidate_fingerprint,
+            plan.reconciliation_snapshot_id,
+            plan.reconciliation_report_hash,
+            plan.broker_snapshot_hash,
+            plan.legacy_snapshot_hash,
+            operator_action_id,
+            recorded_at,
+        ),
+    )
+    await connection.execute(
+        """
+        INSERT INTO fifo_epoch_account_baselines(
+            epoch_id,cash_text,realized_pnl_text,daily_pnl_text,
+            daily_pnl_baseline_text,daily_pnl_date,recorded_at
+        ) VALUES (?,?,?,?,?,?,?)
+        """,
+        (
+            plan.epoch_id,
+            plan.cash_text,
+            plan.realized_pnl_text,
+            plan.daily_pnl_text,
+            plan.daily_pnl_baseline_text,
+            plan.daily_pnl_date,
+            recorded_at,
+        ),
+    )
+    for opening in plan.opening_balances:
+        await connection.execute(
+            """
+            INSERT INTO fifo_opening_balances(
+                opening_balance_id,epoch_id,con_id,symbol,direction,
+                opened_quantity_text,cost_basis_text,mark_price_text,
+                mark_observed_at,mark_evidence_fingerprint,recorded_at
+            ) VALUES (?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                opening.opening_balance_id,
+                plan.epoch_id,
+                opening.con_id,
+                opening.symbol,
+                opening.direction,
+                opening.opened_quantity_text,
+                opening.cost_basis_text,
+                opening.mark_price_text,
+                opening.mark_observed_at,
+                opening.mark_evidence_fingerprint,
+                recorded_at,
+            ),
+        )
+        await connection.execute(
+            """
+            INSERT INTO fifo_lot_openings(
+                lot_id,epoch_id,opening_fill_id,opening_balance_id,lot_ordinal,
+                con_id,symbol,direction,opened_quantity_text,open_price_text,
+                opening_commission_minor,opened_sequence,opened_at
+            ) VALUES (?,?,NULL,?,0,?,?,?,?,?,0,0,?)
+            """,
+            (
+                opening.lot_id,
+                plan.epoch_id,
+                opening.opening_balance_id,
+                opening.con_id,
+                opening.symbol,
+                opening.direction,
+                opening.opened_quantity_text,
+                opening.cost_basis_text,
+                plan.effective_at,
+            ),
+        )
+    counts = await connection.execute(
+        """
+        SELECT
+          (SELECT COUNT(*) FROM fifo_fills WHERE epoch_id=?),
+          (SELECT COUNT(*) FROM fifo_commissions WHERE epoch_id=?),
+          (SELECT COUNT(*) FROM fifo_opening_balances WHERE epoch_id=?),
+          (SELECT COUNT(*) FROM fifo_lot_openings WHERE epoch_id=? AND opening_fill_id IS NOT NULL)
+        """,
+        (plan.epoch_id, plan.epoch_id, plan.epoch_id, plan.epoch_id),
+    )
+    if await counts.fetchone() != (0, 0, len(plan.opening_balances), 0):
+        raise FifoBootstrapError("legacy FIFO bootstrap fabricated or omitted event records")
+    lineage = await connection.execute(
+        """
+        SELECT e.origin_kind,e.source_fingerprint,l.bootstrap_id,
+               l.candidate_fingerprint,l.reconciliation_snapshot_id,
+               l.reconciliation_report_hash,l.broker_snapshot_hash,
+               l.legacy_snapshot_hash,l.operator_action_id,
+               p.candidate_fingerprint,p.operator_action_id,a.evidence_hash
+        FROM fifo_accounting_epochs e
+        JOIN fifo_legacy_bootstrap_lineage l ON l.epoch_id=e.epoch_id
+        JOIN paper_state_bootstraps p ON p.bootstrap_id=l.bootstrap_id
+        JOIN administrator_actions a ON a.action_id=l.operator_action_id
+        WHERE e.epoch_id=?
+        """,
+        (plan.epoch_id,),
+    )
+    if await lineage.fetchone() != (
+        "LEGACY_AGGREGATE_OPENING_BALANCE",
+        plan.candidate_fingerprint,
+        plan.bootstrap_id,
+        plan.candidate_fingerprint,
+        plan.reconciliation_snapshot_id,
+        plan.reconciliation_report_hash,
+        plan.broker_snapshot_hash,
+        plan.legacy_snapshot_hash,
+        operator_action_id,
+        plan.candidate_fingerprint,
+        operator_action_id,
+        plan.candidate_fingerprint,
+    ):
+        raise FifoBootstrapError("FIFO epoch is not bound to the exact bootstrap lineage")
+    baseline = await connection.execute(
+        """
+        SELECT cash_text,realized_pnl_text,daily_pnl_text,
+               daily_pnl_baseline_text,daily_pnl_date
+        FROM fifo_epoch_account_baselines WHERE epoch_id=?
+        """,
+        (plan.epoch_id,),
+    )
+    if await baseline.fetchone() != (
+        plan.cash_text,
+        plan.realized_pnl_text,
+        plan.daily_pnl_text,
+        plan.daily_pnl_baseline_text,
+        plan.daily_pnl_date,
+    ):
+        raise FifoBootstrapError("FIFO pre-epoch account baseline changed during append")
+    openings = await connection.execute(
+        """
+        SELECT b.opening_balance_id,l.lot_id,b.con_id,b.symbol,b.direction,
+               b.opened_quantity_text,b.cost_basis_text,b.mark_price_text,
+               b.mark_observed_at,b.mark_evidence_fingerprint,
+               l.opening_commission_minor,l.opened_sequence
+        FROM fifo_opening_balances b
+        JOIN fifo_lot_openings l
+          ON l.epoch_id=b.epoch_id AND l.opening_balance_id=b.opening_balance_id
+        WHERE b.epoch_id=? ORDER BY b.symbol
+        """,
+        (plan.epoch_id,),
+    )
+    expected_openings = [
+        (
+            opening.opening_balance_id,
+            opening.lot_id,
+            opening.con_id,
+            opening.symbol,
+            opening.direction,
+            opening.opened_quantity_text,
+            opening.cost_basis_text,
+            opening.mark_price_text,
+            opening.mark_observed_at,
+            opening.mark_evidence_fingerprint,
+            0,
+            0,
+        )
+        for opening in plan.opening_balances
+    ]
+    if await openings.fetchall() != expected_openings:
+        raise FifoBootstrapError("FIFO opening balances changed during append")

--- a/robo_trader/accounting/fifo_bootstrap.py
+++ b/robo_trader/accounting/fifo_bootstrap.py
@@ -19,7 +19,10 @@ from .fifo_fixture_migration import (
     _TRIGGER_SQL,
     FIFO_ACCOUNTING_COMPONENT,
     FIFO_ACCOUNTING_MIGRATIONS,
+    _foreign_fifo_triggers,
+    _legacy_opening_manifest_hash,
     _normalize_sql,
+    _trigger_references_fifo_table,
 )
 
 
@@ -82,6 +85,7 @@ class LegacyFifoBootstrapPlan:
     opening_balances: tuple[LegacyOpeningBalance, ...]
 
     def public_dict(self) -> dict[str, object]:
+        opening_manifest_rows = _opening_manifest_rows(self)
         return {
             "account_baseline": {
                 "cash_text": self.cash_text,
@@ -96,10 +100,33 @@ class LegacyFifoBootstrapPlan:
             "authorizes_startup": False,
             "opening_balances": [value.public_dict() for value in self.opening_balances],
             "opening_commission_semantics": "UNKNOWN_PRE_EPOCH_HISTORY_NOT_RECONSTRUCTED",
+            "opening_manifest_count": len(opening_manifest_rows),
+            "opening_manifest_hash": _legacy_opening_manifest_hash(opening_manifest_rows),
             "origin_kind": "LEGACY_AGGREGATE_OPENING_BALANCE",
             "pre_epoch_history_reconstructed": False,
             "synthetic_fill_count": 0,
         }
+
+
+def _opening_manifest_rows(plan: LegacyFifoBootstrapPlan) -> list[tuple[object, ...]]:
+    return [
+        (
+            opening.opening_balance_id,
+            opening.lot_id,
+            opening.con_id,
+            opening.symbol,
+            opening.direction,
+            opening.opened_quantity_text,
+            opening.cost_basis_text,
+            opening.mark_price_text,
+            opening.mark_observed_at,
+            opening.mark_evidence_fingerprint,
+            0,
+            0,
+            plan.effective_at,
+        )
+        for opening in plan.opening_balances
+    ]
 
 
 def build_legacy_fifo_bootstrap_plan(
@@ -184,15 +211,21 @@ async def _assert_fifo_schema(connection: aiosqlite.Connection) -> None:
     protected_tables = tuple(_TABLE_SQL)
     protected_table_names = "|" + "|".join(protected_tables) + "|"
     temporary_query = (
-        "SELECT type,name FROM temp.sqlite_master "
+        "SELECT type,name,tbl_name,sql FROM temp.sqlite_master "
         "WHERE name LIKE 'fifo_%' OR instr(?, '|' || tbl_name || '|') > 0 "
-        "ORDER BY type,name"
+        "OR type='trigger' ORDER BY type,name"
     )
     temporary = await connection.execute(
         temporary_query,
         (protected_table_names,),
     )
-    if await temporary.fetchone() is not None:
+    temporary_rows = await temporary.fetchall()
+    if any(
+        str(row[1]).lower().startswith("fifo_")
+        or str(row[2]).lower() in _TABLE_SQL
+        or (str(row[0]) == "trigger" and _trigger_references_fifo_table(row[3]))
+        for row in temporary_rows
+    ):
         raise FifoBootstrapError("temporary FIFO objects cannot shadow durable state")
     tables = await connection.execute(
         "SELECT name,sql FROM main.sqlite_master "
@@ -204,16 +237,15 @@ async def _assert_fifo_schema(connection: aiosqlite.Connection) -> None:
     for name, statement in _TABLE_SQL.items():
         if actual_tables[name] != _normalize_sql(statement):
             raise FifoBootstrapError(f"FIFO accounting table {name} is malformed")
-    trigger_query = (
-        "SELECT name,sql FROM main.sqlite_master "
-        "WHERE type='trigger' AND "
-        "(name LIKE 'fifo_%' OR instr(?, '|' || tbl_name || '|') > 0) ORDER BY name"
-    )
     triggers = await connection.execute(
-        trigger_query,
-        (protected_table_names,),
+        "SELECT name,tbl_name,sql FROM main.sqlite_master " "WHERE type='trigger' ORDER BY name"
     )
-    actual_triggers = {str(name): _normalize_sql(sql) for name, sql in await triggers.fetchall()}
+    trigger_rows = await triggers.fetchall()
+    if _foreign_fifo_triggers(trigger_rows):
+        raise FifoBootstrapError("foreign triggers cannot reference FIFO accounting tables")
+    actual_triggers = {
+        str(name): _normalize_sql(sql) for name, _, sql in trigger_rows if str(name) in _TRIGGER_SQL
+    }
     if set(actual_triggers) != set(_TRIGGER_SQL):
         raise FifoBootstrapError("FIFO accounting trigger set is incomplete or unknown")
     for name, statement in _TRIGGER_SQL.items():
@@ -258,6 +290,11 @@ async def prepare_fifo_accounting_schema_in_transaction(
     if existing:
         await _assert_fifo_schema(connection)
         return
+    triggers = await connection.execute(
+        "SELECT name,tbl_name,sql FROM main.sqlite_master " "WHERE type='trigger' ORDER BY name"
+    )
+    if _foreign_fifo_triggers(await triggers.fetchall()):
+        raise FifoBootstrapError("foreign triggers cannot reference FIFO accounting tables")
     for statement in _TABLE_SQL.values():
         await connection.execute(statement)
     await connection.executemany(
@@ -291,6 +328,8 @@ async def append_legacy_fifo_bootstrap_in_transaction(
     if type(operator_action_id) is not str or not operator_action_id:
         raise FifoBootstrapError("legacy FIFO bootstrap requires an administrator action")
     await _assert_fifo_schema(connection)
+    expected_openings = _opening_manifest_rows(plan)
+    opening_manifest_hash = _legacy_opening_manifest_hash(expected_openings)
     existing = await connection.execute(
         """
         SELECT epoch_id FROM fifo_accounting_epochs
@@ -329,15 +368,18 @@ async def append_legacy_fifo_bootstrap_in_transaction(
     await connection.execute(
         """
         INSERT INTO fifo_legacy_bootstrap_lineage(
-            epoch_id,bootstrap_id,candidate_fingerprint,reconciliation_snapshot_id,
+            epoch_id,bootstrap_id,candidate_fingerprint,
+            opening_manifest_count,opening_manifest_hash,reconciliation_snapshot_id,
             reconciliation_report_hash,broker_snapshot_hash,legacy_snapshot_hash,
             operator_action_id,recorded_at
-        ) VALUES (?,?,?,?,?,?,?,?,?)
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?)
         """,
         (
             plan.epoch_id,
             plan.bootstrap_id,
             plan.candidate_fingerprint,
+            len(expected_openings),
+            opening_manifest_hash,
             plan.reconciliation_snapshot_id,
             plan.reconciliation_report_hash,
             plan.broker_snapshot_hash,
@@ -421,7 +463,8 @@ async def append_legacy_fifo_bootstrap_in_transaction(
     lineage = await connection.execute(
         """
         SELECT e.origin_kind,e.source_fingerprint,l.bootstrap_id,
-               l.candidate_fingerprint,l.reconciliation_snapshot_id,
+               l.candidate_fingerprint,l.opening_manifest_count,
+               l.opening_manifest_hash,l.reconciliation_snapshot_id,
                l.reconciliation_report_hash,l.broker_snapshot_hash,
                l.legacy_snapshot_hash,l.operator_action_id,
                p.candidate_fingerprint,p.operator_action_id,a.evidence_hash
@@ -438,6 +481,8 @@ async def append_legacy_fifo_bootstrap_in_transaction(
         plan.candidate_fingerprint,
         plan.bootstrap_id,
         plan.candidate_fingerprint,
+        len(expected_openings),
+        opening_manifest_hash,
         plan.reconciliation_snapshot_id,
         plan.reconciliation_report_hash,
         plan.broker_snapshot_hash,
@@ -469,7 +514,7 @@ async def append_legacy_fifo_bootstrap_in_transaction(
         SELECT b.opening_balance_id,l.lot_id,b.con_id,b.symbol,b.direction,
                b.opened_quantity_text,b.cost_basis_text,b.mark_price_text,
                b.mark_observed_at,b.mark_evidence_fingerprint,
-               l.opening_commission_minor,l.opened_sequence
+               l.opening_commission_minor,l.opened_sequence,l.opened_at
         FROM fifo_opening_balances b
         JOIN fifo_lot_openings l
           ON l.epoch_id=b.epoch_id AND l.opening_balance_id=b.opening_balance_id
@@ -477,22 +522,5 @@ async def append_legacy_fifo_bootstrap_in_transaction(
         """,
         (plan.epoch_id,),
     )
-    expected_openings = [
-        (
-            opening.opening_balance_id,
-            opening.lot_id,
-            opening.con_id,
-            opening.symbol,
-            opening.direction,
-            opening.opened_quantity_text,
-            opening.cost_basis_text,
-            opening.mark_price_text,
-            opening.mark_observed_at,
-            opening.mark_evidence_fingerprint,
-            0,
-            0,
-        )
-        for opening in plan.opening_balances
-    ]
     if await openings.fetchall() != expected_openings:
         raise FifoBootstrapError("FIFO opening balances changed during append")

--- a/robo_trader/accounting/fifo_bootstrap.py
+++ b/robo_trader/accounting/fifo_bootstrap.py
@@ -181,8 +181,16 @@ async def _assert_fifo_schema(connection: aiosqlite.Connection) -> None:
     foreign_keys = await connection.execute("PRAGMA foreign_keys")
     if await foreign_keys.fetchone() != (1,):
         raise FifoBootstrapError("FIFO accounting requires foreign-key enforcement")
+    protected_tables = tuple(_TABLE_SQL)
+    protected_table_names = "|" + "|".join(protected_tables) + "|"
+    temporary_query = (
+        "SELECT type,name FROM temp.sqlite_master "
+        "WHERE name LIKE 'fifo_%' OR instr(?, '|' || tbl_name || '|') > 0 "
+        "ORDER BY type,name"
+    )
     temporary = await connection.execute(
-        "SELECT type,name FROM temp.sqlite_master WHERE name LIKE 'fifo_%' ORDER BY type,name"
+        temporary_query,
+        (protected_table_names,),
     )
     if await temporary.fetchone() is not None:
         raise FifoBootstrapError("temporary FIFO objects cannot shadow durable state")
@@ -196,9 +204,14 @@ async def _assert_fifo_schema(connection: aiosqlite.Connection) -> None:
     for name, statement in _TABLE_SQL.items():
         if actual_tables[name] != _normalize_sql(statement):
             raise FifoBootstrapError(f"FIFO accounting table {name} is malformed")
-    triggers = await connection.execute(
+    trigger_query = (
         "SELECT name,sql FROM main.sqlite_master "
-        "WHERE type='trigger' AND name LIKE 'fifo_%' ORDER BY name"
+        "WHERE type='trigger' AND "
+        "(name LIKE 'fifo_%' OR instr(?, '|' || tbl_name || '|') > 0) ORDER BY name"
+    )
+    triggers = await connection.execute(
+        trigger_query,
+        (protected_table_names,),
     )
     actual_triggers = {str(name): _normalize_sql(sql) for name, sql in await triggers.fetchall()}
     if set(actual_triggers) != set(_TRIGGER_SQL):
@@ -206,6 +219,17 @@ async def _assert_fifo_schema(connection: aiosqlite.Connection) -> None:
     for name, statement in _TRIGGER_SQL.items():
         if actual_triggers[name] != _normalize_sql(statement):
             raise FifoBootstrapError(f"FIFO accounting trigger {name} is malformed")
+    foreign_schema_query = (
+        "SELECT type,name FROM main.sqlite_master "
+        "WHERE type IN ('view','index') AND name NOT LIKE 'sqlite_%' AND "
+        "(name LIKE 'fifo_%' OR instr(?, '|' || tbl_name || '|') > 0) ORDER BY type,name"
+    )
+    foreign_schema = await connection.execute(
+        foreign_schema_query,
+        (protected_table_names,),
+    )
+    if await foreign_schema.fetchone() is not None:
+        raise FifoBootstrapError("foreign schema objects cannot target FIFO accounting")
     versions = await connection.execute(
         "SELECT version,description FROM fifo_schema_migrations "
         "WHERE component=? ORDER BY version",

--- a/robo_trader/accounting/fifo_bootstrap.py
+++ b/robo_trader/accounting/fifo_bootstrap.py
@@ -210,14 +210,8 @@ async def _assert_fifo_schema(connection: aiosqlite.Connection) -> None:
         raise FifoBootstrapError("FIFO accounting requires foreign-key enforcement")
     protected_tables = tuple(_TABLE_SQL)
     protected_table_names = "|" + "|".join(protected_tables) + "|"
-    temporary_query = (
-        "SELECT type,name,tbl_name,sql FROM temp.sqlite_master "
-        "WHERE name LIKE 'fifo_%' OR instr(?, '|' || tbl_name || '|') > 0 "
-        "OR type='trigger' ORDER BY type,name"
-    )
     temporary = await connection.execute(
-        temporary_query,
-        (protected_table_names,),
+        "SELECT type,name,tbl_name,sql FROM temp.sqlite_master ORDER BY type,name"
     )
     temporary_rows = await temporary.fetchall()
     if any(

--- a/robo_trader/accounting/fifo_fixture_migration.py
+++ b/robo_trader/accounting/fifo_fixture_migration.py
@@ -14,7 +14,12 @@ from pathlib import Path
 from typing import Optional
 
 FIFO_ACCOUNTING_COMPONENT = "fifo_accounting"
-FIFO_ACCOUNTING_SCHEMA_VERSION = 1
+FIFO_ACCOUNTING_SCHEMA_VERSION = 2
+FIFO_ACCOUNTING_MIGRATIONS = (
+    (1, "dormant exact append-only FIFO accounting foundation"),
+    (2, "sealed legacy aggregate opening balances"),
+)
+FIFO_ACCOUNTING_SCHEMA_VERSIONS = tuple(version for version, _ in FIFO_ACCOUNTING_MIGRATIONS)
 FIXTURE_DATABASE_SUFFIX = ".fifo-fixture.sqlite3"
 
 
@@ -76,6 +81,106 @@ _TABLE_SQL = {
             effective_at TEXT NOT NULL CHECK (effective_at LIKE '%Z'),
             created_at TEXT NOT NULL CHECK (created_at LIKE '%Z'),
             UNIQUE(execution_domain_scope, account_scope, portfolio_id)
+        )
+    """,
+    "fifo_legacy_bootstrap_lineage": """
+        CREATE TABLE fifo_legacy_bootstrap_lineage (
+            epoch_id TEXT PRIMARY KEY,
+            bootstrap_id TEXT NOT NULL UNIQUE CHECK (
+                length(bootstrap_id) = 38 AND substr(bootstrap_id, 1, 6) = 'pboot-'
+                AND substr(bootstrap_id, 7) NOT GLOB '*[^0-9a-f]*'
+            ),
+            candidate_fingerprint TEXT NOT NULL UNIQUE CHECK (
+                length(candidate_fingerprint) = 64
+                AND candidate_fingerprint = lower(candidate_fingerprint)
+                AND candidate_fingerprint NOT GLOB '*[^0-9a-f]*'
+            ),
+            reconciliation_snapshot_id TEXT NOT NULL CHECK (
+                length(trim(reconciliation_snapshot_id)) > 0
+            ),
+            reconciliation_report_hash TEXT NOT NULL CHECK (
+                length(reconciliation_report_hash) = 64
+                AND reconciliation_report_hash = lower(reconciliation_report_hash)
+                AND reconciliation_report_hash NOT GLOB '*[^0-9a-f]*'
+            ),
+            broker_snapshot_hash TEXT NOT NULL CHECK (
+                length(broker_snapshot_hash) = 64
+                AND broker_snapshot_hash = lower(broker_snapshot_hash)
+                AND broker_snapshot_hash NOT GLOB '*[^0-9a-f]*'
+            ),
+            legacy_snapshot_hash TEXT NOT NULL CHECK (
+                length(legacy_snapshot_hash) = 64
+                AND legacy_snapshot_hash = lower(legacy_snapshot_hash)
+                AND legacy_snapshot_hash NOT GLOB '*[^0-9a-f]*'
+            ),
+            operator_action_id TEXT NOT NULL UNIQUE CHECK (
+                length(trim(operator_action_id)) > 0
+            ),
+            recorded_at TEXT NOT NULL CHECK (recorded_at LIKE '%Z'),
+            FOREIGN KEY(epoch_id) REFERENCES fifo_accounting_epochs(epoch_id)
+        )
+    """,
+    "fifo_epoch_account_baselines": f"""
+        CREATE TABLE fifo_epoch_account_baselines (
+            epoch_id TEXT PRIMARY KEY,
+            cash_text TEXT NOT NULL CHECK (
+                length(cash_text) BETWEEN 1 AND 96
+                AND ({_signed_decimal_check('cash_text')})
+            ),
+            realized_pnl_text TEXT NOT NULL CHECK (
+                length(realized_pnl_text) BETWEEN 1 AND 96
+                AND ({_signed_decimal_check('realized_pnl_text')})
+            ),
+            daily_pnl_text TEXT NOT NULL CHECK (
+                length(daily_pnl_text) BETWEEN 1 AND 96
+                AND ({_signed_decimal_check('daily_pnl_text')})
+            ),
+            daily_pnl_baseline_text TEXT NOT NULL CHECK (
+                length(daily_pnl_baseline_text) BETWEEN 1 AND 96
+                AND ({_signed_decimal_check('daily_pnl_baseline_text')})
+            ),
+            daily_pnl_date TEXT NOT NULL CHECK (
+                length(daily_pnl_date) = 10
+                AND daily_pnl_date GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'
+            ),
+            recorded_at TEXT NOT NULL CHECK (recorded_at LIKE '%Z'),
+            FOREIGN KEY(epoch_id) REFERENCES fifo_accounting_epochs(epoch_id)
+        )
+    """,
+    "fifo_opening_balances": f"""
+        CREATE TABLE fifo_opening_balances (
+            opening_balance_id TEXT PRIMARY KEY CHECK (
+                length(opening_balance_id) = 38
+                AND substr(opening_balance_id, 1, 6) = 'fobal-'
+                AND substr(opening_balance_id, 7) NOT GLOB '*[^0-9a-f]*'
+            ),
+            epoch_id TEXT NOT NULL,
+            con_id INTEGER NOT NULL CHECK (typeof(con_id) = 'integer' AND con_id > 0),
+            symbol TEXT NOT NULL CHECK (length(symbol) BETWEEN 1 AND 32),
+            direction TEXT NOT NULL CHECK (direction IN ('LONG', 'SHORT')),
+            opened_quantity_text TEXT NOT NULL CHECK (
+                length(opened_quantity_text) BETWEEN 1 AND 64
+                AND ({_positive_decimal_check('opened_quantity_text')})
+            ),
+            cost_basis_text TEXT NOT NULL CHECK (
+                length(cost_basis_text) BETWEEN 1 AND 64
+                AND ({_positive_decimal_check('cost_basis_text')})
+            ),
+            mark_price_text TEXT NOT NULL CHECK (
+                length(mark_price_text) BETWEEN 1 AND 64
+                AND ({_positive_decimal_check('mark_price_text')})
+            ),
+            mark_observed_at TEXT NOT NULL CHECK (mark_observed_at LIKE '%Z'),
+            mark_evidence_fingerprint TEXT NOT NULL CHECK (
+                length(mark_evidence_fingerprint) = 64
+                AND mark_evidence_fingerprint = lower(mark_evidence_fingerprint)
+                AND mark_evidence_fingerprint NOT GLOB '*[^0-9a-f]*'
+            ),
+            recorded_at TEXT NOT NULL CHECK (recorded_at LIKE '%Z'),
+            UNIQUE(epoch_id, opening_balance_id),
+            UNIQUE(epoch_id, con_id),
+            UNIQUE(epoch_id, symbol),
+            FOREIGN KEY(epoch_id) REFERENCES fifo_accounting_epochs(epoch_id)
         )
     """,
     "fifo_fills": f"""
@@ -142,7 +247,8 @@ _TABLE_SQL = {
                 AND substr(lot_id, 6) NOT GLOB '*[^0-9a-f]*'
             ),
             epoch_id TEXT NOT NULL,
-            opening_fill_id TEXT NOT NULL,
+            opening_fill_id TEXT,
+            opening_balance_id TEXT,
             lot_ordinal INTEGER NOT NULL CHECK (
                 typeof(lot_ordinal) = 'integer' AND lot_ordinal >= 0
             ),
@@ -162,13 +268,24 @@ _TABLE_SQL = {
                 AND opening_commission_minor BETWEEN -1000000000000 AND 1000000000000
             ),
             opened_sequence INTEGER NOT NULL CHECK (
-                typeof(opened_sequence) = 'integer' AND opened_sequence > 0
+                typeof(opened_sequence) = 'integer' AND opened_sequence >= 0
             ),
             opened_at TEXT NOT NULL CHECK (opened_at LIKE '%Z'),
             UNIQUE(epoch_id, lot_id),
             UNIQUE(epoch_id, opening_fill_id, lot_ordinal),
+            UNIQUE(epoch_id, opening_balance_id),
             FOREIGN KEY(epoch_id, opening_fill_id)
-                REFERENCES fifo_fills(epoch_id, fill_id)
+                REFERENCES fifo_fills(epoch_id, fill_id),
+            FOREIGN KEY(epoch_id, opening_balance_id)
+                REFERENCES fifo_opening_balances(epoch_id, opening_balance_id),
+            CHECK (
+                (opening_fill_id IS NOT NULL AND opening_balance_id IS NULL
+                    AND opened_sequence > 0)
+                OR
+                (opening_fill_id IS NULL AND opening_balance_id IS NOT NULL
+                    AND lot_ordinal = 0 AND opening_commission_minor = 0
+                    AND opened_sequence = 0)
+            )
         )
     """,
     "fifo_lot_matches": f"""
@@ -300,6 +417,13 @@ _INSERT_CONFLICT_PREDICATES = {
             AND portfolio_id = NEW.portfolio_id
         )
     """,
+    "fifo_legacy_bootstrap_lineage": "epoch_id = NEW.epoch_id OR bootstrap_id = NEW.bootstrap_id OR candidate_fingerprint = NEW.candidate_fingerprint OR operator_action_id = NEW.operator_action_id",
+    "fifo_epoch_account_baselines": "epoch_id = NEW.epoch_id",
+    "fifo_opening_balances": """
+        opening_balance_id = NEW.opening_balance_id
+        OR (epoch_id = NEW.epoch_id AND con_id = NEW.con_id)
+        OR (epoch_id = NEW.epoch_id AND symbol = NEW.symbol)
+    """,
     "fifo_fills": """
         fill_id = NEW.fill_id
         OR (epoch_id = NEW.epoch_id AND event_sequence = NEW.event_sequence)
@@ -314,6 +438,7 @@ _INSERT_CONFLICT_PREDICATES = {
             AND opening_fill_id = NEW.opening_fill_id
             AND lot_ordinal = NEW.lot_ordinal
         )
+        OR (epoch_id = NEW.epoch_id AND opening_balance_id = NEW.opening_balance_id)
     """,
     "fifo_lot_matches": """
         match_id = NEW.match_id
@@ -410,8 +535,17 @@ def _pragma_foreign_keys_enabled(connection: sqlite3.Connection) -> bool:
     return row is not None and type(row[0]) is int and row[0] == 1
 
 
-def assert_fifo_accounting_schema(connection: sqlite3.Connection) -> None:
-    """Fail closed unless the complete PR4A fixture schema is exact."""
+def assert_fifo_accounting_schema(
+    connection: sqlite3.Connection,
+    *,
+    allow_other_objects: bool = False,
+) -> None:
+    """Fail closed unless every FIFO object is exact.
+
+    Fixture callers retain the original closed-world check.  PR4B's reviewed
+    bootstrap may validate the same objects inside a legacy ledger containing
+    unrelated pre-existing tables.
+    """
 
     _assert_no_temp_fifo_objects(connection)
     if not _pragma_foreign_keys_enabled(connection):
@@ -428,7 +562,7 @@ def assert_fifo_accounting_schema(connection: sqlite3.Connection) -> None:
         raise FifoFixtureMigrationError(
             f"FIFO accounting table {sorted(missing_tables)[0]} is missing"
         )
-    if unexpected_tables:
+    if unexpected_tables and not allow_other_objects:
         raise FifoFixtureMigrationError(
             f"FIFO fixture contains unexpected table {sorted(unexpected_tables)[0]}"
         )
@@ -446,7 +580,7 @@ def assert_fifo_accounting_schema(connection: sqlite3.Connection) -> None:
         raise FifoFixtureMigrationError(
             f"FIFO accounting trigger {sorted(missing_triggers)[0]} is missing"
         )
-    if unexpected_triggers:
+    if unexpected_triggers and not allow_other_objects:
         raise FifoFixtureMigrationError(
             f"FIFO fixture contains unexpected trigger {sorted(unexpected_triggers)[0]}"
         )
@@ -458,16 +592,17 @@ def assert_fifo_accounting_schema(connection: sqlite3.Connection) -> None:
         "SELECT type, name FROM main.sqlite_master "
         "WHERE type IN ('view','index') AND name NOT LIKE 'sqlite_%'"
     ).fetchall()
-    if unexpected_schema:
+    if unexpected_schema and not allow_other_objects:
         raise FifoFixtureMigrationError("FIFO fixture contains unexpected schema objects")
 
     version_rows = connection.execute(
-        "SELECT version FROM main.fifo_schema_migrations WHERE component = ? ORDER BY version",
+        "SELECT version,description FROM main.fifo_schema_migrations "
+        "WHERE component = ? ORDER BY version",
         (FIFO_ACCOUNTING_COMPONENT,),
     ).fetchall()
-    versions = [row[0] for row in version_rows]
-    if versions != [FIFO_ACCOUNTING_SCHEMA_VERSION] or any(
-        type(version) is not int for version in versions
+    migrations = [(row[0], row[1]) for row in version_rows]
+    if migrations != list(FIFO_ACCOUNTING_MIGRATIONS) or any(
+        type(version) is not int for version, _ in migrations
     ):
         raise FifoFixtureMigrationError("FIFO accounting migration evidence is incomplete")
     if connection.execute("PRAGMA main.foreign_key_check").fetchone() is not None:
@@ -510,15 +645,14 @@ def migrate_fifo_fixture_database(
             )
         for statement in _TABLE_SQL.values():
             connection.execute(statement)
-        connection.execute(
+        connection.executemany(
             """
             INSERT INTO main.fifo_schema_migrations(component, version, description, applied_at)
             VALUES (?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
             """,
-            (
-                FIFO_ACCOUNTING_COMPONENT,
-                FIFO_ACCOUNTING_SCHEMA_VERSION,
-                "dormant exact append-only FIFO accounting foundation",
+            tuple(
+                (FIFO_ACCOUNTING_COMPONENT, version, description)
+                for version, description in FIFO_ACCOUNTING_MIGRATIONS
             ),
         )
         for statement in _TRIGGER_SQL.values():

--- a/robo_trader/accounting/fifo_fixture_migration.py
+++ b/robo_trader/accounting/fifo_fixture_migration.py
@@ -563,18 +563,8 @@ def _foreign_fifo_triggers(rows: Sequence[Sequence[object]]) -> set[str]:
 
 
 def _assert_no_temp_fifo_objects(connection: sqlite3.Connection) -> None:
-    protected_tables = tuple(_TABLE_SQL)
-    protected_table_names = "|" + "|".join(protected_tables) + "|"
-    shadow_query = (
-        "SELECT type, name, tbl_name, sql FROM temp.sqlite_master "
-        "WHERE name LIKE 'fifo_%' OR instr(?, '|' || tbl_name || '|') > 0 "
-        "OR type = 'trigger' "
-        "ORDER BY type, name"
-    )
-    shadows = connection.execute(
-        shadow_query,
-        (protected_table_names,),
-    ).fetchall()
+    shadow_query = "SELECT type, name, tbl_name, sql FROM temp.sqlite_master " "ORDER BY type, name"
+    shadows = connection.execute(shadow_query).fetchall()
     if any(
         str(row[1]).lower().startswith("fifo_")
         or str(row[2]).lower() in _TABLE_SQL

--- a/robo_trader/accounting/fifo_fixture_migration.py
+++ b/robo_trader/accounting/fifo_fixture_migration.py
@@ -8,10 +8,12 @@ be applied to an operational ledger.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 import sqlite3
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Sequence
 
 FIFO_ACCOUNTING_COMPONENT = "fifo_accounting"
 FIFO_ACCOUNTING_SCHEMA_VERSION = 2
@@ -25,6 +27,14 @@ FIXTURE_DATABASE_SUFFIX = ".fifo-fixture.sqlite3"
 
 class FifoFixtureMigrationError(RuntimeError):
     """A fixture database cannot safely accept the FIFO schema."""
+
+
+def _legacy_opening_manifest_hash(rows: Sequence[Sequence[object]]) -> str:
+    """Bind one sealed candidate to its complete ordered opening-lot set."""
+
+    payload = [list(row) for row in rows]
+    encoded = json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("ascii")).hexdigest()
 
 
 def _positive_decimal_check(column: str) -> str:
@@ -94,6 +104,14 @@ _TABLE_SQL = {
                 length(candidate_fingerprint) = 64
                 AND candidate_fingerprint = lower(candidate_fingerprint)
                 AND candidate_fingerprint NOT GLOB '*[^0-9a-f]*'
+            ),
+            opening_manifest_count INTEGER NOT NULL CHECK (
+                typeof(opening_manifest_count) = 'integer' AND opening_manifest_count >= 0
+            ),
+            opening_manifest_hash TEXT NOT NULL CHECK (
+                length(opening_manifest_hash) = 64
+                AND opening_manifest_hash = lower(opening_manifest_hash)
+                AND opening_manifest_hash NOT GLOB '*[^0-9a-f]*'
             ),
             reconciliation_snapshot_id TEXT NOT NULL CHECK (
                 length(trim(reconciliation_snapshot_id)) > 0
@@ -522,19 +540,47 @@ def _assert_fixture_target(
         raise FifoFixtureMigrationError("fixture database must not have hard link aliases")
 
 
+def _trigger_references_fifo_table(sql: object) -> bool:
+    if type(sql) is not str:
+        return False
+    return any(
+        re.search(rf"(?<![a-z0-9_]){re.escape(table)}(?![a-z0-9_])", sql, re.IGNORECASE) is not None
+        for table in _TABLE_SQL
+    )
+
+
+def _foreign_fifo_triggers(rows: Sequence[Sequence[object]]) -> set[str]:
+    return {
+        str(name)
+        for name, table, sql in rows
+        if str(name) not in _TRIGGER_SQL
+        and (
+            str(name).lower().startswith("fifo_")
+            or str(table).lower() in _TABLE_SQL
+            or _trigger_references_fifo_table(sql)
+        )
+    }
+
+
 def _assert_no_temp_fifo_objects(connection: sqlite3.Connection) -> None:
     protected_tables = tuple(_TABLE_SQL)
     protected_table_names = "|" + "|".join(protected_tables) + "|"
     shadow_query = (
-        "SELECT type, name FROM temp.sqlite_master "
+        "SELECT type, name, tbl_name, sql FROM temp.sqlite_master "
         "WHERE name LIKE 'fifo_%' OR instr(?, '|' || tbl_name || '|') > 0 "
+        "OR type = 'trigger' "
         "ORDER BY type, name"
     )
     shadows = connection.execute(
         shadow_query,
         (protected_table_names,),
     ).fetchall()
-    if shadows:
+    if any(
+        str(row[1]).lower().startswith("fifo_")
+        or str(row[2]).lower() in _TABLE_SQL
+        or (str(row[0]) == "trigger" and _trigger_references_fifo_table(row[3]))
+        for row in shadows
+    ):
         raise FifoFixtureMigrationError("temporary FIFO objects cannot shadow durable main state")
 
 
@@ -592,11 +638,7 @@ def assert_fifo_accounting_schema(
         raise FifoFixtureMigrationError(
             f"FIFO fixture contains unexpected trigger {sorted(unexpected_triggers)[0]}"
         )
-    protected_foreign_triggers = {
-        str(name)
-        for name, table, _ in rows
-        if name not in _TRIGGER_SQL and (str(name).startswith("fifo_") or str(table) in _TABLE_SQL)
-    }
+    protected_foreign_triggers = _foreign_fifo_triggers(rows)
     if protected_foreign_triggers:
         raise FifoFixtureMigrationError("foreign triggers cannot target FIFO accounting tables")
     for name, statement in _TRIGGER_SQL.items():
@@ -612,7 +654,7 @@ def assert_fifo_accounting_schema(
     protected_foreign_schema = [
         row
         for row in unexpected_schema
-        if str(row[1]).startswith("fifo_") or str(row[2]) in _TABLE_SQL
+        if str(row[1]).lower().startswith("fifo_") or str(row[2]).lower() in _TABLE_SQL
     ]
     if protected_foreign_schema:
         raise FifoFixtureMigrationError(

--- a/robo_trader/accounting/fifo_fixture_migration.py
+++ b/robo_trader/accounting/fifo_fixture_migration.py
@@ -523,8 +523,16 @@ def _assert_fixture_target(
 
 
 def _assert_no_temp_fifo_objects(connection: sqlite3.Connection) -> None:
+    protected_tables = tuple(_TABLE_SQL)
+    protected_table_names = "|" + "|".join(protected_tables) + "|"
+    shadow_query = (
+        "SELECT type, name FROM temp.sqlite_master "
+        "WHERE name LIKE 'fifo_%' OR instr(?, '|' || tbl_name || '|') > 0 "
+        "ORDER BY type, name"
+    )
     shadows = connection.execute(
-        "SELECT type, name FROM temp.sqlite_master WHERE name LIKE 'fifo_%' ORDER BY type, name"
+        shadow_query,
+        (protected_table_names,),
     ).fetchall()
     if shadows:
         raise FifoFixtureMigrationError("temporary FIFO objects cannot shadow durable main state")
@@ -571,9 +579,9 @@ def assert_fifo_accounting_schema(
             raise FifoFixtureMigrationError(f"FIFO accounting table {name} is malformed")
 
     rows = connection.execute(
-        "SELECT name, sql FROM main.sqlite_master WHERE type = 'trigger'"
+        "SELECT name, tbl_name, sql FROM main.sqlite_master WHERE type = 'trigger'"
     ).fetchall()
-    actual_triggers = {str(name): _normalize_sql(sql) for name, sql in rows}
+    actual_triggers = {str(name): _normalize_sql(sql) for name, _, sql in rows}
     missing_triggers = set(_TRIGGER_SQL).difference(actual_triggers)
     unexpected_triggers = set(actual_triggers).difference(_TRIGGER_SQL)
     if missing_triggers:
@@ -584,16 +592,32 @@ def assert_fifo_accounting_schema(
         raise FifoFixtureMigrationError(
             f"FIFO fixture contains unexpected trigger {sorted(unexpected_triggers)[0]}"
         )
+    protected_foreign_triggers = {
+        str(name)
+        for name, table, _ in rows
+        if name not in _TRIGGER_SQL and (str(name).startswith("fifo_") or str(table) in _TABLE_SQL)
+    }
+    if protected_foreign_triggers:
+        raise FifoFixtureMigrationError("foreign triggers cannot target FIFO accounting tables")
     for name, statement in _TRIGGER_SQL.items():
         if actual_triggers.get(name) != _normalize_sql(statement):
             raise FifoFixtureMigrationError(f"FIFO accounting trigger {name} is malformed")
 
     unexpected_schema = connection.execute(
-        "SELECT type, name FROM main.sqlite_master "
+        "SELECT type, name, tbl_name FROM main.sqlite_master "
         "WHERE type IN ('view','index') AND name NOT LIKE 'sqlite_%'"
     ).fetchall()
     if unexpected_schema and not allow_other_objects:
         raise FifoFixtureMigrationError("FIFO fixture contains unexpected schema objects")
+    protected_foreign_schema = [
+        row
+        for row in unexpected_schema
+        if str(row[1]).startswith("fifo_") or str(row[2]) in _TABLE_SQL
+    ]
+    if protected_foreign_schema:
+        raise FifoFixtureMigrationError(
+            "foreign schema objects cannot target FIFO accounting tables"
+        )
 
     version_rows = connection.execute(
         "SELECT version,description FROM main.fifo_schema_migrations "

--- a/robo_trader/database_async.py
+++ b/robo_trader/database_async.py
@@ -27,6 +27,11 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 import aiosqlite
 
+from robo_trader.accounting.fifo_bootstrap import (
+    FifoBootstrapError,
+    append_legacy_fifo_bootstrap_in_transaction,
+    prepare_fifo_accounting_schema_in_transaction,
+)
 from robo_trader.database_migrations import (
     apply_exact_state_migrations,
     assert_exact_state_schema,
@@ -1770,6 +1775,10 @@ class AsyncTradingDatabase:
         """)
         await apply_exact_state_migrations(connection)
         await assert_exact_state_schema(connection)
+        await prepare_fifo_accounting_schema_in_transaction(
+            connection,
+            applied_at=utc_to_text(datetime.now(timezone.utc)),
+        )
 
     async def apply_exact_state_bootstrap_offline_atomic(
         self,
@@ -1933,6 +1942,7 @@ class AsyncTradingDatabase:
                 "bootstrap database identity does not match the runtime contract"
             )
         assert_exact_state_bootstrap_evidence(candidate, evidence, runtime_contract)
+        fifo_plan = candidate.fifo_bootstrap_plan()
         if journal_guard is None:
             raise ExactStateBootstrapError("bootstrap requires a held exact safety-journal guard")
         journal_guard.assert_unchanged()
@@ -1964,6 +1974,7 @@ class AsyncTradingDatabase:
                         )
                 else:
                     await conn.execute("BEGIN IMMEDIATE")
+                    await self._prepare_exact_bootstrap_schema(conn)
                 journal_guard.assert_unchanged()
                 for authentication in evidence.authentication_receipts:
                     replay = await conn.execute(
@@ -2190,6 +2201,17 @@ class AsyncTradingDatabase:
                         utc_to_text(committed_at),
                     ),
                 )
+                self._paper_settlement_fault("BEFORE_FIFO_LEGACY_BOOTSTRAP")
+                try:
+                    await append_legacy_fifo_bootstrap_in_transaction(
+                        conn,
+                        plan=fifo_plan,
+                        operator_action_id=action_id,
+                        recorded_at=utc_to_text(committed_at),
+                    )
+                except FifoBootstrapError as exc:
+                    raise ExactStateBootstrapError(str(exc)) from exc
+                self._paper_settlement_fault("AFTER_FIFO_LEGACY_BOOTSTRAP")
                 for authentication in evidence.authentication_receipts:
                     await conn.execute(
                         """

--- a/robo_trader/financial_state_bootstrap.py
+++ b/robo_trader/financial_state_bootstrap.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal, InvalidOperation, localcontext
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, Sequence
 
 from .bootstrap_evidence_auth import (
     AUTH_SUFFIX,
@@ -48,6 +48,9 @@ from .safety.sqlite_identity import (
     lexical_path_preserving_leaf,
     sqlite_connection_file_identity,
 )
+
+if TYPE_CHECKING:
+    from .accounting.fifo_bootstrap import LegacyFifoBootstrapPlan
 
 BOOTSTRAP_SCHEMA_VERSION = 1
 BOOTSTRAP_ID_PREFIX = "pboot-"
@@ -1623,6 +1626,7 @@ def assert_verified_exact_state_reconciliation_evidence(
 @dataclass(frozen=True, slots=True)
 class ExactBootstrapPosition:
     symbol: str
+    con_id: int
     quantity: int
     cost_basis: Decimal
     mark_price: Decimal
@@ -1633,6 +1637,10 @@ class ExactBootstrapPosition:
         symbol = str(self.symbol).strip().upper()
         if not _SYMBOL.fullmatch(symbol):
             raise ExactStateBootstrapError("bootstrap position symbol is malformed")
+        if type(self.con_id) is not int or self.con_id <= 0:
+            raise ExactStateBootstrapError(
+                "bootstrap position requires a positive authenticated con_id"
+            )
         if isinstance(self.quantity, bool) or type(self.quantity) is not int or self.quantity == 0:
             raise ExactStateBootstrapError("bootstrap position quantity must be a nonzero integer")
         object.__setattr__(self, "symbol", symbol)
@@ -1655,6 +1663,7 @@ class ExactBootstrapPosition:
 
     def public_dict(self) -> dict[str, object]:
         return {
+            "con_id": self.con_id,
             "cost_basis_text": decimal_to_fixed(self.cost_basis),
             "mark_evidence_fingerprint": self.mark_evidence_fingerprint,
             "mark_observed_at": utc_to_text(self.mark_observed_at),
@@ -1751,6 +1760,11 @@ class ExactStateBootstrapCandidate:
         symbols = [position.symbol for position in positions]
         if len(symbols) != len(set(symbols)) or symbols != sorted(symbols):
             raise ExactStateBootstrapError("bootstrap positions must be unique and sorted")
+        con_ids = [position.con_id for position in positions]
+        if len(con_ids) != len(set(con_ids)):
+            raise ExactStateBootstrapError(
+                "bootstrap positions must have unique authenticated con_id values"
+            )
         for position in positions:
             age = effective_at - position.mark_observed_at
             if age < timedelta(0) or age > MAX_MARK_AGE:
@@ -1795,6 +1809,31 @@ class ExactStateBootstrapCandidate:
 
     def fingerprint(self) -> str:
         return hashlib.sha256(self.canonical_payload().encode("utf-8")).hexdigest()
+
+    def fifo_bootstrap_plan(self) -> "LegacyFifoBootstrapPlan":
+        """Return the deterministic non-fill FIFO epoch proposed by this candidate."""
+
+        from .accounting.fifo_bootstrap import build_legacy_fifo_bootstrap_plan
+
+        account = self.account.public_dict()
+        return build_legacy_fifo_bootstrap_plan(
+            bootstrap_id=self.bootstrap_id,
+            candidate_fingerprint=self.fingerprint(),
+            execution_domain_scope=self.execution_domain_scope,
+            account_scope=self.account_scope,
+            portfolio_id=self.portfolio_id,
+            effective_at=utc_to_text(self.effective_at),
+            reconciliation_snapshot_id=self.reconciliation_snapshot_id,
+            reconciliation_report_hash=self.reconciliation_report_hash,
+            broker_snapshot_hash=self.broker_snapshot_hash,
+            legacy_snapshot_hash=self.legacy_snapshot_hash,
+            cash_text=account["cash_text"],
+            realized_pnl_text=account["realized_pnl_text"],
+            daily_pnl_text=account["daily_pnl_text"],
+            daily_pnl_baseline_text=account["daily_pnl_baseline_text"],
+            daily_pnl_date=account["daily_pnl_date"],
+            positions=[position.public_dict() for position in self.positions],
+        )
 
     @classmethod
     def from_mapping(cls, raw: Mapping[str, Any]) -> "ExactStateBootstrapCandidate":
@@ -1857,6 +1896,7 @@ class ExactStateBootstrapCandidate:
             _exact_keys(
                 item,
                 {
+                    "con_id",
                     "symbol",
                     "quantity",
                     "cost_basis_text",
@@ -1869,6 +1909,7 @@ class ExactStateBootstrapCandidate:
             positions_list.append(
                 ExactBootstrapPosition(
                     symbol=item["symbol"],
+                    con_id=item["con_id"],
                     quantity=item["quantity"],
                     cost_basis=item["cost_basis_text"],
                     mark_price=item["mark_price_text"],
@@ -2059,7 +2100,8 @@ def assert_exact_state_bootstrap_evidence(
         mark = evidence_marks[(candidate.portfolio_id, position.symbol)]
         _assert_fresh_against_wall_clock(mark.observed_at, f"protective mark for {position.symbol}")
         if (
-            mark.price != position.mark_price
+            mark.con_id != position.con_id
+            or mark.price != position.mark_price
             or mark.observed_at != position.mark_observed_at
             or not hmac.compare_digest(
                 mark.artifact_hash,

--- a/scripts/bootstrap_exact_paper_state.py
+++ b/scripts/bootstrap_exact_paper_state.py
@@ -37,6 +37,7 @@ from robo_trader.financial_state_bootstrap import (  # noqa: E402
     ExactStateBootstrapCommittedBackupInvalid,
     ExactStateBootstrapError,
     ExactStateBootstrapEvidence,
+    assert_exact_state_bootstrap_evidence,
     inspect_legacy_state,
     load_exact_state_bootstrap_evidence,
     sqlite_table_evidence,
@@ -510,6 +511,7 @@ def preview(
         if runtime_contract is None:
             raise ExactStateBootstrapError("runtime contract is required with evidence")
         _validate_evidence_binding(candidate, evidence, runtime_contract)
+        assert_exact_state_bootstrap_evidence(candidate, evidence, runtime_contract)
     legacy = inspect_legacy_state(database_path)
     if legacy["snapshot_hash"] != candidate.legacy_snapshot_hash:
         raise ExactStateBootstrapError("legacy ledger differs from the reviewed candidate")
@@ -527,10 +529,12 @@ def preview(
         raise ExactStateBootstrapError(
             "candidate does not cover every nonzero position in its portfolio"
         )
+    fifo_plan = candidate.fifo_bootstrap_plan()
     return {
         "authorizes_startup": False,
         "bootstrap_id": candidate.bootstrap_id,
         "candidate_fingerprint": candidate.fingerprint(),
+        "fifo": fifo_plan.public_dict(),
         "legacy_snapshot_hash": candidate.legacy_snapshot_hash,
         "position_count": len(candidate.positions),
         "schema_version": 1,

--- a/tests/accounting/test_fifo_accounting.py
+++ b/tests/accounting/test_fifo_accounting.py
@@ -437,6 +437,20 @@ def test_foreign_main_trigger_targeting_fifo_table_is_rejected(connection):
     assert connection.execute("SELECT COUNT(*) FROM unrelated_audit").fetchone() == (0,)
 
 
+def test_foreign_main_trigger_body_referencing_fifo_table_is_rejected(connection):
+    connection.execute("CREATE TABLE unrelated_source(value TEXT NOT NULL)")
+    connection.execute("""
+        CREATE TRIGGER unrelated_fifo_injector
+        AFTER INSERT ON unrelated_source
+        BEGIN
+            INSERT INTO fifo_opening_balances(opening_balance_id) VALUES ('forged');
+        END
+        """)
+
+    with pytest.raises(FifoFixtureMigrationError, match="foreign triggers"):
+        FifoLedger(connection, allow_other_objects=True)
+
+
 def test_foreign_temp_trigger_targeting_fifo_table_is_rejected(connection):
     connection.execute("""
         CREATE TEMP TRIGGER unrelated_temp_capture

--- a/tests/accounting/test_fifo_accounting.py
+++ b/tests/accounting/test_fifo_accounting.py
@@ -982,7 +982,7 @@ def test_failed_snapshot_insert_rolls_back_fill_commission_matches_and_lots(conn
         with pytest.raises(sqlite3.DatabaseError, match="not authorized"):
             ledger.record_fill(_fill(1, FillSide.BUY, "1", "10", 1))
     finally:
-        connection.set_authorizer(None)
+        connection.set_authorizer(lambda *_arguments: sqlite3.SQLITE_OK)
     for table in (
         "fifo_fills",
         "fifo_commissions",

--- a/tests/accounting/test_fifo_accounting.py
+++ b/tests/accounting/test_fifo_accounting.py
@@ -451,6 +451,23 @@ def test_foreign_main_trigger_body_referencing_fifo_table_is_rejected(connection
         FifoLedger(connection, allow_other_objects=True)
 
 
+def test_durable_trigger_injected_after_construction_blocks_fill_mutation(connection, ledger):
+    operational_ledger = FifoLedger(connection, allow_other_objects=True)
+    connection.execute("""
+        CREATE TRIGGER post_construction_fifo_injector
+        AFTER INSERT ON fifo_position_snapshots
+        BEGIN
+            SELECT 1;
+        END
+        """)
+
+    with pytest.raises(FifoFixtureMigrationError, match="foreign triggers"):
+        operational_ledger.record_fill(_fill(1, FillSide.BUY, "1", "10"))
+
+    assert _table_count(connection, "fifo_fills") == 0
+    assert _table_count(connection, "fifo_position_snapshots") == 0
+
+
 def test_foreign_temp_trigger_targeting_fifo_table_is_rejected(connection):
     connection.execute("""
         CREATE TEMP TRIGGER unrelated_temp_capture
@@ -945,15 +962,17 @@ def test_integrity_verifier_rejects_non_fifo_match_structure(connection, ledger)
 
 
 def test_failed_snapshot_insert_rolls_back_fill_commission_matches_and_lots(connection, ledger):
-    connection.execute("""
-        CREATE TRIGGER fixture_reject_snapshot
-        BEFORE INSERT ON fifo_position_snapshots
-        BEGIN
-            SELECT RAISE(ABORT, 'injected snapshot failure');
-        END
-        """)
-    with pytest.raises(sqlite3.IntegrityError, match="injected snapshot failure"):
-        ledger.record_fill(_fill(1, FillSide.BUY, "1", "10", 1))
+    def reject_snapshot_insert(action, argument_one, _argument_two, _database, _trigger):
+        if action == sqlite3.SQLITE_INSERT and argument_one == "fifo_position_snapshots":
+            return sqlite3.SQLITE_DENY
+        return sqlite3.SQLITE_OK
+
+    connection.set_authorizer(reject_snapshot_insert)
+    try:
+        with pytest.raises(sqlite3.DatabaseError, match="not authorized"):
+            ledger.record_fill(_fill(1, FillSide.BUY, "1", "10", 1))
+    finally:
+        connection.set_authorizer(None)
     for table in (
         "fifo_fills",
         "fifo_commissions",

--- a/tests/accounting/test_fifo_accounting.py
+++ b/tests/accounting/test_fifo_accounting.py
@@ -421,6 +421,35 @@ def test_temp_fifo_shadows_created_after_ledger_init_fail_every_operation(connec
     } == before
 
 
+def test_foreign_main_trigger_targeting_fifo_table_is_rejected(connection):
+    connection.execute("CREATE TABLE unrelated_audit(value TEXT NOT NULL)")
+    connection.execute("""
+        CREATE TRIGGER unrelated_capture
+        AFTER INSERT ON fifo_opening_balances
+        BEGIN
+            INSERT INTO unrelated_audit VALUES ('unexpected mutation');
+        END
+        """)
+
+    with pytest.raises(FifoFixtureMigrationError, match="foreign triggers"):
+        FifoLedger(connection, allow_other_objects=True)
+
+    assert connection.execute("SELECT COUNT(*) FROM unrelated_audit").fetchone() == (0,)
+
+
+def test_foreign_temp_trigger_targeting_fifo_table_is_rejected(connection):
+    connection.execute("""
+        CREATE TEMP TRIGGER unrelated_temp_capture
+        BEFORE INSERT ON main.fifo_fills
+        BEGIN
+            SELECT 1;
+        END
+        """)
+
+    with pytest.raises(FifoFixtureMigrationError, match="temporary FIFO"):
+        FifoLedger(connection, allow_other_objects=True)
+
+
 @pytest.mark.parametrize("bad_decimal", ["abc", "01", "1.0", "0", "-1", "1e2", ".5", "5."])
 def test_schema_rejects_noncanonical_or_nonpositive_fill_decimals(connection, ledger, bad_decimal):
     with pytest.raises(sqlite3.IntegrityError, match="CHECK constraint"):

--- a/tests/accounting/test_fifo_accounting.py
+++ b/tests/accounting/test_fifo_accounting.py
@@ -138,7 +138,7 @@ def test_fixture_migration_is_exact_idempotent_and_foreign_keys_are_on(connectio
     assert connection.execute("PRAGMA foreign_keys").fetchone() == (1,)
     assert connection.execute(
         "SELECT version FROM fifo_schema_migrations WHERE component='fifo_accounting'"
-    ).fetchall() == [(1,)]
+    ).fetchall() == [(1,), (2,)]
 
 
 def test_fixture_migration_rejects_production_style_filename(tmp_path):
@@ -366,7 +366,7 @@ def test_integer_minor_units_reject_fractional_real_storage(connection, ledger):
         connection.execute(
             """
             INSERT INTO fifo_lot_openings VALUES(
-                ?, ?, ?, 0, ?, ?, 'LONG', '1', '10', 1.5, 1, ?
+                ?, ?, ?, NULL, 0, ?, ?, 'LONG', '1', '10', 1.5, 1, ?
             )
             """,
             (
@@ -785,7 +785,7 @@ def test_integrity_verifier_binds_opening_direction_to_source_fill(connection, l
     connection.execute(
         """
         INSERT INTO fifo_lot_openings VALUES(
-            ?, ?, ?, 0, ?, ?, 'SHORT', '2', '10', 0, 1, ?
+            ?, ?, ?, NULL, 0, ?, ?, 'SHORT', '2', '10', 0, 1, ?
         )
         """,
         (

--- a/tests/accounting/test_fifo_accounting.py
+++ b/tests/accounting/test_fifo_accounting.py
@@ -481,6 +481,16 @@ def test_foreign_temp_trigger_targeting_fifo_table_is_rejected(connection):
         FifoLedger(connection, allow_other_objects=True)
 
 
+def test_uppercase_temp_shadow_is_rejected_with_case_sensitive_like(connection, ledger):
+    connection.execute("PRAGMA case_sensitive_like=ON")
+    connection.execute("CREATE TEMP TABLE FIFO_FILLS AS SELECT * FROM main.fifo_fills")
+
+    with pytest.raises(FifoFixtureMigrationError, match="temporary FIFO"):
+        ledger.record_fill(_fill(1, FillSide.BUY, "1", "10"))
+
+    assert _table_count(connection, "fifo_fills") == 0
+
+
 @pytest.mark.parametrize("bad_decimal", ["abc", "01", "1.0", "0", "-1", "1e2", ".5", "5."])
 def test_schema_rejects_noncanonical_or_nonpositive_fill_decimals(connection, ledger, bad_decimal):
     with pytest.raises(sqlite3.IntegrityError, match="CHECK constraint"):

--- a/tests/test_bootstrap_exact_paper_state_cli.py
+++ b/tests/test_bootstrap_exact_paper_state_cli.py
@@ -253,6 +253,7 @@ def test_preview_scopes_position_coverage_to_candidate_portfolio(
     database_path = tmp_path / "ledger.db"
     candidate = _candidate(database_path, portfolio_id="alpha")
     candidate.positions = (SimpleNamespace(symbol="AAPL", quantity=2),)
+    candidate.fifo_bootstrap_plan = lambda: SimpleNamespace(public_dict=lambda: {})
     monkeypatch.setattr(
         cli,
         "inspect_legacy_state",

--- a/tests/test_exact_state_bootstrap.py
+++ b/tests/test_exact_state_bootstrap.py
@@ -20,6 +20,8 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 import robo_trader.bootstrap_evidence_auth as evidence_auth
+from robo_trader.accounting.fifo import FifoLedger, FillEvent, FillSide
+from robo_trader.accounting.fifo_bootstrap import prepare_fifo_accounting_schema_in_transaction
 from robo_trader.config import RuntimeContract, _derive_safety_account_scope
 from robo_trader.database_async import AsyncTradingDatabase
 from robo_trader.financial_state_bootstrap import (
@@ -38,6 +40,7 @@ from robo_trader.financial_state_bootstrap import (
 )
 from robo_trader.reconciliation.domain import fingerprint
 from robo_trader.safety.journal import SafetyJournal
+from scripts.bootstrap_exact_paper_state import preview
 
 ACCOUNT_SCOPE = _derive_safety_account_scope("0123456789abcdef" * 4, "DU_TEST_PAPER")
 _TEST_PRIVATE_KEYS: dict[str, Path] = {}
@@ -549,6 +552,7 @@ def _candidate_bundle(
             else (
                 ExactBootstrapPosition(
                     symbol="NVDA",
+                    con_id=123,
                     quantity=9,
                     cost_basis=Decimal("210.96"),
                     mark_price=Decimal("326.70"),
@@ -557,6 +561,7 @@ def _candidate_bundle(
                 ),
                 ExactBootstrapPosition(
                     symbol="TSLA",
+                    con_id=456,
                     quantity=2,
                     cost_basis=Decimal("370.81"),
                     # The known-bad legacy 203.45 mark is deliberately not adopted.
@@ -679,6 +684,240 @@ async def test_offline_atomic_bootstrap_migrates_raw_legacy_schema_in_one_commit
         assert connection.execute(
             "SELECT COUNT(*) FROM exact_bootstrap_evidence_consumptions"
         ).fetchone() == (4,)
+        epoch_id = candidate.fifo_bootstrap_plan().epoch_id
+        assert connection.execute(
+            "SELECT origin_kind,source_fingerprint FROM fifo_accounting_epochs"
+        ).fetchone() == (
+            "LEGACY_AGGREGATE_OPENING_BALANCE",
+            candidate.fingerprint(),
+        )
+        assert connection.execute(
+            "SELECT bootstrap_id,candidate_fingerprint,legacy_snapshot_hash "
+            "FROM fifo_legacy_bootstrap_lineage WHERE epoch_id=?",
+            (epoch_id,),
+        ).fetchone() == (
+            candidate.bootstrap_id,
+            candidate.fingerprint(),
+            candidate.legacy_snapshot_hash,
+        )
+        assert connection.execute(
+            "SELECT cash_text,realized_pnl_text,daily_pnl_text,"
+            "daily_pnl_baseline_text,daily_pnl_date "
+            "FROM fifo_epoch_account_baselines WHERE epoch_id=?",
+            (epoch_id,),
+        ).fetchone() == (
+            "96739.16",
+            "0",
+            "0",
+            "1039.18",
+            candidate.effective_at.date().isoformat(),
+        )
+        assert connection.execute(
+            "SELECT con_id,symbol,direction,opened_quantity_text,cost_basis_text,"
+            "mark_price_text FROM fifo_opening_balances ORDER BY symbol"
+        ).fetchall() == [
+            (123, "NVDA", "LONG", "9", "210.96", "326.7"),
+            (456, "TSLA", "LONG", "2", "370.81", "369.57"),
+        ]
+        assert connection.execute("SELECT COUNT(*) FROM fifo_fills").fetchone() == (0,)
+        assert connection.execute("SELECT COUNT(*) FROM fifo_commissions").fetchone() == (0,)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM fifo_lot_openings "
+            "WHERE opening_fill_id IS NOT NULL OR opening_commission_minor <> 0"
+        ).fetchone() == (0,)
+
+
+def test_fifo_candidate_preview_is_read_only_and_non_authorizing(tmp_path: Path) -> None:
+    path = tmp_path / "legacy.db"
+    _legacy_database(path)
+    candidate, evidence, runtime_contract = _candidate_bundle(path, tmp_path)
+    before = path.read_bytes()
+
+    report = preview(candidate, path, evidence, runtime_contract)
+
+    assert path.read_bytes() == before
+    assert report["authorizes_startup"] is False
+    assert report["candidate_fingerprint"] == candidate.fingerprint()
+    assert report["fifo"] == candidate.fifo_bootstrap_plan().public_dict()
+    assert report["fifo"]["synthetic_fill_count"] == 0
+    assert report["fifo"]["pre_epoch_history_reconstructed"] is False
+    with sqlite3.connect(path) as connection:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE name LIKE 'fifo_%'"
+        ).fetchone() == (0,)
+
+
+@pytest.mark.asyncio
+async def test_fifo_bootstrap_supports_truthful_post_epoch_fifo_without_synthetic_fill(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "legacy.db"
+    _legacy_database(path)
+    candidate, evidence, runtime_contract = _candidate_bundle(path, tmp_path)
+    backup_receipt = _backup_receipt(path, tmp_path / "backup.db", candidate)
+    database = AsyncTradingDatabase(path, pool_size=1)
+    try:
+        await database.apply_exact_state_bootstrap_offline_atomic(
+            candidate,
+            evidence=evidence,
+            backup_receipt=backup_receipt,
+            operator_reason="Seal explicit aggregate openings before prospective FIFO fills.",
+            runtime_contract=runtime_contract,
+        )
+    finally:
+        await database.close()
+
+    plan = candidate.fifo_bootstrap_plan()
+    with sqlite3.connect(path) as connection:
+        connection.execute("PRAGMA foreign_keys=ON")
+        ledger = FifoLedger(connection, allow_other_objects=True)
+        ledger.verify_epoch_integrity(plan.epoch_id)
+        event = FillEvent(
+            epoch_id=plan.epoch_id,
+            fill_id="ffill-" + "1" * 32,
+            commission_id="fcomm-" + "2" * 32,
+            event_sequence=1,
+            execution_id="post-epoch-execution-1",
+            idempotency_key="post-epoch-idempotency-1",
+            con_id=123,
+            symbol="NVDA",
+            side=FillSide.SELL,
+            quantity=Decimal("2"),
+            price=Decimal("326.7"),
+            commission_minor=5,
+            occurred_at=candidate.effective_at + timedelta(seconds=1),
+            recorded_at=candidate.effective_at + timedelta(seconds=1),
+        )
+        result = ledger.record_fill(event)
+        assert result.snapshot.signed_quantity == Decimal("7")
+        assert result.snapshot.open_cost == Decimal("1476.72")
+        assert result.snapshot.cumulative_realized_pnl == Decimal("231.43")
+        ledger.verify_epoch_integrity(plan.epoch_id)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM fifo_fills WHERE epoch_id=?",
+            (plan.epoch_id,),
+        ).fetchone() == (1,)
+
+
+@pytest.mark.asyncio
+async def test_authenticated_mark_con_id_mismatch_blocks_before_fifo_mutation(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "legacy.db"
+    _legacy_database(path)
+    candidate, evidence, runtime_contract = _candidate_bundle(path, tmp_path)
+    positions = (replace(candidate.positions[0], con_id=999), candidate.positions[1])
+    mismatched = replace(candidate, positions=positions)
+    backup_receipt = _backup_receipt(path, tmp_path / "backup.db", mismatched)
+    database = AsyncTradingDatabase(path, pool_size=1)
+    await database.initialize()
+    try:
+        with pytest.raises(ExactStateBootstrapError, match="candidate mark"):
+            await database.apply_exact_state_bootstrap(
+                mismatched,
+                evidence=evidence,
+                backup_receipt=backup_receipt,
+                operator_reason="Reject a candidate with unbound contract identity.",
+                runtime_contract=runtime_contract,
+            )
+    finally:
+        await database.close()
+    with sqlite3.connect(path) as connection:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE name='fifo_accounting_epochs'"
+        ).fetchone() == (0,)
+
+
+@pytest.mark.asyncio
+async def test_fifo_bootstrap_records_short_as_opening_balance_not_sell_fill(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "legacy.db"
+    _legacy_database(path)
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            "UPDATE positions SET quantity=-2 WHERE portfolio_id='default' AND symbol='TSLA'"
+        )
+        connection.commit()
+    candidate, evidence, runtime_contract = _candidate_bundle(path, tmp_path)
+    short_position = replace(candidate.positions[1], quantity=-2)
+    candidate = replace(
+        candidate,
+        account=replace(candidate.account, daily_pnl_baseline=Decimal("1044.14")),
+        positions=(candidate.positions[0], short_position),
+    )
+    backup_receipt = _backup_receipt(path, tmp_path / "backup.db", candidate)
+    database = AsyncTradingDatabase(path, pool_size=1)
+    try:
+        await database.apply_exact_state_bootstrap_offline_atomic(
+            candidate,
+            evidence=evidence,
+            backup_receipt=backup_receipt,
+            operator_reason="Seal the reviewed signed short as an aggregate opening balance.",
+            runtime_contract=runtime_contract,
+        )
+    finally:
+        await database.close()
+
+    with sqlite3.connect(path) as connection:
+        assert connection.execute(
+            "SELECT direction,opened_quantity_text,cost_basis_text "
+            "FROM fifo_opening_balances WHERE symbol='TSLA'"
+        ).fetchone() == ("SHORT", "2", "370.81")
+        assert connection.execute(
+            "SELECT COUNT(*) FROM fifo_fills WHERE symbol='TSLA'"
+        ).fetchone() == (0,)
+
+
+@pytest.mark.asyncio
+async def test_existing_fifo_epoch_for_scope_blocks_whole_exact_bootstrap(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "legacy.db"
+    _legacy_database(path)
+    async with aiosqlite.connect(path) as connection:
+        await connection.execute("PRAGMA foreign_keys=ON")
+        await connection.execute("BEGIN IMMEDIATE")
+        await prepare_fifo_accounting_schema_in_transaction(
+            connection,
+            applied_at="2026-07-28T14:00:00.000000Z",
+        )
+        await connection.execute(
+            """
+            INSERT INTO fifo_accounting_epochs(
+                epoch_id,schema_version,execution_domain_scope,account_scope,
+                portfolio_id,origin_kind,source_fingerprint,effective_at,created_at
+            ) VALUES (?,1,'paper-simulator-v1',?,'default','EMPTY_LEDGER',?,?,?)
+            """,
+            (
+                "fepoch-" + "1" * 32,
+                ACCOUNT_SCOPE,
+                "2" * 64,
+                "2026-07-28T14:00:00.000000Z",
+                "2026-07-28T14:00:00.000000Z",
+            ),
+        )
+        await connection.commit()
+    candidate, evidence, runtime_contract = _candidate_bundle(path, tmp_path)
+    backup_receipt = _backup_receipt(path, tmp_path / "backup.db", candidate)
+    database = AsyncTradingDatabase(path, pool_size=1)
+    try:
+        with pytest.raises(ExactStateBootstrapError, match="already has a sealed epoch"):
+            await database.apply_exact_state_bootstrap_offline_atomic(
+                candidate,
+                evidence=evidence,
+                backup_receipt=backup_receipt,
+                operator_reason="Reject a second FIFO epoch for the same portfolio scope.",
+                runtime_contract=runtime_contract,
+            )
+    finally:
+        await database.close()
+
+    with sqlite3.connect(path) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM fifo_accounting_epochs").fetchone() == (1,)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE name='paper_state_bootstraps'"
+        ).fetchone() == (0,)
 
 
 @pytest.mark.asyncio
@@ -828,6 +1067,44 @@ async def test_offline_schema_failure_rolls_back_to_byte_identical_raw_legacy_da
 
 
 @pytest.mark.asyncio
+async def test_offline_fifo_append_failure_rolls_back_schema_and_every_bootstrap_row(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "legacy.db"
+    _legacy_database(path)
+    candidate, evidence, runtime_contract = _candidate_bundle(path, tmp_path)
+    backup_receipt = _backup_receipt(path, tmp_path / "backup.db", candidate)
+    before = path.read_bytes()
+    database = AsyncTradingDatabase(path, pool_size=1)
+
+    def fail_after_fifo(step: str) -> None:
+        if step == "AFTER_FIFO_LEGACY_BOOTSTRAP":
+            raise ExactStateBootstrapError("injected post-FIFO failure")
+
+    database._paper_settlement_fault_hook = fail_after_fifo
+    try:
+        with pytest.raises(ExactStateBootstrapError, match="post-FIFO failure"):
+            await database.apply_exact_state_bootstrap_offline_atomic(
+                candidate,
+                evidence=evidence,
+                backup_receipt=backup_receipt,
+                operator_reason="Reject after transactional FIFO opening append.",
+                runtime_contract=runtime_contract,
+            )
+    finally:
+        await database.close()
+
+    assert path.read_bytes() == before
+    with sqlite3.connect(path) as connection:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE name LIKE 'fifo_%'"
+        ).fetchone() == (0,)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE name='paper_state_bootstraps'"
+        ).fetchone() == (0,)
+
+
+@pytest.mark.asyncio
 async def test_bootstrap_is_insert_only_exact_and_receipt_replay_is_rejected(
     tmp_path: Path,
 ) -> None:
@@ -936,6 +1213,20 @@ def test_candidate_rejects_broker_exposure_and_stale_marks(tmp_path: Path) -> No
     ).isoformat()
     with pytest.raises(ExactStateBootstrapError, match="future or stale"):
         ExactStateBootstrapCandidate.from_mapping(values)
+
+    values = base.canonical_dict()
+    del values["positions"][0]["con_id"]
+    with pytest.raises(ExactStateBootstrapError, match="incomplete or unknown"):
+        ExactStateBootstrapCandidate.from_mapping(values)
+
+    with pytest.raises(ExactStateBootstrapError, match="unique authenticated con_id"):
+        replace(
+            base,
+            positions=(
+                base.positions[0],
+                replace(base.positions[1], con_id=base.positions[0].con_id),
+            ),
+        )
 
     values = base.canonical_dict()
     values["account"]["cash_text"] = 96739.16

--- a/tests/test_exact_state_bootstrap.py
+++ b/tests/test_exact_state_bootstrap.py
@@ -20,8 +20,16 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 import robo_trader.bootstrap_evidence_auth as evidence_auth
-from robo_trader.accounting.fifo import FifoLedger, FillEvent, FillSide
-from robo_trader.accounting.fifo_bootstrap import prepare_fifo_accounting_schema_in_transaction
+from robo_trader.accounting.fifo import (
+    FifoAccountingValidationError,
+    FifoLedger,
+    FillEvent,
+    FillSide,
+)
+from robo_trader.accounting.fifo_bootstrap import (
+    FifoBootstrapError,
+    prepare_fifo_accounting_schema_in_transaction,
+)
 from robo_trader.config import RuntimeContract, _derive_safety_account_scope
 from robo_trader.database_async import AsyncTradingDatabase
 from robo_trader.financial_state_bootstrap import (
@@ -797,6 +805,90 @@ async def test_fifo_bootstrap_supports_truthful_post_epoch_fifo_without_syntheti
             "SELECT COUNT(*) FROM fifo_fills WHERE epoch_id=?",
             (plan.epoch_id,),
         ).fetchone() == (1,)
+
+
+@pytest.mark.asyncio
+async def test_fifo_integrity_rejects_opening_pair_outside_sealed_candidate(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "legacy.db"
+    _legacy_database(path)
+    candidate, evidence, runtime_contract = _candidate_bundle(path, tmp_path)
+    backup_receipt = _backup_receipt(path, tmp_path / "backup.db", candidate)
+    database = AsyncTradingDatabase(path, pool_size=1)
+    try:
+        await database.apply_exact_state_bootstrap_offline_atomic(
+            candidate,
+            evidence=evidence,
+            backup_receipt=backup_receipt,
+            operator_reason="Seal the exact reviewed opening set before integrity testing.",
+            runtime_contract=runtime_contract,
+        )
+    finally:
+        await database.close()
+
+    plan = candidate.fifo_bootstrap_plan()
+    effective_at = candidate.effective_at.isoformat(timespec="microseconds").replace("+00:00", "Z")
+    with sqlite3.connect(path) as connection:
+        connection.execute("PRAGMA foreign_keys=ON")
+        opening_id = "fobal-" + "e" * 32
+        lot_id = "flot-" + "e" * 32
+        connection.execute(
+            """
+            INSERT INTO fifo_opening_balances(
+                opening_balance_id,epoch_id,con_id,symbol,direction,
+                opened_quantity_text,cost_basis_text,mark_price_text,
+                mark_observed_at,mark_evidence_fingerprint,recorded_at
+            ) VALUES (?,?,789,'AMD','LONG','1','100','100',?,?,?)
+            """,
+            (opening_id, plan.epoch_id, effective_at, "e" * 64, effective_at),
+        )
+        connection.execute(
+            """
+            INSERT INTO fifo_lot_openings(
+                lot_id,epoch_id,opening_fill_id,opening_balance_id,lot_ordinal,
+                con_id,symbol,direction,opened_quantity_text,open_price_text,
+                opening_commission_minor,opened_sequence,opened_at
+            ) VALUES (?,?,NULL,?,0,789,'AMD','LONG','1','100',0,0,?)
+            """,
+            (lot_id, plan.epoch_id, opening_id, effective_at),
+        )
+        connection.commit()
+
+        ledger = FifoLedger(connection, allow_other_objects=True)
+        with pytest.raises(
+            FifoAccountingValidationError,
+            match="sealed candidate manifest",
+        ):
+            ledger.verify_epoch_integrity(plan.epoch_id)
+
+
+@pytest.mark.asyncio
+async def test_fifo_schema_creation_rejects_foreign_trigger_body_reference(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "foreign-trigger.db"
+    async with aiosqlite.connect(path) as connection:
+        await connection.execute("PRAGMA foreign_keys=ON")
+        await connection.execute("CREATE TABLE unrelated_source(value INTEGER)")
+        await connection.execute("""
+            CREATE TRIGGER inject_fifo_after_unrelated_insert
+            AFTER INSERT ON unrelated_source
+            BEGIN
+                INSERT INTO fifo_opening_balances(opening_balance_id) VALUES ('forged');
+            END
+            """)
+        await connection.execute("BEGIN IMMEDIATE")
+        with pytest.raises(FifoBootstrapError, match="foreign triggers"):
+            await prepare_fifo_accounting_schema_in_transaction(
+                connection,
+                applied_at="2026-07-28T14:00:00.000000Z",
+            )
+        fifo_objects = await connection.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE name LIKE 'fifo_%'"
+        )
+        assert await fifo_objects.fetchone() == (0,)
+        await connection.rollback()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Bind the existing PR112 exact-state bootstrap to the PR4A FIFO ledger without inventing historical activity.

- require a positive candidate `con_id` that exactly matches each authenticated protective mark
- append one `LEGACY_AGGREGATE_OPENING_BALANCE` epoch per reviewed portfolio
- retain candidate, reconciliation, broker, legacy-ledger, administrator-action, and exact-state bootstrap lineage
- preserve an exact pre-epoch account baseline
- record one explicit aggregate opening balance/opening lot per long or short position
- keep FIFO fills, executions, commission events, and snapshots empty at bootstrap
- add a read-only deterministic candidate report with `authorizes_startup=false`
- commit FIFO schema, lineage, baselines, openings, and PR112 exact state in the existing single offline transaction

Zero opening commission is an epoch-boundary convention: pre-epoch fee history is unknown and is not reconstructed. It is not a claim that historical broker fees were zero.

## Safety boundary

This is a stacked PR targeting `codex/pr4a-fifo-accounting` at reviewed head `101beb94921c884c050580973a084e8a8380be8d`.

It does not wire startup, runtime settlement, broker access, or order authority. The existing stopped-runtime check, exact confirmation string, authenticated evidence, safety-journal guard, descriptor binding, verified online backup, and post-commit backup verification remain mandatory. Gate A remains closed.

PR4C runtime settlement integration and PR4D operational migration/restore drills remain out of scope. No authoritative database, broker, runtime, service, or user data was accessed or mutated.

## Validation

- focused FIFO/exact-bootstrap/CLI suite: 124 passed
- broader accounting/bootstrap/database/reconciliation/settlement matrix: 517 passed
- full repository suite: 2849 passed, 5 skipped, 20 known warnings
- Black, isort, Flake8, compileall, and diff checks passed
- targeted mypy passed
- targeted Bandit reported no medium/high findings
- adversarial coverage includes con_id omission/duplication/mismatch, long and short openings, no synthetic fills, read-only preview, conflicting epoch rejection, post-FIFO fault rollback, byte-identical raw-ledger rollback, exact baseline preservation, and prospective FIFO consumption

Detailed design and local evidence are included in:
- `docs/design/PR4B_FIFO_LEGACY_BOOTSTRAP.md`
- `docs/reviews/PR4B_LOCAL_REVIEW_EVIDENCE_2026-07-28.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes offline ledger bootstrap and FIFO accounting schema with atomic all-or-nothing writes, but remain operator-only with existing gates and no runtime startup or order authority.
> 
> **Overview**
> **PR4B** extends the existing offline `bootstrap_exact_paper_state` apply path so a reviewed exact-state candidate also seeds the dormant FIFO ledger in the **same** `BEGIN IMMEDIATE` transaction as today’s PR112 bootstrap—preview and apply still report **`authorizes_startup=false`**.
> 
> Candidates must carry a **positive `con_id` per position** that matches authenticated protective marks. A deterministic **`LEGACY_AGGREGATE_OPENING_BALANCE`** epoch is appended with lineage (bootstrap, reconciliation, broker, legacy snapshot, operator action), an **exact pre-epoch account baseline**, and one **opening balance + opening lot** per long/short position—**no** fills, commissions, executions, or snapshots at bootstrap. Zero opening commission is documented as unknown pre-epoch history, not reconstructed fees.
> 
> FIFO schema moves to **version 2** (opening balances, legacy lineage, baselines; `fifo_lot_openings` can link `opening_balance_id`). New **`fifo_bootstrap`** builds the plan and appends rows transactionally; **`FifoLedger`** can project fills against legacy opening lots and validate sealed legacy epoch shape. **`preview`** returns the deterministic FIFO report without mutating the DB.
> 
> Design/review notes live in `docs/design/PR4B_FIFO_LEGACY_BOOTSTRAP.md` and `docs/reviews/PR4B_LOCAL_REVIEW_EVIDENCE_2026-07-28.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec6699e2dcb6a4c25cc78cef27ceaeb460591bdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->