### PR TITLE
feat: integrate fail-closed runtime reconciliation

### DIFF
--- a/app.py
+++ b/app.py
@@ -2278,7 +2278,11 @@ HTML_TEMPLATE = """
                     return;
                 }
                 const data = await resp.json();
-                if (data && data.healthy) {
+                const reconciliation = data && data.reconciliation;
+                const reconciliationBlocked = !reconciliation ||
+                    reconciliation.entry_eligible !== true ||
+                    reconciliation.quarantined !== false;
+                if (data && data.healthy && !reconciliationBlocked) {
                     banner.classList.remove('visible');
                     banner.textContent = '';
                     return;
@@ -2286,16 +2290,18 @@ HTML_TEMPLATE = """
                 // Unhealthy. Build the message as a plain string assigned via
                 // textContent — defense in depth even though escHTML would
                 // also neutralize the payload.
-                let msg = '⚠ Runner offline';
+                let msg = data && data.healthy
+                    ? '⚠ New entries quarantined — broker reconciliation unavailable'
+                    : '⚠ Runner offline';
                 const secs = data && data.last_market_update_seconds_ago;
-                if (typeof secs === 'number' && isFinite(secs)) {
+                if (!(data && data.healthy) && typeof secs === 'number' && isFinite(secs)) {
                     const mins = Math.floor(secs / 60);
                     if (mins >= 1) {
                         msg += ' — last update ' + mins + ' minute' + (mins === 1 ? '' : 's') + ' ago';
                     } else {
                         msg += ' — last update ' + Math.round(secs) + 's ago';
                     }
-                } else {
+                } else if (!(data && data.healthy)) {
                     msg += ' — no updates received this session';
                 }
                 const audit = data && data.exit_audit;
@@ -2308,6 +2314,15 @@ HTML_TEMPLATE = """
                         if (!isNaN(dt.getTime())) {
                             msg += ' (' + escHTML(dt.toLocaleString()) + ')';
                         }
+                    }
+                }
+                if (reconciliationBlocked && reconciliation) {
+                    if (typeof reconciliation.state === 'string' && reconciliation.state) {
+                        msg += '. Reconciliation: ' + reconciliation.state;
+                    }
+                    if (typeof reconciliation.age_seconds === 'number' &&
+                            isFinite(reconciliation.age_seconds)) {
+                        msg += ' (' + Math.round(reconciliation.age_seconds) + 's old)';
                     }
                 }
                 banner.textContent = msg;

--- a/app.py
+++ b/app.py
@@ -5318,6 +5318,17 @@ def api_runner_status():
             healthy = False
 
         audit = _read_runner_exit_audit()
+        from robo_trader.reconciliation.runtime_integration import (
+            read_runtime_reconciliation_status,
+            runtime_reconciliation_status_path,
+        )
+
+        reconciliation = read_runtime_reconciliation_status(
+            runtime_reconciliation_status_path(
+                runtime_contract,
+                os.environ,
+            )
+        )
 
         return (
             jsonify(
@@ -5327,6 +5338,7 @@ def api_runner_status():
                     "last_market_update_seconds_ago": seconds_ago_out,
                     "stale_threshold_seconds": RUNNER_STALE_SECONDS,
                     "exit_audit": audit,
+                    "reconciliation": reconciliation,
                 }
             ),
             200,

--- a/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
+++ b/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
@@ -726,7 +726,7 @@ Make broker truth visible and authoritative before any broker-writing capability
   suspended-provider recovery, broker-envelope replay, complete account-wide
   protective symbol scope, reduce-only continuity after artifact failures,
   non-destructive retention ceilings, and persisted eligibility expiry.
-- Synthetic and mocked verification on 2026-07-30: `3077 passed, 5 skipped`
+- Synthetic and mocked verification on 2026-07-30: `3078 passed, 5 skipped`
   across the complete pytest suite; Black and Flake8 passed for all changed
   Python files. No trader process, Gateway, broker session, or authoritative
   trading database was started or accessed.

--- a/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
+++ b/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
@@ -706,7 +706,9 @@ Make broker truth visible and authoritative before any broker-writing capability
 - Dashboard status exposes only sanitized reconciliation state, age, trigger,
   and quarantine/eligibility fields; signing-capability paths and broker
   evidence are not exposed.
-- Synthetic and mocked verification on 2026-07-30: `3029 passed, 5 skipped`
+- Adversarial regressions cover protected status targets, suspended-provider
+  recovery, broker-envelope replay, and persisted eligibility expiry.
+- Synthetic and mocked verification on 2026-07-30: `3037 passed, 5 skipped`
   across the complete pytest suite; Black and Flake8 passed for all changed
   Python files. No trader process, Gateway, broker session, or authoritative
   trading database was started or accessed.

--- a/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
+++ b/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
@@ -703,12 +703,27 @@ Make broker truth visible and authoritative before any broker-writing capability
 - Risk-increasing entries require a fresh eligible reconciliation. Quarantine
   preserves the existing semantic reduce-only path so protective reductions are
   not stranded.
+- Every protective-mark request carries the complete unique account-wide set
+  of active position symbols, so reconciliation cannot cancel another
+  position's shared-worker quote subscription.
 - Dashboard status exposes only sanitized reconciliation state, age, trigger,
   and quarantine/eligibility fields; signing-capability paths and broker
-  evidence are not exposed.
-- Adversarial regressions cover protected status targets, suspended-provider
-  recovery, broker-envelope replay, and persisted eligibility expiry.
-- Synthetic and mocked verification on 2026-07-30: `3037 passed, 5 skipped`
+  evidence are not exposed. Existing owned status is replaced only through an
+  atomic, fully synced inode exchange; unrelated targets are restored rather
+  than overwritten, and a crash leaves a complete old or new artifact.
+- Published evidence is never auto-deleted, moved, or rewritten. The runtime
+  applies a non-destructive ceiling before publication (defaults: 10,000
+  runtime bundles and 2 GiB, configurable with
+  `RT_RECONCILIATION_EVIDENCE_MAX_BUNDLES` and
+  `RT_RECONCILIATION_EVIDENCE_MAX_BYTES`). Reaching either ceiling quarantines
+  new entries while portfolio cycles continue through reduce-only gates; an
+  operator-reviewed archival action is required before evidence collection can
+  resume. Active/bootstrap/audit lineage remains intact.
+- Adversarial regressions cover protected and raced status targets,
+  suspended-provider recovery, broker-envelope replay, complete account-wide
+  protective symbol scope, reduce-only continuity after artifact failures,
+  non-destructive retention ceilings, and persisted eligibility expiry.
+- Synthetic and mocked verification on 2026-07-30: `3074 passed, 5 skipped`
   across the complete pytest suite; Black and Flake8 passed for all changed
   Python files. No trader process, Gateway, broker session, or authoritative
   trading database was started or accessed.

--- a/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
+++ b/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
@@ -718,12 +718,15 @@ Make broker truth visible and authoritative before any broker-writing capability
   `RT_RECONCILIATION_EVIDENCE_MAX_BYTES`). Reaching either ceiling quarantines
   new entries while portfolio cycles continue through reduce-only gates; an
   operator-reviewed archival action is required before evidence collection can
-  resume. Active/bootstrap/audit lineage remains intact.
+  resume. The receiver binds admission to the exact sealed entry identities,
+  hashes, and final completion-marker bytes immediately before publication;
+  any raced bundle is left incomplete and preserved for inspection.
+  Active/bootstrap/audit lineage remains intact.
 - Adversarial regressions cover protected and raced status targets,
   suspended-provider recovery, broker-envelope replay, complete account-wide
   protective symbol scope, reduce-only continuity after artifact failures,
   non-destructive retention ceilings, and persisted eligibility expiry.
-- Synthetic and mocked verification on 2026-07-30: `3075 passed, 5 skipped`
+- Synthetic and mocked verification on 2026-07-30: `3077 passed, 5 skipped`
   across the complete pytest suite; Black and Flake8 passed for all changed
   Python files. No trader process, Gateway, broker session, or authoritative
   trading database was started or accessed.

--- a/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
+++ b/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
@@ -44,10 +44,11 @@ terminal-settlement readiness gate. PR 2B.3 merged through PR #107 as
 `017f43e`. PR 3 merged through PR #111 as `8596920`. The PR 4 exact-state
 bootstrap code slice merged through PR #112 as `bccb96b`; strict FIFO,
 operator-reviewed bootstrap/application, and restore evidence remain open. PR
-5 foundations merged through PR #113 (`6176931`) and PR #115 (`1ae6480`);
-production startup/reconnect/periodic wiring and a current operator-reviewed
-reconciliation remain open. Gate A remains closed, the trader remains stopped,
-and none of these merges authorizes startup.
+5 foundations merged through PR #113 (`6176931`) and PR #115 (`1ae6480`). The
+PR 5 runtime-integration draft adds fail-closed startup, reconnect, and periodic
+reconciliation plus sanitized dashboard status. A current operator-reviewed
+broker reconciliation remains open. Gate A remains closed, the trader remains
+stopped, and none of these merges or draft changes authorizes startup.
 
 ## 1. Purpose
 
@@ -690,6 +691,29 @@ Make broker truth visible and authoritative before any broker-writing capability
 - Wrong account, wrong quantity, stale cash, unknown order, and reconnect scenarios.
 - Database unavailable or partially migrated.
 - Operator resolution without destructive replacement.
+
+### Runtime-integration draft evidence (2026-07-30)
+
+- Startup, reconnect, and fixed-period triggers use one read-only diagnostic
+  provider and publish a fresh, one-shot signed reconciliation result from the
+  same broker transport generation.
+- Runtime database and bootstrap-receipt readiness are verified read-only before
+  broker collection; absent, partial, or unauthenticated state fails closed
+  without schema repair or data mutation.
+- Risk-increasing entries require a fresh eligible reconciliation. Quarantine
+  preserves the existing semantic reduce-only path so protective reductions are
+  not stranded.
+- Dashboard status exposes only sanitized reconciliation state, age, trigger,
+  and quarantine/eligibility fields; signing-capability paths and broker
+  evidence are not exposed.
+- Synthetic and mocked verification on 2026-07-30: `3029 passed, 5 skipped`
+  across the complete pytest suite; Black and Flake8 passed for all changed
+  Python files. No trader process, Gateway, broker session, or authoritative
+  trading database was started or accessed.
+- Operational evidence is still required: provision the owner-only signing and
+  evidence directories, run the authoritative launcher under supervision, and
+  obtain operator review of a current broker reconciliation. Those actions are
+  not authorized by this draft, and Gate A remains closed.
 
 ### Done means
 

--- a/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
+++ b/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
@@ -723,7 +723,7 @@ Make broker truth visible and authoritative before any broker-writing capability
   suspended-provider recovery, broker-envelope replay, complete account-wide
   protective symbol scope, reduce-only continuity after artifact failures,
   non-destructive retention ceilings, and persisted eligibility expiry.
-- Synthetic and mocked verification on 2026-07-30: `3074 passed, 5 skipped`
+- Synthetic and mocked verification on 2026-07-30: `3075 passed, 5 skipped`
   across the complete pytest suite; Black and Flake8 passed for all changed
   Python files. No trader process, Gateway, broker session, or authoritative
   trading database was started or accessed.

--- a/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
+++ b/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
@@ -718,7 +718,10 @@ Make broker truth visible and authoritative before any broker-writing capability
   `RT_RECONCILIATION_EVIDENCE_MAX_BYTES`). Reaching either ceiling quarantines
   new entries while portfolio cycles continue through reduce-only gates; an
   operator-reviewed archival action is required before evidence collection can
-  resume. The receiver binds admission to the exact sealed entry identities,
+  resume. Every admission performs a fresh held-root usage scan, excluding
+  only the exact device/inode binding of its own current staging directory, so
+  externally added bundles cannot hide behind cached counters. The receiver
+  binds admission to the exact sealed entry identities,
   hashes, and final completion-marker bytes immediately before publication.
   Completion-marker schema v2 commits that exact artifact manifest, and the
   loader rejects any added, replaced, removed, or rewritten directory entry;
@@ -728,7 +731,7 @@ Make broker truth visible and authoritative before any broker-writing capability
   suspended-provider recovery, broker-envelope replay, complete account-wide
   protective symbol scope, reduce-only continuity after artifact failures,
   non-destructive retention ceilings, and persisted eligibility expiry.
-- Synthetic and mocked verification on 2026-07-30: `3079 passed, 5 skipped`
+- Synthetic and mocked verification on 2026-07-30: `3081 passed, 5 skipped`
   across the complete pytest suite; Black and Flake8 passed for all changed
   Python files. No trader process, Gateway, broker session, or authoritative
   trading database was started or accessed.

--- a/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
+++ b/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
@@ -719,14 +719,16 @@ Make broker truth visible and authoritative before any broker-writing capability
   new entries while portfolio cycles continue through reduce-only gates; an
   operator-reviewed archival action is required before evidence collection can
   resume. The receiver binds admission to the exact sealed entry identities,
-  hashes, and final completion-marker bytes immediately before publication;
-  any raced bundle is left incomplete and preserved for inspection.
+  hashes, and final completion-marker bytes immediately before publication.
+  Completion-marker schema v2 commits that exact artifact manifest, and the
+  loader rejects any added, replaced, removed, or rewritten directory entry;
+  any pre-marker raced bundle is left incomplete and preserved for inspection.
   Active/bootstrap/audit lineage remains intact.
 - Adversarial regressions cover protected and raced status targets,
   suspended-provider recovery, broker-envelope replay, complete account-wide
   protective symbol scope, reduce-only continuity after artifact failures,
   non-destructive retention ceilings, and persisted eligibility expiry.
-- Synthetic and mocked verification on 2026-07-30: `3078 passed, 5 skipped`
+- Synthetic and mocked verification on 2026-07-30: `3079 passed, 5 skipped`
   across the complete pytest suite; Black and Flake8 passed for all changed
   Python files. No trader process, Gateway, broker session, or authoritative
   trading database was started or accessed.

--- a/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
+++ b/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
@@ -696,7 +696,9 @@ Make broker truth visible and authoritative before any broker-writing capability
 
 - Startup, reconnect, and fixed-period triggers use one read-only diagnostic
   provider and publish a fresh, one-shot signed reconciliation result from the
-  same broker transport generation.
+  same broker transport generation. An exact provider-generation lease is held
+  from snapshot collection through protective marks and publication, so health
+  refresh, suspension, and close cannot splice two generations into one bundle.
 - Runtime database and bootstrap-receipt readiness are verified read-only before
   broker collection; absent, partial, or unauthenticated state fails closed
   without schema repair or data mutation.
@@ -720,8 +722,10 @@ Make broker truth visible and authoritative before any broker-writing capability
   operator-reviewed archival action is required before evidence collection can
   resume. Every admission performs a fresh held-root usage scan, excluding
   only the exact device/inode binding of its own current staging directory, so
-  externally added bundles cannot hide behind cached counters. The receiver
-  binds admission to the exact sealed entry identities,
+  externally added bundles cannot hide behind cached counters. A non-blocking
+  POSIX lock on the held evidence-root directory serializes that final scan
+  through completion-marker publication across cooperating processes. The
+  receiver binds admission to the exact sealed entry identities,
   hashes, and final completion-marker bytes immediately before publication.
   Completion-marker schema v2 commits that exact artifact manifest, and the
   loader rejects any added, replaced, removed, or rewritten directory entry;
@@ -731,7 +735,7 @@ Make broker truth visible and authoritative before any broker-writing capability
   suspended-provider recovery, broker-envelope replay, complete account-wide
   protective symbol scope, reduce-only continuity after artifact failures,
   non-destructive retention ceilings, and persisted eligibility expiry.
-- Synthetic and mocked verification on 2026-07-30: `3081 passed, 5 skipped`
+- Synthetic and mocked verification on 2026-07-30: `3082 passed, 5 skipped`
   across the complete pytest suite; Black and Flake8 passed for all changed
   Python files. No trader process, Gateway, broker session, or authoritative
   trading database was started or accessed.

--- a/robo_trader/bootstrap_evidence_receivers.py
+++ b/robo_trader/bootstrap_evidence_receivers.py
@@ -322,6 +322,26 @@ def assert_and_consume_verified_broker_evidence(
     return envelope
 
 
+def _handoff_consumed_verified_broker_evidence_to_runtime(
+    envelope: VerifiedBrokerEvidenceEnvelope,
+) -> VerifiedBrokerEvidenceEnvelope:
+    """Re-register the producer-consumed envelope for one runtime bind.
+
+    The bootstrap reconciliation producer consumes the signer-owned envelope
+    before it inspects any broker field.  After the signed reconciliation stage
+    commits, runtime still needs to consume that *same* broker generation while
+    binding the report to the exact database inode.  This private handoff keeps
+    the lineage one-shot without collecting a second snapshot.
+    """
+
+    if type(envelope) is not VerifiedBrokerEvidenceEnvelope:
+        raise BootstrapEvidenceReceiverError("exact verified broker envelope is required")
+    with _VERIFIED_BROKER_REGISTRY_LOCK:
+        if id(envelope) in _VERIFIED_BROKER_REGISTRY:
+            raise BootstrapEvidenceReceiverError("verified broker envelope is already registered")
+    return _register_verified_broker_envelope(envelope)
+
+
 @dataclass(slots=True)
 class _BundleBindings:
     bundle_id: str

--- a/robo_trader/bootstrap_evidence_receivers.py
+++ b/robo_trader/bootstrap_evidence_receivers.py
@@ -624,6 +624,36 @@ class BootstrapEvidenceReceiverSet:
         state.published = True
         return state.final_output_directory
 
+    def unpublished_bundle_size_bytes(
+        self,
+        expected_marks: set[tuple[str, str]],
+    ) -> int:
+        """Return the exact sealed staging size before irreversible publication."""
+
+        self.assert_complete(expected_marks)
+        state = self._state
+        if state.published:
+            raise BootstrapEvidenceReceiverError("evidence bundle was already published")
+        self._assert_lexical_publication_binding(require_final=False)
+        total = 0
+        for name in os.listdir(state.staging_output_fd):
+            metadata = os.stat(
+                name,
+                dir_fd=state.staging_output_fd,
+                follow_symlinks=False,
+            )
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_uid != os.geteuid()
+                or metadata.st_nlink != 1
+                or stat.S_IMODE(metadata.st_mode) != 0o400
+            ):
+                raise BootstrapEvidenceReceiverError(
+                    "unpublished evidence contains an unsafe entry"
+                )
+            total += metadata.st_size
+        return total
+
     def _assert_lexical_publication_binding(self, *, require_final: bool) -> None:
         state = self._state
         lexical_parent_fd: int | None = None

--- a/robo_trader/bootstrap_evidence_receivers.py
+++ b/robo_trader/bootstrap_evidence_receivers.py
@@ -252,10 +252,17 @@ class VerifiedBrokerEvidenceEnvelope:
         raise TypeError("verified broker envelope cannot be pickled")
 
 
-_VerifiedBrokerRegistryEntry = tuple[
-    weakref.ReferenceType[VerifiedBrokerEvidenceEnvelope],
-    str,
-]
+@dataclass(frozen=True, slots=True)
+class _VerifiedBrokerRegistryEntry:
+    reference: weakref.ReferenceType[VerifiedBrokerEvidenceEnvelope]
+    digest: str
+    phase: str
+
+
+_BROKER_PHASE_PRODUCER_READY = "producer_ready"
+_BROKER_PHASE_PRODUCER_CONSUMED = "producer_consumed"
+_BROKER_PHASE_RUNTIME_READY = "runtime_ready"
+_BROKER_PHASE_RUNTIME_CONSUMED = "runtime_consumed"
 _VERIFIED_BROKER_REGISTRY: dict[int, _VerifiedBrokerRegistryEntry] = {}
 
 
@@ -288,14 +295,18 @@ def _register_verified_broker_envelope(
     def discard(reference: weakref.ReferenceType[VerifiedBrokerEvidenceEnvelope]) -> None:
         with _VERIFIED_BROKER_REGISTRY_LOCK:
             current = _VERIFIED_BROKER_REGISTRY.get(object_id)
-            if current is not None and current[0] is reference:
+            if current is not None and current.reference is reference:
                 _VERIFIED_BROKER_REGISTRY.pop(object_id, None)
 
     reference = weakref.ref(envelope, discard)
     with _VERIFIED_BROKER_REGISTRY_LOCK:
-        _VERIFIED_BROKER_REGISTRY[object_id] = (
-            reference,
-            _verified_broker_digest(envelope),
+        current = _VERIFIED_BROKER_REGISTRY.get(object_id)
+        if current is not None and current.reference() is not None:
+            raise BootstrapEvidenceReceiverError("verified broker envelope is already registered")
+        _VERIFIED_BROKER_REGISTRY[object_id] = _VerifiedBrokerRegistryEntry(
+            reference=reference,
+            digest=_verified_broker_digest(envelope),
+            phase=_BROKER_PHASE_PRODUCER_READY,
         )
     return envelope
 
@@ -309,16 +320,27 @@ def assert_and_consume_verified_broker_evidence(
         raise BootstrapEvidenceReceiverError("exact verified broker envelope is required")
     digest = _verified_broker_digest(envelope)
     with _VERIFIED_BROKER_REGISTRY_LOCK:
-        registered = _VERIFIED_BROKER_REGISTRY.pop(id(envelope), None)
+        registered = _VERIFIED_BROKER_REGISTRY.get(id(envelope))
         if (
             registered is None
-            or registered[0]() is not envelope
+            or registered.reference() is not envelope
             or envelope._marker is not _VERIFIED_BROKER_MARKER
-            or not secrets.compare_digest(registered[1], digest)
+            or not secrets.compare_digest(registered.digest, digest)
+            or registered.phase not in {_BROKER_PHASE_PRODUCER_READY, _BROKER_PHASE_RUNTIME_READY}
         ):
             raise BootstrapEvidenceReceiverError(
                 "verified broker envelope is forged, changed, or already consumed"
             )
+        phase = (
+            _BROKER_PHASE_PRODUCER_CONSUMED
+            if registered.phase == _BROKER_PHASE_PRODUCER_READY
+            else _BROKER_PHASE_RUNTIME_CONSUMED
+        )
+        _VERIFIED_BROKER_REGISTRY[id(envelope)] = _VerifiedBrokerRegistryEntry(
+            reference=registered.reference,
+            digest=registered.digest,
+            phase=phase,
+        )
     return envelope
 
 
@@ -336,10 +358,25 @@ def _handoff_consumed_verified_broker_evidence_to_runtime(
 
     if type(envelope) is not VerifiedBrokerEvidenceEnvelope:
         raise BootstrapEvidenceReceiverError("exact verified broker envelope is required")
+    digest = _verified_broker_digest(envelope)
     with _VERIFIED_BROKER_REGISTRY_LOCK:
-        if id(envelope) in _VERIFIED_BROKER_REGISTRY:
-            raise BootstrapEvidenceReceiverError("verified broker envelope is already registered")
-    return _register_verified_broker_envelope(envelope)
+        registered = _VERIFIED_BROKER_REGISTRY.get(id(envelope))
+        if (
+            registered is None
+            or registered.reference() is not envelope
+            or envelope._marker is not _VERIFIED_BROKER_MARKER
+            or not secrets.compare_digest(registered.digest, digest)
+            or registered.phase != _BROKER_PHASE_PRODUCER_CONSUMED
+        ):
+            raise BootstrapEvidenceReceiverError(
+                "verified broker envelope was not producer-consumed or was already handed off"
+            )
+        _VERIFIED_BROKER_REGISTRY[id(envelope)] = _VerifiedBrokerRegistryEntry(
+            reference=registered.reference,
+            digest=registered.digest,
+            phase=_BROKER_PHASE_RUNTIME_READY,
+        )
+    return envelope
 
 
 @dataclass(slots=True)

--- a/robo_trader/bootstrap_evidence_receivers.py
+++ b/robo_trader/bootstrap_evidence_receivers.py
@@ -716,6 +716,37 @@ class BootstrapEvidenceReceiverSet:
         state.retention_measurement = measurement
         return total + len(_completion_marker_payload(state, measurement))
 
+    def unpublished_bundle_directory_binding(self) -> tuple[str, int, int]:
+        """Return the exact staging directory identity for retention exclusion."""
+
+        state = self._state
+        if state.published:
+            raise BootstrapEvidenceReceiverError("evidence bundle was already published")
+        self._assert_lexical_publication_binding(require_final=False)
+        held = os.fstat(state.staging_output_fd)
+        try:
+            current = os.stat(
+                state.staging_output_directory.name,
+                dir_fd=state.output_parent_fd,
+                follow_symlinks=False,
+            )
+        except OSError as exc:
+            raise BootstrapEvidenceReceiverError(
+                "evidence staging directory cannot be bound for retention"
+            ) from exc
+        if (
+            not stat.S_ISDIR(held.st_mode)
+            or held.st_uid != os.geteuid()
+            or stat.S_IMODE(held.st_mode) != 0o700
+            or (held.st_dev, held.st_ino) != (current.st_dev, current.st_ino)
+            or (held.st_dev, held.st_ino)
+            != (state.staging_output_device, state.staging_output_inode)
+        ):
+            raise BootstrapEvidenceReceiverError(
+                "evidence staging directory changed before retention admission"
+            )
+        return state.staging_output_directory.name, held.st_dev, held.st_ino
+
     def _assert_lexical_publication_binding(self, *, require_final: bool) -> None:
         state = self._state
         lexical_parent_fd: int | None = None

--- a/robo_trader/bootstrap_evidence_receivers.py
+++ b/robo_trader/bootstrap_evidence_receivers.py
@@ -457,13 +457,26 @@ class _StagedProtectiveMarkEvidence:
     marker: object = field(repr=False, compare=False)
 
 
-def _completion_marker_payload(state: _BundleBindings) -> bytes:
+def _completion_marker_payload(
+    state: _BundleBindings,
+    measurement: tuple[tuple[str, int, int, int, str], ...],
+) -> bytes:
     return json.dumps(
         {
+            "artifact_manifest": [
+                {
+                    "device": device,
+                    "filename": filename,
+                    "inode": inode,
+                    "sha256": digest,
+                    "size_bytes": size_bytes,
+                }
+                for filename, device, inode, size_bytes, digest in measurement
+            ],
             "bundle_id": state.bundle_id,
             "publication_directory": str(state.final_output_directory),
             "publication_nonce": state.publication_nonce,
-            "schema_version": 1,
+            "schema_version": 2,
         },
         ensure_ascii=True,
         separators=(",", ":"),
@@ -612,14 +625,14 @@ class BootstrapEvidenceReceiverSet:
                 )
             self._assert_lexical_publication_binding(require_final=True)
             os.fsync(state.output_parent_fd)
-            completion_payload = _completion_marker_payload(state)
+            # From this point onward any failure is ambiguous with respect to
+            # same-UID additions inside the final directory. Preserve every
+            # entry and omit the trusted completion marker instead of rolling
+            # back through destructive staging cleanup.
+            preserve_failed_publication = True
+            measurement, artifact_bytes = _sealed_staging_measurement(state)
+            completion_payload = _completion_marker_payload(state, measurement)
             if expected_bundle_size_bytes is not None:
-                # From this point onward any failure is ambiguous with respect
-                # to same-UID additions inside the final directory. Preserve
-                # every entry and omit the trusted completion marker instead
-                # of rolling back through destructive staging cleanup.
-                preserve_failed_publication = True
-                measurement, artifact_bytes = _sealed_staging_measurement(state)
                 if (
                     type(expected_bundle_size_bytes) is not int
                     or expected_bundle_size_bytes <= 0
@@ -701,7 +714,7 @@ class BootstrapEvidenceReceiverSet:
         self._assert_lexical_publication_binding(require_final=False)
         measurement, total = _sealed_staging_measurement(state)
         state.retention_measurement = measurement
-        return total + len(_completion_marker_payload(state))
+        return total + len(_completion_marker_payload(state, measurement))
 
     def _assert_lexical_publication_binding(self, *, require_final: bool) -> None:
         state = self._state

--- a/robo_trader/bootstrap_evidence_receivers.py
+++ b/robo_trader/bootstrap_evidence_receivers.py
@@ -417,6 +417,7 @@ class _BundleBindings:
     broker_positions_count: int | None = None
     broker_open_orders_count: int | None = None
     marks: set[tuple[str, str]] = field(default_factory=set)
+    retention_measurement: tuple[tuple[str, int, int, int, str], ...] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -470,6 +471,38 @@ def _completion_marker_payload(state: _BundleBindings) -> bytes:
     ).encode("utf-8")
 
 
+def _sealed_staging_measurement(
+    state: _BundleBindings,
+) -> tuple[tuple[tuple[str, int, int, int, str], ...], int]:
+    entries: list[tuple[str, int, int, int, str]] = []
+    total = 0
+    for name in os.listdir(state.staging_output_fd):
+        metadata = os.stat(
+            name,
+            dir_fd=state.staging_output_fd,
+            follow_symlinks=False,
+        )
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != os.geteuid()
+            or metadata.st_nlink != 1
+            or stat.S_IMODE(metadata.st_mode) != 0o400
+        ):
+            raise BootstrapEvidenceReceiverError("unpublished evidence contains an unsafe entry")
+        payload = _read_sealed_file_at(state.staging_output_fd, name)
+        entries.append(
+            (
+                name,
+                metadata.st_dev,
+                metadata.st_ino,
+                metadata.st_size,
+                hashlib.sha256(payload).hexdigest(),
+            )
+        )
+        total += len(payload)
+    return tuple(sorted(entries)), total
+
+
 @dataclass(frozen=True, slots=True)
 class BootstrapEvidenceReceiverSet:
     broker_snapshot: "BrokerSnapshotEvidenceReceiver"
@@ -507,6 +540,8 @@ class BootstrapEvidenceReceiverSet:
     def publish_complete_bundle(
         self,
         expected_marks: set[tuple[str, str]],
+        *,
+        expected_bundle_size_bytes: int | None = None,
     ) -> Path:
         """Atomically publish the complete, provider-closed evidence directory."""
 
@@ -553,6 +588,7 @@ class BootstrapEvidenceReceiverSet:
                 "evidence publication paths changed or final output already exists"
             )
         renamed = False
+        preserve_failed_publication = False
         completion_temp = f".{_COMPLETION_MARKER_FILENAME}.stage-{secrets.token_hex(32)}"
         try:
             os.fsync(state.staging_output_fd)
@@ -577,6 +613,23 @@ class BootstrapEvidenceReceiverSet:
             self._assert_lexical_publication_binding(require_final=True)
             os.fsync(state.output_parent_fd)
             completion_payload = _completion_marker_payload(state)
+            if expected_bundle_size_bytes is not None:
+                measurement, artifact_bytes = _sealed_staging_measurement(state)
+                if (
+                    type(expected_bundle_size_bytes) is not int
+                    or expected_bundle_size_bytes <= 0
+                    or state.retention_measurement is None
+                    or measurement != state.retention_measurement
+                    or artifact_bytes + len(completion_payload) != expected_bundle_size_bytes
+                ):
+                    # The directory is already at its final random name. Leave
+                    # it there without a completion marker so injected or
+                    # raced contents are preserved for operator inspection,
+                    # never loaded, and never deleted as disposable staging.
+                    preserve_failed_publication = True
+                    raise BootstrapEvidenceReceiverError(
+                        "evidence bundle changed after retention measurement"
+                    )
             _write_new_sealed_file_at(
                 state.staging_output_fd,
                 completion_temp,
@@ -613,7 +666,7 @@ class BootstrapEvidenceReceiverSet:
                 os.unlink(completion_temp, dir_fd=state.staging_output_fd)
             except FileNotFoundError:
                 pass
-            if renamed:
+            if renamed and not preserve_failed_publication:
                 try:
                     _rename_directory_exclusive(
                         state.output_parent_fd,
@@ -639,23 +692,8 @@ class BootstrapEvidenceReceiverSet:
         if state.published:
             raise BootstrapEvidenceReceiverError("evidence bundle was already published")
         self._assert_lexical_publication_binding(require_final=False)
-        total = 0
-        for name in os.listdir(state.staging_output_fd):
-            metadata = os.stat(
-                name,
-                dir_fd=state.staging_output_fd,
-                follow_symlinks=False,
-            )
-            if (
-                not stat.S_ISREG(metadata.st_mode)
-                or metadata.st_uid != os.geteuid()
-                or metadata.st_nlink != 1
-                or stat.S_IMODE(metadata.st_mode) != 0o400
-            ):
-                raise BootstrapEvidenceReceiverError(
-                    "unpublished evidence contains an unsafe entry"
-                )
-            total += metadata.st_size
+        measurement, total = _sealed_staging_measurement(state)
+        state.retention_measurement = measurement
         return total + len(_completion_marker_payload(state))
 
     def _assert_lexical_publication_binding(self, *, require_final: bool) -> None:

--- a/robo_trader/bootstrap_evidence_receivers.py
+++ b/robo_trader/bootstrap_evidence_receivers.py
@@ -614,6 +614,11 @@ class BootstrapEvidenceReceiverSet:
             os.fsync(state.output_parent_fd)
             completion_payload = _completion_marker_payload(state)
             if expected_bundle_size_bytes is not None:
+                # From this point onward any failure is ambiguous with respect
+                # to same-UID additions inside the final directory. Preserve
+                # every entry and omit the trusted completion marker instead
+                # of rolling back through destructive staging cleanup.
+                preserve_failed_publication = True
                 measurement, artifact_bytes = _sealed_staging_measurement(state)
                 if (
                     type(expected_bundle_size_bytes) is not int
@@ -626,7 +631,6 @@ class BootstrapEvidenceReceiverSet:
                     # it there without a completion marker so injected or
                     # raced contents are preserved for operator inspection,
                     # never loaded, and never deleted as disposable staging.
-                    preserve_failed_publication = True
                     raise BootstrapEvidenceReceiverError(
                         "evidence bundle changed after retention measurement"
                     )
@@ -657,15 +661,17 @@ class BootstrapEvidenceReceiverSet:
                     self._assert_lexical_publication_binding(require_final=True)
                     if secrets.compare_digest(committed_payload, completion_payload):
                         state.published = True
+                        preserve_failed_publication = False
                         return state.final_output_directory
                 except BootstrapEvidenceReceiverError:
                     pass
                 raise
         except BaseException:
-            try:
-                os.unlink(completion_temp, dir_fd=state.staging_output_fd)
-            except FileNotFoundError:
-                pass
+            if not preserve_failed_publication:
+                try:
+                    os.unlink(completion_temp, dir_fd=state.staging_output_fd)
+                except FileNotFoundError:
+                    pass
             if renamed and not preserve_failed_publication:
                 try:
                     _rename_directory_exclusive(
@@ -679,6 +685,7 @@ class BootstrapEvidenceReceiverSet:
                     ) from exc
             raise
         state.published = True
+        preserve_failed_publication = False
         return state.final_output_directory
 
     def unpublished_bundle_size_bytes(

--- a/robo_trader/bootstrap_evidence_receivers.py
+++ b/robo_trader/bootstrap_evidence_receivers.py
@@ -456,6 +456,20 @@ class _StagedProtectiveMarkEvidence:
     marker: object = field(repr=False, compare=False)
 
 
+def _completion_marker_payload(state: _BundleBindings) -> bytes:
+    return json.dumps(
+        {
+            "bundle_id": state.bundle_id,
+            "publication_directory": str(state.final_output_directory),
+            "publication_nonce": state.publication_nonce,
+            "schema_version": 1,
+        },
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
 @dataclass(frozen=True, slots=True)
 class BootstrapEvidenceReceiverSet:
     broker_snapshot: "BrokerSnapshotEvidenceReceiver"
@@ -562,17 +576,7 @@ class BootstrapEvidenceReceiverSet:
                 )
             self._assert_lexical_publication_binding(require_final=True)
             os.fsync(state.output_parent_fd)
-            completion_payload = json.dumps(
-                {
-                    "bundle_id": state.bundle_id,
-                    "publication_directory": str(state.final_output_directory),
-                    "publication_nonce": state.publication_nonce,
-                    "schema_version": 1,
-                },
-                ensure_ascii=True,
-                separators=(",", ":"),
-                sort_keys=True,
-            ).encode("utf-8")
+            completion_payload = _completion_marker_payload(state)
             _write_new_sealed_file_at(
                 state.staging_output_fd,
                 completion_temp,
@@ -628,7 +632,7 @@ class BootstrapEvidenceReceiverSet:
         self,
         expected_marks: set[tuple[str, str]],
     ) -> int:
-        """Return the exact sealed staging size before irreversible publication."""
+        """Return exact final bytes, including the not-yet-written completion marker."""
 
         self.assert_complete(expected_marks)
         state = self._state
@@ -652,7 +656,7 @@ class BootstrapEvidenceReceiverSet:
                     "unpublished evidence contains an unsafe entry"
                 )
             total += metadata.st_size
-        return total
+        return total + len(_completion_marker_payload(state))
 
     def _assert_lexical_publication_binding(self, *, require_final: bool) -> None:
         state = self._state

--- a/robo_trader/bootstrap_mark_producer.py
+++ b/robo_trader/bootstrap_mark_producer.py
@@ -1083,6 +1083,7 @@ async def collect_and_produce_bootstrap_protective_mark(
     expected_con_id: int,
     expected_transport_generation: str,
     expected_source_event_id: str | None = None,
+    expected_active_symbols: tuple[str, ...] | None = None,
 ) -> ReceiverResult:
     """Collect one live quote and deliver its producer-owned accounting mark.
 
@@ -1113,6 +1114,18 @@ async def collect_and_produce_bootstrap_protective_mark(
             _SOURCE_EVENT_ID,
         )
     )
+    active_symbols = (
+        (symbol,)
+        if expected_active_symbols is None
+        else tuple(
+            _strict_text(active_symbol, "expected_active_symbol", _SYMBOL)
+            for active_symbol in expected_active_symbols
+        )
+    )
+    if not active_symbols or len(set(active_symbols)) != len(active_symbols):
+        raise BootstrapMarkBlocked("active protective symbol scope is invalid")
+    if symbol not in active_symbols:
+        raise BootstrapMarkBlocked("protective symbol is outside the active account scope")
     runtime, database_binding = _validate_runtime(runtime_contract)
     _assert_producer_context(
         producer,
@@ -1128,7 +1141,7 @@ async def collect_and_produce_bootstrap_protective_mark(
     )
     capability, capability_identity = _quote_collector_capability(quote_source)
     try:
-        collected = await capability((symbol,), active_symbols=(symbol,))
+        collected = await capability((symbol,), active_symbols=active_symbols)
     except BootstrapMarkBlocked:
         raise
     except Exception as exc:

--- a/robo_trader/financial_state_bootstrap.py
+++ b/robo_trader/financial_state_bootstrap.py
@@ -506,6 +506,129 @@ def _verified_canonical_json(path: Path, label: str) -> tuple[Mapping[str, Any],
     return raw, hashlib.sha256(payload).hexdigest()
 
 
+def _verified_manifest_file_at(
+    directory_fd: int,
+    filename: str,
+) -> tuple[bytes, os.stat_result]:
+    """Read one manifest entry by held directory identity without following links."""
+
+    flags = os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(filename, flags, dir_fd=directory_fd)
+        before = os.fstat(descriptor)
+        getuid = getattr(os, "getuid", None)
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_nlink != 1
+            or (getuid is not None and before.st_uid != getuid())
+            or stat.S_IMODE(before.st_mode) & 0o077
+            or before.st_size > MAX_EVIDENCE_BYTES
+        ):
+            raise ExactStateBootstrapError("bundle manifest entry is not an owner-only file")
+        chunks: list[bytes] = []
+        remaining = MAX_EVIDENCE_BYTES + 1
+        while remaining:
+            chunk = os.read(descriptor, min(65536, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        payload = b"".join(chunks)
+        after = os.fstat(descriptor)
+        current = os.stat(filename, dir_fd=directory_fd, follow_symlinks=False)
+        if (
+            len(payload) > MAX_EVIDENCE_BYTES
+            or os.read(descriptor, 1)
+            or (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns)
+            != (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns)
+            or (after.st_dev, after.st_ino) != (current.st_dev, current.st_ino)
+            or current.st_nlink != 1
+        ):
+            raise ExactStateBootstrapError("bundle manifest entry changed while read")
+        return payload, after
+    except OSError as exc:
+        raise ExactStateBootstrapError("bundle manifest entry cannot be read safely") from exc
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def _verify_published_bundle_manifest(
+    publication_directory: Path,
+    raw_manifest: object,
+) -> None:
+    """Bind a completion marker to every exact file in its published directory."""
+
+    if type(raw_manifest) is not list or not raw_manifest:
+        raise ExactStateBootstrapError("bundle completion manifest is malformed")
+    expected: dict[str, tuple[int, int, int, str]] = {}
+    for raw_entry in raw_manifest:
+        if type(raw_entry) is not dict:
+            raise ExactStateBootstrapError("bundle completion manifest is malformed")
+        _exact_keys(
+            raw_entry,
+            {"device", "filename", "inode", "sha256", "size_bytes"},
+            "bundle completion manifest entry",
+        )
+        filename = _json_string(raw_entry["filename"], "manifest filename")
+        if (
+            not filename
+            or Path(filename).name != filename
+            or filename in {".", "..", "bundle_complete.json"}
+            or filename in expected
+        ):
+            raise ExactStateBootstrapError("bundle completion manifest filename is malformed")
+        expected[filename] = (
+            _json_int(raw_entry["device"], "manifest device"),
+            _json_int(raw_entry["inode"], "manifest inode", minimum=1),
+            _json_int(raw_entry["size_bytes"], "manifest size_bytes"),
+            _hash(raw_entry["sha256"], "manifest sha256"),
+        )
+    if list(expected) != sorted(expected):
+        raise ExactStateBootstrapError("bundle completion manifest is not sorted")
+
+    directory_fd: int | None = None
+    try:
+        directory_fd = os.open(
+            publication_directory,
+            os.O_RDONLY
+            | os.O_NOFOLLOW
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_CLOEXEC", 0),
+        )
+        held_directory = os.fstat(directory_fd)
+        if not stat.S_ISDIR(held_directory.st_mode):
+            raise ExactStateBootstrapError("evidence publication path is not a directory")
+        expected_names = set(expected) | {"bundle_complete.json"}
+        if set(os.listdir(directory_fd)) != expected_names:
+            raise ExactStateBootstrapError(
+                "published evidence entries do not match the completion manifest"
+            )
+        for filename, binding in expected.items():
+            payload, metadata = _verified_manifest_file_at(directory_fd, filename)
+            if (
+                metadata.st_dev,
+                metadata.st_ino,
+                len(payload),
+                hashlib.sha256(payload).hexdigest(),
+            ) != binding:
+                raise ExactStateBootstrapError(
+                    "published evidence entry does not match the completion manifest"
+                )
+        current_directory = os.stat(publication_directory, follow_symlinks=False)
+        if (held_directory.st_dev, held_directory.st_ino) != (
+            current_directory.st_dev,
+            current_directory.st_ino,
+        ) or set(os.listdir(directory_fd)) != expected_names:
+            raise ExactStateBootstrapError("published evidence directory changed during validation")
+    except OSError as exc:
+        raise ExactStateBootstrapError("bundle completion manifest cannot be verified") from exc
+    finally:
+        if directory_fd is not None:
+            os.close(directory_fd)
+
+
 def _verify_artifact_authentication(
     *,
     artifact_path: Path,
@@ -1478,6 +1601,7 @@ def load_exact_state_bootstrap_evidence(
     _exact_keys(
         completion,
         {
+            "artifact_manifest",
             "bundle_id",
             "publication_directory",
             "publication_nonce",
@@ -1486,7 +1610,7 @@ def load_exact_state_bootstrap_evidence(
         "bundle completion record",
     )
     if (
-        _json_int(completion["schema_version"], "completion schema_version") != 1
+        _json_int(completion["schema_version"], "completion schema_version") != 2
         or _json_string(completion["bundle_id"], "completion bundle_id") != bundle_id
         or _json_string(
             completion["publication_directory"],
@@ -1499,6 +1623,10 @@ def load_exact_state_bootstrap_evidence(
         raise ExactStateBootstrapError(
             "bundle completion record is outside the signed publication lineage"
         )
+    _verify_published_bundle_manifest(
+        publication_directory,
+        completion["artifact_manifest"],
+    )
     _assert_authentication_receipts_unconsumed(database_path, authentication_receipts)
 
     evidence = ExactStateBootstrapEvidence(

--- a/robo_trader/paper_reduction_gateway.py
+++ b/robo_trader/paper_reduction_gateway.py
@@ -43,11 +43,11 @@ from .protective_quote_evidence import (
     ProtectiveQuoteSource,
     assert_current_authoritative_protective_quote,
 )
+from .reconciliation.ibkr_adapter import IBKRDiagnosticSnapshotProvider
 from .reconciliation.identity import (
     RuntimeSafetyContext,
     assert_validated_runtime_safety_context,
 )
-from .reconciliation.ibkr_adapter import IBKRDiagnosticSnapshotProvider
 from .safety import (
     OrderSide,
     OrderType,

--- a/robo_trader/paper_reduction_gateway.py
+++ b/robo_trader/paper_reduction_gateway.py
@@ -47,6 +47,7 @@ from .reconciliation.identity import (
     RuntimeSafetyContext,
     assert_validated_runtime_safety_context,
 )
+from .reconciliation.ibkr_adapter import IBKRDiagnosticSnapshotProvider
 from .safety import (
     OrderSide,
     OrderType,
@@ -95,6 +96,7 @@ class PaperReductionGateway:
         coordinator: SafetyRuntimeCoordinator,
         database: AsyncTradingDatabase,
         *,
+        diagnostic_provider: IBKRDiagnosticSnapshotProvider | None = None,
         monotonic: Callable[[], float] = time.monotonic,
         sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
     ) -> None:
@@ -141,9 +143,21 @@ class PaperReductionGateway:
                 "shared safety database does not match the runtime ledger path"
             )
         self._database = database
-        self._client = SubprocessIBKRClient(
-            worker_runtime_environment=self._runtime_context.runtime_contract.environment,
-        )
+        self._diagnostic_provider = diagnostic_provider
+        self._owns_diagnostic_client = diagnostic_provider is None
+        if diagnostic_provider is None:
+            self._client = SubprocessIBKRClient(
+                worker_runtime_environment=self._runtime_context.runtime_contract.environment,
+            )
+        else:
+            try:
+                self._client = diagnostic_provider._shared_gateway_transport(
+                    runtime_context=self._runtime_context,
+                )
+            except Exception as exc:
+                raise PaperReductionGatewayError(
+                    "shared diagnostic provider binding is invalid"
+                ) from exc
         self._account_order_gate = asyncio.Lock()
         self._bindings: dict[str, _PaperRuntimeBinding] = {}
         self._active_runtime_binding_session: _PaperRuntimeBindingSession | None = None
@@ -209,14 +223,25 @@ class PaperReductionGateway:
             context = assert_validated_runtime_safety_context(self._runtime_context)
             connection = context.diagnostic_connection
             try:
-                await self._client.start()
-                connected = await self._client.connect(
-                    host=connection.host,
-                    port=connection.port,
-                    client_id=connection.client_id,
-                    readonly=connection.readonly,
-                    timeout=30.0,
-                )
+                if getattr(self, "_owns_diagnostic_client", True):
+                    await self._client.start()
+                    connected = await self._client.connect(
+                        host=connection.host,
+                        port=connection.port,
+                        client_id=connection.client_id,
+                        readonly=connection.readonly,
+                        timeout=30.0,
+                    )
+                else:
+                    provider = self._diagnostic_provider
+                    if type(provider) is not IBKRDiagnosticSnapshotProvider:
+                        raise PaperReductionGatewayError(
+                            "shared diagnostic provider is unavailable"
+                        )
+                    self._client = provider._shared_gateway_transport(
+                        runtime_context=context,
+                    )
+                    connected = await self._client.ping()
                 if connected is not True:
                     raise PaperReductionGatewayError(
                         "diagnostic broker connection was not established"
@@ -249,7 +274,14 @@ class PaperReductionGateway:
         if subscribed is not None:
             subscribed.clear()
 
-        task = asyncio.create_task(self._client.stop())
+        if getattr(self, "_owns_diagnostic_client", True):
+            cleanup = self._client.stop()
+        else:
+            provider = self._diagnostic_provider
+            if type(provider) is not IBKRDiagnosticSnapshotProvider:
+                raise PaperReductionGatewayError("shared diagnostic provider is unavailable")
+            cleanup = provider.suspend()
+        task = asyncio.create_task(cleanup)
         cancellation: asyncio.CancelledError | None = None
         stop_failure: BaseException | None = None
         while not task.done():
@@ -558,7 +590,8 @@ class PaperReductionGateway:
                     pass
             await self._invalidate_protective_quote_producers()
             try:
-                await self._stop_client_owned()
+                if getattr(self, "_owns_diagnostic_client", True):
+                    await self._stop_client_owned()
             finally:
                 self._started = False
                 self._diagnostic_recovery_required = False
@@ -572,15 +605,22 @@ class PaperReductionGateway:
         try:
             context = assert_validated_runtime_safety_context(self._runtime_context)
             connection = context.diagnostic_connection
-            await self._stop_client_owned()
-            await self._client.start()
-            connected = await self._client.connect(
-                host=connection.host,
-                port=connection.port,
-                client_id=connection.client_id,
-                readonly=connection.readonly,
-                timeout=30.0,
-            )
+            if getattr(self, "_owns_diagnostic_client", True):
+                await self._stop_client_owned()
+                await self._client.start()
+                connected = await self._client.connect(
+                    host=connection.host,
+                    port=connection.port,
+                    client_id=connection.client_id,
+                    readonly=connection.readonly,
+                    timeout=30.0,
+                )
+            else:
+                provider = self._diagnostic_provider
+                if type(provider) is not IBKRDiagnosticSnapshotProvider:
+                    raise PaperReductionGatewayError("shared diagnostic provider is unavailable")
+                await provider.refresh()
+                connected = True
             if connected is not True or await self._client.ping() is not True:
                 raise PaperReductionGatewayError("diagnostic broker connection did not recover")
         except BaseException as error:
@@ -593,11 +633,13 @@ class PaperReductionGateway:
     async def refresh_diagnostic_connection(self) -> None:
         """Replace stale broker state before order admission can resume.
 
-        The runner and this gateway intentionally own separate read-only IBKR
-        clients.  A runner recovery therefore cannot prove that the gateway's
-        diagnostic session survived the same outage.  Hold the account-wide
-        gate, mark this boundary unavailable before the first await, and only
-        restore ``started`` after a fresh connect and active ping both succeed.
+        The gateway borrows the reconciliation provider's read-only generation
+        in production. A runner recovery therefore must replace that shared
+        diagnostic generation before either reconciliation or reductions may
+        resume. Hold the account-wide gate, mark this boundary unavailable
+        before the first await, and only restore ``started`` after a fresh
+        connect and active ping both succeed. Legacy isolated construction
+        retains the independently owned-client path for compatibility.
         """
 
         require_paper_terminal_settlement_ready()

--- a/robo_trader/reconciliation/bootstrap_producer.py
+++ b/robo_trader/reconciliation/bootstrap_producer.py
@@ -1269,6 +1269,7 @@ class BootstrapReconciliationDelivery(Generic[ReceiverResult]):
 
     receiver_result: ReceiverResult
     local_position_identities: tuple[tuple[str, str], ...]
+    verified_broker_evidence: VerifiedBrokerEvidenceEnvelope = field(repr=False)
 
 
 def _validate_runtime(runtime: object) -> RuntimeContract:
@@ -1319,6 +1320,27 @@ def _consume_verified_broker_evidence(
         return assert_and_consume_verified_broker_evidence(envelope)
     except Exception as exc:
         raise BootstrapReconciliationBlocked("broker evidence is not verifier-owned") from exc
+
+
+def _handoff_verified_broker_evidence_to_runtime(
+    envelope: VerifiedBrokerEvidenceEnvelope,
+) -> VerifiedBrokerEvidenceEnvelope:
+    """Move one consumed broker envelope into the runtime binder registry."""
+
+    try:
+        from robo_trader.bootstrap_evidence_receivers import (
+            _handoff_consumed_verified_broker_evidence_to_runtime,
+        )
+    except (ImportError, AttributeError) as exc:
+        raise BootstrapReconciliationBlocked(
+            "runtime broker evidence handoff is unavailable"
+        ) from exc
+    try:
+        return _handoff_consumed_verified_broker_evidence_to_runtime(envelope)
+    except Exception as exc:
+        raise BootstrapReconciliationBlocked(
+            "runtime broker evidence handoff failed closed"
+        ) from exc
 
 
 def _assert_core_reconciliation_receiver_capability(
@@ -1491,9 +1513,11 @@ def produce_bootstrap_reconciliation(
             collection.assert_unchanged_after_receiver_claim()
             receiver_result = receiver.commit_staged_bootstrap_reconciliation(stage)
             committed = True
+            runtime_broker_evidence = _handoff_verified_broker_evidence_to_runtime(envelope)
             return BootstrapReconciliationDelivery(
                 receiver_result=receiver_result,
                 local_position_identities=position_identities,
+                verified_broker_evidence=runtime_broker_evidence,
             )
     except BaseException:
         if stage is not _NO_RECEIVER_STAGE and not committed:

--- a/robo_trader/reconciliation/ibkr_adapter.py
+++ b/robo_trader/reconciliation/ibkr_adapter.py
@@ -1333,6 +1333,7 @@ def assert_factory_owned_diagnostic_provider(
         or entry.provider is not provider
         or provider._factory_marker is not _FACTORY_PROVIDER_MARKER
         or provider._closed is not False
+        or provider._suspended is not False
         or type(provider._transport) is not SubprocessIBKRClient
         or entry.transport is not provider._transport
         or entry.runtime_contract is not provider._runtime_contract
@@ -1347,6 +1348,42 @@ def assert_factory_owned_diagnostic_provider(
     if generation != entry.transport_generation or not hmac.compare_digest(entry.digest, digest):
         _invalidate_factory_provider(provider)
         raise BrokerEvidenceError("diagnostic provider generation or runtime binding changed")
+    return provider
+
+
+def _claim_factory_provider_for_refresh(
+    provider: object,
+) -> IBKRDiagnosticSnapshotProvider:
+    """Consume factory ownership even when the registered transport is suspended."""
+
+    if type(provider) is not IBKRDiagnosticSnapshotProvider:
+        raise BrokerEvidenceError("exact diagnostic provider is required")
+    with _FACTORY_PROVIDER_LOCK:
+        entry = _FACTORY_PROVIDERS.get(id(provider))
+        if (
+            entry is None
+            or entry.provider is not provider
+            or provider._factory_marker is not _FACTORY_PROVIDER_MARKER
+            or provider._closed is not False
+            or type(provider._transport) is not SubprocessIBKRClient
+            or entry.transport is not provider._transport
+            or entry.runtime_contract is not provider._runtime_contract
+            or provider._diagnostic_connection is None
+        ):
+            raise BrokerEvidenceError("diagnostic provider is not factory-owned")
+        generation = entry.transport_generation
+        if provider._suspended is not True:
+            try:
+                generation = entry.transport.protective_quote_generation
+            except Exception as exc:
+                raise BrokerEvidenceError("diagnostic provider generation is unavailable") from exc
+        digest = _factory_provider_digest(provider, transport_generation=generation)
+        if generation != entry.transport_generation or not hmac.compare_digest(
+            entry.digest, digest
+        ):
+            _FACTORY_PROVIDERS.pop(id(provider), None)
+            raise BrokerEvidenceError("diagnostic provider generation or runtime binding changed")
+        _FACTORY_PROVIDERS.pop(id(provider), None)
     return provider
 
 
@@ -1545,6 +1582,7 @@ class IBKRDiagnosticSnapshotProvider:
         "_diagnostic_connection",
         "_factory_marker",
         "_closed",
+        "_suspended",
     )
 
     def __init__(
@@ -1566,6 +1604,7 @@ class IBKRDiagnosticSnapshotProvider:
         self._diagnostic_connection = diagnostic_connection
         self._factory_marker = _factory_marker
         self._closed = False
+        self._suspended = False
 
     async def get_broker_snapshot(
         self, expected_account: str, *, max_age_seconds: float
@@ -1654,6 +1693,7 @@ class IBKRDiagnosticSnapshotProvider:
         if self._closed:
             return
         self._closed = True
+        self._suspended = True
         _invalidate_factory_provider(self)
         await _stop_transport_required(self._transport)
 
@@ -1667,16 +1707,16 @@ class IBKRDiagnosticSnapshotProvider:
         except BaseException:
             await _stop_transport_required(self._transport)
             raise
+        self._suspended = True
         await _stop_transport_required(self._transport)
 
     async def refresh(self) -> None:
         """Replace the owned read-only transport generation in place."""
 
-        assert_factory_owned_diagnostic_provider(self)
         connection = self._diagnostic_connection
         if connection is None:
             raise BrokerEvidenceError("diagnostic connection binding is unavailable")
-        _invalidate_factory_provider(self)
+        _claim_factory_provider_for_refresh(self)
         try:
             await _stop_transport_required(self._transport)
             await self._transport.start()
@@ -1689,6 +1729,7 @@ class IBKRDiagnosticSnapshotProvider:
             )
             if connected is not True or await self._transport.ping() is not True:
                 raise BrokerEvidenceError("diagnostic broker connection did not recover")
+            self._suspended = False
             _register_factory_provider(
                 self,
                 transport=self._transport,
@@ -1696,6 +1737,7 @@ class IBKRDiagnosticSnapshotProvider:
             )
         except BaseException:
             self._closed = True
+            self._suspended = True
             try:
                 await await_cleanup_required(_stop_transport_required(self._transport))
             except Exception as cleanup_exc:

--- a/robo_trader/reconciliation/ibkr_adapter.py
+++ b/robo_trader/reconciliation/ibkr_adapter.py
@@ -34,6 +34,7 @@ from .domain import (
 )
 from .errors import BrokerEvidenceError
 from .identity import (
+    DiagnosticConnectionContract,
     RuntimeSafetyContext,
     assert_validated_runtime_safety_context,
     mask_account_identifier,
@@ -1288,7 +1289,8 @@ def _factory_provider_digest(
         (
             f"{id(provider)}|{id(provider._transport)}|{id(provider._runtime_contract)}|"
             f"{provider._runtime_fingerprint}|{provider._account_scope}|"
-            f"{provider._expected_account}|{transport_generation}"
+            f"{provider._expected_account}|{id(provider._diagnostic_connection)}|"
+            f"{transport_generation}"
         ).encode("utf-8"),
         hashlib.sha256,
     ).hexdigest()
@@ -1334,6 +1336,7 @@ def assert_factory_owned_diagnostic_provider(
         or type(provider._transport) is not SubprocessIBKRClient
         or entry.transport is not provider._transport
         or entry.runtime_contract is not provider._runtime_contract
+        or provider._diagnostic_connection is None
     ):
         raise BrokerEvidenceError("diagnostic provider is not factory-owned")
     try:
@@ -1539,6 +1542,7 @@ class IBKRDiagnosticSnapshotProvider:
         "_account_scope",
         "_runtime_contract",
         "_runtime_fingerprint",
+        "_diagnostic_connection",
         "_factory_marker",
         "_closed",
     )
@@ -1551,6 +1555,7 @@ class IBKRDiagnosticSnapshotProvider:
         account_scope: str | None = None,
         runtime_contract: object = None,
         runtime_fingerprint: str | None = None,
+        diagnostic_connection: DiagnosticConnectionContract | None = None,
         _factory_marker: object = None,
     ) -> None:
         self._transport = transport
@@ -1558,6 +1563,7 @@ class IBKRDiagnosticSnapshotProvider:
         self._account_scope = account_scope
         self._runtime_contract = runtime_contract
         self._runtime_fingerprint = runtime_fingerprint
+        self._diagnostic_connection = diagnostic_connection
         self._factory_marker = _factory_marker
         self._closed = False
 
@@ -1645,9 +1651,75 @@ class IBKRDiagnosticSnapshotProvider:
         return source
 
     async def close(self) -> None:
+        if self._closed:
+            return
         self._closed = True
         _invalidate_factory_provider(self)
         await _stop_transport_required(self._transport)
+
+    async def suspend(self) -> None:
+        """Stop the current generation while retaining factory ownership."""
+
+        if self._closed:
+            return
+        try:
+            assert_factory_owned_diagnostic_provider(self)
+        except BaseException:
+            await _stop_transport_required(self._transport)
+            raise
+        await _stop_transport_required(self._transport)
+
+    async def refresh(self) -> None:
+        """Replace the owned read-only transport generation in place."""
+
+        assert_factory_owned_diagnostic_provider(self)
+        connection = self._diagnostic_connection
+        if connection is None:
+            raise BrokerEvidenceError("diagnostic connection binding is unavailable")
+        _invalidate_factory_provider(self)
+        try:
+            await _stop_transport_required(self._transport)
+            await self._transport.start()
+            connected = await self._transport.connect(
+                host=connection.host,
+                port=connection.port,
+                client_id=connection.client_id,
+                readonly=connection.readonly,
+                timeout=30.0,
+            )
+            if connected is not True or await self._transport.ping() is not True:
+                raise BrokerEvidenceError("diagnostic broker connection did not recover")
+            _register_factory_provider(
+                self,
+                transport=self._transport,
+                runtime_contract=self._runtime_contract,
+            )
+        except BaseException:
+            self._closed = True
+            try:
+                await await_cleanup_required(_stop_transport_required(self._transport))
+            except Exception as cleanup_exc:
+                raise BrokerEvidenceError(
+                    "diagnostic broker recovery cleanup failed"
+                ) from cleanup_exc
+            raise
+
+    def _shared_gateway_transport(
+        self,
+        *,
+        runtime_context: RuntimeSafetyContext,
+    ) -> SubprocessIBKRClient:
+        """Return the exact read-only client only to the in-process gateway."""
+
+        provider = assert_factory_owned_diagnostic_provider(self)
+        context = assert_validated_runtime_safety_context(runtime_context)
+        if provider._runtime_contract is not context.runtime_contract:
+            raise BrokerEvidenceError("diagnostic provider runtime binding changed")
+        if provider._diagnostic_connection is not context.diagnostic_connection:
+            raise BrokerEvidenceError("diagnostic connection binding changed")
+        if type(provider._transport) is not SubprocessIBKRClient:
+            raise BrokerEvidenceError("diagnostic provider transport is not shareable")
+        return provider._transport
 
 
 async def _stop_transport_required(
@@ -1737,6 +1809,7 @@ async def build_diagnostic_provider(
         account_scope=account_scope,
         runtime_contract=runtime_contract,
         runtime_fingerprint=runtime_fingerprint,
+        diagnostic_connection=connection,
         _factory_marker=_FACTORY_PROVIDER_MARKER,
     )
     if type(transport) is SubprocessIBKRClient:

--- a/robo_trader/reconciliation/ibkr_adapter.py
+++ b/robo_trader/reconciliation/ibkr_adapter.py
@@ -1354,7 +1354,7 @@ def assert_factory_owned_diagnostic_provider(
 def _claim_factory_provider_for_refresh(
     provider: object,
 ) -> IBKRDiagnosticSnapshotProvider:
-    """Consume factory ownership even when the registered transport is suspended."""
+    """Validate factory ownership even when the registered transport is suspended."""
 
     if type(provider) is not IBKRDiagnosticSnapshotProvider:
         raise BrokerEvidenceError("exact diagnostic provider is required")
@@ -1383,7 +1383,6 @@ def _claim_factory_provider_for_refresh(
         ):
             _FACTORY_PROVIDERS.pop(id(provider), None)
             raise BrokerEvidenceError("diagnostic provider generation or runtime binding changed")
-        _FACTORY_PROVIDERS.pop(id(provider), None)
     return provider
 
 
@@ -1583,6 +1582,7 @@ class IBKRDiagnosticSnapshotProvider:
         "_factory_marker",
         "_closed",
         "_suspended",
+        "_refresh_lock",
     )
 
     def __init__(
@@ -1605,6 +1605,7 @@ class IBKRDiagnosticSnapshotProvider:
         self._factory_marker = _factory_marker
         self._closed = False
         self._suspended = False
+        self._refresh_lock = asyncio.Lock()
 
     async def get_broker_snapshot(
         self, expected_account: str, *, max_age_seconds: float
@@ -1690,61 +1691,64 @@ class IBKRDiagnosticSnapshotProvider:
         return source
 
     async def close(self) -> None:
-        if self._closed:
-            return
-        self._closed = True
-        self._suspended = True
-        _invalidate_factory_provider(self)
-        await _stop_transport_required(self._transport)
+        async with self._refresh_lock:
+            if self._closed:
+                return
+            self._closed = True
+            self._suspended = True
+            _invalidate_factory_provider(self)
+            await _stop_transport_required(self._transport)
 
     async def suspend(self) -> None:
         """Stop the current generation while retaining factory ownership."""
 
-        if self._closed:
-            return
-        try:
-            assert_factory_owned_diagnostic_provider(self)
-        except BaseException:
+        async with self._refresh_lock:
+            if self._closed:
+                return
+            self._suspended = True
+            try:
+                _claim_factory_provider_for_refresh(self)
+            except BaseException:
+                await _stop_transport_required(self._transport)
+                raise
             await _stop_transport_required(self._transport)
-            raise
-        self._suspended = True
-        await _stop_transport_required(self._transport)
 
     async def refresh(self) -> None:
         """Replace the owned read-only transport generation in place."""
 
-        connection = self._diagnostic_connection
-        if connection is None:
-            raise BrokerEvidenceError("diagnostic connection binding is unavailable")
-        _claim_factory_provider_for_refresh(self)
-        try:
-            await _stop_transport_required(self._transport)
-            await self._transport.start()
-            connected = await self._transport.connect(
-                host=connection.host,
-                port=connection.port,
-                client_id=connection.client_id,
-                readonly=connection.readonly,
-                timeout=30.0,
-            )
-            if connected is not True or await self._transport.ping() is not True:
-                raise BrokerEvidenceError("diagnostic broker connection did not recover")
-            self._suspended = False
-            _register_factory_provider(
-                self,
-                transport=self._transport,
-                runtime_contract=self._runtime_contract,
-            )
-        except BaseException:
-            self._closed = True
+        async with self._refresh_lock:
+            connection = self._diagnostic_connection
+            if connection is None:
+                raise BrokerEvidenceError("diagnostic connection binding is unavailable")
+            _claim_factory_provider_for_refresh(self)
             self._suspended = True
             try:
-                await await_cleanup_required(_stop_transport_required(self._transport))
-            except Exception as cleanup_exc:
-                raise BrokerEvidenceError(
-                    "diagnostic broker recovery cleanup failed"
-                ) from cleanup_exc
-            raise
+                await _stop_transport_required(self._transport)
+                await self._transport.start()
+                connected = await self._transport.connect(
+                    host=connection.host,
+                    port=connection.port,
+                    client_id=connection.client_id,
+                    readonly=connection.readonly,
+                    timeout=30.0,
+                )
+                if connected is not True or await self._transport.ping() is not True:
+                    raise BrokerEvidenceError("diagnostic broker connection did not recover")
+                self._suspended = False
+                _register_factory_provider(
+                    self,
+                    transport=self._transport,
+                    runtime_contract=self._runtime_contract,
+                )
+            except BaseException:
+                self._suspended = True
+                try:
+                    await await_cleanup_required(_stop_transport_required(self._transport))
+                except Exception as cleanup_exc:
+                    raise BrokerEvidenceError(
+                        "diagnostic broker recovery cleanup failed"
+                    ) from cleanup_exc
+                raise
 
     def _shared_gateway_transport(
         self,

--- a/robo_trader/reconciliation/ibkr_adapter.py
+++ b/robo_trader/reconciliation/ibkr_adapter.py
@@ -1583,6 +1583,7 @@ class IBKRDiagnosticSnapshotProvider:
         "_closed",
         "_suspended",
         "_refresh_lock",
+        "_generation_lease_token",
     )
 
     def __init__(
@@ -1606,6 +1607,36 @@ class IBKRDiagnosticSnapshotProvider:
         self._closed = False
         self._suspended = False
         self._refresh_lock = asyncio.Lock()
+        self._generation_lease_token: object | None = None
+
+    async def _acquire_generation_lease(self) -> tuple[object, str]:
+        """Hold the exact transport generation against suspend/refresh/close."""
+
+        await self._refresh_lock.acquire()
+        try:
+            provider = assert_factory_owned_diagnostic_provider(self)
+            generation = provider._transport.protective_quote_generation
+            if self._generation_lease_token is not None:
+                raise BrokerEvidenceError("diagnostic provider generation is already leased")
+            token = object()
+            self._generation_lease_token = token
+            return token, generation
+        except BaseException:
+            self._refresh_lock.release()
+            raise
+
+    def _release_generation_lease(self, token: object, generation: str) -> None:
+        """Release only the exact lease after proving its generation stayed fixed."""
+
+        if token is not self._generation_lease_token or not self._refresh_lock.locked():
+            raise BrokerEvidenceError("diagnostic provider generation lease is invalid")
+        try:
+            provider = assert_factory_owned_diagnostic_provider(self)
+            if provider._transport.protective_quote_generation != generation:
+                raise BrokerEvidenceError("diagnostic provider changed during generation lease")
+        finally:
+            self._generation_lease_token = None
+            self._refresh_lock.release()
 
     async def get_broker_snapshot(
         self, expected_account: str, *, max_age_seconds: float

--- a/robo_trader/reconciliation/ibkr_adapter.py
+++ b/robo_trader/reconciliation/ibkr_adapter.py
@@ -1805,7 +1805,7 @@ async def await_cleanup_required(cleanup: Awaitable[None]) -> bool:
 async def build_diagnostic_provider(
     runtime: RuntimeSafetyContext,
     *,
-    transport_factory=SubprocessIBKRClient,
+    transport_factory=None,
 ) -> IBKRDiagnosticSnapshotProvider:
     """Start a dedicated paper/read-only transport or fail closed and reap it."""
     connection = runtime.diagnostic_connection
@@ -1819,7 +1819,12 @@ async def build_diagnostic_provider(
         raise BrokerEvidenceError("diagnostic broker runtime fingerprint is unavailable")
     if type(account_scope) is not str or not account_scope:
         raise BrokerEvidenceError("diagnostic broker account scope is unavailable")
-    transport = transport_factory()
+    if transport_factory is None:
+        transport = SubprocessIBKRClient(
+            worker_runtime_environment=runtime_contract.environment,
+        )
+    else:
+        transport = transport_factory()
     try:
         await transport.start()
         connected = await transport.connect(

--- a/robo_trader/reconciliation/persistence.py
+++ b/robo_trader/reconciliation/persistence.py
@@ -184,9 +184,19 @@ class ReconciliationPersistence:
                 "runtime evidence belongs to a different database identity"
             )
 
-    async def initialize(self) -> None:
-        """Register and validate this component without touching legacy rows."""
+    async def migrate_for_operator(self, *, operator_confirmed: bool) -> None:
+        """Apply reconciliation schema migrations after explicit operator approval.
 
+        Runtime startup must never call this method.  Keeping the mutating path
+        separately named and confirmation-gated makes schema installation an
+        operator-backed deployment action rather than an implicit side effect of
+        collecting broker evidence.
+        """
+
+        if operator_confirmed is not True:
+            raise ReconciliationPersistenceError(
+                "reconciliation migration requires explicit operator confirmation"
+            )
         connection, binding = await self._connect(initialize=True)
         try:
             await connection.execute("BEGIN IMMEDIATE")
@@ -201,6 +211,33 @@ class ReconciliationPersistence:
         finally:
             await connection.close()
             binding.close()
+
+    async def initialize(self) -> None:
+        """Assert the installed schema read-only; never create or repair it."""
+
+        binding: SQLitePathBinding | None = None
+        connection: aiosqlite.Connection | None = None
+        try:
+            binding = SQLitePathBinding.open_readonly(self._database_path)
+            uri = f"file:{binding.path.as_posix()}?mode=ro"
+            connection = await aiosqlite.connect(uri, uri=True, isolation_level=None)
+            binding = binding.bind_sqlite_connection(await self._descriptor_identity(connection))
+            await connection.execute("PRAGMA query_only = ON")
+            await connection.execute("PRAGMA foreign_keys = ON")
+            await assert_reconciliation_schema(connection)
+            await self._assert_binding(connection, binding)
+            binding.assert_path_identity()
+        except (ReconciliationPersistenceError, RuntimeError):
+            raise
+        except Exception as exc:
+            raise ReconciliationPersistenceError(
+                "reconciliation schema is unavailable or malformed"
+            ) from exc
+        finally:
+            if connection is not None:
+                await connection.close()
+            if binding is not None:
+                binding.close()
 
     async def append_reconciliation(
         self,

--- a/robo_trader/reconciliation/runtime_integration.py
+++ b/robo_trader/reconciliation/runtime_integration.py
@@ -201,7 +201,6 @@ async def assert_runtime_bootstrap_ready(runtime_context: RuntimeSafetyContext) 
             raise RuntimeReconciliationIntegrationError("runtime portfolio state is unavailable")
         bootstrap_ids: dict[str, str] = {}
         expected_receipts: dict[str, dict[str, list[str]]] = {}
-        expected_positions: set[tuple[str, str]] = set()
         for row in portfolio_rows:
             portfolio_id, bootstrap_id = row[0], row[1]
             if (
@@ -234,9 +233,6 @@ async def assert_runtime_bootstrap_ready(runtime_context: RuntimeSafetyContext) 
                 raise RuntimeReconciliationIntegrationError(
                     "exact bootstrap candidate lineage is mismatched"
                 )
-            expected_positions.update(
-                (portfolio_id, position.symbol) for position in candidate.positions
-            )
             expected_receipts[bootstrap_id] = {
                 "broker_snapshot": [str(row[10])],
                 "reconciliation_report": [str(row[11])],
@@ -255,7 +251,6 @@ async def assert_runtime_bootstrap_ready(runtime_context: RuntimeSafetyContext) 
             ORDER BY p.portfolio_id, p.symbol
             """)
         position_rows = await cursor.fetchall()
-        observed_positions: set[tuple[str, str]] = set()
         for row in position_rows:
             if (
                 row[0] not in bootstrap_ids
@@ -268,11 +263,6 @@ async def assert_runtime_bootstrap_ready(runtime_context: RuntimeSafetyContext) 
                 raise RuntimeReconciliationIntegrationError(
                     "exact position bootstrap state is missing or partial"
                 )
-            observed_positions.add((row[0], row[1]))
-        if observed_positions != expected_positions:
-            raise RuntimeReconciliationIntegrationError(
-                "exact position bootstrap coverage is missing or mismatched"
-            )
 
         cursor = await connection.execute("""
             SELECT bootstrap_id, artifact_kind, artifact_sha256,

--- a/robo_trader/reconciliation/runtime_integration.py
+++ b/robo_trader/reconciliation/runtime_integration.py
@@ -1,0 +1,594 @@
+"""Production-only runtime integration for signed broker reconciliation.
+
+This module owns the diagnostic read-only provider, produces one signed
+broker/reconciliation/mark bundle per trigger, binds it to the exact SQLite
+inode, and exposes only sanitized operational status.  It never repairs local
+or broker state and never grants order authority.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+import os
+import secrets
+import stat
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Mapping
+
+import aiosqlite
+
+from robo_trader.bootstrap_evidence_receivers import (
+    BootstrapEvidenceReceiverSet,
+    SealedBootstrapEvidenceArtifact,
+    create_bootstrap_evidence_receivers,
+)
+from robo_trader.bootstrap_mark_producer import (
+    collect_and_produce_bootstrap_protective_mark,
+    create_runtime_bound_mark_only_producer,
+)
+from robo_trader.config import RuntimeContract
+from robo_trader.database_migrations import assert_exact_state_schema
+from robo_trader.financial_state_bootstrap import load_exact_state_bootstrap_evidence
+from robo_trader.safety.sqlite_identity import SQLitePathBinding
+
+from .bootstrap_producer import produce_bootstrap_reconciliation
+from .ibkr_adapter import (
+    IBKRDiagnosticSnapshotProvider,
+    assert_factory_owned_protective_quote_source,
+    await_cleanup_required,
+    build_diagnostic_provider,
+)
+from .identity import RuntimeSafetyContext, assert_validated_runtime_safety_context
+from .persistence import ReconciliationPersistence
+from .runtime_evidence import (
+    VerifiedRuntimeReconciliationEvidence,
+    bind_verified_runtime_reconciliation_evidence,
+)
+from .service import ReconciliationService, ReconciliationServiceOutcome
+
+_CAPABILITY_DIRECTORY_ENV = "RT_RECONCILIATION_SIGNING_CAPABILITY_DIR"
+_EVIDENCE_ROOT_ENV = "RT_RECONCILIATION_EVIDENCE_ROOT"
+_STATUS_PATH_ENV = "RT_RECONCILIATION_STATUS_PATH"
+_STATUS_FILENAME = "reconciliation_runtime_status.json"
+
+
+class RuntimeReconciliationIntegrationError(RuntimeError):
+    """Runtime reconciliation cannot establish a safe entry boundary."""
+
+
+def _absolute_lexical_path(value: object, label: str) -> Path:
+    if not isinstance(value, str) or not value.strip():
+        raise RuntimeReconciliationIntegrationError(f"{label} is not configured")
+    path = Path(value)
+    if not path.is_absolute() or str(path) != value:
+        raise RuntimeReconciliationIntegrationError(f"{label} must be an absolute lexical path")
+    return path
+
+
+def _require_private_directory(path: Path, label: str) -> None:
+    try:
+        metadata = os.lstat(path)
+    except OSError as exc:
+        raise RuntimeReconciliationIntegrationError(f"{label} is unavailable") from exc
+    if (
+        stat.S_ISLNK(metadata.st_mode)
+        or not stat.S_ISDIR(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(metadata.st_mode) != 0o700
+    ):
+        raise RuntimeReconciliationIntegrationError(
+            f"{label} must be an owner-only non-symlink directory"
+        )
+
+
+def runtime_reconciliation_status_path(
+    runtime_contract: RuntimeContract,
+    environment: Mapping[str, str],
+) -> Path:
+    configured = environment.get(_STATUS_PATH_ENV, "").strip()
+    if configured:
+        return _absolute_lexical_path(configured, "reconciliation status path")
+    return Path(runtime_contract.database_path).parent / _STATUS_FILENAME
+
+
+async def assert_runtime_bootstrap_ready(runtime_context: RuntimeSafetyContext) -> None:
+    """Read-only proof that every portfolio has complete exact bootstrap lineage."""
+
+    context = assert_validated_runtime_safety_context(runtime_context)
+    contract = context.runtime_contract
+    if type(contract) is not RuntimeContract:
+        raise RuntimeReconciliationIntegrationError("exact runtime contract is required")
+    database_path = Path(contract.database_path)
+    binding: SQLitePathBinding | None = None
+    connection: aiosqlite.Connection | None = None
+    try:
+        binding = SQLitePathBinding.open_readonly(database_path)
+        uri = f"file:{binding.path.as_posix()}?mode=ro"
+        connection = await aiosqlite.connect(uri, uri=True, isolation_level=None)
+        await connection.execute("PRAGMA query_only = ON")
+        await connection.execute("PRAGMA foreign_keys = ON")
+        await assert_exact_state_schema(connection)
+        binding.assert_path_identity()
+
+        cursor = await connection.execute("""
+            SELECT p.id, b.bootstrap_id, b.execution_domain_scope, b.account_scope,
+                   b.database_path, b.database_identity, b.database_device,
+                   b.database_inode, a.origin_bootstrap_id
+            FROM portfolios AS p
+            LEFT JOIN paper_state_bootstraps AS b ON b.portfolio_id = p.id
+            LEFT JOIN paper_account_settlement_state AS a ON a.portfolio_id = p.id
+            ORDER BY p.id
+            """)
+        portfolio_rows = await cursor.fetchall()
+        if not portfolio_rows:
+            raise RuntimeReconciliationIntegrationError("runtime portfolio state is unavailable")
+        bootstrap_ids: dict[str, str] = {}
+        for row in portfolio_rows:
+            portfolio_id, bootstrap_id = row[0], row[1]
+            if (
+                not isinstance(portfolio_id, str)
+                or not isinstance(bootstrap_id, str)
+                or row[2] != contract.safety_execution_domain_scope
+                or row[3] != contract.safety_account_scope
+                or row[4] != contract.database_path
+                or row[5] != contract.database_identity
+                or (row[6], row[7]) != (binding.device, binding.inode)
+                or row[8] != bootstrap_id
+            ):
+                raise RuntimeReconciliationIntegrationError(
+                    "exact bootstrap lineage is missing or mismatched"
+                )
+            bootstrap_ids[portfolio_id] = bootstrap_id
+
+        cursor = await connection.execute("""
+            SELECT p.portfolio_id, p.symbol, s.cost_basis_text, s.mark_price_text,
+                   s.origin_bootstrap_id
+            FROM positions AS p
+            LEFT JOIN paper_position_settlement_state AS s
+              ON s.portfolio_id = p.portfolio_id AND s.symbol = p.symbol
+            WHERE p.quantity <> 0
+            ORDER BY p.portfolio_id, p.symbol
+            """)
+        position_rows = await cursor.fetchall()
+        for row in position_rows:
+            if (
+                row[0] not in bootstrap_ids
+                or not isinstance(row[2], str)
+                or not row[2]
+                or not isinstance(row[3], str)
+                or not row[3]
+                or row[4] != bootstrap_ids[row[0]]
+            ):
+                raise RuntimeReconciliationIntegrationError(
+                    "exact position bootstrap state is missing or partial"
+                )
+
+        cursor = await connection.execute("""
+            SELECT b.bootstrap_id,
+                   SUM(CASE WHEN c.artifact_kind = 'broker_snapshot' THEN 1 ELSE 0 END),
+                   SUM(CASE WHEN c.artifact_kind = 'reconciliation_report' THEN 1 ELSE 0 END)
+            FROM paper_state_bootstraps AS b
+            LEFT JOIN exact_bootstrap_evidence_consumptions AS c
+              ON c.bootstrap_id = b.bootstrap_id
+            GROUP BY b.bootstrap_id
+            """)
+        receipt_rows = await cursor.fetchall()
+        if len(receipt_rows) != len(bootstrap_ids) or any(
+            row[1] != 1 or row[2] != 1 for row in receipt_rows
+        ):
+            raise RuntimeReconciliationIntegrationError(
+                "exact bootstrap authentication receipts are incomplete"
+            )
+        binding.assert_path_identity()
+    except RuntimeReconciliationIntegrationError:
+        raise
+    except Exception as exc:
+        raise RuntimeReconciliationIntegrationError(
+            "runtime database or exact bootstrap schema is unavailable"
+        ) from exc
+    finally:
+        if connection is not None:
+            await connection.close()
+        if binding is not None:
+            binding.close()
+
+
+class ProductionRuntimeEvidenceSource:
+    """Collect one fresh, signed, broker-bound generation per service trigger."""
+
+    def __init__(
+        self,
+        *,
+        runtime_context: RuntimeSafetyContext,
+        provider: IBKRDiagnosticSnapshotProvider,
+        capability_directory: Path,
+        evidence_root: Path,
+    ) -> None:
+        self._runtime_context = assert_validated_runtime_safety_context(runtime_context)
+        self._provider = provider
+        self._capability_directory = capability_directory
+        self._evidence_root = evidence_root
+        self._closed = False
+
+    async def collect_verified_evidence(
+        self,
+        *,
+        max_age_seconds: float,
+    ) -> VerifiedRuntimeReconciliationEvidence:
+        if self._closed:
+            raise RuntimeReconciliationIntegrationError("reconciliation evidence source is closed")
+        if (
+            not isinstance(max_age_seconds, (int, float))
+            or isinstance(max_age_seconds, bool)
+            or not math.isfinite(float(max_age_seconds))
+            or float(max_age_seconds) <= 0
+        ):
+            raise RuntimeReconciliationIntegrationError("evidence freshness bound is invalid")
+        context = assert_validated_runtime_safety_context(self._runtime_context)
+        runtime = context.runtime_contract
+        if type(runtime) is not RuntimeContract:
+            raise RuntimeReconciliationIntegrationError("exact runtime contract is required")
+        _require_private_directory(self._capability_directory, "signing capability directory")
+        _require_private_directory(self._evidence_root, "reconciliation evidence root")
+        output = self._evidence_root / ("runtime-reconciliation-" + secrets.token_hex(24))
+        receivers: BootstrapEvidenceReceiverSet | None = None
+        published = False
+        try:
+            receivers = create_bootstrap_evidence_receivers(
+                runtime_contract=runtime,
+                capability_directory=self._capability_directory,
+                output_directory=output,
+            )
+            broker_envelope = await self._provider.produce_normalized_snapshot(
+                receiver=receivers.broker_snapshot,
+                max_age_seconds=float(max_age_seconds),
+            )
+            broker_artifact = receivers.broker_artifact
+            delivery = produce_bootstrap_reconciliation(
+                broker_envelope,
+                runtime,
+                receivers.reconciliation_report,
+            )
+            reconciliation_artifact = delivery.receiver_result
+            if type(reconciliation_artifact) is not SealedBootstrapEvidenceArtifact:
+                raise RuntimeReconciliationIntegrationError(
+                    "reconciliation receiver returned invalid evidence"
+                )
+            quote_source = self._provider.issue_protective_quote_source(runtime_contract=runtime)
+            quote_identity = assert_factory_owned_protective_quote_source(
+                quote_source,
+                runtime_contract=runtime,
+            )
+            mark_artifacts: list[SealedBootstrapEvidenceArtifact] = []
+            for portfolio_id, symbol in delivery.local_position_identities:
+                discovery = await quote_source.get_protective_quotes(
+                    (symbol,),
+                    active_symbols=(symbol,),
+                )
+                if type(discovery) is not tuple or len(discovery) != 1:
+                    raise RuntimeReconciliationIntegrationError(
+                        "protective quote evidence is incomplete"
+                    )
+                quote = discovery[0]
+                if (
+                    quote.symbol != symbol
+                    or quote.transport_generation != quote_identity.transport_generation
+                ):
+                    raise RuntimeReconciliationIntegrationError(
+                        "protective quote generation changed during collection"
+                    )
+                producer = create_runtime_bound_mark_only_producer(
+                    runtime,
+                    portfolio_id=portfolio_id,
+                )
+                mark = await collect_and_produce_bootstrap_protective_mark(
+                    quote_source,
+                    producer,
+                    runtime,
+                    receivers.protective_mark,
+                    expected_portfolio_id=portfolio_id,
+                    expected_symbol=symbol,
+                    expected_con_id=quote.con_id,
+                    expected_transport_generation=quote_identity.transport_generation,
+                )
+                if type(mark) is not SealedBootstrapEvidenceArtifact:
+                    raise RuntimeReconciliationIntegrationError(
+                        "protective mark receiver returned invalid evidence"
+                    )
+                mark_artifacts.append(mark)
+            expected_marks = set(delivery.local_position_identities)
+            receivers.assert_complete(expected_marks)
+            receivers.publish_complete_bundle(expected_marks)
+            published = True
+            broker_path = receivers.published_artifact_path(broker_artifact)
+            reconciliation_path = receivers.published_artifact_path(reconciliation_artifact)
+            mark_paths = tuple(receivers.published_artifact_path(mark) for mark in mark_artifacts)
+            exact_state = load_exact_state_bootstrap_evidence(
+                reconciliation_path=reconciliation_path,
+                broker_snapshot_path=broker_path,
+                protective_mark_paths=mark_paths,
+                expected_runtime_contract=runtime,
+            )
+            return bind_verified_runtime_reconciliation_evidence(
+                delivery.verified_broker_evidence,
+                exact_state,
+                context,
+                receivers.protective_mark,
+            )
+        except BaseException:
+            if receivers is not None and not published:
+                receivers.discard_unpublished_bundle()
+            raise
+        finally:
+            if receivers is not None:
+                receivers.close()
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        cancellation_received = await await_cleanup_required(self._provider.close())
+        if cancellation_received:
+            raise asyncio.CancelledError
+
+
+class RuntimeReconciliationController:
+    """Fail-closed service facade plus sanitized cross-process status."""
+
+    def __init__(self, service: ReconciliationService, *, status_path: Path) -> None:
+        self._service = service
+        self._status_path = status_path
+        self._status_available = True
+
+    @property
+    def service(self) -> ReconciliationService:
+        return self._service
+
+    def entry_eligible(self) -> bool:
+        eligible = self._status_available and self._service.entry_eligible()
+        if not eligible:
+            self._publish_quarantine_best_effort()
+        return eligible
+
+    async def reconcile_startup(self) -> ReconciliationServiceOutcome:
+        return await self._run(self._service.reconcile_startup)
+
+    async def reconcile_reconnect(self) -> ReconciliationServiceOutcome:
+        return await self._run(self._service.reconcile_reconnect)
+
+    async def reconcile_periodic_if_due(self) -> ReconciliationServiceOutcome | None:
+        try:
+            outcome = await self._service.reconcile_periodic_if_due()
+            if outcome is not None:
+                self._publish_outcome(outcome)
+            return outcome
+        except BaseException:
+            self._publish_quarantine_best_effort()
+            raise
+
+    async def _run(self, operation) -> ReconciliationServiceOutcome:
+        try:
+            outcome = await operation()
+            self._publish_outcome(outcome)
+            return outcome
+        except BaseException:
+            self._publish_quarantine_best_effort()
+            raise
+
+    async def close(self) -> None:
+        try:
+            await self._service.close()
+        finally:
+            self._publish_quarantine_best_effort(state="closed")
+
+    def _publish_outcome(self, outcome: ReconciliationServiceOutcome) -> None:
+        payload = {
+            "schema_version": 1,
+            "state": outcome.state.value,
+            "trigger": outcome.trigger.value,
+            "completed_at": outcome.completed_at.isoformat(),
+            "eligible_until": outcome.eligible_until.isoformat(),
+            "entry_eligible": bool(outcome.entry_eligible),
+            "quarantined": not bool(outcome.entry_eligible),
+            "run_id": outcome.persisted.run_id,
+            "snapshot_id": outcome.persisted.snapshot_id,
+        }
+        try:
+            _write_status(self._status_path, payload)
+        except Exception as exc:
+            self._status_available = False
+            raise RuntimeReconciliationIntegrationError(
+                "reconciliation status publication failed closed"
+            ) from exc
+        self._status_available = True
+
+    def _publish_quarantine_best_effort(self, *, state: str = "quarantined") -> None:
+        self._status_available = False
+        payload = {
+            "schema_version": 1,
+            "state": state,
+            "trigger": None,
+            "completed_at": None,
+            "eligible_until": None,
+            "entry_eligible": False,
+            "quarantined": True,
+            "run_id": None,
+            "snapshot_id": None,
+        }
+        try:
+            _write_status(self._status_path, payload)
+        except Exception:
+            pass
+
+
+def _write_status(path: Path, payload: dict[str, object]) -> None:
+    parent = path.parent
+    parent_descriptor = os.open(
+        parent,
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0),
+    )
+    metadata = os.fstat(parent_descriptor)
+    if not stat.S_ISDIR(metadata.st_mode) or metadata.st_uid != os.geteuid():
+        os.close(parent_descriptor)
+        raise RuntimeReconciliationIntegrationError("status directory is unavailable")
+    temporary_name = f".{path.name}.stage-{secrets.token_hex(16)}"
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("ascii")
+    descriptor = -1
+    try:
+        descriptor = os.open(
+            temporary_name,
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+            dir_fd=parent_descriptor,
+        )
+        offset = 0
+        while offset < len(encoded):
+            written = os.write(descriptor, encoded[offset:])
+            if written <= 0:
+                raise RuntimeReconciliationIntegrationError(
+                    "reconciliation status write did not complete"
+                )
+            offset += written
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = -1
+        os.replace(
+            temporary_name,
+            path.name,
+            src_dir_fd=parent_descriptor,
+            dst_dir_fd=parent_descriptor,
+        )
+        os.fsync(parent_descriptor)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        try:
+            os.unlink(temporary_name, dir_fd=parent_descriptor)
+        except FileNotFoundError:
+            pass
+        finally:
+            os.close(parent_descriptor)
+
+
+def read_runtime_reconciliation_status(path: Path) -> dict[str, object]:
+    """Read only the fixed, sanitized status surface; uncertainty quarantines."""
+
+    unavailable = {
+        "state": "unavailable",
+        "trigger": None,
+        "completed_at": None,
+        "eligible_until": None,
+        "entry_eligible": False,
+        "quarantined": True,
+        "age_seconds": None,
+    }
+    descriptor = -1
+    try:
+        descriptor = os.open(
+            path,
+            os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+        )
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+            or metadata.st_size > 16 * 1024
+        ):
+            return unavailable
+        encoded = os.read(descriptor, 16 * 1024 + 1)
+        if len(encoded) != metadata.st_size:
+            return unavailable
+        payload = json.loads(encoded.decode("ascii"))
+        allowed = {
+            "schema_version",
+            "state",
+            "trigger",
+            "completed_at",
+            "eligible_until",
+            "entry_eligible",
+            "quarantined",
+            "run_id",
+            "snapshot_id",
+        }
+        if type(payload) is not dict or set(payload) != allowed:
+            return unavailable
+        completed_at = payload["completed_at"]
+        age_seconds = None
+        if isinstance(completed_at, str):
+            observed = datetime.fromisoformat(completed_at.replace("Z", "+00:00"))
+            if observed.tzinfo is None:
+                return unavailable
+            age_seconds = max(
+                0.0,
+                (datetime.now(timezone.utc) - observed.astimezone(timezone.utc)).total_seconds(),
+            )
+        return {
+            "state": payload["state"],
+            "trigger": payload["trigger"],
+            "completed_at": completed_at,
+            "eligible_until": payload["eligible_until"],
+            "entry_eligible": payload["entry_eligible"] is True,
+            "quarantined": payload["quarantined"] is True,
+            "age_seconds": None if age_seconds is None else round(age_seconds, 3),
+        }
+    except Exception:
+        return unavailable
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+async def build_runtime_reconciliation_controller(
+    runtime_context: RuntimeSafetyContext,
+) -> tuple[RuntimeReconciliationController, IBKRDiagnosticSnapshotProvider]:
+    """Build the production source only after exact-state readiness is proven."""
+
+    context = assert_validated_runtime_safety_context(runtime_context)
+    runtime = context.runtime_contract
+    if type(runtime) is not RuntimeContract:
+        raise RuntimeReconciliationIntegrationError("exact runtime contract is required")
+    environment = os.environ
+    capability_directory = _absolute_lexical_path(
+        environment.get(_CAPABILITY_DIRECTORY_ENV),
+        "signing capability directory",
+    )
+    evidence_root = _absolute_lexical_path(
+        environment.get(_EVIDENCE_ROOT_ENV),
+        "reconciliation evidence root",
+    )
+    _require_private_directory(capability_directory, "signing capability directory")
+    _require_private_directory(evidence_root, "reconciliation evidence root")
+    await assert_runtime_bootstrap_ready(context)
+    provider = await build_diagnostic_provider(context)
+    try:
+        source = ProductionRuntimeEvidenceSource(
+            runtime_context=context,
+            provider=provider,
+            capability_directory=capability_directory,
+            evidence_root=evidence_root,
+        )
+        service = ReconciliationService(
+            evidence_source=source,
+            persistence=ReconciliationPersistence(Path(runtime.database_path)),
+            expected_account_scope=runtime.safety_account_scope,
+        )
+        controller = RuntimeReconciliationController(
+            service,
+            status_path=runtime_reconciliation_status_path(runtime, environment),
+        )
+        return controller, provider
+    except BaseException:
+        cleanup_cancelled = await await_cleanup_required(provider.close())
+        if cleanup_cancelled:
+            raise asyncio.CancelledError
+        raise

--- a/robo_trader/reconciliation/runtime_integration.py
+++ b/robo_trader/reconciliation/runtime_integration.py
@@ -660,7 +660,10 @@ class ProductionRuntimeEvidenceSource:
             receivers.assert_complete(expected_marks)
             staged_bytes = receivers.unpublished_bundle_size_bytes(expected_marks)
             self._assert_retention_capacity(staged_bytes=staged_bytes)
-            receivers.publish_complete_bundle(expected_marks)
+            receivers.publish_complete_bundle(
+                expected_marks,
+                expected_bundle_size_bytes=staged_bytes,
+            )
             published = True
             assert self._published_bundle_count is not None
             assert self._published_evidence_bytes is not None
@@ -682,6 +685,8 @@ class ProductionRuntimeEvidenceSource:
                 receivers.protective_mark,
             )
         except BaseException:
+            self._published_bundle_count = None
+            self._published_evidence_bytes = None
             if receivers is not None and not published:
                 receivers.discard_unpublished_bundle()
             raise
@@ -948,8 +953,8 @@ def _write_status(
             # is authenticated. A crash can expose either complete version,
             # never a partial status, and a raced unrelated target can be put
             # back rather than overwritten.
-            _exchange_status_entries(parent_descriptor, temporary_name, path.name)
             preserve_temporary = True
+            _exchange_status_entries(parent_descriptor, temporary_name, path.name)
             displaced = os.stat(
                 temporary_name,
                 dir_fd=parent_descriptor,

--- a/robo_trader/reconciliation/runtime_integration.py
+++ b/robo_trader/reconciliation/runtime_integration.py
@@ -151,8 +151,26 @@ def _runtime_staging_bundle_name(name: str) -> bool:
     )
 
 
-def _published_evidence_usage(evidence_root: Path) -> tuple[int, int]:
+def _published_evidence_usage(
+    evidence_root: Path,
+    *,
+    excluded_staging_binding: tuple[str, int, int] | None = None,
+) -> tuple[int, int]:
     """Measure every runtime-owned bundle without mutating audit evidence."""
+
+    if excluded_staging_binding is not None and (
+        type(excluded_staging_binding) is not tuple
+        or len(excluded_staging_binding) != 3
+        or type(excluded_staging_binding[0]) is not str
+        or not _runtime_staging_bundle_name(excluded_staging_binding[0])
+        or type(excluded_staging_binding[1]) is not int
+        or excluded_staging_binding[1] < 0
+        or type(excluded_staging_binding[2]) is not int
+        or excluded_staging_binding[2] <= 0
+    ):
+        raise RuntimeReconciliationIntegrationError(
+            "current reconciliation staging binding is malformed"
+        )
 
     root_descriptor = os.open(
         evidence_root,
@@ -189,6 +207,15 @@ def _published_evidence_usage(evidence_root: Path) -> tuple[int, int]:
                 raise RuntimeReconciliationIntegrationError(
                     "published reconciliation evidence bundle is unsafe"
                 )
+            if excluded_staging_binding is not None and name == excluded_staging_binding[0]:
+                if (bundle_metadata.st_dev, bundle_metadata.st_ino) != (
+                    excluded_staging_binding[1],
+                    excluded_staging_binding[2],
+                ):
+                    raise RuntimeReconciliationIntegrationError(
+                        "current reconciliation staging bundle changed identity"
+                    )
+                continue
             bundle_descriptor = os.open(
                 name,
                 os.O_RDONLY
@@ -549,12 +576,21 @@ class ProductionRuntimeEvidenceSource:
         self._published_evidence_bytes: int | None = None
         self._closed = False
 
-    def _assert_retention_capacity(self, *, staged_bytes: int = 0) -> None:
-        if self._published_bundle_count is None or self._published_evidence_bytes is None:
-            (
-                self._published_bundle_count,
-                self._published_evidence_bytes,
-            ) = _published_evidence_usage(self._evidence_root)
+    def _assert_retention_capacity(
+        self,
+        *,
+        staged_bytes: int = 0,
+        excluded_staging_binding: tuple[str, int, int] | None = None,
+    ) -> None:
+        # Admission is always based on a fresh held-directory scan. Cached
+        # counters cannot detect bundles added by another same-UID process.
+        (
+            self._published_bundle_count,
+            self._published_evidence_bytes,
+        ) = _published_evidence_usage(
+            self._evidence_root,
+            excluded_staging_binding=excluded_staging_binding,
+        )
         if (
             self._published_bundle_count >= self._max_published_bundles
             or self._published_evidence_bytes >= self._max_published_bytes
@@ -659,7 +695,11 @@ class ProductionRuntimeEvidenceSource:
             expected_marks = set(delivery.local_position_identities)
             receivers.assert_complete(expected_marks)
             staged_bytes = receivers.unpublished_bundle_size_bytes(expected_marks)
-            self._assert_retention_capacity(staged_bytes=staged_bytes)
+            staging_binding = receivers.unpublished_bundle_directory_binding()
+            self._assert_retention_capacity(
+                staged_bytes=staged_bytes,
+                excluded_staging_binding=staging_binding,
+            )
             receivers.publish_complete_bundle(
                 expected_marks,
                 expected_bundle_size_bytes=staged_bytes,

--- a/robo_trader/reconciliation/runtime_integration.py
+++ b/robo_trader/reconciliation/runtime_integration.py
@@ -9,6 +9,7 @@ or broker state and never grants order authority.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import math
 import os
@@ -31,7 +32,11 @@ from robo_trader.bootstrap_mark_producer import (
 )
 from robo_trader.config import RuntimeContract
 from robo_trader.database_migrations import assert_exact_state_schema
-from robo_trader.financial_state_bootstrap import load_exact_state_bootstrap_evidence
+from robo_trader.financial_state_bootstrap import (
+    ExactStateBootstrapCandidate,
+    load_exact_state_bootstrap_evidence,
+)
+from robo_trader.reconciliation_migrations import assert_reconciliation_schema
 from robo_trader.safety.sqlite_identity import SQLitePathBinding, lexical_path_preserving_leaf
 
 from .bootstrap_producer import produce_bootstrap_reconciliation
@@ -53,6 +58,18 @@ _CAPABILITY_DIRECTORY_ENV = "RT_RECONCILIATION_SIGNING_CAPABILITY_DIR"
 _EVIDENCE_ROOT_ENV = "RT_RECONCILIATION_EVIDENCE_ROOT"
 _STATUS_PATH_ENV = "RT_RECONCILIATION_STATUS_PATH"
 _STATUS_FILENAME = "reconciliation_runtime_status.json"
+_STATUS_FIELDS = {
+    "schema_version",
+    "owner_binding",
+    "state",
+    "trigger",
+    "completed_at",
+    "eligible_until",
+    "entry_eligible",
+    "quarantined",
+    "run_id",
+    "snapshot_id",
+}
 
 
 class RuntimeReconciliationIntegrationError(RuntimeError):
@@ -132,6 +149,22 @@ def _assert_status_path_is_unprotected(
         )
 
 
+def _status_owner_binding(runtime: RuntimeContract, status_path: Path) -> str:
+    payload = (
+        "robotrader-reconciliation-status-v1\0" + runtime.fingerprint + "\0" + str(status_path)
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _valid_status_owner_binding(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and value == value.lower()
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
 async def assert_runtime_bootstrap_ready(runtime_context: RuntimeSafetyContext) -> None:
     """Read-only proof that every portfolio has complete exact bootstrap lineage."""
 
@@ -149,12 +182,15 @@ async def assert_runtime_bootstrap_ready(runtime_context: RuntimeSafetyContext) 
         await connection.execute("PRAGMA query_only = ON")
         await connection.execute("PRAGMA foreign_keys = ON")
         await assert_exact_state_schema(connection)
+        await assert_reconciliation_schema(connection)
         binding.assert_path_identity()
 
         cursor = await connection.execute("""
             SELECT p.id, b.bootstrap_id, b.execution_domain_scope, b.account_scope,
                    b.database_path, b.database_identity, b.database_device,
-                   b.database_inode, a.origin_bootstrap_id
+                   b.database_inode, a.origin_bootstrap_id,
+                   b.candidate_payload_json, b.broker_snapshot_hash,
+                   b.reconciliation_report_hash
             FROM portfolios AS p
             LEFT JOIN paper_state_bootstraps AS b ON b.portfolio_id = p.id
             LEFT JOIN paper_account_settlement_state AS a ON a.portfolio_id = p.id
@@ -164,6 +200,8 @@ async def assert_runtime_bootstrap_ready(runtime_context: RuntimeSafetyContext) 
         if not portfolio_rows:
             raise RuntimeReconciliationIntegrationError("runtime portfolio state is unavailable")
         bootstrap_ids: dict[str, str] = {}
+        expected_receipts: dict[str, dict[str, list[str]]] = {}
+        expected_positions: set[tuple[str, str]] = set()
         for row in portfolio_rows:
             portfolio_id, bootstrap_id = row[0], row[1]
             if (
@@ -180,6 +218,32 @@ async def assert_runtime_bootstrap_ready(runtime_context: RuntimeSafetyContext) 
                     "exact bootstrap lineage is missing or mismatched"
                 )
             bootstrap_ids[portfolio_id] = bootstrap_id
+            try:
+                candidate_raw = json.loads(row[9])
+                candidate = ExactStateBootstrapCandidate.from_mapping(candidate_raw)
+            except Exception as exc:
+                raise RuntimeReconciliationIntegrationError(
+                    "exact bootstrap candidate is missing or malformed"
+                ) from exc
+            if (
+                candidate.bootstrap_id != bootstrap_id
+                or candidate.portfolio_id != portfolio_id
+                or candidate.database_path != contract.database_path
+                or candidate.database_identity != contract.database_identity
+            ):
+                raise RuntimeReconciliationIntegrationError(
+                    "exact bootstrap candidate lineage is mismatched"
+                )
+            expected_positions.update(
+                (portfolio_id, position.symbol) for position in candidate.positions
+            )
+            expected_receipts[bootstrap_id] = {
+                "broker_snapshot": [str(row[10])],
+                "reconciliation_report": [str(row[11])],
+                "protective_mark": [
+                    position.mark_evidence_fingerprint for position in candidate.positions
+                ],
+            }
 
         cursor = await connection.execute("""
             SELECT p.portfolio_id, p.symbol, s.cost_basis_text, s.mark_price_text,
@@ -191,6 +255,7 @@ async def assert_runtime_bootstrap_ready(runtime_context: RuntimeSafetyContext) 
             ORDER BY p.portfolio_id, p.symbol
             """)
         position_rows = await cursor.fetchall()
+        observed_positions: set[tuple[str, str]] = set()
         for row in position_rows:
             if (
                 row[0] not in bootstrap_ids
@@ -203,19 +268,48 @@ async def assert_runtime_bootstrap_ready(runtime_context: RuntimeSafetyContext) 
                 raise RuntimeReconciliationIntegrationError(
                     "exact position bootstrap state is missing or partial"
                 )
+            observed_positions.add((row[0], row[1]))
+        if observed_positions != expected_positions:
+            raise RuntimeReconciliationIntegrationError(
+                "exact position bootstrap coverage is missing or mismatched"
+            )
 
         cursor = await connection.execute("""
-            SELECT b.bootstrap_id,
-                   SUM(CASE WHEN c.artifact_kind = 'broker_snapshot' THEN 1 ELSE 0 END),
-                   SUM(CASE WHEN c.artifact_kind = 'reconciliation_report' THEN 1 ELSE 0 END)
-            FROM paper_state_bootstraps AS b
-            LEFT JOIN exact_bootstrap_evidence_consumptions AS c
-              ON c.bootstrap_id = b.bootstrap_id
-            GROUP BY b.bootstrap_id
+            SELECT bootstrap_id, artifact_kind, artifact_sha256,
+                   runtime_fingerprint, account_scope
+            FROM exact_bootstrap_evidence_consumptions
+            ORDER BY bootstrap_id, artifact_kind, receipt_id
             """)
         receipt_rows = await cursor.fetchall()
-        if len(receipt_rows) != len(bootstrap_ids) or any(
-            row[1] != 1 or row[2] != 1 for row in receipt_rows
+        observed_receipts: dict[str, dict[str, list[str]]] = {
+            bootstrap_id: {
+                "broker_snapshot": [],
+                "reconciliation_report": [],
+                "protective_mark": [],
+            }
+            for bootstrap_id in bootstrap_ids.values()
+        }
+        for (
+            bootstrap_id,
+            artifact_kind,
+            artifact_hash,
+            runtime_fingerprint,
+            account_scope,
+        ) in receipt_rows:
+            if (
+                bootstrap_id not in observed_receipts
+                or artifact_kind not in observed_receipts[bootstrap_id]
+                or runtime_fingerprint != contract.fingerprint
+                or account_scope != contract.safety_account_scope
+            ):
+                raise RuntimeReconciliationIntegrationError(
+                    "exact bootstrap authentication receipt lineage is mismatched"
+                )
+            observed_receipts[bootstrap_id][artifact_kind].append(artifact_hash)
+        if any(
+            {kind: sorted(hashes) for kind, hashes in observed_receipts[bootstrap_id].items()}
+            != {kind: sorted(hashes) for kind, hashes in expected_receipts[bootstrap_id].items()}
+            for bootstrap_id in expected_receipts
         ):
             raise RuntimeReconciliationIntegrationError(
                 "exact bootstrap authentication receipts are incomplete"
@@ -376,9 +470,24 @@ class ProductionRuntimeEvidenceSource:
 class RuntimeReconciliationController:
     """Fail-closed service facade plus sanitized cross-process status."""
 
-    def __init__(self, service: ReconciliationService, *, status_path: Path) -> None:
+    def __init__(
+        self,
+        service: ReconciliationService,
+        *,
+        status_path: Path,
+        status_owner_binding: str | None = None,
+    ) -> None:
         self._service = service
         self._status_path = status_path
+        self._status_owner_binding = (
+            status_owner_binding
+            if status_owner_binding is not None
+            else hashlib.sha256(secrets.token_bytes(32)).hexdigest()
+        )
+        if not _valid_status_owner_binding(self._status_owner_binding):
+            raise RuntimeReconciliationIntegrationError(
+                "reconciliation status owner binding is malformed"
+            )
         self._status_available = True
 
     @property
@@ -425,6 +534,7 @@ class RuntimeReconciliationController:
     def _publish_outcome(self, outcome: ReconciliationServiceOutcome) -> None:
         payload = {
             "schema_version": 1,
+            "owner_binding": self._status_owner_binding,
             "state": outcome.state.value,
             "trigger": outcome.trigger.value,
             "completed_at": outcome.completed_at.isoformat(),
@@ -435,7 +545,11 @@ class RuntimeReconciliationController:
             "snapshot_id": outcome.persisted.snapshot_id,
         }
         try:
-            _write_status(self._status_path, payload)
+            _write_status(
+                self._status_path,
+                payload,
+                owner_binding=self._status_owner_binding,
+            )
         except Exception as exc:
             self._status_available = False
             raise RuntimeReconciliationIntegrationError(
@@ -447,6 +561,7 @@ class RuntimeReconciliationController:
         self._status_available = False
         payload = {
             "schema_version": 1,
+            "owner_binding": self._status_owner_binding,
             "state": state,
             "trigger": None,
             "completed_at": None,
@@ -457,12 +572,77 @@ class RuntimeReconciliationController:
             "snapshot_id": None,
         }
         try:
-            _write_status(self._status_path, payload)
+            _write_status(
+                self._status_path,
+                payload,
+                owner_binding=self._status_owner_binding,
+            )
         except Exception:
             pass
 
 
-def _write_status(path: Path, payload: dict[str, object]) -> None:
+def _read_owned_status_descriptor(descriptor: int, owner_binding: str) -> None:
+    metadata = os.fstat(descriptor)
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or metadata.st_nlink != 1
+        or stat.S_IMODE(metadata.st_mode) != 0o600
+        or metadata.st_size > 16 * 1024
+    ):
+        raise RuntimeReconciliationIntegrationError(
+            "existing reconciliation status artifact is not owner-bound"
+        )
+    encoded = os.read(descriptor, 16 * 1024 + 1)
+    if len(encoded) != metadata.st_size:
+        raise RuntimeReconciliationIntegrationError(
+            "existing reconciliation status artifact changed while inspected"
+        )
+    try:
+        prior = json.loads(encoded.decode("ascii"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeReconciliationIntegrationError(
+            "existing reconciliation status artifact is malformed"
+        ) from exc
+    if (
+        type(prior) is not dict
+        or set(prior) != _STATUS_FIELDS
+        or prior.get("schema_version") != 1
+        or prior.get("owner_binding") != owner_binding
+        or not isinstance(prior.get("state"), str)
+        or not prior.get("state")
+        or (prior.get("trigger") is not None and not isinstance(prior.get("trigger"), str))
+        or type(prior.get("entry_eligible")) is not bool
+        or type(prior.get("quarantined")) is not bool
+        or prior.get("entry_eligible") is prior.get("quarantined")
+        or any(
+            value is not None and not isinstance(value, str)
+            for value in (
+                prior.get("completed_at"),
+                prior.get("eligible_until"),
+                prior.get("run_id"),
+                prior.get("snapshot_id"),
+            )
+        )
+    ):
+        raise RuntimeReconciliationIntegrationError(
+            "existing reconciliation status artifact belongs to another owner"
+        )
+
+
+def _write_status(
+    path: Path,
+    payload: dict[str, object],
+    *,
+    owner_binding: str | None = None,
+) -> None:
+    binding = owner_binding if owner_binding is not None else payload.get("owner_binding")
+    if not _valid_status_owner_binding(binding):
+        raise RuntimeReconciliationIntegrationError(
+            "reconciliation status owner binding is malformed"
+        )
+    if set(payload) != _STATUS_FIELDS or payload.get("owner_binding") != binding:
+        raise RuntimeReconciliationIntegrationError("reconciliation status payload is malformed")
     parent = path.parent
     parent_descriptor = os.open(
         parent,
@@ -478,7 +658,43 @@ def _write_status(path: Path, payload: dict[str, object]) -> None:
     temporary_name = f".{path.name}.stage-{secrets.token_hex(16)}"
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("ascii")
     descriptor = -1
+    prior_descriptor = -1
+    prior_identity: tuple[int, int] | None = None
     try:
+        try:
+            prior_descriptor = os.open(
+                path.name,
+                os.O_RDWR | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+                dir_fd=parent_descriptor,
+            )
+        except FileNotFoundError:
+            pass
+        else:
+            _read_owned_status_descriptor(prior_descriptor, binding)
+            prior_metadata = os.fstat(prior_descriptor)
+            prior_identity = (prior_metadata.st_dev, prior_metadata.st_ino)
+            os.lseek(prior_descriptor, 0, os.SEEK_SET)
+            os.ftruncate(prior_descriptor, 0)
+            offset = 0
+            while offset < len(encoded):
+                written = os.write(prior_descriptor, encoded[offset:])
+                if written <= 0:
+                    raise RuntimeReconciliationIntegrationError(
+                        "reconciliation status write did not complete"
+                    )
+                offset += written
+            os.fsync(prior_descriptor)
+            current = os.stat(
+                path.name,
+                dir_fd=parent_descriptor,
+                follow_symlinks=False,
+            )
+            if (current.st_dev, current.st_ino) != prior_identity:
+                raise RuntimeReconciliationIntegrationError(
+                    "existing reconciliation status artifact changed during publication"
+                )
+            os.fsync(parent_descriptor)
+            return
         descriptor = os.open(
             temporary_name,
             os.O_WRONLY
@@ -500,16 +716,20 @@ def _write_status(path: Path, payload: dict[str, object]) -> None:
         os.fsync(descriptor)
         os.close(descriptor)
         descriptor = -1
-        os.replace(
+        os.link(
             temporary_name,
             path.name,
             src_dir_fd=parent_descriptor,
             dst_dir_fd=parent_descriptor,
+            follow_symlinks=False,
         )
+        os.unlink(temporary_name, dir_fd=parent_descriptor)
         os.fsync(parent_descriptor)
     finally:
         if descriptor >= 0:
             os.close(descriptor)
+        if prior_descriptor >= 0:
+            os.close(prior_descriptor)
         try:
             os.unlink(temporary_name, dir_fd=parent_descriptor)
         except FileNotFoundError:
@@ -547,20 +767,11 @@ def read_runtime_reconciliation_status(path: Path) -> dict[str, object]:
         if len(encoded) != metadata.st_size:
             return unavailable
         payload = json.loads(encoded.decode("ascii"))
-        allowed = {
-            "schema_version",
-            "state",
-            "trigger",
-            "completed_at",
-            "eligible_until",
-            "entry_eligible",
-            "quarantined",
-            "run_id",
-            "snapshot_id",
-        }
-        if type(payload) is not dict or set(payload) != allowed:
+        if type(payload) is not dict or set(payload) != _STATUS_FIELDS:
             return unavailable
-        if payload["schema_version"] != 1:
+        if payload["schema_version"] != 1 or not _valid_status_owner_binding(
+            payload["owner_binding"]
+        ):
             return unavailable
         entry_eligible = payload["entry_eligible"]
         quarantined = payload["quarantined"]
@@ -660,6 +871,7 @@ async def build_runtime_reconciliation_controller(
         controller = RuntimeReconciliationController(
             service,
             status_path=status_path,
+            status_owner_binding=_status_owner_binding(runtime, status_path),
         )
         return controller, provider
     except BaseException:

--- a/robo_trader/reconciliation/runtime_integration.py
+++ b/robo_trader/reconciliation/runtime_integration.py
@@ -64,7 +64,6 @@ _EVIDENCE_MAX_BYTES_ENV = "RT_RECONCILIATION_EVIDENCE_MAX_BYTES"
 _STATUS_FILENAME = "reconciliation_runtime_status.json"
 _DEFAULT_EVIDENCE_MAX_BUNDLES = 10_000
 _DEFAULT_EVIDENCE_MAX_BYTES = 2 * 1024 * 1024 * 1024
-_COMPLETION_MARKER_RESERVE_BYTES = 4 * 1024
 _RUNTIME_BUNDLE_PREFIX = "runtime-reconciliation-"
 _STATUS_FIELDS = {
     "schema_version",
@@ -558,8 +557,8 @@ class ProductionRuntimeEvidenceSource:
             ) = _published_evidence_usage(self._evidence_root)
         if (
             self._published_bundle_count >= self._max_published_bundles
-            or self._published_evidence_bytes + staged_bytes + _COMPLETION_MARKER_RESERVE_BYTES
-            > self._max_published_bytes
+            or self._published_evidence_bytes >= self._max_published_bytes
+            or self._published_evidence_bytes + staged_bytes > self._max_published_bytes
         ):
             raise RuntimeReconciliationIntegrationError(
                 "reconciliation evidence retention ceiling reached; "
@@ -666,7 +665,7 @@ class ProductionRuntimeEvidenceSource:
             assert self._published_bundle_count is not None
             assert self._published_evidence_bytes is not None
             self._published_bundle_count += 1
-            self._published_evidence_bytes += staged_bytes + _COMPLETION_MARKER_RESERVE_BYTES
+            self._published_evidence_bytes += staged_bytes
             broker_path = receivers.published_artifact_path(broker_artifact)
             reconciliation_path = receivers.published_artifact_path(reconciliation_artifact)
             mark_paths = tuple(receivers.published_artifact_path(mark) for mark in mark_artifacts)
@@ -896,6 +895,7 @@ def _write_status(
     descriptor = -1
     prior_descriptor = -1
     prior_identity: tuple[int, int] | None = None
+    preserve_temporary = False
     try:
         try:
             prior_descriptor = os.open(
@@ -949,17 +949,26 @@ def _write_status(
             # never a partial status, and a raced unrelated target can be put
             # back rather than overwritten.
             _exchange_status_entries(parent_descriptor, temporary_name, path.name)
+            preserve_temporary = True
             displaced = os.stat(
                 temporary_name,
                 dir_fd=parent_descriptor,
                 follow_symlinks=False,
             )
             if (displaced.st_dev, displaced.st_ino) != prior_identity:
-                _exchange_status_entries(parent_descriptor, temporary_name, path.name)
+                try:
+                    _exchange_status_entries(parent_descriptor, temporary_name, path.name)
+                except BaseException as rollback_error:
+                    raise RuntimeReconciliationIntegrationError(
+                        "raced reconciliation status target could not be restored; "
+                        "displaced inode was preserved"
+                    ) from rollback_error
+                preserve_temporary = False
                 raise RuntimeReconciliationIntegrationError(
                     "existing reconciliation status artifact changed during publication"
                 )
             os.unlink(temporary_name, dir_fd=parent_descriptor)
+            preserve_temporary = False
         os.fsync(parent_descriptor)
     finally:
         if descriptor >= 0:
@@ -967,7 +976,8 @@ def _write_status(
         if prior_descriptor >= 0:
             os.close(prior_descriptor)
         try:
-            os.unlink(temporary_name, dir_fd=parent_descriptor)
+            if not preserve_temporary:
+                os.unlink(temporary_name, dir_fd=parent_descriptor)
         except FileNotFoundError:
             pass
         finally:

--- a/robo_trader/reconciliation/runtime_integration.py
+++ b/robo_trader/reconciliation/runtime_integration.py
@@ -23,6 +23,11 @@ from typing import Mapping
 
 import aiosqlite
 
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - production runtime is POSIX
+    fcntl = None  # type: ignore[assignment]
+
 from robo_trader.bootstrap_evidence_receivers import (
     BootstrapEvidenceReceiverSet,
     SealedBootstrapEvidenceArtifact,
@@ -247,6 +252,65 @@ def _published_evidence_usage(
     finally:
         os.close(root_descriptor)
     return count, total
+
+
+def _acquire_evidence_admission_lock(evidence_root: Path) -> int:
+    """Exclusively serialize capacity admission through final publication."""
+
+    if fcntl is None:
+        raise RuntimeReconciliationIntegrationError(
+            "interprocess evidence admission locking is unavailable"
+        )
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(
+            evidence_root,
+            os.O_RDONLY
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NOFOLLOW", 0),
+        )
+        held = os.fstat(descriptor)
+        current = os.stat(evidence_root, follow_symlinks=False)
+        if (
+            not stat.S_ISDIR(held.st_mode)
+            or held.st_uid != os.geteuid()
+            or stat.S_IMODE(held.st_mode) != 0o700
+            or (held.st_dev, held.st_ino) != (current.st_dev, current.st_ino)
+        ):
+            raise RuntimeReconciliationIntegrationError(
+                "reconciliation evidence root changed before admission"
+            )
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        acquired = descriptor
+        descriptor = None
+        return acquired
+    except BlockingIOError as exc:
+        raise RuntimeReconciliationIntegrationError(
+            "reconciliation evidence admission is already in progress"
+        ) from exc
+    except OSError as exc:
+        raise RuntimeReconciliationIntegrationError(
+            "reconciliation evidence admission lock cannot be acquired"
+        ) from exc
+    finally:
+        if descriptor is not None and descriptor >= 0:
+            try:
+                if fcntl is not None:
+                    fcntl.flock(descriptor, fcntl.LOCK_UN)
+            finally:
+                os.close(descriptor)
+
+
+def _release_evidence_admission_lock(descriptor: int) -> None:
+    if fcntl is None:
+        raise RuntimeReconciliationIntegrationError(
+            "interprocess evidence admission locking is unavailable"
+        )
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+    finally:
+        os.close(descriptor)
 
 
 def runtime_reconciliation_status_path(
@@ -625,6 +689,7 @@ class ProductionRuntimeEvidenceSource:
         output = self._evidence_root / ("runtime-reconciliation-" + secrets.token_hex(24))
         receivers: BootstrapEvidenceReceiverSet | None = None
         published = False
+        lease_token, leased_generation = await self._provider._acquire_generation_lease()
         try:
             receivers = create_bootstrap_evidence_receivers(
                 runtime_contract=runtime,
@@ -651,6 +716,10 @@ class ProductionRuntimeEvidenceSource:
                 quote_source,
                 runtime_contract=runtime,
             )
+            if quote_identity.transport_generation != leased_generation:
+                raise RuntimeReconciliationIntegrationError(
+                    "broker snapshot and protective marks crossed transport generations"
+                )
             mark_artifacts: list[SealedBootstrapEvidenceArtifact] = []
             active_symbols = tuple(
                 sorted({symbol for _, symbol in delivery.local_position_identities})
@@ -696,15 +765,19 @@ class ProductionRuntimeEvidenceSource:
             receivers.assert_complete(expected_marks)
             staged_bytes = receivers.unpublished_bundle_size_bytes(expected_marks)
             staging_binding = receivers.unpublished_bundle_directory_binding()
-            self._assert_retention_capacity(
-                staged_bytes=staged_bytes,
-                excluded_staging_binding=staging_binding,
-            )
-            receivers.publish_complete_bundle(
-                expected_marks,
-                expected_bundle_size_bytes=staged_bytes,
-            )
-            published = True
+            admission_descriptor = _acquire_evidence_admission_lock(self._evidence_root)
+            try:
+                self._assert_retention_capacity(
+                    staged_bytes=staged_bytes,
+                    excluded_staging_binding=staging_binding,
+                )
+                receivers.publish_complete_bundle(
+                    expected_marks,
+                    expected_bundle_size_bytes=staged_bytes,
+                )
+                published = True
+            finally:
+                _release_evidence_admission_lock(admission_descriptor)
             assert self._published_bundle_count is not None
             assert self._published_evidence_bytes is not None
             self._published_bundle_count += 1
@@ -731,8 +804,14 @@ class ProductionRuntimeEvidenceSource:
                 receivers.discard_unpublished_bundle()
             raise
         finally:
-            if receivers is not None:
-                receivers.close()
+            try:
+                if receivers is not None:
+                    receivers.close()
+            finally:
+                self._provider._release_generation_lease(
+                    lease_token,
+                    leased_generation,
+                )
 
     async def close(self) -> None:
         if self._closed:

--- a/robo_trader/reconciliation/runtime_integration.py
+++ b/robo_trader/reconciliation/runtime_integration.py
@@ -9,12 +9,14 @@ or broker state and never grants order authority.
 from __future__ import annotations
 
 import asyncio
+import ctypes
 import hashlib
 import json
 import math
 import os
 import secrets
 import stat
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Mapping
@@ -57,7 +59,13 @@ from .service import ReconciliationService, ReconciliationServiceOutcome
 _CAPABILITY_DIRECTORY_ENV = "RT_RECONCILIATION_SIGNING_CAPABILITY_DIR"
 _EVIDENCE_ROOT_ENV = "RT_RECONCILIATION_EVIDENCE_ROOT"
 _STATUS_PATH_ENV = "RT_RECONCILIATION_STATUS_PATH"
+_EVIDENCE_MAX_BUNDLES_ENV = "RT_RECONCILIATION_EVIDENCE_MAX_BUNDLES"
+_EVIDENCE_MAX_BYTES_ENV = "RT_RECONCILIATION_EVIDENCE_MAX_BYTES"
 _STATUS_FILENAME = "reconciliation_runtime_status.json"
+_DEFAULT_EVIDENCE_MAX_BUNDLES = 10_000
+_DEFAULT_EVIDENCE_MAX_BYTES = 2 * 1024 * 1024 * 1024
+_COMPLETION_MARKER_RESERVE_BYTES = 4 * 1024
+_RUNTIME_BUNDLE_PREFIX = "runtime-reconciliation-"
 _STATUS_FIELDS = {
     "schema_version",
     "owner_binding",
@@ -99,6 +107,120 @@ def _require_private_directory(path: Path, label: str) -> None:
         raise RuntimeReconciliationIntegrationError(
             f"{label} must be an owner-only non-symlink directory"
         )
+
+
+def _configured_positive_limit(
+    environment: Mapping[str, str],
+    name: str,
+    default: int,
+) -> int:
+    raw = environment.get(name)
+    if raw is None or raw == "":
+        return default
+    if raw != raw.strip() or not raw.isascii() or not raw.isdecimal():
+        raise RuntimeReconciliationIntegrationError(f"{name} must be a positive integer")
+    value = int(raw)
+    if value <= 0 or value > 2**63 - 1:
+        raise RuntimeReconciliationIntegrationError(f"{name} must be a positive integer")
+    return value
+
+
+def _runtime_bundle_name(name: str) -> bool:
+    if not name.startswith(_RUNTIME_BUNDLE_PREFIX):
+        return False
+    suffix = name[len(_RUNTIME_BUNDLE_PREFIX) :]
+    return (
+        len(suffix) == 48
+        and suffix == suffix.lower()
+        and all(character in "0123456789abcdef" for character in suffix)
+    )
+
+
+def _runtime_staging_bundle_name(name: str) -> bool:
+    prefix = "." + _RUNTIME_BUNDLE_PREFIX
+    separator = ".unpublished-"
+    if not name.startswith(prefix) or separator not in name:
+        return False
+    final_suffix, staging_suffix = name[len(prefix) :].split(separator, 1)
+    return (
+        len(final_suffix) == 48
+        and len(staging_suffix) == 64
+        and final_suffix == final_suffix.lower()
+        and staging_suffix == staging_suffix.lower()
+        and all(character in "0123456789abcdef" for character in final_suffix)
+        and all(character in "0123456789abcdef" for character in staging_suffix)
+    )
+
+
+def _published_evidence_usage(evidence_root: Path) -> tuple[int, int]:
+    """Measure every runtime-owned bundle without mutating audit evidence."""
+
+    root_descriptor = os.open(
+        evidence_root,
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0),
+    )
+    count = 0
+    total = 0
+    try:
+        root_metadata = os.fstat(root_descriptor)
+        if (
+            not stat.S_ISDIR(root_metadata.st_mode)
+            or root_metadata.st_uid != os.geteuid()
+            or stat.S_IMODE(root_metadata.st_mode) != 0o700
+        ):
+            raise RuntimeReconciliationIntegrationError(
+                "reconciliation evidence root changed identity"
+            )
+        for name in os.listdir(root_descriptor):
+            if not (_runtime_bundle_name(name) or _runtime_staging_bundle_name(name)):
+                continue
+            bundle_metadata = os.stat(
+                name,
+                dir_fd=root_descriptor,
+                follow_symlinks=False,
+            )
+            if (
+                not stat.S_ISDIR(bundle_metadata.st_mode)
+                or bundle_metadata.st_uid != os.geteuid()
+                or stat.S_IMODE(bundle_metadata.st_mode) != 0o700
+            ):
+                raise RuntimeReconciliationIntegrationError(
+                    "published reconciliation evidence bundle is unsafe"
+                )
+            bundle_descriptor = os.open(
+                name,
+                os.O_RDONLY
+                | getattr(os, "O_DIRECTORY", 0)
+                | getattr(os, "O_CLOEXEC", 0)
+                | getattr(os, "O_NOFOLLOW", 0),
+                dir_fd=root_descriptor,
+            )
+            try:
+                for artifact_name in os.listdir(bundle_descriptor):
+                    artifact = os.stat(
+                        artifact_name,
+                        dir_fd=bundle_descriptor,
+                        follow_symlinks=False,
+                    )
+                    if (
+                        not stat.S_ISREG(artifact.st_mode)
+                        or artifact.st_uid != os.geteuid()
+                        or artifact.st_nlink != 1
+                        or stat.S_IMODE(artifact.st_mode) != 0o400
+                    ):
+                        raise RuntimeReconciliationIntegrationError(
+                            "published reconciliation evidence artifact is unsafe"
+                        )
+                    total += artifact.st_size
+            finally:
+                os.close(bundle_descriptor)
+            count += 1
+    finally:
+        os.close(root_descriptor)
+    return count, total
 
 
 def runtime_reconciliation_status_path(
@@ -163,6 +285,84 @@ def _valid_status_owner_binding(value: object) -> bool:
         and value == value.lower()
         and all(character in "0123456789abcdef" for character in value)
     )
+
+
+def _exchange_status_entries(parent_descriptor: int, left: str, right: str) -> None:
+    """Atomically exchange sibling names without overwriting either inode."""
+
+    libc = ctypes.CDLL(None, use_errno=True)
+    left_bytes = os.fsencode(left)
+    right_bytes = os.fsencode(right)
+    if sys.platform == "darwin":
+        rename_exchange = getattr(libc, "renameatx_np", None)
+        if rename_exchange is None:  # pragma: no cover - supported macOS invariant
+            raise RuntimeReconciliationIntegrationError(
+                "atomic reconciliation status exchange is unavailable"
+            )
+        result = rename_exchange(
+            ctypes.c_int(parent_descriptor),
+            ctypes.c_char_p(left_bytes),
+            ctypes.c_int(parent_descriptor),
+            ctypes.c_char_p(right_bytes),
+            ctypes.c_uint(0x00000002),
+        )
+    else:
+        rename_exchange = getattr(libc, "renameat2", None)
+        if rename_exchange is None:
+            raise RuntimeReconciliationIntegrationError(
+                "atomic reconciliation status exchange is unavailable"
+            )
+        result = rename_exchange(
+            ctypes.c_int(parent_descriptor),
+            ctypes.c_char_p(left_bytes),
+            ctypes.c_int(parent_descriptor),
+            ctypes.c_char_p(right_bytes),
+            ctypes.c_uint(2),
+        )
+    if result != 0:
+        error_number = ctypes.get_errno()
+        raise RuntimeReconciliationIntegrationError(
+            "atomic reconciliation status exchange failed"
+        ) from OSError(error_number, os.strerror(error_number), right)
+
+
+def _publish_status_exclusive(parent_descriptor: int, source: str, target: str) -> None:
+    """Atomically publish one sibling name without replacing an existing target."""
+
+    libc = ctypes.CDLL(None, use_errno=True)
+    source_bytes = os.fsencode(source)
+    target_bytes = os.fsencode(target)
+    if sys.platform == "darwin":
+        rename_exclusive = getattr(libc, "renameatx_np", None)
+        if rename_exclusive is None:  # pragma: no cover - supported macOS invariant
+            raise RuntimeReconciliationIntegrationError(
+                "exclusive reconciliation status publication is unavailable"
+            )
+        result = rename_exclusive(
+            ctypes.c_int(parent_descriptor),
+            ctypes.c_char_p(source_bytes),
+            ctypes.c_int(parent_descriptor),
+            ctypes.c_char_p(target_bytes),
+            ctypes.c_uint(0x00000004),
+        )
+    else:
+        rename_exclusive = getattr(libc, "renameat2", None)
+        if rename_exclusive is None:
+            raise RuntimeReconciliationIntegrationError(
+                "exclusive reconciliation status publication is unavailable"
+            )
+        result = rename_exclusive(
+            ctypes.c_int(parent_descriptor),
+            ctypes.c_char_p(source_bytes),
+            ctypes.c_int(parent_descriptor),
+            ctypes.c_char_p(target_bytes),
+            ctypes.c_uint(1),
+        )
+    if result != 0:
+        error_number = ctypes.get_errno()
+        raise RuntimeReconciliationIntegrationError(
+            "exclusive reconciliation status publication failed"
+        ) from OSError(error_number, os.strerror(error_number), target)
 
 
 async def assert_runtime_bootstrap_ready(runtime_context: RuntimeSafetyContext) -> None:
@@ -328,12 +528,43 @@ class ProductionRuntimeEvidenceSource:
         provider: IBKRDiagnosticSnapshotProvider,
         capability_directory: Path,
         evidence_root: Path,
+        max_published_bundles: int = _DEFAULT_EVIDENCE_MAX_BUNDLES,
+        max_published_bytes: int = _DEFAULT_EVIDENCE_MAX_BYTES,
     ) -> None:
         self._runtime_context = assert_validated_runtime_safety_context(runtime_context)
         self._provider = provider
         self._capability_directory = capability_directory
         self._evidence_root = evidence_root
+        if (
+            type(max_published_bundles) is not int
+            or max_published_bundles <= 0
+            or type(max_published_bytes) is not int
+            or max_published_bytes <= 0
+        ):
+            raise RuntimeReconciliationIntegrationError(
+                "reconciliation evidence retention limits are invalid"
+            )
+        self._max_published_bundles = max_published_bundles
+        self._max_published_bytes = max_published_bytes
+        self._published_bundle_count: int | None = None
+        self._published_evidence_bytes: int | None = None
         self._closed = False
+
+    def _assert_retention_capacity(self, *, staged_bytes: int = 0) -> None:
+        if self._published_bundle_count is None or self._published_evidence_bytes is None:
+            (
+                self._published_bundle_count,
+                self._published_evidence_bytes,
+            ) = _published_evidence_usage(self._evidence_root)
+        if (
+            self._published_bundle_count >= self._max_published_bundles
+            or self._published_evidence_bytes + staged_bytes + _COMPLETION_MARKER_RESERVE_BYTES
+            > self._max_published_bytes
+        ):
+            raise RuntimeReconciliationIntegrationError(
+                "reconciliation evidence retention ceiling reached; "
+                "operator archival is required"
+            )
 
     async def collect_verified_evidence(
         self,
@@ -355,6 +586,7 @@ class ProductionRuntimeEvidenceSource:
             raise RuntimeReconciliationIntegrationError("exact runtime contract is required")
         _require_private_directory(self._capability_directory, "signing capability directory")
         _require_private_directory(self._evidence_root, "reconciliation evidence root")
+        self._assert_retention_capacity()
         output = self._evidence_root / ("runtime-reconciliation-" + secrets.token_hex(24))
         receivers: BootstrapEvidenceReceiverSet | None = None
         published = False
@@ -385,10 +617,13 @@ class ProductionRuntimeEvidenceSource:
                 runtime_contract=runtime,
             )
             mark_artifacts: list[SealedBootstrapEvidenceArtifact] = []
+            active_symbols = tuple(
+                sorted({symbol for _, symbol in delivery.local_position_identities})
+            )
             for portfolio_id, symbol in delivery.local_position_identities:
                 discovery = await quote_source.get_protective_quotes(
                     (symbol,),
-                    active_symbols=(symbol,),
+                    active_symbols=active_symbols,
                 )
                 if type(discovery) is not tuple or len(discovery) != 1:
                     raise RuntimeReconciliationIntegrationError(
@@ -415,6 +650,7 @@ class ProductionRuntimeEvidenceSource:
                     expected_symbol=symbol,
                     expected_con_id=quote.con_id,
                     expected_transport_generation=quote_identity.transport_generation,
+                    expected_active_symbols=active_symbols,
                 )
                 if type(mark) is not SealedBootstrapEvidenceArtifact:
                     raise RuntimeReconciliationIntegrationError(
@@ -423,8 +659,14 @@ class ProductionRuntimeEvidenceSource:
                 mark_artifacts.append(mark)
             expected_marks = set(delivery.local_position_identities)
             receivers.assert_complete(expected_marks)
+            staged_bytes = receivers.unpublished_bundle_size_bytes(expected_marks)
+            self._assert_retention_capacity(staged_bytes=staged_bytes)
             receivers.publish_complete_bundle(expected_marks)
             published = True
+            assert self._published_bundle_count is not None
+            assert self._published_evidence_bytes is not None
+            self._published_bundle_count += 1
+            self._published_evidence_bytes += staged_bytes + _COMPLETION_MARKER_RESERVE_BYTES
             broker_path = receivers.published_artifact_path(broker_artifact)
             reconciliation_path = receivers.published_artifact_path(reconciliation_artifact)
             mark_paths = tuple(receivers.published_artifact_path(mark) for mark in mark_artifacts)
@@ -642,7 +884,11 @@ def _write_status(
         | getattr(os, "O_NOFOLLOW", 0),
     )
     metadata = os.fstat(parent_descriptor)
-    if not stat.S_ISDIR(metadata.st_mode) or metadata.st_uid != os.geteuid():
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(metadata.st_mode) & 0o022
+    ):
         os.close(parent_descriptor)
         raise RuntimeReconciliationIntegrationError("status directory is unavailable")
     temporary_name = f".{path.name}.stage-{secrets.token_hex(16)}"
@@ -663,28 +909,6 @@ def _write_status(
             _read_owned_status_descriptor(prior_descriptor, binding)
             prior_metadata = os.fstat(prior_descriptor)
             prior_identity = (prior_metadata.st_dev, prior_metadata.st_ino)
-            os.lseek(prior_descriptor, 0, os.SEEK_SET)
-            os.ftruncate(prior_descriptor, 0)
-            offset = 0
-            while offset < len(encoded):
-                written = os.write(prior_descriptor, encoded[offset:])
-                if written <= 0:
-                    raise RuntimeReconciliationIntegrationError(
-                        "reconciliation status write did not complete"
-                    )
-                offset += written
-            os.fsync(prior_descriptor)
-            current = os.stat(
-                path.name,
-                dir_fd=parent_descriptor,
-                follow_symlinks=False,
-            )
-            if (current.st_dev, current.st_ino) != prior_identity:
-                raise RuntimeReconciliationIntegrationError(
-                    "existing reconciliation status artifact changed during publication"
-                )
-            os.fsync(parent_descriptor)
-            return
         descriptor = os.open(
             temporary_name,
             os.O_WRONLY
@@ -706,14 +930,36 @@ def _write_status(
         os.fsync(descriptor)
         os.close(descriptor)
         descriptor = -1
-        os.link(
-            temporary_name,
-            path.name,
-            src_dir_fd=parent_descriptor,
-            dst_dir_fd=parent_descriptor,
-            follow_symlinks=False,
-        )
-        os.unlink(temporary_name, dir_fd=parent_descriptor)
+        if prior_identity is None:
+            # Exclusive rename is crash-safe and no-replace: the target is
+            # either absent or one complete inode, with no two-link window.
+            _publish_status_exclusive(parent_descriptor, temporary_name, path.name)
+        else:
+            current = os.stat(
+                path.name,
+                dir_fd=parent_descriptor,
+                follow_symlinks=False,
+            )
+            if (current.st_dev, current.st_ino) != prior_identity:
+                raise RuntimeReconciliationIntegrationError(
+                    "existing reconciliation status artifact changed during publication"
+                )
+            # Exchange preserves both complete inodes until the displaced one
+            # is authenticated. A crash can expose either complete version,
+            # never a partial status, and a raced unrelated target can be put
+            # back rather than overwritten.
+            _exchange_status_entries(parent_descriptor, temporary_name, path.name)
+            displaced = os.stat(
+                temporary_name,
+                dir_fd=parent_descriptor,
+                follow_symlinks=False,
+            )
+            if (displaced.st_dev, displaced.st_ino) != prior_identity:
+                _exchange_status_entries(parent_descriptor, temporary_name, path.name)
+                raise RuntimeReconciliationIntegrationError(
+                    "existing reconciliation status artifact changed during publication"
+                )
+            os.unlink(temporary_name, dir_fd=parent_descriptor)
         os.fsync(parent_descriptor)
     finally:
         if descriptor >= 0:
@@ -838,6 +1084,16 @@ async def build_runtime_reconciliation_controller(
     _require_private_directory(capability_directory, "signing capability directory")
     _require_private_directory(evidence_root, "reconciliation evidence root")
     status_path = runtime_reconciliation_status_path(runtime, environment)
+    max_published_bundles = _configured_positive_limit(
+        environment,
+        _EVIDENCE_MAX_BUNDLES_ENV,
+        _DEFAULT_EVIDENCE_MAX_BUNDLES,
+    )
+    max_published_bytes = _configured_positive_limit(
+        environment,
+        _EVIDENCE_MAX_BYTES_ENV,
+        _DEFAULT_EVIDENCE_MAX_BYTES,
+    )
     _assert_status_path_is_unprotected(
         status_path,
         runtime_contract=runtime,
@@ -852,6 +1108,8 @@ async def build_runtime_reconciliation_controller(
             provider=provider,
             capability_directory=capability_directory,
             evidence_root=evidence_root,
+            max_published_bundles=max_published_bundles,
+            max_published_bytes=max_published_bytes,
         )
         service = ReconciliationService(
             evidence_source=source,

--- a/robo_trader/reconciliation/runtime_integration.py
+++ b/robo_trader/reconciliation/runtime_integration.py
@@ -32,7 +32,7 @@ from robo_trader.bootstrap_mark_producer import (
 from robo_trader.config import RuntimeContract
 from robo_trader.database_migrations import assert_exact_state_schema
 from robo_trader.financial_state_bootstrap import load_exact_state_bootstrap_evidence
-from robo_trader.safety.sqlite_identity import SQLitePathBinding
+from robo_trader.safety.sqlite_identity import SQLitePathBinding, lexical_path_preserving_leaf
 
 from .bootstrap_producer import produce_bootstrap_reconciliation
 from .ibkr_adapter import (
@@ -92,6 +92,44 @@ def runtime_reconciliation_status_path(
     if configured:
         return _absolute_lexical_path(configured, "reconciliation status path")
     return Path(runtime_contract.database_path).parent / _STATUS_FILENAME
+
+
+def _assert_status_path_is_unprotected(
+    status_path: Path,
+    *,
+    runtime_contract: RuntimeContract,
+    capability_directory: Path,
+    evidence_root: Path,
+) -> None:
+    """Reject status targets that could replace protected runtime artifacts."""
+
+    protected_files: set[Path] = set()
+    for configured in (
+        runtime_contract.database_path,
+        runtime_contract.safety_journal_path,
+    ):
+        if not isinstance(configured, str) or not configured:
+            continue
+        protected = lexical_path_preserving_leaf(configured)
+        protected_files.update(
+            {
+                protected,
+                Path(f"{protected}-wal"),
+                Path(f"{protected}-shm"),
+                Path(f"{protected}-journal"),
+            }
+        )
+    target = lexical_path_preserving_leaf(status_path)
+    protected_directories = (
+        lexical_path_preserving_leaf(capability_directory),
+        lexical_path_preserving_leaf(evidence_root),
+    )
+    if target in protected_files or any(
+        target == directory or directory in target.parents for directory in protected_directories
+    ):
+        raise RuntimeReconciliationIntegrationError(
+            "reconciliation status path overlaps protected runtime state"
+        )
 
 
 async def assert_runtime_bootstrap_ready(runtime_context: RuntimeSafetyContext) -> None:
@@ -522,23 +560,53 @@ def read_runtime_reconciliation_status(path: Path) -> dict[str, object]:
         }
         if type(payload) is not dict or set(payload) != allowed:
             return unavailable
+        if payload["schema_version"] != 1:
+            return unavailable
+        entry_eligible = payload["entry_eligible"]
+        quarantined = payload["quarantined"]
+        if type(entry_eligible) is not bool or type(quarantined) is not bool:
+            return unavailable
+        if entry_eligible is quarantined:
+            return unavailable
         completed_at = payload["completed_at"]
+        eligible_until = payload["eligible_until"]
         age_seconds = None
+        now = datetime.now(timezone.utc)
         if isinstance(completed_at, str):
             observed = datetime.fromisoformat(completed_at.replace("Z", "+00:00"))
             if observed.tzinfo is None:
                 return unavailable
+            observed = observed.astimezone(timezone.utc)
+            if observed > now:
+                return unavailable
             age_seconds = max(
                 0.0,
-                (datetime.now(timezone.utc) - observed.astimezone(timezone.utc)).total_seconds(),
+                (now - observed).total_seconds(),
             )
+        elif completed_at is not None:
+            return unavailable
+        if isinstance(eligible_until, str):
+            expires = datetime.fromisoformat(eligible_until.replace("Z", "+00:00"))
+            if expires.tzinfo is None:
+                return unavailable
+            expires = expires.astimezone(timezone.utc)
+            if not isinstance(completed_at, str) or expires < observed:
+                return unavailable
+        elif eligible_until is not None:
+            return unavailable
+        if entry_eligible and (
+            not isinstance(completed_at, str)
+            or not isinstance(eligible_until, str)
+            or now > expires
+        ):
+            return unavailable
         return {
             "state": payload["state"],
             "trigger": payload["trigger"],
             "completed_at": completed_at,
-            "eligible_until": payload["eligible_until"],
-            "entry_eligible": payload["entry_eligible"] is True,
-            "quarantined": payload["quarantined"] is True,
+            "eligible_until": eligible_until,
+            "entry_eligible": entry_eligible,
+            "quarantined": quarantined,
             "age_seconds": None if age_seconds is None else round(age_seconds, 3),
         }
     except Exception:
@@ -568,6 +636,13 @@ async def build_runtime_reconciliation_controller(
     )
     _require_private_directory(capability_directory, "signing capability directory")
     _require_private_directory(evidence_root, "reconciliation evidence root")
+    status_path = runtime_reconciliation_status_path(runtime, environment)
+    _assert_status_path_is_unprotected(
+        status_path,
+        runtime_contract=runtime,
+        capability_directory=capability_directory,
+        evidence_root=evidence_root,
+    )
     await assert_runtime_bootstrap_ready(context)
     provider = await build_diagnostic_provider(context)
     try:
@@ -584,7 +659,7 @@ async def build_runtime_reconciliation_controller(
         )
         controller = RuntimeReconciliationController(
             service,
-            status_path=runtime_reconciliation_status_path(runtime, environment),
+            status_path=status_path,
         )
         return controller, provider
     except BaseException:

--- a/robo_trader/reconciliation/service.py
+++ b/robo_trader/reconciliation/service.py
@@ -58,6 +58,7 @@ class ReconciliationServiceOutcome:
     state: ReconciliationServiceState
     entry_eligible: bool
     eligible_until: datetime
+    completed_at: datetime
 
 
 class VerifiedEvidenceSource(Protocol):
@@ -347,6 +348,7 @@ class ReconciliationService:
             state=state,
             entry_eligible=persisted.entry_eligible,
             eligible_until=eligible_until,
+            completed_at=completed_at,
         )
         self._state = state
         self._latest_outcome = outcome

--- a/robo_trader/runner_async.py
+++ b/robo_trader/runner_async.py
@@ -86,6 +86,10 @@ from .reconciliation.identity import (
     resolve_environment,
     validate_runtime_safety,
 )
+from .reconciliation.runtime_integration import (
+    RuntimeReconciliationController,
+    build_runtime_reconciliation_controller,
+)
 from .utils.robust_connection import (
     CircuitBreakerConfig,
     connect_ibkr_robust,
@@ -494,6 +498,7 @@ class AsyncRunner:
         safety_runtime: Optional[SafetyRuntimeCoordinator] = None,
         shared_database: Optional[AsyncTradingDatabase] = None,
         paper_reduction_gateway: Optional[PaperReductionGateway] = None,
+        reconciliation_controller: Optional[RuntimeReconciliationController] = None,
     ):
         assert_gate_a_runner_options(
             use_ml_strategy=use_ml_strategy,
@@ -518,6 +523,7 @@ class AsyncRunner:
         self._shared_database = shared_database
         self._owns_database = shared_database is None
         self.paper_reduction_gateway = paper_reduction_gateway
+        self.reconciliation_controller = reconciliation_controller
         self._baseline_entry_handle = None
         self.portfolio_id = portfolio_id
         self.duration = duration
@@ -926,8 +932,15 @@ class AsyncRunner:
             ):
                 reason = self.advanced_risk.kill_switch.trigger_reason or "Kill switch active"
                 return True, f"Kill switch active: {reason}"
+            reconciliation = getattr(self, "reconciliation_controller", None)
+            if (
+                type(reconciliation) is not RuntimeReconciliationController
+                or not reconciliation.entry_eligible()
+            ):
+                return True, "Runtime reconciliation is unavailable, stale, or quarantined"
         except Exception as exc:  # pragma: no cover - defensive
             logger.error(f"Error in _trading_blocked: {exc}")
+            return True, "Risk-increasing entry safety state is unavailable"
         return False, ""
 
     @staticmethod
@@ -7419,11 +7432,14 @@ class AsyncRunner:
                         raise RuntimeError(
                             "connection recovery requires the exact paper reduction gateway"
                         )
-                    # The runner and gateway own distinct diagnostic clients.
-                    # Recovery is incomplete until both have fresh read-only
-                    # sessions; otherwise entries could resume while broker-
-                    # bound reductions remain unavailable.
+                    # The gateway and reconciliation service share one owned
+                    # diagnostic generation. Recovery is incomplete until that
+                    # read-only generation is replaced.
                     await gateway.refresh_diagnostic_connection()
+                reconciliation = getattr(self, "reconciliation_controller", None)
+                if type(reconciliation) is not RuntimeReconciliationController:
+                    raise RuntimeError("runtime reconciliation controller is unavailable")
+                await reconciliation.reconcile_reconnect()
                 health = getattr(self, "health", None)
                 if health is not None:
                     # initialize_connection installs a new monitor whose
@@ -7498,6 +7514,37 @@ class AsyncRunner:
 class _PaperOrderRuntimeResources:
     database: AsyncTradingDatabase
     gateway: PaperReductionGateway
+    reconciliation: RuntimeReconciliationController
+
+
+async def _close_partial_paper_order_runtime(
+    database: AsyncTradingDatabase,
+    gateway: Optional[PaperReductionGateway],
+    reconciliation: Optional[RuntimeReconciliationController],
+) -> None:
+    """Reap every acquired startup resource while preserving first failure."""
+
+    first_failure: Optional[BaseException] = None
+    cleanups = (
+        None if gateway is None else gateway.close,
+        None if reconciliation is None else reconciliation.close,
+        database.close,
+    )
+    for cleanup in cleanups:
+        if cleanup is None:
+            continue
+        try:
+            await cleanup()
+        except BaseException as error:
+            if first_failure is None:
+                first_failure = error
+            else:
+                logger.error(
+                    "event=paper_order_runtime_additional_cleanup_failed",
+                    exc_info=(type(error), error, error.__traceback__),
+                )
+    if first_failure is not None:
+        raise first_failure.with_traceback(first_failure.__traceback__)
 
 
 async def _start_paper_order_runtime(
@@ -7512,34 +7559,50 @@ async def _start_paper_order_runtime(
         raise RuntimeError("started paper safety coordinator is required")
     database = AsyncTradingDatabase(Path(context.runtime_contract.database_path))
     gateway: Optional[PaperReductionGateway] = None
+    reconciliation: Optional[RuntimeReconciliationController] = None
     try:
+        reconciliation, diagnostic_provider = await build_runtime_reconciliation_controller(context)
         await database.initialize()
         gateway = PaperReductionGateway(
             context,
             safety_runtime,
             database,
+            diagnostic_provider=diagnostic_provider,
         )
         await gateway.start()
+        await reconciliation.reconcile_startup()
     except BaseException as startup_error:
         try:
             await _await_cleanup_owned(
-                database.close(),
-                failure_event="paper_order_runtime_database_cleanup_failed_during_startup",
+                _close_partial_paper_order_runtime(
+                    database,
+                    gateway,
+                    reconciliation,
+                ),
+                failure_event="paper_order_runtime_cleanup_failed_during_startup",
             )
         except BaseException:
-            logger.exception("event=paper_order_runtime_database_cleanup_failed_during_startup")
+            logger.exception("event=paper_order_runtime_cleanup_failed_during_startup")
         raise startup_error.with_traceback(startup_error.__traceback__)
-    if gateway is None:
-        missing_gateway = RuntimeError("paper reduction gateway startup returned no gateway")
+    if gateway is None or reconciliation is None:
+        missing_gateway = RuntimeError("paper order runtime startup returned partial resources")
         try:
             await _await_cleanup_owned(
-                database.close(),
-                failure_event="paper_order_runtime_database_cleanup_failed_without_gateway",
+                _close_partial_paper_order_runtime(
+                    database,
+                    gateway,
+                    reconciliation,
+                ),
+                failure_event="paper_order_runtime_cleanup_failed_without_gateway",
             )
         except BaseException:
-            logger.exception("event=paper_order_runtime_database_cleanup_failed_without_gateway")
+            logger.exception("event=paper_order_runtime_cleanup_failed_without_gateway")
         raise missing_gateway
-    return _PaperOrderRuntimeResources(database=database, gateway=gateway)
+    return _PaperOrderRuntimeResources(
+        database=database,
+        gateway=gateway,
+        reconciliation=reconciliation,
+    )
 
 
 async def _close_paper_order_runtime(
@@ -7550,7 +7613,10 @@ async def _close_paper_order_runtime(
     try:
         await resources.gateway.close()
     finally:
-        await resources.database.close()
+        try:
+            await resources.reconciliation.close()
+        finally:
+            await resources.database.close()
 
 
 async def _await_cleanup_owned(
@@ -7667,6 +7733,7 @@ async def run_once(
             safety_runtime=safety_runtime,
             shared_database=resources.database,
             paper_reduction_gateway=resources.gateway,
+            reconciliation_controller=resources.reconciliation,
         )
         await runner.run(symbols)
     finally:
@@ -7911,6 +7978,8 @@ async def run_continuous(
                     f"Starting trading cycle at {current_time.strftime('%Y-%m-%d %H:%M:%S %Z')}"
                 )
 
+                await resources.reconciliation.reconcile_periodic_if_due()
+
                 # Load portfolio configurations
                 from .multiuser.portfolio_config import load_portfolio_configs
 
@@ -7950,6 +8019,7 @@ async def run_continuous(
                             safety_runtime=safety_runtime,
                             shared_database=resources.database,
                             paper_reduction_gateway=resources.gateway,
+                            reconciliation_controller=resources.reconciliation,
                         )
                         await _setup_continuous_runner(new_runner)
                         runners[portfolio_id] = new_runner

--- a/robo_trader/runner_async.py
+++ b/robo_trader/runner_async.py
@@ -7978,7 +7978,19 @@ async def run_continuous(
                     f"Starting trading cycle at {current_time.strftime('%Y-%m-%d %H:%M:%S %Z')}"
                 )
 
-                await resources.reconciliation.reconcile_periodic_if_due()
+                try:
+                    await resources.reconciliation.reconcile_periodic_if_due()
+                except Exception as reconciliation_error:
+                    # The controller has already revoked entry eligibility and
+                    # attempted to publish quarantine.  Keep the portfolio
+                    # cycles alive so their controller-backed entry gate still
+                    # blocks BUYs while semantic SELL/reduction paths remain
+                    # available.
+                    logger.exception(
+                        "event=periodic_reconciliation_failed "
+                        "action=continue_reduce_only error=%r",
+                        reconciliation_error,
+                    )
 
                 # Load portfolio configurations
                 from .multiuser.portfolio_config import load_portfolio_configs

--- a/scripts/produce_exact_state_bootstrap_evidence.py
+++ b/scripts/produce_exact_state_bootstrap_evidence.py
@@ -155,10 +155,11 @@ async def _collect_production_marks(
         runtime_contract=runtime_contract,
     )
     artifacts: list[SealedBootstrapEvidenceArtifact] = []
+    active_symbols = tuple(sorted({symbol for _, symbol in mark_identities}))
     for portfolio_id, symbol in mark_identities:
         discovery = await quote_source.get_protective_quotes(
             (symbol,),
-            active_symbols=(symbol,),
+            active_symbols=active_symbols,
         )
         if type(discovery) is not tuple or len(discovery) != 1:
             raise BootstrapEvidencePipelineError(
@@ -182,6 +183,7 @@ async def _collect_production_marks(
             expected_symbol=symbol,
             expected_con_id=quote.con_id,
             expected_transport_generation=identity.transport_generation,
+            expected_active_symbols=active_symbols,
         )
         if type(artifact) is not SealedBootstrapEvidenceArtifact:
             raise BootstrapEvidencePipelineError(

--- a/tests/security/test_web.py
+++ b/tests/security/test_web.py
@@ -1038,6 +1038,10 @@ def test_dashboard_html_has_stale_banner(monkeypatch):
     body = resp.get_data(as_text=True)
     assert 'id="runner-stale-banner"' in body
     assert "checkRunnerHealth" in body
+    assert "reconciliation.entry_eligible !== true" in body
+    assert "reconciliation.quarantined !== false" in body
+    assert "data && data.healthy && !reconciliationBlocked" in body
+    assert "New entries quarantined — broker reconciliation unavailable" in body
     # And it must be wired into the boot sequence.
     assert "setInterval(checkRunnerHealth" in body
 

--- a/tests/test_bootstrap_evidence_receivers.py
+++ b/tests/test_bootstrap_evidence_receivers.py
@@ -281,6 +281,36 @@ class _Provider:
 
 
 @pytest.mark.asyncio
+async def test_runtime_consumed_broker_envelope_cannot_be_handed_off_again(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    capability = _install_test_trust(monkeypatch, tmp_path)
+    database = tmp_path / "ledger.db"
+    _ledger(database)
+    receivers = create_bootstrap_evidence_receivers(
+        runtime_contract=_runtime(database),
+        capability_directory=capability,
+        output_directory=tmp_path / "evidence",
+    )
+    provider = _Provider(_broker_result(datetime.now(timezone.utc)))
+    envelope = await provider.produce_normalized_snapshot(
+        receiver=receivers.broker_snapshot,
+        max_age_seconds=30.0,
+    )
+
+    receiver_core.assert_and_consume_verified_broker_evidence(envelope)
+    receiver_core._handoff_consumed_verified_broker_evidence_to_runtime(envelope)
+    receiver_core.assert_and_consume_verified_broker_evidence(envelope)
+
+    with pytest.raises(BootstrapEvidenceReceiverError, match="already handed off"):
+        receiver_core._handoff_consumed_verified_broker_evidence_to_runtime(envelope)
+    with pytest.raises(BootstrapEvidenceReceiverError, match="already consumed"):
+        receiver_core.assert_and_consume_verified_broker_evidence(envelope)
+    receivers.close()
+
+
+@pytest.mark.asyncio
 async def test_full_empty_position_evidence_chain_is_typed_and_one_shot(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_bootstrap_evidence_receivers.py
+++ b/tests/test_bootstrap_evidence_receivers.py
@@ -319,13 +319,15 @@ async def test_full_empty_position_evidence_chain_is_typed_and_one_shot(
     database = tmp_path / "ledger.db"
     _ledger(database)
     runtime = _runtime(database)
+    output = tmp_path / ("evidence-" + "é" * 40)
     receivers = create_bootstrap_evidence_receivers(
         runtime_contract=runtime,
         capability_directory=capability,
-        output_directory=tmp_path / "evidence",
+        output_directory=output,
     )
     result = _broker_result(datetime.now(timezone.utc) - timedelta(milliseconds=50))
     provider = _Provider(result)
+    predicted_bundle_size: list[int] = []
 
     async def no_marks(**kwargs: object) -> tuple:
         assert kwargs["mark_identities"] == ()
@@ -337,6 +339,7 @@ async def test_full_empty_position_evidence_chain_is_typed_and_one_shot(
         )
         assert type(mark_identity) is ProtectiveMarkBundleIdentity
         assert mark_identity.reconciliation_snapshot_id.startswith("bootstrap-reconciliation-v1-")
+        predicted_bundle_size.append(receivers.unpublished_bundle_size_bytes(set()))
         provider.events.append("marks")
         return ()
 
@@ -351,11 +354,12 @@ async def test_full_empty_position_evidence_chain_is_typed_and_one_shot(
     assert provider.events == ["snapshot", "quote-source", "marks", "close"]
     assert report["authorizes_startup"] is False
     assert report["status"] == "EVIDENCE_COMPLETE_GATE_A_STILL_CLOSED"
-    assert (tmp_path / "evidence" / "broker_snapshot.json").stat().st_mode & 0o777 == 0o400
-    assert (tmp_path / "evidence" / "reconciliation_report.json").is_file()
+    assert (output / "broker_snapshot.json").stat().st_mode & 0o777 == 0o400
+    assert (output / "reconciliation_report.json").is_file()
+    assert predicted_bundle_size == [sum(path.stat().st_size for path in output.iterdir())]
     loaded = load_exact_state_bootstrap_evidence(
-        reconciliation_path=tmp_path / "evidence" / "reconciliation_report.json",
-        broker_snapshot_path=tmp_path / "evidence" / "broker_snapshot.json",
+        reconciliation_path=output / "reconciliation_report.json",
+        broker_snapshot_path=output / "broker_snapshot.json",
         protective_mark_paths=[],
         expected_runtime_contract=runtime,
     )

--- a/tests/test_bootstrap_evidence_receivers.py
+++ b/tests/test_bootstrap_evidence_receivers.py
@@ -1088,3 +1088,80 @@ async def test_completion_rename_success_then_error_resolves_as_committed(
         expected_runtime_contract=runtime,
     )
     assert loaded.marks == ()
+
+    broker_path = Path(str(report["broker_snapshot"]))
+    replacement = output / ".same-broker-new-inode"
+    replacement.write_bytes(broker_path.read_bytes())
+    replacement.chmod(0o400)
+    os.replace(replacement, broker_path)
+    with pytest.raises(
+        ExactStateBootstrapError,
+        match="entry does not match the completion manifest",
+    ):
+        load_exact_state_bootstrap_evidence(
+            reconciliation_path=Path(str(report["reconciliation_report"])),
+            broker_snapshot_path=broker_path,
+            protective_mark_paths=[],
+            expected_runtime_contract=runtime,
+        )
+
+
+@pytest.mark.asyncio
+async def test_completion_manifest_rejects_file_injected_before_marker_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    capability = _install_test_trust(monkeypatch, tmp_path)
+    database = tmp_path / "ledger.db"
+    _ledger(database)
+    runtime = _runtime(database)
+    output = tmp_path / "evidence"
+    receivers = create_bootstrap_evidence_receivers(
+        runtime_contract=runtime,
+        capability_directory=capability,
+        output_directory=output,
+    )
+    provider = _Provider(_broker_result(datetime.now(timezone.utc) - timedelta(milliseconds=50)))
+    real_write = receiver_core._write_new_sealed_file_at
+    injected = False
+
+    def inject_before_completion_write(
+        directory_fd: int,
+        filename: str,
+        payload: bytes,
+    ) -> None:
+        nonlocal injected
+        if not injected and filename.startswith(".bundle_complete.json.stage-"):
+            injected = True
+            path = output / "raced-after-measurement.json"
+            path.write_bytes(b"preserve-untrusted-raced-evidence")
+            path.chmod(0o400)
+        real_write(directory_fd, filename, payload)
+
+    monkeypatch.setattr(receiver_core, "_write_new_sealed_file_at", inject_before_completion_write)
+
+    async def no_marks(**_kwargs: object) -> tuple:
+        return ()
+
+    report = await produce_bootstrap_evidence_bundle(
+        runtime_contract=runtime,
+        snapshot_provider=provider,
+        receivers=receivers,
+        protective_mark_collector=no_marks,
+    )
+
+    assert injected is True
+    assert (output / "raced-after-measurement.json").read_bytes() == (
+        b"preserve-untrusted-raced-evidence"
+    )
+    assert (output / "bundle_complete.json").is_file()
+    with pytest.raises(
+        ExactStateBootstrapError,
+        match="entries do not match the completion manifest",
+    ):
+        load_exact_state_bootstrap_evidence(
+            reconciliation_path=Path(str(report["reconciliation_report"])),
+            broker_snapshot_path=Path(str(report["broker_snapshot"])),
+            protective_mark_paths=[],
+            expected_runtime_contract=runtime,
+        )

--- a/tests/test_bootstrap_evidence_receivers.py
+++ b/tests/test_bootstrap_evidence_receivers.py
@@ -374,9 +374,18 @@ async def test_full_empty_position_evidence_chain_is_typed_and_one_shot(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("injected_mode", "error_match"),
+    [
+        (0o400, "changed after retention measurement"),
+        (0o600, "unsafe entry"),
+    ],
+)
 async def test_retention_measurement_change_preserves_unpublished_bundle(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    injected_mode: int,
+    error_match: str,
 ) -> None:
     capability = _install_test_trust(monkeypatch, tmp_path)
     database = tmp_path / "ledger.db"
@@ -396,7 +405,7 @@ async def test_retention_measurement_change_preserves_unpublished_bundle(
         measured_size.append(receivers.unpublished_bundle_size_bytes(set()))
         injected = receivers._state.staging_output_directory / "raced-sealed-evidence.json"
         injected.write_bytes(b"operator-evidence-must-survive")
-        injected.chmod(0o400)
+        injected.chmod(injected_mode)
         return ()
 
     original_publish = receiver_core.BootstrapEvidenceReceiverSet.publish_complete_bundle
@@ -416,7 +425,7 @@ async def test_retention_measurement_change_preserves_unpublished_bundle(
 
     with pytest.raises(
         BootstrapEvidenceReceiverError,
-        match="changed after retention measurement",
+        match=error_match,
     ):
         await produce_bootstrap_evidence_bundle(
             runtime_contract=runtime,

--- a/tests/test_bootstrap_evidence_receivers.py
+++ b/tests/test_bootstrap_evidence_receivers.py
@@ -373,6 +373,65 @@ async def test_full_empty_position_evidence_chain_is_typed_and_one_shot(
         receivers.broker_snapshot.receive_broker_snapshot_producer_result(result)
 
 
+@pytest.mark.asyncio
+async def test_retention_measurement_change_preserves_unpublished_bundle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    capability = _install_test_trust(monkeypatch, tmp_path)
+    database = tmp_path / "ledger.db"
+    _ledger(database)
+    runtime = _runtime(database)
+    output = tmp_path / "evidence"
+    receivers = create_bootstrap_evidence_receivers(
+        runtime_contract=runtime,
+        capability_directory=capability,
+        output_directory=output,
+    )
+    provider = _Provider(_broker_result(datetime.now(timezone.utc)))
+    measured_size: list[int] = []
+
+    async def inject_after_measurement(**kwargs: object) -> tuple:
+        assert kwargs["mark_identities"] == ()
+        measured_size.append(receivers.unpublished_bundle_size_bytes(set()))
+        injected = receivers._state.staging_output_directory / "raced-sealed-evidence.json"
+        injected.write_bytes(b"operator-evidence-must-survive")
+        injected.chmod(0o400)
+        return ()
+
+    original_publish = receiver_core.BootstrapEvidenceReceiverSet.publish_complete_bundle
+
+    def publish_with_admission_binding(self, expected_marks):
+        return original_publish(
+            self,
+            expected_marks,
+            expected_bundle_size_bytes=measured_size[0],
+        )
+
+    monkeypatch.setattr(
+        receiver_core.BootstrapEvidenceReceiverSet,
+        "publish_complete_bundle",
+        publish_with_admission_binding,
+    )
+
+    with pytest.raises(
+        BootstrapEvidenceReceiverError,
+        match="changed after retention measurement",
+    ):
+        await produce_bootstrap_evidence_bundle(
+            runtime_contract=runtime,
+            snapshot_provider=provider,
+            receivers=receivers,
+            protective_mark_collector=inject_after_measurement,
+        )
+
+    assert measured_size
+    assert (output / "raced-sealed-evidence.json").read_bytes() == (
+        b"operator-evidence-must-survive"
+    )
+    assert not (output / "bundle_complete.json").exists()
+
+
 def test_invalid_capability_does_not_create_output_directory(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_bootstrap_mark_producer.py
+++ b/tests/test_bootstrap_mark_producer.py
@@ -553,6 +553,7 @@ async def _collect(
     con_id: int = 265598,
     transport_generation: str = "generation-1",
     source_event_id: str | None = None,
+    active_symbols: tuple[str, ...] | None = None,
 ) -> tuple[UnsignedBootstrapProtectiveMark, object]:
     sink = receiver or Receiver()
     result = await collect_and_produce_bootstrap_protective_mark(
@@ -565,6 +566,7 @@ async def _collect(
         expected_con_id=con_id,
         expected_transport_generation=transport_generation,
         expected_source_event_id=source_event_id,
+        expected_active_symbols=active_symbols,
     )
     return result, sink
 
@@ -586,6 +588,22 @@ async def test_collector_uses_real_typed_path_before_receiver_delivery(database:
     evidence = monitor.get_protective_quote_evidence("AAPL")
     assert evidence is not None
     assert evidence.quote_id == result.protective_quote_id
+
+
+@pytest.mark.asyncio
+async def test_collector_preserves_complete_account_protective_symbol_scope(
+    database: Path,
+) -> None:
+    source = QuoteSource((_broker_quote(),))
+
+    await _collect(
+        source,
+        _monitor(database),
+        database,
+        active_symbols=("AAPL", "MSFT"),
+    )
+
+    assert source.requests == [(("AAPL",), ("AAPL", "MSFT"))]
 
 
 @pytest.mark.asyncio
@@ -1414,6 +1432,7 @@ def test_interface_has_no_price_path_json_signer_or_key_capability() -> None:
         "expected_con_id",
         "expected_transport_generation",
         "expected_source_event_id",
+        "expected_active_symbols",
     }
     assert all(
         fragment not in name

--- a/tests/test_exact_state_bootstrap.py
+++ b/tests/test_exact_state_bootstrap.py
@@ -55,6 +55,10 @@ _TEST_PRIVATE_KEYS: dict[str, Path] = {}
 _TEST_PUBLICATION_NONCE = "bootstrap-publication-v1-" + "a" * 64
 
 
+def _evidence_path(root: Path, filename: str) -> Path:
+    return root / "evidence" / filename
+
+
 @pytest.fixture(autouse=True)
 def _bootstrap_evidence_keys(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     producers = ("broker_snapshot", "reconciliation_report", "protective_mark")
@@ -283,6 +287,9 @@ def _candidate_bundle(
     legacy_hash: str | None = None,
     flat: bool = False,
 ) -> tuple[ExactStateBootstrapCandidate, object, RuntimeContract]:
+    if artifact_root == path.parent:
+        artifact_root = artifact_root / "evidence"
+        artifact_root.mkdir(exist_ok=True)
     effective = datetime.now(timezone.utc).replace(microsecond=0)
     runtime_contract = _runtime_contract(path)
     journal_path = Path(str(runtime_contract.safety_journal_path))
@@ -519,13 +526,28 @@ def _candidate_bundle(
         artifact_kind="reconciliation_report",
     )
     completion_path = artifact_root / "bundle_complete.json"
+    completion_path.unlink(missing_ok=True)
+    artifact_manifest = []
+    for artifact_path in sorted(artifact_root.iterdir(), key=lambda item: item.name):
+        metadata = artifact_path.stat(follow_symlinks=False)
+        payload = artifact_path.read_bytes()
+        artifact_manifest.append(
+            {
+                "device": metadata.st_dev,
+                "filename": artifact_path.name,
+                "inode": metadata.st_ino,
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "size_bytes": len(payload),
+            }
+        )
     completion_path.write_text(
         json.dumps(
             {
+                "artifact_manifest": artifact_manifest,
                 "bundle_id": bundle_id,
                 "publication_directory": str(artifact_root),
                 "publication_nonce": _TEST_PUBLICATION_NONCE,
-                "schema_version": 1,
+                "schema_version": 2,
             },
             sort_keys=True,
             separators=(",", ":"),
@@ -1217,11 +1239,11 @@ async def test_bootstrap_is_insert_only_exact_and_receipt_replay_is_rejected(
         )
         with pytest.raises(ExactStateBootstrapError, match="receipt replay"):
             load_exact_state_bootstrap_evidence(
-                reconciliation_path=tmp_path / "reconciliation.json",
-                broker_snapshot_path=tmp_path / "broker.json",
+                reconciliation_path=_evidence_path(tmp_path, "reconciliation.json"),
+                broker_snapshot_path=_evidence_path(tmp_path, "broker.json"),
                 protective_mark_paths=[
-                    tmp_path / "mark-NVDA.json",
-                    tmp_path / "mark-TSLA.json",
+                    _evidence_path(tmp_path, "mark-NVDA.json"),
+                    _evidence_path(tmp_path, "mark-TSLA.json"),
                 ],
                 expected_runtime_contract=runtime_contract,
             )
@@ -1416,7 +1438,7 @@ def test_evidence_loader_rejects_tampered_broker_and_wrong_runtime_scope(
     path = tmp_path / "legacy.db"
     _legacy_database(path)
     _, _, runtime_contract = _candidate_bundle(path, tmp_path)
-    broker_path = tmp_path / "broker.json"
+    broker_path = _evidence_path(tmp_path, "broker.json")
     broker = json.loads(broker_path.read_text(encoding="utf-8"))
     broker["snapshot"]["positions"] = [{"symbol": "AAPL", "quantity": "1"}]
     _write_artifact(
@@ -1429,9 +1451,12 @@ def test_evidence_loader_rejects_tampered_broker_and_wrong_runtime_scope(
 
     with pytest.raises(ExactStateBootstrapError, match="collection evidence counts"):
         load_exact_state_bootstrap_evidence(
-            reconciliation_path=tmp_path / "reconciliation.json",
+            reconciliation_path=_evidence_path(tmp_path, "reconciliation.json"),
             broker_snapshot_path=broker_path,
-            protective_mark_paths=[tmp_path / "mark-NVDA.json", tmp_path / "mark-TSLA.json"],
+            protective_mark_paths=[
+                _evidence_path(tmp_path, "mark-NVDA.json"),
+                _evidence_path(tmp_path, "mark-TSLA.json"),
+            ],
             expected_runtime_contract=runtime_contract,
         )
 
@@ -1592,12 +1617,15 @@ def test_external_json_without_authenticated_receipt_has_no_authority(tmp_path: 
     path = tmp_path / "legacy.db"
     _legacy_database(path)
     _, _, runtime = _candidate_bundle(path, tmp_path)
-    (tmp_path / "broker.json.auth.json").unlink()
+    _evidence_path(tmp_path, "broker.json.auth.json").unlink()
     with pytest.raises(ExactStateBootstrapError, match="authentication receipt"):
         load_exact_state_bootstrap_evidence(
-            reconciliation_path=tmp_path / "reconciliation.json",
-            broker_snapshot_path=tmp_path / "broker.json",
-            protective_mark_paths=[tmp_path / "mark-NVDA.json", tmp_path / "mark-TSLA.json"],
+            reconciliation_path=_evidence_path(tmp_path, "reconciliation.json"),
+            broker_snapshot_path=_evidence_path(tmp_path, "broker.json"),
+            protective_mark_paths=[
+                _evidence_path(tmp_path, "mark-NVDA.json"),
+                _evidence_path(tmp_path, "mark-TSLA.json"),
+            ],
             expected_runtime_contract=runtime,
         )
 
@@ -1606,7 +1634,7 @@ def test_current_authentication_cannot_refresh_thirty_day_old_snapshot(tmp_path:
     path = tmp_path / "legacy.db"
     _legacy_database(path)
     _, _, runtime = _candidate_bundle(path, tmp_path)
-    broker_path = tmp_path / "broker.json"
+    broker_path = _evidence_path(tmp_path, "broker.json")
     broker = json.loads(broker_path.read_text())
     stale = datetime.now(timezone.utc) - timedelta(days=30)
     snapshot = broker["snapshot"]
@@ -1641,7 +1669,7 @@ def test_current_authentication_cannot_refresh_thirty_day_old_snapshot(tmp_path:
         runtime_fingerprint=runtime.fingerprint,
         account_scope=ACCOUNT_SCOPE,
     )
-    reconciliation_path = tmp_path / "reconciliation.json"
+    reconciliation_path = _evidence_path(tmp_path, "reconciliation.json")
     reconciliation = json.loads(reconciliation_path.read_text())
     reconciliation["broker_snapshot_hash"] = broker_hash
     _write_artifact(
@@ -1653,7 +1681,10 @@ def test_current_authentication_cannot_refresh_thirty_day_old_snapshot(tmp_path:
         load_exact_state_bootstrap_evidence(
             reconciliation_path=reconciliation_path,
             broker_snapshot_path=broker_path,
-            protective_mark_paths=[tmp_path / "mark-NVDA.json", tmp_path / "mark-TSLA.json"],
+            protective_mark_paths=[
+                _evidence_path(tmp_path, "mark-NVDA.json"),
+                _evidence_path(tmp_path, "mark-TSLA.json"),
+            ],
             expected_runtime_contract=runtime,
         )
 
@@ -1662,7 +1693,7 @@ def test_expired_producer_receipt_is_rejected(tmp_path: Path) -> None:
     path = tmp_path / "legacy.db"
     _legacy_database(path)
     _, _, runtime = _candidate_bundle(path, tmp_path)
-    broker_path = tmp_path / "broker.json"
+    broker_path = _evidence_path(tmp_path, "broker.json")
     broker = json.loads(broker_path.read_text())
     _write_artifact(
         broker_path,
@@ -1674,9 +1705,12 @@ def test_expired_producer_receipt_is_rejected(tmp_path: Path) -> None:
     )
     with pytest.raises(ExactStateBootstrapError, match="expired"):
         load_exact_state_bootstrap_evidence(
-            reconciliation_path=tmp_path / "reconciliation.json",
+            reconciliation_path=_evidence_path(tmp_path, "reconciliation.json"),
             broker_snapshot_path=broker_path,
-            protective_mark_paths=[tmp_path / "mark-NVDA.json", tmp_path / "mark-TSLA.json"],
+            protective_mark_paths=[
+                _evidence_path(tmp_path, "mark-NVDA.json"),
+                _evidence_path(tmp_path, "mark-TSLA.json"),
+            ],
             expected_runtime_contract=runtime,
         )
 
@@ -1691,7 +1725,7 @@ def test_broker_integer_fields_reject_json_booleans(
     path = tmp_path / "legacy.db"
     _legacy_database(path)
     _, _, runtime = _candidate_bundle(path, tmp_path)
-    broker_path = tmp_path / "broker.json"
+    broker_path = _evidence_path(tmp_path, "broker.json")
     broker = json.loads(broker_path.read_text())
     if field == "schema_version":
         broker["snapshot"]["schema_version"] = invalid
@@ -1706,9 +1740,12 @@ def test_broker_integer_fields_reject_json_booleans(
     )
     with pytest.raises(ExactStateBootstrapError, match="JSON integer"):
         load_exact_state_bootstrap_evidence(
-            reconciliation_path=tmp_path / "reconciliation.json",
+            reconciliation_path=_evidence_path(tmp_path, "reconciliation.json"),
             broker_snapshot_path=broker_path,
-            protective_mark_paths=[tmp_path / "mark-NVDA.json", tmp_path / "mark-TSLA.json"],
+            protective_mark_paths=[
+                _evidence_path(tmp_path, "mark-NVDA.json"),
+                _evidence_path(tmp_path, "mark-TSLA.json"),
+            ],
             expected_runtime_contract=runtime,
         )
 
@@ -1730,7 +1767,7 @@ def test_reconciliation_integer_fields_reject_json_floats(tmp_path: Path, field:
     path = tmp_path / "legacy.db"
     _legacy_database(path)
     _, _, runtime = _candidate_bundle(path, tmp_path)
-    reconciliation_path = tmp_path / "reconciliation.json"
+    reconciliation_path = _evidence_path(tmp_path, "reconciliation.json")
     reconciliation = json.loads(reconciliation_path.read_text())
     reconciliation[field] = float(reconciliation[field])
     _write_artifact(
@@ -1741,8 +1778,11 @@ def test_reconciliation_integer_fields_reject_json_floats(tmp_path: Path, field:
     with pytest.raises(ExactStateBootstrapError, match="JSON integer"):
         load_exact_state_bootstrap_evidence(
             reconciliation_path=reconciliation_path,
-            broker_snapshot_path=tmp_path / "broker.json",
-            protective_mark_paths=[tmp_path / "mark-NVDA.json", tmp_path / "mark-TSLA.json"],
+            broker_snapshot_path=_evidence_path(tmp_path, "broker.json"),
+            protective_mark_paths=[
+                _evidence_path(tmp_path, "mark-NVDA.json"),
+                _evidence_path(tmp_path, "mark-TSLA.json"),
+            ],
             expected_runtime_contract=runtime,
         )
 
@@ -1763,7 +1803,7 @@ def test_reconciliation_strong_broker_and_position_bindings_cannot_drift(
     path = tmp_path / "legacy.db"
     _legacy_database(path)
     _, _, runtime = _candidate_bundle(path, tmp_path)
-    reconciliation_path = tmp_path / "reconciliation.json"
+    reconciliation_path = _evidence_path(tmp_path, "reconciliation.json")
     reconciliation = json.loads(reconciliation_path.read_text(encoding="utf-8"))
     if field == "broker_artifact_hash":
         reconciliation[field] = "0" * 64
@@ -1788,10 +1828,10 @@ def test_reconciliation_strong_broker_and_position_bindings_cannot_drift(
     ):
         load_exact_state_bootstrap_evidence(
             reconciliation_path=reconciliation_path,
-            broker_snapshot_path=tmp_path / "broker.json",
+            broker_snapshot_path=_evidence_path(tmp_path, "broker.json"),
             protective_mark_paths=[
-                tmp_path / "mark-NVDA.json",
-                tmp_path / "mark-TSLA.json",
+                _evidence_path(tmp_path, "mark-NVDA.json"),
+                _evidence_path(tmp_path, "mark-TSLA.json"),
             ],
             expected_runtime_contract=runtime,
         )
@@ -1803,7 +1843,7 @@ def test_fabricated_current_authentication_receipt_is_rejected(
     path = tmp_path / "legacy.db"
     _legacy_database(path)
     _, _, runtime = _candidate_bundle(path, tmp_path)
-    receipt_path = tmp_path / "broker.json.auth.json"
+    receipt_path = _evidence_path(tmp_path, "broker.json.auth.json")
     monkeypatch.setenv("SAFETY_ACCOUNT_SCOPE_KEY", "fedcba9876543210" * 4)
     receipt = json.loads(receipt_path.read_text())
     receipt["issued_at"] = datetime.now(timezone.utc).isoformat()
@@ -1814,9 +1854,12 @@ def test_fabricated_current_authentication_receipt_is_rejected(
     receipt_path.chmod(0o400)
     with pytest.raises(ExactStateBootstrapError, match="signature is invalid"):
         load_exact_state_bootstrap_evidence(
-            reconciliation_path=tmp_path / "reconciliation.json",
-            broker_snapshot_path=tmp_path / "broker.json",
-            protective_mark_paths=[tmp_path / "mark-NVDA.json", tmp_path / "mark-TSLA.json"],
+            reconciliation_path=_evidence_path(tmp_path, "reconciliation.json"),
+            broker_snapshot_path=_evidence_path(tmp_path, "broker.json"),
+            protective_mark_paths=[
+                _evidence_path(tmp_path, "mark-NVDA.json"),
+                _evidence_path(tmp_path, "mark-TSLA.json"),
+            ],
             expected_runtime_contract=runtime,
         )
 
@@ -1847,9 +1890,12 @@ def test_bootstrap_consumer_refuses_private_signing_capability(
     )
     with pytest.raises(ExactStateBootstrapError, match="refuses evidence trust/signing overrides"):
         load_exact_state_bootstrap_evidence(
-            reconciliation_path=tmp_path / "reconciliation.json",
-            broker_snapshot_path=tmp_path / "broker.json",
-            protective_mark_paths=[tmp_path / "mark-NVDA.json", tmp_path / "mark-TSLA.json"],
+            reconciliation_path=_evidence_path(tmp_path, "reconciliation.json"),
+            broker_snapshot_path=_evidence_path(tmp_path, "broker.json"),
+            protective_mark_paths=[
+                _evidence_path(tmp_path, "mark-NVDA.json"),
+                _evidence_path(tmp_path, "mark-TSLA.json"),
+            ],
             expected_runtime_contract=runtime,
         )
 
@@ -1866,9 +1912,12 @@ def test_bootstrap_consumer_refuses_public_trust_root_substitution(
     )
     with pytest.raises(ExactStateBootstrapError, match="refuses evidence trust/signing overrides"):
         load_exact_state_bootstrap_evidence(
-            reconciliation_path=tmp_path / "reconciliation.json",
-            broker_snapshot_path=tmp_path / "broker.json",
-            protective_mark_paths=[tmp_path / "mark-NVDA.json", tmp_path / "mark-TSLA.json"],
+            reconciliation_path=_evidence_path(tmp_path, "reconciliation.json"),
+            broker_snapshot_path=_evidence_path(tmp_path, "broker.json"),
+            protective_mark_paths=[
+                _evidence_path(tmp_path, "mark-NVDA.json"),
+                _evidence_path(tmp_path, "mark-TSLA.json"),
+            ],
             expected_runtime_contract=runtime,
         )
 
@@ -1895,11 +1944,11 @@ def test_wrong_producer_key_or_kind_cannot_authenticate_broker(tmp_path: Path, a
     path = tmp_path / "legacy.db"
     _legacy_database(path)
     _, _, runtime = _candidate_bundle(path, tmp_path)
-    receipt_path = tmp_path / "broker.json.auth.json"
+    receipt_path = _evidence_path(tmp_path, "broker.json.auth.json")
     receipt_path.unlink()
     if attack == "wrong_key":
         _emit_test_receipt(
-            artifact_path=tmp_path / "broker.json",
+            artifact_path=_evidence_path(tmp_path, "broker.json"),
             artifact_kind="broker_snapshot",
             signing_kind="protective_mark",
             runtime_fingerprint=runtime.fingerprint,
@@ -1907,16 +1956,19 @@ def test_wrong_producer_key_or_kind_cannot_authenticate_broker(tmp_path: Path, a
         )
     else:
         _emit_test_receipt(
-            artifact_path=tmp_path / "broker.json",
+            artifact_path=_evidence_path(tmp_path, "broker.json"),
             artifact_kind="protective_mark",
             runtime_fingerprint=runtime.fingerprint,
             account_scope=ACCOUNT_SCOPE,
         )
     with pytest.raises(ExactStateBootstrapError, match="wrong key|wrong producer|wrong.*kind"):
         load_exact_state_bootstrap_evidence(
-            reconciliation_path=tmp_path / "reconciliation.json",
-            broker_snapshot_path=tmp_path / "broker.json",
-            protective_mark_paths=[tmp_path / "mark-NVDA.json", tmp_path / "mark-TSLA.json"],
+            reconciliation_path=_evidence_path(tmp_path, "reconciliation.json"),
+            broker_snapshot_path=_evidence_path(tmp_path, "broker.json"),
+            protective_mark_paths=[
+                _evidence_path(tmp_path, "mark-NVDA.json"),
+                _evidence_path(tmp_path, "mark-TSLA.json"),
+            ],
             expected_runtime_contract=runtime,
         )
 
@@ -1937,9 +1989,12 @@ def test_pinned_public_verification_key_identity_is_strict(tmp_path: Path, attac
         os.link(public_path, tmp_path / "broker-public-alias.pem")
     with pytest.raises(ExactStateBootstrapError, match="immutable fingerprint|sealed owner file"):
         load_exact_state_bootstrap_evidence(
-            reconciliation_path=tmp_path / "reconciliation.json",
-            broker_snapshot_path=tmp_path / "broker.json",
-            protective_mark_paths=[tmp_path / "mark-NVDA.json", tmp_path / "mark-TSLA.json"],
+            reconciliation_path=_evidence_path(tmp_path, "reconciliation.json"),
+            broker_snapshot_path=_evidence_path(tmp_path, "broker.json"),
+            protective_mark_paths=[
+                _evidence_path(tmp_path, "mark-NVDA.json"),
+                _evidence_path(tmp_path, "mark-TSLA.json"),
+            ],
             expected_runtime_contract=runtime,
         )
 

--- a/tests/test_persistent_connection_e2e_smoke.py
+++ b/tests/test_persistent_connection_e2e_smoke.py
@@ -32,6 +32,7 @@ import pytest
 
 from robo_trader.connection_health import ConnectionHealth, HealthStatus
 from robo_trader.runner_async import AsyncRunner
+from robo_trader.reconciliation.runtime_integration import RuntimeReconciliationController
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -56,6 +57,9 @@ def _make_runner():
 
     # health is set by _attach_health_monitor; start as None
     runner.health = None
+    reconciliation = object.__new__(RuntimeReconciliationController)
+    reconciliation.reconcile_reconnect = AsyncMock()
+    runner.reconciliation_controller = reconciliation
 
     return runner
 

--- a/tests/test_persistent_connection_e2e_smoke.py
+++ b/tests/test_persistent_connection_e2e_smoke.py
@@ -31,8 +31,8 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 import pytest
 
 from robo_trader.connection_health import ConnectionHealth, HealthStatus
-from robo_trader.runner_async import AsyncRunner
 from robo_trader.reconciliation.runtime_integration import RuntimeReconciliationController
+from robo_trader.runner_async import AsyncRunner
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_pr1a_runner_event_time.py
+++ b/tests/test_pr1a_runner_event_time.py
@@ -45,6 +45,7 @@ from robo_trader.runner_async import (
     SymbolResult,
     run_continuous,
 )
+from robo_trader.reconciliation.runtime_integration import RuntimeReconciliationController
 from robo_trader.stop_loss_monitor import StopLossMonitor
 
 
@@ -70,6 +71,9 @@ def continuous_safety_args(monkeypatch):
     resources = SimpleNamespace(
         database=object(),
         gateway=object(),
+        reconciliation=SimpleNamespace(
+            reconcile_periodic_if_due=AsyncMock(return_value=None),
+        ),
     )
     monkeypatch.setattr(
         runner_module,
@@ -582,6 +586,9 @@ async def _configure_order_runtime(runner: AsyncRunner, executor_result=None) ->
     runner._order_admitted_tasks = set()
     runner._kill_switch_log_last = {}
     runner._kill_switch_log_throttle_seconds = 60
+    reconciliation = object.__new__(RuntimeReconciliationController)
+    reconciliation.entry_eligible = lambda: True
+    runner.reconciliation_controller = reconciliation
     runner._protective_feed_status = {
         symbol: {
             "available": True,

--- a/tests/test_pr1a_runner_event_time.py
+++ b/tests/test_pr1a_runner_event_time.py
@@ -37,6 +37,7 @@ from robo_trader.protective_quote_evidence import (
     ProtectiveQuoteSource,
     assert_producer_owned_protective_quote,
 )
+from robo_trader.reconciliation.runtime_integration import RuntimeReconciliationController
 from robo_trader.runner_async import (
     AsyncRunner,
     MarketDataContractError,
@@ -45,7 +46,6 @@ from robo_trader.runner_async import (
     SymbolResult,
     run_continuous,
 )
-from robo_trader.reconciliation.runtime_integration import RuntimeReconciliationController
 from robo_trader.stop_loss_monitor import StopLossMonitor
 
 

--- a/tests/test_pr2b1_runtime_startup.py
+++ b/tests/test_pr2b1_runtime_startup.py
@@ -946,6 +946,72 @@ async def test_continuous_reuses_one_account_coordinator_for_portfolio_runners(t
 
 
 @pytest.mark.asyncio
+async def test_periodic_reconciliation_failure_keeps_reduce_only_cycle_running(tmp_path):
+    cfg = _cfg(tmp_path)
+    SafetyJournal(Path(cfg.runtime_contract.safety_journal_path)).initialize(
+        execution_domain_scope=cfg.runtime_contract.safety_execution_domain_scope,
+        account_scope=cfg.runtime_contract.safety_account_scope,
+    )
+    coordinator = _start_paper_safety_runtime(cfg)
+    reconciliation = _reconciliation_resource()
+    reconciliation.reconcile_periodic_if_due.side_effect = RuntimeError(
+        "status artifact unavailable"
+    )
+    resources = SimpleNamespace(database=object(), gateway=object(), reconciliation=reconciliation)
+    runner = MagicMock()
+    runner.recovery_in_progress = False
+    runner._recovery_exhausted = False
+    runner.health = None
+    runner.run = AsyncMock()
+    runner.cleanup = AsyncMock()
+    portfolio = SimpleNamespace(
+        id="default",
+        name="Default",
+        starting_cash=100000,
+        symbols=["AAPL"],
+        active=True,
+    )
+
+    with (
+        patch("signal.signal"),
+        patch("robo_trader.runner_async.RuntimeSafetyContext", object),
+        patch(
+            "robo_trader.runner_async._start_paper_order_runtime",
+            new_callable=AsyncMock,
+            return_value=resources,
+        ),
+        patch(
+            "robo_trader.runner_async._close_paper_order_runtime",
+            new_callable=AsyncMock,
+        ),
+        patch("robo_trader.runner_async.AsyncRunner", return_value=runner),
+        patch("robo_trader.runner_async._setup_continuous_runner", new_callable=AsyncMock),
+        patch("robo_trader.runner_async.is_trading_allowed", return_value=True),
+        patch(
+            "robo_trader.multiuser.portfolio_config.load_portfolio_configs",
+            return_value=[portfolio],
+        ),
+        patch(
+            "robo_trader.runner_async.sleep_unless_shutdown",
+            new_callable=AsyncMock,
+            side_effect=asyncio.CancelledError,
+        ),
+        patch("robo_trader.runner_async._write_exit_audit"),
+        patch("robo_trader.runner_async._fire_runner_exit_alert"),
+    ):
+        await run_continuous(
+            symbols=["AAPL"],
+            interval_seconds=1,
+            safety_runtime=coordinator,
+            runtime_context=object(),
+        )
+
+    reconciliation.reconcile_periodic_if_due.assert_awaited_once_with()
+    runner.run.assert_awaited_once_with(["AAPL"])
+    runner.cleanup.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
 async def test_continuous_closes_shared_runtime_after_runner_cleanup_cancellation(
     tmp_path,
 ) -> None:

--- a/tests/test_pr2b1_runtime_startup.py
+++ b/tests/test_pr2b1_runtime_startup.py
@@ -53,6 +53,10 @@ def _cfg(tmp_path: Path):
     return SimpleNamespace(runtime_contract=_runtime_contract(tmp_path))
 
 
+def _reconciliation_resource():
+    return SimpleNamespace(reconcile_periodic_if_due=AsyncMock(return_value=None))
+
+
 def test_startup_replays_existing_journal_without_initializing_it(tmp_path):
     cfg = _cfg(tmp_path)
     journal_path = Path(cfg.runtime_contract.safety_journal_path)
@@ -347,6 +351,9 @@ async def test_shared_runtime_startup_database_cleanup_drains_repeated_cancellat
     database.close = AsyncMock(side_effect=blocking_close)
     gateway = MagicMock()
     gateway.start = AsyncMock(side_effect=RuntimeError("gateway startup failed"))
+    gateway.close = AsyncMock()
+    reconciliation = MagicMock()
+    reconciliation.close = AsyncMock()
 
     with (
         patch.object(
@@ -360,6 +367,11 @@ async def test_shared_runtime_startup_database_cleanup_drains_repeated_cancellat
         ),
         patch.object(runner_module, "SafetyRuntimeCoordinator", ExactSafetyRuntime),
         patch.object(runner_module, "AsyncTradingDatabase", return_value=database),
+        patch.object(
+            runner_module,
+            "build_runtime_reconciliation_controller",
+            new=AsyncMock(return_value=(reconciliation, object())),
+        ),
         patch.object(runner_module, "PaperReductionGateway", return_value=gateway),
     ):
         owner = asyncio.create_task(_start_paper_order_runtime(context, ExactSafetyRuntime()))
@@ -377,6 +389,8 @@ async def test_shared_runtime_startup_database_cleanup_drains_repeated_cancellat
 
     assert close_finished.is_set()
     database.close.assert_awaited_once()
+    gateway.close.assert_awaited_once()
+    reconciliation.close.assert_awaited_once()
 
 
 def _install_minimal_cleanup_state(runner: AsyncRunner) -> None:
@@ -647,7 +661,9 @@ async def test_run_once_retains_started_coordinator_for_runner(tmp_path):
     )
     coordinator = _start_paper_safety_runtime(cfg)
     runtime_context = object()
-    resources = SimpleNamespace(database=object(), gateway=object())
+    resources = SimpleNamespace(
+        database=object(), gateway=object(), reconciliation=_reconciliation_resource()
+    )
     runner = MagicMock()
     runner.run = AsyncMock()
     runner.cleanup = AsyncMock()
@@ -693,7 +709,9 @@ async def test_run_once_closes_shared_runtime_after_runner_cleanup_failure(
         account_scope=cfg.runtime_contract.safety_account_scope,
     )
     coordinator = _start_paper_safety_runtime(cfg)
-    resources = SimpleNamespace(database=object(), gateway=object())
+    resources = SimpleNamespace(
+        database=object(), gateway=object(), reconciliation=_reconciliation_resource()
+    )
     runner = MagicMock()
     runner.run = AsyncMock()
     runner.cleanup = AsyncMock(side_effect=cleanup_error)
@@ -729,7 +747,9 @@ async def test_run_once_preserves_run_error_after_all_cleanup_attempts(tmp_path)
         account_scope=cfg.runtime_contract.safety_account_scope,
     )
     coordinator = _start_paper_safety_runtime(cfg)
-    resources = SimpleNamespace(database=object(), gateway=object())
+    resources = SimpleNamespace(
+        database=object(), gateway=object(), reconciliation=_reconciliation_resource()
+    )
     runner = MagicMock()
     runner.run = AsyncMock(side_effect=ValueError("primary run failure"))
     runner.cleanup = AsyncMock(side_effect=RuntimeError("secondary cleanup failure"))
@@ -769,7 +789,9 @@ async def test_run_once_drains_runner_cleanup_through_repeated_cancellation(
         account_scope=cfg.runtime_contract.safety_account_scope,
     )
     coordinator = _start_paper_safety_runtime(cfg)
-    resources = SimpleNamespace(database=object(), gateway=object())
+    resources = SimpleNamespace(
+        database=object(), gateway=object(), reconciliation=_reconciliation_resource()
+    )
     cleanup_entered = asyncio.Event()
     release_cleanup = asyncio.Event()
     cleanup_finished = asyncio.Event()
@@ -821,7 +843,9 @@ async def test_run_once_drains_runner_cleanup_through_repeated_cancellation(
 
 @pytest.mark.asyncio
 async def test_shared_runtime_close_survives_repeated_outer_cancellation() -> None:
-    resources = SimpleNamespace(database=object(), gateway=object())
+    resources = SimpleNamespace(
+        database=object(), gateway=object(), reconciliation=_reconciliation_resource()
+    )
     close_entered = asyncio.Event()
     release_close = asyncio.Event()
     close_finished = asyncio.Event()
@@ -860,7 +884,9 @@ async def test_continuous_reuses_one_account_coordinator_for_portfolio_runners(t
     )
     coordinator = _start_paper_safety_runtime(cfg)
     runtime_context = object()
-    resources = SimpleNamespace(database=object(), gateway=object())
+    resources = SimpleNamespace(
+        database=object(), gateway=object(), reconciliation=_reconciliation_resource()
+    )
     runner = MagicMock()
     runner.recovery_in_progress = False
     runner._recovery_exhausted = False
@@ -929,7 +955,9 @@ async def test_continuous_closes_shared_runtime_after_runner_cleanup_cancellatio
         account_scope=cfg.runtime_contract.safety_account_scope,
     )
     coordinator = _start_paper_safety_runtime(cfg)
-    resources = SimpleNamespace(database=object(), gateway=object())
+    resources = SimpleNamespace(
+        database=object(), gateway=object(), reconciliation=_reconciliation_resource()
+    )
     runner = MagicMock()
     runner.recovery_in_progress = False
     runner._recovery_exhausted = False
@@ -997,7 +1025,9 @@ async def test_continuous_drains_every_runner_cleanup_through_repeated_cancellat
         account_scope=cfg.runtime_contract.safety_account_scope,
     )
     coordinator = _start_paper_safety_runtime(cfg)
-    resources = SimpleNamespace(database=object(), gateway=object())
+    resources = SimpleNamespace(
+        database=object(), gateway=object(), reconciliation=_reconciliation_resource()
+    )
     first_cleanup_entered = asyncio.Event()
     release_first_cleanup = asyncio.Event()
     first_cleanup_finished = asyncio.Event()

--- a/tests/test_pr2b2_runner_routing.py
+++ b/tests/test_pr2b2_runner_routing.py
@@ -35,6 +35,7 @@ from robo_trader.protective_quote_evidence import (
     _produce_protective_quote,
 )
 from robo_trader.runner_async import AsyncRunner
+from robo_trader.reconciliation.runtime_integration import RuntimeReconciliationController
 from robo_trader.stop_loss_monitor import StopLossMonitor
 
 
@@ -118,6 +119,9 @@ def _runner(
     runner._order_admitted_tasks = set()
     runner._kill_switch_log_last = {}
     runner._kill_switch_log_throttle_seconds = 60.0
+    reconciliation = object.__new__(RuntimeReconciliationController)
+    reconciliation.entry_eligible = lambda: True
+    runner.reconciliation_controller = reconciliation
 
     probe = getattr(getattr(gateway, "serialize_entry", None), "return_value", None)
     now = (
@@ -349,6 +353,34 @@ async def test_entries_remain_blocked_before_gateway_or_executor(
     gateway.serialize_entry.assert_not_called()
     runner.executor.place_order.assert_not_called()
     runner.rate_limiter.acquire.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_quarantine_blocks_entries_before_executor() -> None:
+    gateway, _ = _exact_gateway()
+    runner = _runner(gateway)
+    runner.reconciliation_controller.entry_eligible = lambda: False
+
+    result = await _place(runner, _order("BUY"))
+
+    assert result.ok is False
+    assert result.message == (
+        "Trading blocked: Runtime reconciliation is unavailable, stale, or quarantined"
+    )
+    gateway.submit_reduction.assert_not_awaited()
+    runner.executor.place_order.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_quarantine_does_not_block_semantic_reduction() -> None:
+    gateway, _ = _exact_gateway()
+    runner = _runner(gateway)
+    runner.reconciliation_controller.entry_eligible = lambda: False
+
+    result = await _place(runner, _order("SELL"))
+
+    assert result.ok is True
+    gateway.submit_reduction.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_pr2b2_runner_routing.py
+++ b/tests/test_pr2b2_runner_routing.py
@@ -34,8 +34,8 @@ from robo_trader.protective_quote_evidence import (
     ProtectiveQuoteSource,
     _produce_protective_quote,
 )
-from robo_trader.runner_async import AsyncRunner
 from robo_trader.reconciliation.runtime_integration import RuntimeReconciliationController
+from robo_trader.runner_async import AsyncRunner
 from robo_trader.stop_loss_monitor import StopLossMonitor
 
 

--- a/tests/test_pr2b3_emergency_protection.py
+++ b/tests/test_pr2b3_emergency_protection.py
@@ -11,8 +11,8 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 
 from robo_trader.execution import Order
-from robo_trader.runner_async import AsyncRunner
 from robo_trader.reconciliation.runtime_integration import RuntimeReconciliationController
+from robo_trader.runner_async import AsyncRunner
 
 
 def _minimal_runner() -> AsyncRunner:

--- a/tests/test_pr2b3_emergency_protection.py
+++ b/tests/test_pr2b3_emergency_protection.py
@@ -12,6 +12,7 @@ import pytest
 
 from robo_trader.execution import Order
 from robo_trader.runner_async import AsyncRunner
+from robo_trader.reconciliation.runtime_integration import RuntimeReconciliationController
 
 
 def _minimal_runner() -> AsyncRunner:
@@ -30,6 +31,9 @@ def _minimal_runner() -> AsyncRunner:
     runner.stop_loss_monitor = None
     runner._baseline_entry_handle = object()
     runner._baseline_entry_intent = object()
+    reconciliation = object.__new__(RuntimeReconciliationController)
+    reconciliation.entry_eligible = lambda: True
+    runner.reconciliation_controller = reconciliation
     return runner
 
 

--- a/tests/test_pr5_bootstrap_reconciliation_producer.py
+++ b/tests/test_pr5_bootstrap_reconciliation_producer.py
@@ -527,6 +527,11 @@ def _produce(
     with (
         patch.object(producer_module, "_system_clock", clock or (lambda: NOW)),
         patch.object(producer_module, "_consume_verified_broker_evidence", authority.consume),
+        patch.object(
+            producer_module,
+            "_handoff_verified_broker_evidence_to_runtime",
+            lambda value: value,
+        ),
     ):
         delivery: producer_module.BootstrapReconciliationDelivery[object] = (
             produce_bootstrap_reconciliation(
@@ -547,6 +552,7 @@ def test_clean_stage_collects_ledger_and_binds_non_authorizing_result(database: 
     result = receiver.results[0]
     assert delivery.receiver_result is result
     assert delivery.local_position_identities == (("default", "AAPL"), ("default", "MSFT"))
+    assert delivery.verified_broker_evidence is envelope
     assert result.status == BOOTSTRAP_RECONCILIATION_STATUS
     assert result.bundle_id == BUNDLE_ID
     assert result.binding_dict()["bundle_id"] == BUNDLE_ID

--- a/tests/test_pr5_reconciliation_runtime.py
+++ b/tests/test_pr5_reconciliation_runtime.py
@@ -10,6 +10,7 @@ import weakref
 from dataclasses import FrozenInstanceError
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
+from pathlib import Path
 from types import SimpleNamespace
 
 import aiosqlite
@@ -315,6 +316,7 @@ async def _service(
     database_path = (tmp_path / "reconciliation.sqlite3").resolve()
     source = _EvidenceSource(database_path, snapshot or _snapshot(), comparison or _comparison())
     persistence = ReconciliationPersistence(database_path)
+    await persistence.migrate_for_operator(operator_confirmed=True)
     service = ReconciliationService(
         evidence_source=source,
         persistence=persistence,
@@ -362,7 +364,7 @@ async def test_component_migration_preserves_unrelated_schema_and_rows(tmp_path)
         await connection.commit()
     persistence = ReconciliationPersistence(database_path)
 
-    await persistence.initialize()
+    await persistence.migrate_for_operator(operator_confirmed=True)
     await persistence.initialize()
 
     with sqlite3.connect(database_path) as connection:
@@ -372,6 +374,35 @@ async def test_component_migration_preserves_unrelated_schema_and_rows(tmp_path)
         assert connection.execute(
             "SELECT component, version FROM rt_schema_migrations"
         ).fetchall() == [(RECONCILIATION_COMPONENT, 1), (RECONCILIATION_COMPONENT, 2)]
+
+
+@pytest.mark.asyncio
+async def test_runtime_initialize_is_read_only_and_operator_migration_is_explicit(
+    tmp_path,
+) -> None:
+    database_path = (tmp_path / "reconciliation.sqlite3").resolve()
+    with sqlite3.connect(database_path) as connection:
+        connection.execute("CREATE TABLE irreplaceable_history(value TEXT NOT NULL)")
+        connection.execute("INSERT INTO irreplaceable_history VALUES ('preserve-me')")
+    persistence = ReconciliationPersistence(database_path)
+    before = database_path.read_bytes()
+
+    with pytest.raises(ReconciliationPersistenceError, match="schema is unavailable"):
+        await persistence.initialize()
+
+    assert database_path.read_bytes() == before
+    assert not Path(f"{database_path}-wal").exists()
+    assert not Path(f"{database_path}-shm").exists()
+    with pytest.raises(ReconciliationPersistenceError, match="operator confirmation"):
+        await persistence.migrate_for_operator(operator_confirmed=False)
+    assert database_path.read_bytes() == before
+
+    await persistence.migrate_for_operator(operator_confirmed=True)
+    await persistence.initialize()
+    with sqlite3.connect(database_path) as connection:
+        assert connection.execute("SELECT * FROM irreplaceable_history").fetchall() == [
+            ("preserve-me",)
+        ]
 
 
 @pytest.mark.asyncio
@@ -458,7 +489,7 @@ async def test_exact_old_v1_schema_upgrades_additively_without_row_loss(tmp_path
         )
         await connection.commit()
 
-    await ReconciliationPersistence(database_path).initialize()
+    await ReconciliationPersistence(database_path).migrate_for_operator(operator_confirmed=True)
 
     with sqlite3.connect(database_path) as connection:
         assert connection.execute(
@@ -585,7 +616,7 @@ async def test_v2_constraint_mutation_matrix_fails_closed(
 ) -> None:
     database_path = (tmp_path / "reconciliation.sqlite3").resolve()
     persistence = ReconciliationPersistence(database_path)
-    await persistence.initialize()
+    await persistence.migrate_for_operator(operator_confirmed=True)
     _rewrite_table_definition(database_path, table, old, new)
 
     with pytest.raises((RuntimeError, sqlite3.DatabaseError), match="malformed"):
@@ -647,7 +678,7 @@ async def test_v1_constraint_mutation_matrix_fails_closed(
 ) -> None:
     database_path = (tmp_path / "reconciliation.sqlite3").resolve()
     persistence = ReconciliationPersistence(database_path)
-    await persistence.initialize()
+    await persistence.migrate_for_operator(operator_confirmed=True)
     _rewrite_table_definition(database_path, table, old, new)
 
     with pytest.raises((RuntimeError, sqlite3.DatabaseError), match="malformed"):
@@ -667,7 +698,7 @@ async def test_v1_constraint_mutation_matrix_fails_closed(
 async def test_every_v1_append_only_trigger_is_exact(tmp_path, table: str) -> None:
     database_path = (tmp_path / "reconciliation.sqlite3").resolve()
     persistence = ReconciliationPersistence(database_path)
-    await persistence.initialize()
+    await persistence.migrate_for_operator(operator_confirmed=True)
     trigger = f"{table}_no_delete"
     _rewrite_schema_definition(
         database_path,
@@ -706,7 +737,7 @@ async def test_every_v2_append_only_trigger_is_exact(
 ) -> None:
     database_path = (tmp_path / "reconciliation.sqlite3").resolve()
     persistence = ReconciliationPersistence(database_path)
-    await persistence.initialize()
+    await persistence.migrate_for_operator(operator_confirmed=True)
     trigger = f"{table}_{suffix}"
     _rewrite_schema_definition(
         database_path,
@@ -724,7 +755,7 @@ async def test_every_v2_append_only_trigger_is_exact(
 async def test_v2_composite_identity_index_mutation_fails_closed(tmp_path) -> None:
     database_path = (tmp_path / "reconciliation.sqlite3").resolve()
     persistence = ReconciliationPersistence(database_path)
-    await persistence.initialize()
+    await persistence.migrate_for_operator(operator_confirmed=True)
     with sqlite3.connect(database_path) as connection:
         connection.execute("DROP INDEX rt_reconciliation_differences_run_difference_uq")
         connection.execute(
@@ -752,7 +783,7 @@ async def test_v2_duplicate_null_identity_probe_fails_closed(
 ) -> None:
     database_path = (tmp_path / "reconciliation.sqlite3").resolve()
     persistence = ReconciliationPersistence(database_path)
-    await persistence.initialize()
+    await persistence.migrate_for_operator(operator_confirmed=True)
     constrained = f"{identity_column} TEXT PRIMARY KEY NOT NULL"
     nullable = f"{identity_column} TEXT PRIMARY KEY"
     _rewrite_table_definition(database_path, table, constrained, nullable)
@@ -914,7 +945,7 @@ async def test_partial_migration_fails_closed_without_using_runtime_state(tmp_pa
 @pytest.mark.asyncio
 async def test_duplicate_append_is_idempotent_not_a_duplicate_callback(tmp_path) -> None:
     persistence = ReconciliationPersistence((tmp_path / "reconciliation.sqlite3").resolve())
-    await persistence.initialize()
+    await persistence.migrate_for_operator(operator_confirmed=True)
     snapshot = _snapshot()
     verdict = evaluate_paper_simulator_reconciliation(
         snapshot,

--- a/tests/test_pr5_runtime_integration.py
+++ b/tests/test_pr5_runtime_integration.py
@@ -712,6 +712,46 @@ async def test_position_protective_receipt_exact_coverage_is_ready(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("evolution", ["closed-bootstrap-position", "later-entry"])
+async def test_bootstrap_receipts_remain_ready_after_valid_position_evolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    evolution: str,
+) -> None:
+    database = tmp_path / "ledger.db"
+    runtime = _runtime(database)
+    _readiness_database(
+        database,
+        runtime,
+        include_bootstrap=True,
+        include_position=evolution == "closed-bootstrap-position",
+    )
+    with sqlite3.connect(database) as connection:
+        if evolution == "closed-bootstrap-position":
+            connection.execute("DELETE FROM positions WHERE symbol='AAPL'")
+            connection.execute("DELETE FROM paper_position_settlement_state WHERE symbol='AAPL'")
+        else:
+            connection.execute(
+                "INSERT INTO positions VALUES (?,?,?)",
+                ("default", "MSFT", 2),
+            )
+            connection.execute(
+                "INSERT INTO paper_position_settlement_state VALUES (?,?,?,?,?)",
+                ("default", "MSFT", "200", "210", BOOTSTRAP_ID),
+            )
+    context = SimpleNamespace(runtime_contract=runtime)
+    monkeypatch.setattr(
+        integration,
+        "assert_validated_runtime_safety_context",
+        lambda value: value,
+    )
+    monkeypatch.setattr(integration, "assert_exact_state_schema", AsyncMock())
+    monkeypatch.setattr(integration, "assert_reconciliation_schema", AsyncMock())
+
+    await assert_runtime_bootstrap_ready(context)
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("schema_state", ["absent", "partial"])
 async def test_runtime_schema_assertion_is_byte_preserving_and_precedes_provider(
     tmp_path: Path,

--- a/tests/test_pr5_runtime_integration.py
+++ b/tests/test_pr5_runtime_integration.py
@@ -148,6 +148,13 @@ async def test_source_uses_one_broker_generation_through_marks_and_runtime_bind(
         protective_mark=object(),
         assert_complete=MagicMock(),
         unpublished_bundle_size_bytes=MagicMock(return_value=1024),
+        unpublished_bundle_directory_binding=MagicMock(
+            return_value=(
+                ".runtime-reconciliation-" + "c" * 48 + ".unpublished-" + "d" * 64,
+                1,
+                1,
+            )
+        ),
         publish_complete_bundle=MagicMock(),
         published_artifact_path=MagicMock(
             side_effect=lambda artifact: tmp_path / artifact.artifact_path.name
@@ -291,6 +298,69 @@ async def test_evidence_retention_ceiling_quarantines_without_deleting_audit_bun
     assert artifact.read_bytes() == before
     assert bundle.is_dir()
     provider.produce_normalized_snapshot.assert_not_awaited()
+
+
+def test_evidence_retention_admission_rescans_after_external_bundle_addition(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database = tmp_path / "ledger.db"
+    database.touch()
+    runtime = _runtime(database)
+    context = SimpleNamespace(runtime_contract=runtime)
+    monkeypatch.setattr(
+        integration,
+        "assert_validated_runtime_safety_context",
+        lambda value: value,
+    )
+    capability_directory = tmp_path / "capabilities"
+    evidence_root = tmp_path / "evidence"
+    capability_directory.mkdir(mode=0o700)
+    evidence_root.mkdir(mode=0o700)
+    source = ProductionRuntimeEvidenceSource(
+        runtime_context=context,
+        provider=SimpleNamespace(close=AsyncMock()),
+        capability_directory=capability_directory,
+        evidence_root=evidence_root,
+        max_published_bundles=1,
+    )
+
+    source._assert_retention_capacity()
+    injected_bundle = evidence_root / ("runtime-reconciliation-" + "b" * 48)
+    injected_bundle.mkdir(mode=0o700)
+    artifact = injected_bundle / "bundle_complete.json"
+    artifact.write_bytes(b"externally-added-audit-lineage")
+    artifact.chmod(0o400)
+
+    with pytest.raises(
+        RuntimeReconciliationIntegrationError,
+        match="retention ceiling reached",
+    ):
+        source._assert_retention_capacity()
+
+
+def test_evidence_usage_excludes_only_exact_current_staging_identity(tmp_path: Path) -> None:
+    evidence_root = tmp_path / "evidence"
+    evidence_root.mkdir(mode=0o700)
+    staging = evidence_root / (".runtime-reconciliation-" + "c" * 48 + ".unpublished-" + "d" * 64)
+    staging.mkdir(mode=0o700)
+    staged_artifact = staging / "broker_snapshot.json"
+    staged_artifact.write_bytes(b"current-staging")
+    staged_artifact.chmod(0o400)
+    metadata = staging.stat(follow_symlinks=False)
+
+    assert integration._published_evidence_usage(
+        evidence_root,
+        excluded_staging_binding=(staging.name, metadata.st_dev, metadata.st_ino),
+    ) == (0, 0)
+    with pytest.raises(
+        RuntimeReconciliationIntegrationError,
+        match="changed identity",
+    ):
+        integration._published_evidence_usage(
+            evidence_root,
+            excluded_staging_binding=(staging.name, metadata.st_dev, metadata.st_ino + 1),
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_pr5_runtime_integration.py
+++ b/tests/test_pr5_runtime_integration.py
@@ -14,9 +14,9 @@ import robo_trader.reconciliation.runtime_integration as integration
 from robo_trader.bootstrap_evidence_receivers import SealedBootstrapEvidenceArtifact
 from robo_trader.config import RuntimeContract
 from robo_trader.reconciliation.runtime_integration import (
+    ProductionRuntimeEvidenceSource,
     RuntimeReconciliationController,
     RuntimeReconciliationIntegrationError,
-    ProductionRuntimeEvidenceSource,
     assert_runtime_bootstrap_ready,
     build_runtime_reconciliation_controller,
     read_runtime_reconciliation_status,

--- a/tests/test_pr5_runtime_integration.py
+++ b/tests/test_pr5_runtime_integration.py
@@ -1017,6 +1017,77 @@ def test_status_atomic_exchange_restores_raced_unrelated_target(
     assert held_owned.is_file()
 
 
+def test_status_failed_race_rollback_preserves_displaced_unrelated_inode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    status_path = tmp_path / "status.json"
+    payload = {
+        "schema_version": 1,
+        "owner_binding": STATUS_OWNER_BINDING,
+        "state": "quarantined",
+        "trigger": None,
+        "completed_at": None,
+        "eligible_until": None,
+        "entry_eligible": False,
+        "quarantined": True,
+        "run_id": None,
+        "snapshot_id": None,
+    }
+    integration._write_status(
+        status_path,
+        payload,
+        owner_binding=STATUS_OWNER_BINDING,
+    )
+    held_owned = tmp_path / "held-owned-status.json"
+    real_exchange = integration._exchange_status_entries
+    calls = 0
+
+    def race_then_fail_rollback(parent_descriptor: int, left: str, right: str) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            os.rename(
+                right,
+                held_owned.name,
+                src_dir_fd=parent_descriptor,
+                dst_dir_fd=parent_descriptor,
+            )
+            raced = os.open(
+                right,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+                dir_fd=parent_descriptor,
+            )
+            os.write(raced, b"unrelated-raced-state")
+            os.close(raced)
+            real_exchange(parent_descriptor, left, right)
+            return
+        raise OSError("simulated rollback failure")
+
+    monkeypatch.setattr(
+        integration,
+        "_exchange_status_entries",
+        race_then_fail_rollback,
+    )
+
+    with pytest.raises(
+        RuntimeReconciliationIntegrationError,
+        match="displaced inode was preserved",
+    ):
+        integration._write_status(
+            status_path,
+            dict(payload, state="ready"),
+            owner_binding=STATUS_OWNER_BINDING,
+        )
+
+    displaced = list(tmp_path.glob(".status.json.stage-*"))
+    assert calls == 2
+    assert len(displaced) == 1
+    assert displaced[0].read_bytes() == b"unrelated-raced-state"
+    assert held_owned.is_file()
+
+
 def test_first_status_publication_race_never_replaces_unrelated_target(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_pr5_runtime_integration.py
+++ b/tests/test_pr5_runtime_integration.py
@@ -133,14 +133,25 @@ async def test_source_uses_one_broker_generation_through_marks_and_runtime_bind(
     quote_source = SimpleNamespace(
         get_protective_quotes=AsyncMock(side_effect=collect_quote),
     )
+    lease_token = object()
     provider = SimpleNamespace(
         produce_normalized_snapshot=AsyncMock(return_value=broker_envelope),
         issue_protective_quote_source=MagicMock(return_value=quote_source),
+        _acquire_generation_lease=AsyncMock(return_value=(lease_token, "generation-1")),
+        _release_generation_lease=MagicMock(),
         close=AsyncMock(),
     )
     broker_artifact = _artifact(tmp_path, "broker_snapshot")
     reconciliation_artifact = _artifact(tmp_path, "reconciliation_report")
     mark_artifact = _artifact(tmp_path, "protective_mark")
+
+    def publish_while_admission_is_locked(*_args: object, **_kwargs: object) -> None:
+        with pytest.raises(
+            RuntimeReconciliationIntegrationError,
+            match="already in progress",
+        ):
+            integration._acquire_evidence_admission_lock(evidence_root)
+
     receivers = SimpleNamespace(
         broker_snapshot=object(),
         broker_artifact=broker_artifact,
@@ -155,7 +166,7 @@ async def test_source_uses_one_broker_generation_through_marks_and_runtime_bind(
                 1,
             )
         ),
-        publish_complete_bundle=MagicMock(),
+        publish_complete_bundle=MagicMock(side_effect=publish_while_admission_is_locked),
         published_artifact_path=MagicMock(
             side_effect=lambda artifact: tmp_path / artifact.artifact_path.name
         ),
@@ -221,6 +232,11 @@ async def test_source_uses_one_broker_generation_through_marks_and_runtime_bind(
         receivers.reconciliation_report,
     )
     provider.issue_protective_quote_source.assert_called_once_with(runtime_contract=runtime)
+    provider._acquire_generation_lease.assert_awaited_once_with()
+    provider._release_generation_lease.assert_called_once_with(
+        lease_token,
+        "generation-1",
+    )
     assert quote_source.get_protective_quotes.await_args_list == [
         call(("AAPL",), active_symbols=("AAPL", "MSFT")),
         call(("MSFT",), active_symbols=("AAPL", "MSFT")),

--- a/tests/test_pr5_runtime_integration.py
+++ b/tests/test_pr5_runtime_integration.py
@@ -265,6 +265,41 @@ def test_missing_or_malformed_status_is_quarantined(tmp_path: Path) -> None:
     assert read_runtime_reconciliation_status(malformed) == expected
 
 
+@pytest.mark.parametrize(
+    "eligible_until",
+    [
+        (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat(),
+        "not-a-timestamp",
+        "2026-07-30T12:00:00",
+    ],
+)
+def test_expired_or_malformed_persisted_eligibility_is_quarantined(
+    tmp_path: Path,
+    eligible_until: str,
+) -> None:
+    status_path = tmp_path / "status.json"
+    integration._write_status(
+        status_path,
+        {
+            "schema_version": 1,
+            "state": "ready",
+            "trigger": "startup",
+            "completed_at": (datetime.now(timezone.utc) - timedelta(seconds=2)).isoformat(),
+            "eligible_until": eligible_until,
+            "entry_eligible": True,
+            "quarantined": False,
+            "run_id": "not-exposed",
+            "snapshot_id": "not-exposed",
+        },
+    )
+
+    status = read_runtime_reconciliation_status(status_path)
+
+    assert status["state"] == "unavailable"
+    assert status["entry_eligible"] is False
+    assert status["quarantined"] is True
+
+
 @pytest.mark.asyncio
 async def test_builder_requires_explicit_signing_paths_before_provider_start(
     tmp_path: Path,
@@ -290,6 +325,59 @@ async def test_builder_requires_explicit_signing_paths_before_provider_start(
     ):
         await build_runtime_reconciliation_controller(context)
 
+    readiness.assert_not_awaited()
+    provider.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("protected_target", ["database", "journal", "capability"])
+async def test_builder_rejects_protected_status_target_before_overwrite_or_provider_start(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    protected_target: str,
+) -> None:
+    database = tmp_path / "ledger.db"
+    database.write_bytes(b"ledger-state")
+    runtime = _runtime(database)
+    journal = Path(runtime.safety_journal_path)
+    journal.write_bytes(b"journal-state")
+    capability_directory = tmp_path / "capabilities"
+    evidence_root = tmp_path / "evidence"
+    capability_directory.mkdir(mode=0o700)
+    evidence_root.mkdir(mode=0o700)
+    capability_file = capability_directory / "broker_snapshot_private.pem"
+    capability_file.write_bytes(b"signing-capability")
+    targets = {
+        "database": database,
+        "journal": journal,
+        "capability": capability_file,
+    }
+    target = targets[protected_target]
+    before = target.read_bytes()
+    context = SimpleNamespace(runtime_contract=runtime)
+    monkeypatch.setattr(
+        integration,
+        "assert_validated_runtime_safety_context",
+        lambda value: value,
+    )
+    monkeypatch.setenv(
+        "RT_RECONCILIATION_SIGNING_CAPABILITY_DIR",
+        str(capability_directory),
+    )
+    monkeypatch.setenv("RT_RECONCILIATION_EVIDENCE_ROOT", str(evidence_root))
+    monkeypatch.setenv("RT_RECONCILIATION_STATUS_PATH", str(target))
+    readiness = AsyncMock()
+    provider = AsyncMock()
+    monkeypatch.setattr(integration, "assert_runtime_bootstrap_ready", readiness)
+    monkeypatch.setattr(integration, "build_diagnostic_provider", provider)
+
+    with pytest.raises(
+        RuntimeReconciliationIntegrationError,
+        match="overlaps protected runtime state",
+    ):
+        await build_runtime_reconciliation_controller(context)
+
+    assert target.read_bytes() == before
     readiness.assert_not_awaited()
     provider.assert_not_awaited()
 

--- a/tests/test_pr5_runtime_integration.py
+++ b/tests/test_pr5_runtime_integration.py
@@ -951,7 +951,9 @@ def test_status_republication_failure_preserves_complete_prior_artifact(
         )
 
     assert status_path.read_bytes() == prior
-    assert not list(tmp_path.glob(".status.json.stage-*"))
+    preserved = list(tmp_path.glob(".status.json.stage-*"))
+    assert len(preserved) == 1
+    assert json.loads(preserved[0].read_text(encoding="ascii"))["run_id"] == "run-second"
 
 
 def test_status_atomic_exchange_restores_raced_unrelated_target(
@@ -1083,6 +1085,68 @@ def test_status_failed_race_rollback_preserves_displaced_unrelated_inode(
 
     displaced = list(tmp_path.glob(".status.json.stage-*"))
     assert calls == 2
+    assert len(displaced) == 1
+    assert displaced[0].read_bytes() == b"unrelated-raced-state"
+    assert held_owned.is_file()
+
+
+def test_status_ambiguous_first_exchange_preserves_displaced_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    status_path = tmp_path / "status.json"
+    payload = {
+        "schema_version": 1,
+        "owner_binding": STATUS_OWNER_BINDING,
+        "state": "quarantined",
+        "trigger": None,
+        "completed_at": None,
+        "eligible_until": None,
+        "entry_eligible": False,
+        "quarantined": True,
+        "run_id": None,
+        "snapshot_id": None,
+    }
+    integration._write_status(
+        status_path,
+        payload,
+        owner_binding=STATUS_OWNER_BINDING,
+    )
+    held_owned = tmp_path / "held-owned-status.json"
+    real_exchange = integration._exchange_status_entries
+
+    def exchange_then_interrupt(parent_descriptor: int, left: str, right: str) -> None:
+        os.rename(
+            right,
+            held_owned.name,
+            src_dir_fd=parent_descriptor,
+            dst_dir_fd=parent_descriptor,
+        )
+        raced = os.open(
+            right,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+            dir_fd=parent_descriptor,
+        )
+        os.write(raced, b"unrelated-raced-state")
+        os.close(raced)
+        real_exchange(parent_descriptor, left, right)
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(
+        integration,
+        "_exchange_status_entries",
+        exchange_then_interrupt,
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        integration._write_status(
+            status_path,
+            dict(payload, state="ready"),
+            owner_binding=STATUS_OWNER_BINDING,
+        )
+
+    displaced = list(tmp_path.glob(".status.json.stage-*"))
     assert len(displaced) == 1
     assert displaced[0].read_bytes() == b"unrelated-raced-state"
     assert held_owned.is_file()

--- a/tests/test_pr5_runtime_integration.py
+++ b/tests/test_pr5_runtime_integration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -23,6 +24,8 @@ from robo_trader.reconciliation.runtime_integration import (
 )
 
 ACCOUNT_SCOPE = "acct_v1_0123456789abcdef0123456789abcdef" "fedcba9876543210fedcba9876543210"
+STATUS_OWNER_BINDING = "a" * 64
+BOOTSTRAP_ID = "pboot-" + "1" * 32
 
 
 def _runtime(database: Path) -> RuntimeContract:
@@ -236,6 +239,9 @@ async def test_controller_publishes_only_sanitized_status_and_age(tmp_path: Path
     assert "run-safe" not in str(status)
     assert "snapshot-safe" not in str(status)
 
+    await controller.reconcile_reconnect()
+    assert read_runtime_reconciliation_status(status_path)["state"] == "ready"
+
 
 @pytest.mark.asyncio
 async def test_status_publication_failure_blocks_entry_eligibility(tmp_path: Path) -> None:
@@ -282,6 +288,7 @@ def test_expired_or_malformed_persisted_eligibility_is_quarantined(
         status_path,
         {
             "schema_version": 1,
+            "owner_binding": STATUS_OWNER_BINDING,
             "state": "ready",
             "trigger": "startup",
             "completed_at": (datetime.now(timezone.utc) - timedelta(seconds=2)).isoformat(),
@@ -291,6 +298,7 @@ def test_expired_or_malformed_persisted_eligibility_is_quarantined(
             "run_id": "not-exposed",
             "snapshot_id": "not-exposed",
         },
+        owner_binding=STATUS_OWNER_BINDING,
     )
 
     status = read_runtime_reconciliation_status(status_path)
@@ -421,8 +429,50 @@ def _readiness_database(
     *,
     include_bootstrap: bool,
     include_reconciliation_receipt: bool = True,
+    include_position: bool = False,
 ) -> None:
     with sqlite3.connect(database) as connection:
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+        candidate = {
+            "schema_version": 1,
+            "bootstrap_id": BOOTSTRAP_ID,
+            "execution_domain_scope": runtime.safety_execution_domain_scope,
+            "account_scope": runtime.safety_account_scope,
+            "portfolio_id": "default",
+            "reconciliation_snapshot_id": "snapshot-1",
+            "reconciliation_report_hash": "b" * 64,
+            "broker_snapshot_hash": "c" * 64,
+            "legacy_snapshot_hash": "d" * 64,
+            "database_path": runtime.database_path,
+            "database_identity": runtime.database_identity,
+            "effective_at": now.isoformat(),
+            "broker_position_count": 0,
+            "broker_open_order_count": 0,
+            "account": {
+                "cash_text": "1000",
+                "realized_pnl_text": "0",
+                "daily_pnl_text": "0",
+                "daily_pnl_baseline_text": "0",
+                "daily_pnl_date": now.date().isoformat(),
+            },
+            "positions": (
+                [
+                    {
+                        "con_id": 265598,
+                        "symbol": "AAPL",
+                        "quantity": 1,
+                        "cost_basis_text": "100",
+                        "mark_price_text": "110",
+                        "mark_observed_at": now.isoformat(),
+                        "mark_evidence_fingerprint": "e" * 64,
+                    }
+                ]
+                if include_position
+                else []
+            ),
+        }
+        if include_position:
+            candidate["account"]["daily_pnl_text"] = "10"  # type: ignore[index]
         connection.executescript("""
             CREATE TABLE portfolios(id TEXT PRIMARY KEY);
             CREATE TABLE paper_state_bootstraps(
@@ -433,7 +483,10 @@ def _readiness_database(
                 database_path TEXT,
                 database_identity TEXT,
                 database_device INTEGER,
-                database_inode INTEGER
+                database_inode INTEGER,
+                candidate_payload_json TEXT,
+                broker_snapshot_hash TEXT,
+                reconciliation_report_hash TEXT
             );
             CREATE TABLE paper_account_settlement_state(
                 portfolio_id TEXT PRIMARY KEY,
@@ -452,17 +505,21 @@ def _readiness_database(
                 origin_bootstrap_id TEXT
             );
             CREATE TABLE exact_bootstrap_evidence_consumptions(
+                receipt_id TEXT,
                 bootstrap_id TEXT,
-                artifact_kind TEXT
+                artifact_kind TEXT,
+                artifact_sha256 TEXT,
+                runtime_fingerprint TEXT,
+                account_scope TEXT
             );
             INSERT INTO portfolios VALUES ('default');
             """)
         if include_bootstrap:
             metadata = database.stat()
             connection.execute(
-                "INSERT INTO paper_state_bootstraps VALUES (?,?,?,?,?,?,?,?)",
+                "INSERT INTO paper_state_bootstraps VALUES (?,?,?,?,?,?,?,?,?,?,?)",
                 (
-                    "bootstrap-1",
+                    BOOTSTRAP_ID,
                     runtime.safety_execution_domain_scope,
                     runtime.safety_account_scope,
                     "default",
@@ -470,20 +527,58 @@ def _readiness_database(
                     runtime.database_identity,
                     metadata.st_dev,
                     metadata.st_ino,
+                    json.dumps(candidate, sort_keys=True, separators=(",", ":")),
+                    "c" * 64,
+                    "b" * 64,
                 ),
             )
             connection.execute(
                 "INSERT INTO paper_account_settlement_state VALUES (?,?)",
-                ("default", "bootstrap-1"),
+                ("default", BOOTSTRAP_ID),
             )
+            if include_position:
+                connection.execute(
+                    "INSERT INTO positions VALUES (?,?,?)",
+                    ("default", "AAPL", 1),
+                )
+                connection.execute(
+                    "INSERT INTO paper_position_settlement_state VALUES (?,?,?,?,?)",
+                    ("default", "AAPL", "100", "110", BOOTSTRAP_ID),
+                )
             connection.execute(
-                "INSERT INTO exact_bootstrap_evidence_consumptions VALUES (?,?)",
-                ("bootstrap-1", "broker_snapshot"),
+                "INSERT INTO exact_bootstrap_evidence_consumptions VALUES (?,?,?,?,?,?)",
+                (
+                    "receipt-broker",
+                    BOOTSTRAP_ID,
+                    "broker_snapshot",
+                    "c" * 64,
+                    runtime.fingerprint,
+                    runtime.safety_account_scope,
+                ),
             )
             if include_reconciliation_receipt:
                 connection.execute(
-                    "INSERT INTO exact_bootstrap_evidence_consumptions VALUES (?,?)",
-                    ("bootstrap-1", "reconciliation_report"),
+                    "INSERT INTO exact_bootstrap_evidence_consumptions VALUES (?,?,?,?,?,?)",
+                    (
+                        "receipt-reconciliation",
+                        BOOTSTRAP_ID,
+                        "reconciliation_report",
+                        "b" * 64,
+                        runtime.fingerprint,
+                        runtime.safety_account_scope,
+                    ),
+                )
+            if include_position:
+                connection.execute(
+                    "INSERT INTO exact_bootstrap_evidence_consumptions VALUES (?,?,?,?,?,?)",
+                    (
+                        "receipt-mark",
+                        BOOTSTRAP_ID,
+                        "protective_mark",
+                        "e" * 64,
+                        runtime.fingerprint,
+                        runtime.safety_account_scope,
+                    ),
                 )
 
 
@@ -519,6 +614,12 @@ async def test_bootstrap_and_receipt_readiness_is_fail_closed(
     )
     schema_assertion = AsyncMock()
     monkeypatch.setattr(integration, "assert_exact_state_schema", schema_assertion)
+    reconciliation_schema_assertion = AsyncMock()
+    monkeypatch.setattr(
+        integration,
+        "assert_reconciliation_schema",
+        reconciliation_schema_assertion,
+    )
 
     if should_pass:
         await assert_runtime_bootstrap_ready(context)
@@ -527,3 +628,170 @@ async def test_bootstrap_and_receipt_readiness_is_fail_closed(
             await assert_runtime_bootstrap_ready(context)
 
     schema_assertion.assert_awaited_once()
+    reconciliation_schema_assertion.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "receipt_mutation",
+    ["missing", "duplicate", "extra", "wrong-bootstrap"],
+)
+async def test_position_protective_receipts_require_exact_bootstrap_coverage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    receipt_mutation: str,
+) -> None:
+    database = tmp_path / "ledger.db"
+    runtime = _runtime(database)
+    _readiness_database(
+        database,
+        runtime,
+        include_bootstrap=True,
+        include_position=True,
+    )
+    with sqlite3.connect(database) as connection:
+        if receipt_mutation == "missing":
+            connection.execute(
+                "DELETE FROM exact_bootstrap_evidence_consumptions "
+                "WHERE artifact_kind='protective_mark'"
+            )
+        elif receipt_mutation == "wrong-bootstrap":
+            connection.execute(
+                "UPDATE exact_bootstrap_evidence_consumptions SET bootstrap_id=? "
+                "WHERE artifact_kind='protective_mark'",
+                ("pboot-" + "2" * 32,),
+            )
+        else:
+            connection.execute(
+                "INSERT INTO exact_bootstrap_evidence_consumptions VALUES (?,?,?,?,?,?)",
+                (
+                    "receipt-mark-extra",
+                    BOOTSTRAP_ID,
+                    "protective_mark",
+                    "e" * 64 if receipt_mutation == "duplicate" else "f" * 64,
+                    runtime.fingerprint,
+                    runtime.safety_account_scope,
+                ),
+            )
+    context = SimpleNamespace(runtime_contract=runtime)
+    monkeypatch.setattr(
+        integration,
+        "assert_validated_runtime_safety_context",
+        lambda value: value,
+    )
+    monkeypatch.setattr(integration, "assert_exact_state_schema", AsyncMock())
+    monkeypatch.setattr(integration, "assert_reconciliation_schema", AsyncMock())
+
+    with pytest.raises(RuntimeReconciliationIntegrationError):
+        await assert_runtime_bootstrap_ready(context)
+
+
+@pytest.mark.asyncio
+async def test_position_protective_receipt_exact_coverage_is_ready(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database = tmp_path / "ledger.db"
+    runtime = _runtime(database)
+    _readiness_database(
+        database,
+        runtime,
+        include_bootstrap=True,
+        include_position=True,
+    )
+    context = SimpleNamespace(runtime_contract=runtime)
+    monkeypatch.setattr(
+        integration,
+        "assert_validated_runtime_safety_context",
+        lambda value: value,
+    )
+    monkeypatch.setattr(integration, "assert_exact_state_schema", AsyncMock())
+    monkeypatch.setattr(integration, "assert_reconciliation_schema", AsyncMock())
+
+    await assert_runtime_bootstrap_ready(context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("schema_state", ["absent", "partial"])
+async def test_runtime_schema_assertion_is_byte_preserving_and_precedes_provider(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    schema_state: str,
+) -> None:
+    database = tmp_path / "ledger.db"
+    with sqlite3.connect(database) as connection:
+        connection.execute("CREATE TABLE portfolios(id TEXT PRIMARY KEY)")
+        if schema_state == "partial":
+            connection.execute("CREATE TABLE rt_schema_migrations(component TEXT, version INTEGER)")
+    before = database.read_bytes()
+    runtime = _runtime(database)
+    context = SimpleNamespace(runtime_contract=runtime)
+    capability_directory = tmp_path / "capabilities"
+    evidence_root = tmp_path / "evidence"
+    capability_directory.mkdir(mode=0o700)
+    evidence_root.mkdir(mode=0o700)
+    monkeypatch.setenv(
+        "RT_RECONCILIATION_SIGNING_CAPABILITY_DIR",
+        str(capability_directory),
+    )
+    monkeypatch.setenv("RT_RECONCILIATION_EVIDENCE_ROOT", str(evidence_root))
+    monkeypatch.setattr(
+        integration,
+        "assert_validated_runtime_safety_context",
+        lambda value: value,
+    )
+    monkeypatch.setattr(integration, "assert_exact_state_schema", AsyncMock())
+    provider = AsyncMock()
+    monkeypatch.setattr(integration, "build_diagnostic_provider", provider)
+
+    with pytest.raises(RuntimeReconciliationIntegrationError):
+        await build_runtime_reconciliation_controller(context)
+
+    assert database.read_bytes() == before
+    assert not Path(f"{database}-wal").exists()
+    assert not Path(f"{database}-shm").exists()
+    provider.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("existing_kind", ["unrelated", "other-owner"])
+async def test_status_publication_never_replaces_unrelated_existing_file(
+    tmp_path: Path,
+    existing_kind: str,
+) -> None:
+    status_path = tmp_path / "status.json"
+    if existing_kind == "unrelated":
+        status_path.write_bytes(b"irreplaceable unrelated state")
+    else:
+        other_payload = {
+            "schema_version": 1,
+            "owner_binding": "b" * 64,
+            "state": "quarantined",
+            "trigger": None,
+            "completed_at": None,
+            "eligible_until": None,
+            "entry_eligible": False,
+            "quarantined": True,
+            "run_id": None,
+            "snapshot_id": None,
+        }
+        status_path.write_text(
+            json.dumps(other_payload, sort_keys=True, separators=(",", ":")),
+            encoding="ascii",
+        )
+    status_path.chmod(0o600)
+    before = status_path.read_bytes()
+    controller = RuntimeReconciliationController(
+        _Service(_outcome(datetime.now(timezone.utc))),
+        status_path=status_path,
+        status_owner_binding=STATUS_OWNER_BINDING,
+    )
+
+    with pytest.raises(
+        RuntimeReconciliationIntegrationError,
+        match="status publication failed closed",
+    ):
+        await controller.reconcile_startup()
+
+    assert status_path.read_bytes() == before
+    assert controller.entry_eligible() is False

--- a/tests/test_pr5_runtime_integration.py
+++ b/tests/test_pr5_runtime_integration.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
@@ -112,13 +113,25 @@ async def test_source_uses_one_broker_generation_through_marks_and_runtime_bind(
     runtime_handoff = object()
     exact_state = object()
     bound_runtime_evidence = object()
-    quote = SimpleNamespace(
-        symbol="AAPL",
-        con_id=265598,
-        transport_generation="generation-1",
-    )
+    quotes = {
+        "AAPL": SimpleNamespace(
+            symbol="AAPL",
+            con_id=265598,
+            transport_generation="generation-1",
+        ),
+        "MSFT": SimpleNamespace(
+            symbol="MSFT",
+            con_id=272093,
+            transport_generation="generation-1",
+        ),
+    }
+
+    async def collect_quote(symbols, *, active_symbols):
+        assert active_symbols == ("AAPL", "MSFT")
+        return (quotes[symbols[0]],)
+
     quote_source = SimpleNamespace(
-        get_protective_quotes=AsyncMock(return_value=(quote,)),
+        get_protective_quotes=AsyncMock(side_effect=collect_quote),
     )
     provider = SimpleNamespace(
         produce_normalized_snapshot=AsyncMock(return_value=broker_envelope),
@@ -134,6 +147,7 @@ async def test_source_uses_one_broker_generation_through_marks_and_runtime_bind(
         reconciliation_report=object(),
         protective_mark=object(),
         assert_complete=MagicMock(),
+        unpublished_bundle_size_bytes=MagicMock(return_value=1024),
         publish_complete_bundle=MagicMock(),
         published_artifact_path=MagicMock(
             side_effect=lambda artifact: tmp_path / artifact.artifact_path.name
@@ -143,7 +157,7 @@ async def test_source_uses_one_broker_generation_through_marks_and_runtime_bind(
     )
     delivery = SimpleNamespace(
         receiver_result=reconciliation_artifact,
-        local_position_identities=(("default", "AAPL"),),
+        local_position_identities=(("default", "AAPL"), ("growth", "MSFT")),
         verified_broker_evidence=runtime_handoff,
     )
     produce = MagicMock(return_value=delivery)
@@ -200,9 +214,17 @@ async def test_source_uses_one_broker_generation_through_marks_and_runtime_bind(
         receivers.reconciliation_report,
     )
     provider.issue_protective_quote_source.assert_called_once_with(runtime_contract=runtime)
-    quote_source.get_protective_quotes.assert_awaited_once_with(
-        ("AAPL",),
-        active_symbols=("AAPL",),
+    assert quote_source.get_protective_quotes.await_args_list == [
+        call(("AAPL",), active_symbols=("AAPL", "MSFT")),
+        call(("MSFT",), active_symbols=("AAPL", "MSFT")),
+    ]
+    assert collect_mark.await_args_list[0].kwargs["expected_active_symbols"] == (
+        "AAPL",
+        "MSFT",
+    )
+    assert collect_mark.await_args_list[1].kwargs["expected_active_symbols"] == (
+        "AAPL",
+        "MSFT",
     )
     bind.assert_called_once_with(
         runtime_handoff,
@@ -215,6 +237,60 @@ async def test_source_uses_one_broker_generation_through_marks_and_runtime_bind(
 
     await source.close()
     provider.close.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("max_bundles", "max_bytes"),
+    [(1, 1024 * 1024), (100, 5)],
+)
+async def test_evidence_retention_ceiling_quarantines_without_deleting_audit_bundle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    max_bundles: int,
+    max_bytes: int,
+) -> None:
+    database = tmp_path / "ledger.db"
+    database.touch()
+    runtime = _runtime(database)
+    context = SimpleNamespace(runtime_contract=runtime)
+    monkeypatch.setattr(
+        integration,
+        "assert_validated_runtime_safety_context",
+        lambda value: value,
+    )
+    capability_directory = tmp_path / "capabilities"
+    evidence_root = tmp_path / "evidence"
+    capability_directory.mkdir(mode=0o700)
+    evidence_root.mkdir(mode=0o700)
+    bundle = evidence_root / ("runtime-reconciliation-" + "a" * 48)
+    bundle.mkdir(mode=0o700)
+    artifact = bundle / "bundle_complete.json"
+    artifact.write_bytes(b"audit-lineage")
+    artifact.chmod(0o400)
+    before = artifact.read_bytes()
+    provider = SimpleNamespace(
+        produce_normalized_snapshot=AsyncMock(),
+        close=AsyncMock(),
+    )
+    source = ProductionRuntimeEvidenceSource(
+        runtime_context=context,
+        provider=provider,
+        capability_directory=capability_directory,
+        evidence_root=evidence_root,
+        max_published_bundles=max_bundles,
+        max_published_bytes=max_bytes,
+    )
+
+    with pytest.raises(
+        RuntimeReconciliationIntegrationError,
+        match="retention ceiling reached",
+    ):
+        await source.collect_verified_evidence(max_age_seconds=30.0)
+
+    assert artifact.read_bytes() == before
+    assert bundle.is_dir()
+    provider.produce_normalized_snapshot.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -835,3 +911,153 @@ async def test_status_publication_never_replaces_unrelated_existing_file(
 
     assert status_path.read_bytes() == before
     assert controller.entry_eligible() is False
+
+
+def test_status_republication_failure_preserves_complete_prior_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    status_path = tmp_path / "status.json"
+    first_payload = {
+        "schema_version": 1,
+        "owner_binding": STATUS_OWNER_BINDING,
+        "state": "ready",
+        "trigger": "startup",
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+        "eligible_until": (datetime.now(timezone.utc) + timedelta(seconds=30)).isoformat(),
+        "entry_eligible": True,
+        "quarantined": False,
+        "run_id": "run-first",
+        "snapshot_id": "snapshot-first",
+    }
+    integration._write_status(
+        status_path,
+        first_payload,
+        owner_binding=STATUS_OWNER_BINDING,
+    )
+    prior = status_path.read_bytes()
+
+    def fail_exchange(*args, **kwargs):
+        raise OSError("simulated crash boundary")
+
+    monkeypatch.setattr(integration, "_exchange_status_entries", fail_exchange)
+    second_payload = dict(first_payload, run_id="run-second", snapshot_id="snapshot-second")
+
+    with pytest.raises(OSError, match="simulated crash boundary"):
+        integration._write_status(
+            status_path,
+            second_payload,
+            owner_binding=STATUS_OWNER_BINDING,
+        )
+
+    assert status_path.read_bytes() == prior
+    assert not list(tmp_path.glob(".status.json.stage-*"))
+
+
+def test_status_atomic_exchange_restores_raced_unrelated_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    status_path = tmp_path / "status.json"
+    payload = {
+        "schema_version": 1,
+        "owner_binding": STATUS_OWNER_BINDING,
+        "state": "quarantined",
+        "trigger": None,
+        "completed_at": None,
+        "eligible_until": None,
+        "entry_eligible": False,
+        "quarantined": True,
+        "run_id": None,
+        "snapshot_id": None,
+    }
+    integration._write_status(
+        status_path,
+        payload,
+        owner_binding=STATUS_OWNER_BINDING,
+    )
+    held_owned = tmp_path / "held-owned-status.json"
+    real_exchange = integration._exchange_status_entries
+    calls = 0
+
+    def race_then_exchange(parent_descriptor: int, left: str, right: str) -> None:
+        nonlocal calls
+        if calls == 0:
+            os.rename(
+                right,
+                held_owned.name,
+                src_dir_fd=parent_descriptor,
+                dst_dir_fd=parent_descriptor,
+            )
+            raced = os.open(
+                right,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+                dir_fd=parent_descriptor,
+            )
+            os.write(raced, b"unrelated-raced-state")
+            os.close(raced)
+        calls += 1
+        real_exchange(parent_descriptor, left, right)
+
+    monkeypatch.setattr(integration, "_exchange_status_entries", race_then_exchange)
+
+    with pytest.raises(
+        RuntimeReconciliationIntegrationError,
+        match="changed during publication",
+    ):
+        integration._write_status(
+            status_path,
+            dict(payload, state="ready"),
+            owner_binding=STATUS_OWNER_BINDING,
+        )
+
+    assert calls == 2
+    assert status_path.read_bytes() == b"unrelated-raced-state"
+    assert held_owned.is_file()
+
+
+def test_first_status_publication_race_never_replaces_unrelated_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    status_path = tmp_path / "status.json"
+    payload = {
+        "schema_version": 1,
+        "owner_binding": STATUS_OWNER_BINDING,
+        "state": "quarantined",
+        "trigger": None,
+        "completed_at": None,
+        "eligible_until": None,
+        "entry_eligible": False,
+        "quarantined": True,
+        "run_id": None,
+        "snapshot_id": None,
+    }
+    real_publish = integration._publish_status_exclusive
+
+    def race_then_publish(parent_descriptor: int, source: str, target: str) -> None:
+        raced = os.open(
+            target,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+            dir_fd=parent_descriptor,
+        )
+        os.write(raced, b"unrelated-raced-state")
+        os.close(raced)
+        real_publish(parent_descriptor, source, target)
+
+    monkeypatch.setattr(integration, "_publish_status_exclusive", race_then_publish)
+
+    with pytest.raises(
+        RuntimeReconciliationIntegrationError,
+        match="exclusive reconciliation status publication failed",
+    ):
+        integration._write_status(
+            status_path,
+            payload,
+            owner_binding=STATUS_OWNER_BINDING,
+        )
+
+    assert status_path.read_bytes() == b"unrelated-raced-state"
+    assert not list(tmp_path.glob(".status.json.stage-*"))

--- a/tests/test_pr5_runtime_integration.py
+++ b/tests/test_pr5_runtime_integration.py
@@ -1,0 +1,441 @@
+"""Synthetic production-integration tests for PR5 runtime reconciliation."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import robo_trader.reconciliation.runtime_integration as integration
+from robo_trader.bootstrap_evidence_receivers import SealedBootstrapEvidenceArtifact
+from robo_trader.config import RuntimeContract
+from robo_trader.reconciliation.runtime_integration import (
+    RuntimeReconciliationController,
+    RuntimeReconciliationIntegrationError,
+    ProductionRuntimeEvidenceSource,
+    assert_runtime_bootstrap_ready,
+    build_runtime_reconciliation_controller,
+    read_runtime_reconciliation_status,
+)
+
+ACCOUNT_SCOPE = "acct_v1_0123456789abcdef0123456789abcdef" "fedcba9876543210fedcba9876543210"
+
+
+def _runtime(database: Path) -> RuntimeContract:
+    return RuntimeContract(
+        environment="dev",
+        execution_mode="paper",
+        execution_source="paper_simulator",
+        ibkr_host="127.0.0.1",
+        ibkr_port=4002,
+        ibkr_readonly=True,
+        database_path=str(database),
+        account_alias="***1234",
+        account_type="paper",
+        model_artifact_set="test-models",
+        build_id="test-build",
+        state_namespace="paper",
+        safety_account_scope=ACCOUNT_SCOPE,
+        safety_execution_domain_scope="paper-simulator-v1",
+        safety_journal_path=str(database.with_name("safety-journal.db")),
+    )
+
+
+class _Service:
+    def __init__(self, outcome: object, *, eligible: bool = True) -> None:
+        self.outcome = outcome
+        self.eligible = eligible
+        self.close = AsyncMock()
+
+    def entry_eligible(self) -> bool:
+        return self.eligible
+
+    async def reconcile_startup(self):
+        return self.outcome
+
+    async def reconcile_reconnect(self):
+        return self.outcome
+
+    async def reconcile_periodic_if_due(self):
+        return self.outcome
+
+
+def _outcome(now: datetime) -> object:
+    return SimpleNamespace(
+        state=SimpleNamespace(value="ready"),
+        trigger=SimpleNamespace(value="startup"),
+        verdict=SimpleNamespace(checked_at=now),
+        completed_at=now,
+        eligible_until=now + timedelta(seconds=30),
+        entry_eligible=True,
+        persisted=SimpleNamespace(run_id="run-safe", snapshot_id="snapshot-safe"),
+    )
+
+
+def _artifact(tmp_path: Path, kind: str) -> SealedBootstrapEvidenceArtifact:
+    return SealedBootstrapEvidenceArtifact(
+        artifact_kind=kind,
+        artifact_path=tmp_path / f"{kind}.json",
+        authentication_receipt_path=tmp_path / f"{kind}.receipt.json",
+        artifact_sha256="a" * 64,
+        producer_object_id=f"producer-{kind}",
+    )
+
+
+@pytest.mark.asyncio
+async def test_source_uses_one_broker_generation_through_marks_and_runtime_bind(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database = tmp_path / "ledger.db"
+    database.touch()
+    runtime = _runtime(database)
+    context = SimpleNamespace(runtime_contract=runtime)
+    monkeypatch.setattr(
+        integration,
+        "assert_validated_runtime_safety_context",
+        lambda value: value,
+    )
+    capability_directory = tmp_path / "capabilities"
+    evidence_root = tmp_path / "evidence"
+    capability_directory.mkdir(mode=0o700)
+    evidence_root.mkdir(mode=0o700)
+
+    broker_envelope = object()
+    runtime_handoff = object()
+    exact_state = object()
+    bound_runtime_evidence = object()
+    quote = SimpleNamespace(
+        symbol="AAPL",
+        con_id=265598,
+        transport_generation="generation-1",
+    )
+    quote_source = SimpleNamespace(
+        get_protective_quotes=AsyncMock(return_value=(quote,)),
+    )
+    provider = SimpleNamespace(
+        produce_normalized_snapshot=AsyncMock(return_value=broker_envelope),
+        issue_protective_quote_source=MagicMock(return_value=quote_source),
+        close=AsyncMock(),
+    )
+    broker_artifact = _artifact(tmp_path, "broker_snapshot")
+    reconciliation_artifact = _artifact(tmp_path, "reconciliation_report")
+    mark_artifact = _artifact(tmp_path, "protective_mark")
+    receivers = SimpleNamespace(
+        broker_snapshot=object(),
+        broker_artifact=broker_artifact,
+        reconciliation_report=object(),
+        protective_mark=object(),
+        assert_complete=MagicMock(),
+        publish_complete_bundle=MagicMock(),
+        published_artifact_path=MagicMock(
+            side_effect=lambda artifact: tmp_path / artifact.artifact_path.name
+        ),
+        discard_unpublished_bundle=MagicMock(),
+        close=MagicMock(),
+    )
+    delivery = SimpleNamespace(
+        receiver_result=reconciliation_artifact,
+        local_position_identities=(("default", "AAPL"),),
+        verified_broker_evidence=runtime_handoff,
+    )
+    produce = MagicMock(return_value=delivery)
+    bind = MagicMock(return_value=bound_runtime_evidence)
+    monkeypatch.setattr(
+        integration,
+        "create_bootstrap_evidence_receivers",
+        MagicMock(return_value=receivers),
+    )
+    monkeypatch.setattr(integration, "produce_bootstrap_reconciliation", produce)
+    monkeypatch.setattr(
+        integration,
+        "assert_factory_owned_protective_quote_source",
+        MagicMock(return_value=SimpleNamespace(transport_generation="generation-1")),
+    )
+    monkeypatch.setattr(
+        integration,
+        "create_runtime_bound_mark_only_producer",
+        MagicMock(return_value=object()),
+    )
+    collect_mark = AsyncMock(return_value=mark_artifact)
+    monkeypatch.setattr(
+        integration,
+        "collect_and_produce_bootstrap_protective_mark",
+        collect_mark,
+    )
+    monkeypatch.setattr(
+        integration,
+        "load_exact_state_bootstrap_evidence",
+        MagicMock(return_value=exact_state),
+    )
+    monkeypatch.setattr(
+        integration,
+        "bind_verified_runtime_reconciliation_evidence",
+        bind,
+    )
+    source = ProductionRuntimeEvidenceSource(
+        runtime_context=context,
+        provider=provider,
+        capability_directory=capability_directory,
+        evidence_root=evidence_root,
+    )
+
+    observed = await source.collect_verified_evidence(max_age_seconds=30.0)
+
+    assert observed is bound_runtime_evidence
+    provider.produce_normalized_snapshot.assert_awaited_once_with(
+        receiver=receivers.broker_snapshot,
+        max_age_seconds=30.0,
+    )
+    produce.assert_called_once_with(
+        broker_envelope,
+        runtime,
+        receivers.reconciliation_report,
+    )
+    provider.issue_protective_quote_source.assert_called_once_with(runtime_contract=runtime)
+    quote_source.get_protective_quotes.assert_awaited_once_with(
+        ("AAPL",),
+        active_symbols=("AAPL",),
+    )
+    bind.assert_called_once_with(
+        runtime_handoff,
+        exact_state,
+        context,
+        receivers.protective_mark,
+    )
+    provider.close.assert_not_awaited()
+    receivers.close.assert_called_once_with()
+
+    await source.close()
+    provider.close.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_controller_publishes_only_sanitized_status_and_age(tmp_path: Path) -> None:
+    now = datetime.now(timezone.utc)
+    service = _Service(_outcome(now))
+    status_path = tmp_path / "status.json"
+    controller = RuntimeReconciliationController(service, status_path=status_path)
+
+    await controller.reconcile_startup()
+    status = read_runtime_reconciliation_status(status_path)
+
+    assert status == {
+        "state": "ready",
+        "trigger": "startup",
+        "completed_at": now.isoformat(),
+        "eligible_until": (now + timedelta(seconds=30)).isoformat(),
+        "entry_eligible": True,
+        "quarantined": False,
+        "age_seconds": pytest.approx(0.0, abs=1.0),
+    }
+    assert "run-safe" not in str(status)
+    assert "snapshot-safe" not in str(status)
+
+
+@pytest.mark.asyncio
+async def test_status_publication_failure_blocks_entry_eligibility(tmp_path: Path) -> None:
+    service = _Service(_outcome(datetime.now(timezone.utc)))
+    controller = RuntimeReconciliationController(
+        service,
+        status_path=tmp_path / "missing" / "status.json",
+    )
+
+    with pytest.raises(
+        RuntimeReconciliationIntegrationError,
+        match="status publication failed closed",
+    ):
+        await controller.reconcile_startup()
+
+    assert controller.entry_eligible() is False
+
+
+def test_missing_or_malformed_status_is_quarantined(tmp_path: Path) -> None:
+    expected = read_runtime_reconciliation_status(tmp_path / "missing.json")
+    assert expected["state"] == "unavailable"
+    assert expected["entry_eligible"] is False
+    assert expected["quarantined"] is True
+
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text('{"state":"ready"}', encoding="ascii")
+    assert read_runtime_reconciliation_status(malformed) == expected
+
+
+@pytest.mark.asyncio
+async def test_builder_requires_explicit_signing_paths_before_provider_start(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _runtime(tmp_path / "ledger.db")
+    context = SimpleNamespace(runtime_contract=runtime)
+    monkeypatch.setattr(
+        integration,
+        "assert_validated_runtime_safety_context",
+        lambda value: value,
+    )
+    monkeypatch.delenv("RT_RECONCILIATION_SIGNING_CAPABILITY_DIR", raising=False)
+    monkeypatch.delenv("RT_RECONCILIATION_EVIDENCE_ROOT", raising=False)
+    readiness = AsyncMock()
+    provider = AsyncMock()
+    monkeypatch.setattr(integration, "assert_runtime_bootstrap_ready", readiness)
+    monkeypatch.setattr(integration, "build_diagnostic_provider", provider)
+
+    with pytest.raises(
+        RuntimeReconciliationIntegrationError,
+        match="signing capability directory is not configured",
+    ):
+        await build_runtime_reconciliation_controller(context)
+
+    readiness.assert_not_awaited()
+    provider.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("database_state", ["missing", "partial"])
+async def test_database_unavailable_or_partial_blocks_without_repair(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    database_state: str,
+) -> None:
+    database = tmp_path / "ledger.db"
+    if database_state == "partial":
+        with sqlite3.connect(database) as connection:
+            connection.execute("CREATE TABLE portfolios(id TEXT PRIMARY KEY)")
+    runtime = _runtime(database)
+    context = SimpleNamespace(runtime_contract=runtime)
+    monkeypatch.setattr(
+        integration,
+        "assert_validated_runtime_safety_context",
+        lambda value: value,
+    )
+
+    with pytest.raises(RuntimeReconciliationIntegrationError):
+        await assert_runtime_bootstrap_ready(context)
+
+    if database_state == "missing":
+        assert database.exists() is False
+    else:
+        with sqlite3.connect(f"file:{database}?mode=ro", uri=True) as connection:
+            tables = {
+                row[0]
+                for row in connection.execute("SELECT name FROM sqlite_master WHERE type='table'")
+            }
+        assert tables == {"portfolios"}
+
+
+def _readiness_database(
+    database: Path,
+    runtime: RuntimeContract,
+    *,
+    include_bootstrap: bool,
+    include_reconciliation_receipt: bool = True,
+) -> None:
+    with sqlite3.connect(database) as connection:
+        connection.executescript("""
+            CREATE TABLE portfolios(id TEXT PRIMARY KEY);
+            CREATE TABLE paper_state_bootstraps(
+                bootstrap_id TEXT PRIMARY KEY,
+                execution_domain_scope TEXT,
+                account_scope TEXT,
+                portfolio_id TEXT,
+                database_path TEXT,
+                database_identity TEXT,
+                database_device INTEGER,
+                database_inode INTEGER
+            );
+            CREATE TABLE paper_account_settlement_state(
+                portfolio_id TEXT PRIMARY KEY,
+                origin_bootstrap_id TEXT
+            );
+            CREATE TABLE positions(
+                portfolio_id TEXT,
+                symbol TEXT,
+                quantity INTEGER
+            );
+            CREATE TABLE paper_position_settlement_state(
+                portfolio_id TEXT,
+                symbol TEXT,
+                cost_basis_text TEXT,
+                mark_price_text TEXT,
+                origin_bootstrap_id TEXT
+            );
+            CREATE TABLE exact_bootstrap_evidence_consumptions(
+                bootstrap_id TEXT,
+                artifact_kind TEXT
+            );
+            INSERT INTO portfolios VALUES ('default');
+            """)
+        if include_bootstrap:
+            metadata = database.stat()
+            connection.execute(
+                "INSERT INTO paper_state_bootstraps VALUES (?,?,?,?,?,?,?,?)",
+                (
+                    "bootstrap-1",
+                    runtime.safety_execution_domain_scope,
+                    runtime.safety_account_scope,
+                    "default",
+                    runtime.database_path,
+                    runtime.database_identity,
+                    metadata.st_dev,
+                    metadata.st_ino,
+                ),
+            )
+            connection.execute(
+                "INSERT INTO paper_account_settlement_state VALUES (?,?)",
+                ("default", "bootstrap-1"),
+            )
+            connection.execute(
+                "INSERT INTO exact_bootstrap_evidence_consumptions VALUES (?,?)",
+                ("bootstrap-1", "broker_snapshot"),
+            )
+            if include_reconciliation_receipt:
+                connection.execute(
+                    "INSERT INTO exact_bootstrap_evidence_consumptions VALUES (?,?)",
+                    ("bootstrap-1", "reconciliation_report"),
+                )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("include_bootstrap", "include_reconciliation_receipt", "should_pass"),
+    [
+        (False, False, False),
+        (True, False, False),
+        (True, True, True),
+    ],
+)
+async def test_bootstrap_and_receipt_readiness_is_fail_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    include_bootstrap: bool,
+    include_reconciliation_receipt: bool,
+    should_pass: bool,
+) -> None:
+    database = tmp_path / "ledger.db"
+    runtime = _runtime(database)
+    _readiness_database(
+        database,
+        runtime,
+        include_bootstrap=include_bootstrap,
+        include_reconciliation_receipt=include_reconciliation_receipt,
+    )
+    context = SimpleNamespace(runtime_contract=runtime)
+    monkeypatch.setattr(
+        integration,
+        "assert_validated_runtime_safety_context",
+        lambda value: value,
+    )
+    schema_assertion = AsyncMock()
+    monkeypatch.setattr(integration, "assert_exact_state_schema", schema_assertion)
+
+    if should_pass:
+        await assert_runtime_bootstrap_ready(context)
+    else:
+        with pytest.raises(RuntimeReconciliationIntegrationError):
+            await assert_runtime_bootstrap_ready(context)
+
+    schema_assertion.assert_awaited_once()

--- a/tests/test_reconciliation_ibkr_adapter.py
+++ b/tests/test_reconciliation_ibkr_adapter.py
@@ -609,6 +609,58 @@ async def test_suspended_factory_provider_recovers_with_new_transport_generation
     assert transport.protective_quote_generation == "quote-generation-2"
 
 
+@pytest.mark.asyncio
+async def test_poisoned_generation_can_suspend_then_refresh(monkeypatch):
+    provider, transport, runtime = await _factory_provider(monkeypatch)
+    replacement = _WorkerGeneration("quote-generation-recovered", Mock())
+    transport._generation = None
+    transport._connection_generation_id = None
+
+    async def connect_transport(**kwargs) -> bool:
+        transport._generation = replacement
+        transport._connected = True
+        transport._connection_identity = (
+            kwargs["host"],
+            kwargs["port"],
+            kwargs["client_id"],
+            kwargs["readonly"],
+        )
+        transport._connection_generation_id = replacement.generation_id
+        return True
+
+    transport.connect = AsyncMock(side_effect=connect_transport)
+    transport.ping = AsyncMock(return_value=True)
+
+    await provider.suspend()
+    await provider.refresh()
+
+    assert provider._closed is False
+    assert provider._suspended is False
+    assert provider._shared_gateway_transport(runtime_context=runtime) is transport
+    assert transport.protective_quote_generation == replacement.generation_id
+
+
+@pytest.mark.asyncio
+async def test_failed_refresh_remains_suspended_and_retryable(monkeypatch):
+    provider, transport, runtime = await _factory_provider(monkeypatch)
+    transport.ping = AsyncMock(return_value=True)
+    await provider.suspend()
+    transport.start = AsyncMock(side_effect=[RuntimeError("transient start failure"), None])
+
+    with pytest.raises(RuntimeError, match="transient start failure"):
+        await provider.refresh()
+
+    assert provider._closed is False
+    assert provider._suspended is True
+
+    await provider.refresh()
+
+    assert provider._closed is False
+    assert provider._suspended is False
+    assert provider._shared_gateway_transport(runtime_context=runtime) is transport
+    assert transport.start.await_count == 2
+
+
 @pytest.mark.parametrize(
     "mutate",
     [

--- a/tests/test_reconciliation_ibkr_adapter.py
+++ b/tests/test_reconciliation_ibkr_adapter.py
@@ -20,6 +20,7 @@ from robo_trader.reconciliation.ibkr_adapter import (
     IBKRDiagnosticSnapshotProvider,
     ProtectiveQuoteSourceCapability,
     ProtectiveQuoteSourceIdentity,
+    assert_factory_owned_diagnostic_provider,
     assert_factory_owned_protective_quote_source,
     assert_producer_owned_broker_snapshot_result,
     build_diagnostic_provider,
@@ -570,6 +571,42 @@ async def test_factory_provider_refreshes_one_shared_read_only_transport(monkeyp
     )
     transport.ping.assert_awaited_once_with()
     assert provider._shared_gateway_transport(runtime_context=runtime) is transport
+
+
+@pytest.mark.asyncio
+async def test_suspended_factory_provider_recovers_with_new_transport_generation(monkeypatch):
+    provider, transport, runtime = await _factory_provider(monkeypatch)
+    replacement = _WorkerGeneration("quote-generation-2", Mock())
+
+    async def stop_transport() -> None:
+        transport._generation = None
+        transport._connected = False
+        transport._connection_generation_id = None
+
+    async def connect_transport(**kwargs) -> bool:
+        assert kwargs["readonly"] is True
+        transport._generation = replacement
+        transport._connected = True
+        transport._connection_identity = ("127.0.0.1", 4002, 997, True)
+        transport._connection_generation_id = replacement.generation_id
+        return True
+
+    transport.stop = AsyncMock(side_effect=stop_transport)
+    transport.connect = AsyncMock(side_effect=connect_transport)
+    transport.ping = AsyncMock(return_value=True)
+
+    await provider.suspend()
+
+    with pytest.raises(BrokerEvidenceError, match="factory-owned"):
+        assert_factory_owned_diagnostic_provider(provider)
+    with pytest.raises(BrokerEvidenceError, match="factory-owned"):
+        provider._shared_gateway_transport(runtime_context=runtime)
+
+    await provider.refresh()
+
+    assert transport.stop.await_count == 2
+    assert provider._shared_gateway_transport(runtime_context=runtime) is transport
+    assert transport.protective_quote_generation == "quote-generation-2"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_reconciliation_ibkr_adapter.py
+++ b/tests/test_reconciliation_ibkr_adapter.py
@@ -550,6 +550,28 @@ async def test_quote_source_rejects_copy_wrong_runtime_reconnect_and_cleanup(mon
         )
 
 
+@pytest.mark.asyncio
+async def test_factory_provider_refreshes_one_shared_read_only_transport(monkeypatch):
+    provider, transport, runtime = await _factory_provider(monkeypatch)
+    transport.ping = AsyncMock(return_value=True)
+
+    shared = provider._shared_gateway_transport(runtime_context=runtime)
+    await provider.refresh()
+
+    assert shared is transport
+    transport.stop.assert_awaited_once_with()
+    transport.start.assert_awaited()
+    transport.connect.assert_awaited_with(
+        host="127.0.0.1",
+        port=4002,
+        client_id=997,
+        readonly=True,
+        timeout=30.0,
+    )
+    transport.ping.assert_awaited_once_with()
+    assert provider._shared_gateway_transport(runtime_context=runtime) is transport
+
+
 @pytest.mark.parametrize(
     "mutate",
     [

--- a/tests/test_reconciliation_ibkr_adapter.py
+++ b/tests/test_reconciliation_ibkr_adapter.py
@@ -574,6 +574,29 @@ async def test_factory_provider_refreshes_one_shared_read_only_transport(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_generation_lease_blocks_refresh_until_evidence_collection_releases(
+    monkeypatch,
+):
+    provider, transport, _runtime = await _factory_provider(monkeypatch)
+    transport.ping = AsyncMock(return_value=True)
+    transport.start.reset_mock()
+
+    token, generation = await provider._acquire_generation_lease()
+    refresh = asyncio.create_task(provider.refresh())
+    await asyncio.sleep(0)
+
+    assert generation == "quote-generation-1"
+    assert refresh.done() is False
+    transport.stop.assert_not_awaited()
+
+    provider._release_generation_lease(token, generation)
+    await refresh
+
+    transport.stop.assert_awaited_once_with()
+    transport.start.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
 async def test_suspended_factory_provider_recovers_with_new_transport_generation(monkeypatch):
     provider, transport, runtime = await _factory_provider(monkeypatch)
     replacement = _WorkerGeneration("quote-generation-2", Mock())

--- a/tests/test_reconciliation_ibkr_adapter.py
+++ b/tests/test_reconciliation_ibkr_adapter.py
@@ -753,6 +753,7 @@ def _runtime():
         runtime_contract=SimpleNamespace(
             safety_account_scope=ACCOUNT_SCOPE,
             fingerprint=RUNTIME_FINGERPRINT,
+            environment="dev",
         ),
         diagnostic_connection=SimpleNamespace(
             host="127.0.0.1",
@@ -762,6 +763,41 @@ def _runtime():
         ),
         expected_account_for_provider=ACCOUNT,
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("runtime_environment", ["dev", "test", "production"])
+async def test_default_diagnostic_transport_receives_validated_worker_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    runtime_environment: str,
+) -> None:
+    observed: list[object] = []
+    if runtime_environment == "production":
+        production_transport = SubprocessIBKRClient(worker_runtime_environment=runtime_environment)
+        assert production_transport._worker_synthetic_account_environment == ""
+
+    class _EnvironmentCapturingTransport:
+        def __init__(self, *, worker_runtime_environment: object = None) -> None:
+            observed.append(worker_runtime_environment)
+
+        async def start(self) -> None:
+            raise RuntimeError("stop after constructor proof")
+
+        async def stop(self) -> None:
+            return None
+
+    runtime = _runtime()
+    runtime.runtime_contract.environment = runtime_environment
+    monkeypatch.setattr(
+        adapter_module,
+        "SubprocessIBKRClient",
+        _EnvironmentCapturingTransport,
+    )
+
+    with pytest.raises(BrokerEvidenceError, match="initialization failed"):
+        await build_diagnostic_provider(runtime)
+
+    assert observed == [runtime_environment]
 
 
 @pytest.mark.asyncio

--- a/tests/test_recover_connection.py
+++ b/tests/test_recover_connection.py
@@ -21,6 +21,7 @@ from robo_trader.paper_reduction_gateway import PaperReductionGateway
 from robo_trader.protective_quote_evidence import ProtectiveQuoteSource
 from robo_trader.risk_manager import Position
 from robo_trader.runner_async import AsyncRunner
+from robo_trader.reconciliation.runtime_integration import RuntimeReconciliationController
 from robo_trader.stop_loss_monitor import StopLossMonitor
 
 
@@ -39,6 +40,9 @@ def make_runner_for_recovery(initialize_succeeds_on=None):
     runner.subprocess_client.stop = AsyncMock()
 
     runner._safe_disconnect = AsyncMock()
+    reconciliation = object.__new__(RuntimeReconciliationController)
+    reconciliation.reconcile_reconnect = AsyncMock()
+    runner.reconciliation_controller = reconciliation
 
     if initialize_succeeds_on is None:
         runner.initialize_connection = AsyncMock()
@@ -76,6 +80,7 @@ async def test_recovery_refreshes_separate_paper_gateway_before_success():
 
     assert result is True
     gateway.refresh_diagnostic_connection.assert_awaited_once()
+    runner.reconciliation_controller.reconcile_reconnect.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_recover_connection.py
+++ b/tests/test_recover_connection.py
@@ -19,9 +19,9 @@ from robo_trader.market_data_contract import (
 )
 from robo_trader.paper_reduction_gateway import PaperReductionGateway
 from robo_trader.protective_quote_evidence import ProtectiveQuoteSource
+from robo_trader.reconciliation.runtime_integration import RuntimeReconciliationController
 from robo_trader.risk_manager import Position
 from robo_trader.runner_async import AsyncRunner
-from robo_trader.reconciliation.runtime_integration import RuntimeReconciliationController
 from robo_trader.stop_loss_monitor import StopLossMonitor
 
 

--- a/tests/test_recover_connection_cross_portfolio_lock.py
+++ b/tests/test_recover_connection_cross_portfolio_lock.py
@@ -24,8 +24,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from robo_trader import connection_health
-from robo_trader.runner_async import AsyncRunner
 from robo_trader.reconciliation.runtime_integration import RuntimeReconciliationController
+from robo_trader.runner_async import AsyncRunner
 
 
 def _make_runner_for_recovery() -> AsyncRunner:

--- a/tests/test_recover_connection_cross_portfolio_lock.py
+++ b/tests/test_recover_connection_cross_portfolio_lock.py
@@ -25,6 +25,7 @@ import pytest
 
 from robo_trader import connection_health
 from robo_trader.runner_async import AsyncRunner
+from robo_trader.reconciliation.runtime_integration import RuntimeReconciliationController
 
 
 def _make_runner_for_recovery() -> AsyncRunner:
@@ -45,6 +46,9 @@ def _make_runner_for_recovery() -> AsyncRunner:
     # Inner-loop helpers called by recover_connection on success.
     runner._rewarm_stop_loss_prices_after_recovery = AsyncMock()
     runner._maybe_auto_reset_kill_switch_after_recovery = MagicMock()
+    reconciliation = object.__new__(RuntimeReconciliationController)
+    reconciliation.reconcile_reconnect = AsyncMock()
+    runner.reconciliation_controller = reconciliation
     return runner
 
 

--- a/tests/test_recovery_state_machine.py
+++ b/tests/test_recovery_state_machine.py
@@ -31,6 +31,7 @@ import pytest
 
 from robo_trader.connection_health import ConnectionHealth, HealthStatus
 from robo_trader.runner_async import AsyncRunner
+from robo_trader.reconciliation.runtime_integration import RuntimeReconciliationController
 
 
 def make_fake_ib_client():
@@ -58,6 +59,9 @@ def make_runner_for_recovery(initialize_succeeds_on=None):
     runner.subprocess_client.stop = AsyncMock()
     runner.health = None
     runner._safe_disconnect = AsyncMock()
+    reconciliation = object.__new__(RuntimeReconciliationController)
+    reconciliation.reconcile_reconnect = AsyncMock()
+    runner.reconciliation_controller = reconciliation
 
     if initialize_succeeds_on is None:
         runner.initialize_connection = AsyncMock()

--- a/tests/test_recovery_state_machine.py
+++ b/tests/test_recovery_state_machine.py
@@ -30,8 +30,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from robo_trader.connection_health import ConnectionHealth, HealthStatus
-from robo_trader.runner_async import AsyncRunner
 from robo_trader.reconciliation.runtime_integration import RuntimeReconciliationController
+from robo_trader.runner_async import AsyncRunner
 
 
 def make_fake_ib_client():


### PR DESCRIPTION
## Summary

- wire PR 5 reconciliation into paper-runtime startup, reconnect, and fixed-period cycle boundaries
- derive signed reconciliation, protective marks, and exact SQLite identity from one factory-owned read-only diagnostic generation
- require complete exact-state bootstrap lineage and authenticated receipts before broker collection
- block risk-increasing entries when reconciliation is missing, stale, or quarantined while preserving semantic reduce-only protection
- expose sanitized reconciliation state and current age on the authenticated runner-status endpoint

## Safety boundary

- does not place broker orders, add live capability, repair state, delete history, start the trader, or access authoritative trading data
- signing and evidence directories must be explicitly configured as owner-only directories
- Gate A remains closed and a current operator-reviewed broker reconciliation remains outstanding

## Verification

- full suite: `3029 passed, 5 skipped, 20 warnings`
- focused runtime, startup, adapter, reconnect, and recovery suite: `151 passed`
- Black and Flake8 passed for all changed Python files
- `git diff --check` passed

No Gateway, trader process, broker session, or authoritative trading database was started or accessed during verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core trading admission, shared broker diagnostic sessions, and signed evidence handling—areas where mistakes could allow entries without valid reconciliation or strand protective quote subscriptions.
> 
> **Overview**
> Wires **signed broker reconciliation** into the paper runtime so startup, reconnect, and periodic cycles each produce one evidence bundle from a **single shared read-only IBKR diagnostic generation**, then gate risk-increasing entries on fresh eligibility while **reduce-only** paths stay available.
> 
> Adds `runtime_integration` with read-only bootstrap/schema checks before collection, non-destructive evidence retention ceilings, atomic status publication, and sanitized fields on `/api/runner/status`. The dashboard runner banner now stays visible when reconciliation is quarantined even if the runner heartbeat is healthy.
> 
> **Runner** builds a `RuntimeReconciliationController` alongside `PaperReductionGateway` (shared `IBKRDiagnosticSnapshotProvider`), runs reconcile on startup/reconnect, polls periodically in continuous mode, and blocks BUY admission when reconciliation is missing, stale, or quarantined.
> 
> Supporting hardening: broker envelope **producer→runtime handoff** after one-shot consume; bundle **completion manifest v2** with per-file inode/hash binding; protective quote collection scoped to the **full account-wide active symbol set**; reconciliation DB **`initialize` is read-only** with schema changes behind `migrate_for_operator`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16d1f99d92237a951aded3d6b7172787f38ee8cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->