### PR TITLE
PR4C: settle paper fills through exact FIFO

### DIFF
--- a/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
+++ b/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
@@ -1,7 +1,7 @@
 # RoboTrader Remediation and Launch Plan
 
 Document date: 2026-07-20
-Last updated: 2026-07-28
+Last updated: 2026-07-30
 Status: Active execution plan; Gate A remains closed
 Source baseline: repository audit at commit `51f0e99`; execution baseline
 `1ae64808ae20956e412e95f17f194776f4851478` on branch `main`
@@ -48,6 +48,15 @@ operator-reviewed bootstrap/application, and restore evidence remain open. PR
 production startup/reconnect/periodic wiring and a current operator-reviewed
 reconciliation remain open. Gate A remains closed, the trader remains stopped,
 and none of these merges authorizes startup.
+
+PR4A's dormant exact FIFO foundation is merged through PR #120. PR4B's
+operator-reviewed legacy-opening bridge is under review as PR #123 at exact
+head `318532e`; it includes sealed opening-manifest count/hash, exact trigger
+body verification, and in-transaction schema revalidation. PR4C
+transactionally connecting producer-owned local-paper fills to FIFO is
+implemented on `codex/pr4c-fifo-settlement`, stacked on that
+exact PR4B head, and is awaiting independent review. These code slices do not
+apply an operational bootstrap, authorize startup, or close Gate A.
 
 ## 1. Purpose
 
@@ -650,6 +659,28 @@ Create a recoverable financial ledger with constrained schema, safe pooling, saf
 - An invalid financial row cannot enter through normal application paths.
 - Backups include WAL state and restore to an integrity-clean database.
 - Every order and fill has durable correlation identifiers.
+
+### PR4C implementation checkpoint (2026-07-30)
+
+The local-paper terminal settlement now appends each producer-authenticated
+fill, exact USD commission, FIFO lots/matches/snapshot, compatibility
+projections, terminal outbox, and immutable settlement-to-FIFO link in one
+SQLite transaction. Exact replay re-authenticates the stored event and link;
+missing epochs, conflicting evidence, projection divergence, and partial writes
+fail closed. Stopped-system recovery also verifies the full FIFO epoch and link
+from its existing query-only snapshot before releasing safety authority.
+
+The full local suite passed 3,036 tests with 5 expected skips and 20 known
+warnings. Detailed design and evidence are recorded in
+`docs/design/PR4C_FIFO_RUNTIME_SETTLEMENT.md` and
+`docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md`.
+
+This checkpoint does not complete PR4. PR4B must merge first; the reviewed
+bootstrap must then be applied only through the stopped-system operator path,
+and WAL-safe backup/clean-room restore plus current reconciliation evidence
+remain mandatory. The active simulator still emits complete fills only;
+partial order-lifecycle support remains quarantined. Gate A remains closed and
+the trader remains stopped.
 
 ## PR 5 - Add read-only broker reconciliation
 
@@ -1557,8 +1588,11 @@ Update after each merge.
   contract and adversarial tests are present; cumulative Gate-A operational
   evidence remains required.
 - PR 4: The exact-state bootstrap code slice merged through PR #112 as
-  `bccb96b`. Strict FIFO lot accounting, stopped-system operator review and
-  application, and clean-room backup/restore evidence remain open.
+  `bccb96b`, and dormant FIFO PR4A merged through PR #120. PR4B is under review
+  as PR #123 at exact head `318532e`. PR4C transactional runtime FIFO settlement
+  is implemented and awaiting independent review. Stopped-system operator
+  application, WAL-safe clean-room backup/restore, and current reconciliation
+  evidence remain open; no PR4 slice authorizes startup.
 - PR 5: Reconciliation domain and runtime evidence/service foundations merged
   through PR #113 (`6176931`) and PR #115 (`1ae6480`). Production
   startup/reconnect/periodic integration and a current reviewed read-only

--- a/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
+++ b/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
@@ -674,7 +674,7 @@ event sequence. The locked settlement transaction also rejects temporary
 shadows and foreign persistent triggers on all hot settlement tables before it
 writes, and all such statements explicitly target the durable `main` schema.
 
-The full local suite passed 3,036 tests with 5 expected skips and 20 known
+The full local suite passed 3,042 tests with 5 expected skips and 20 known
 warnings. Detailed design and evidence are recorded in
 `docs/design/PR4C_FIFO_RUNTIME_SETTLEMENT.md` and
 `docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md`.

--- a/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
+++ b/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
@@ -674,7 +674,7 @@ event sequence. The locked settlement transaction also rejects temporary
 shadows and foreign persistent triggers on all hot settlement tables before it
 writes, and all such statements explicitly target the durable `main` schema.
 
-The full local suite passed 3,049 tests with 5 expected skips and 20 known
+The full local suite passed 3,054 tests with 5 expected skips and 20 known
 warnings. Detailed design and evidence are recorded in
 `docs/design/PR4C_FIFO_RUNTIME_SETTLEMENT.md` and
 `docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md`.

--- a/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
+++ b/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
@@ -674,7 +674,7 @@ event sequence. The locked settlement transaction also rejects temporary
 shadows and foreign persistent triggers on all hot settlement tables before it
 writes, and all such statements explicitly target the durable `main` schema.
 
-The full local suite passed 3,054 tests with 5 expected skips and 20 known
+The full local suite passed 3,055 tests with 5 expected skips and 20 known
 warnings. Detailed design and evidence are recorded in
 `docs/design/PR4C_FIFO_RUNTIME_SETTLEMENT.md` and
 `docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md`.

--- a/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
+++ b/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
@@ -674,7 +674,7 @@ event sequence. The locked settlement transaction also rejects temporary
 shadows and foreign persistent triggers on all hot settlement tables before it
 writes, and all such statements explicitly target the durable `main` schema.
 
-The full local suite passed 3,042 tests with 5 expected skips and 20 known
+The full local suite passed 3,044 tests with 5 expected skips and 20 known
 warnings. Detailed design and evidence are recorded in
 `docs/design/PR4C_FIFO_RUNTIME_SETTLEMENT.md` and
 `docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md`.

--- a/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
+++ b/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
@@ -674,7 +674,7 @@ event sequence. The locked settlement transaction also rejects temporary
 shadows and foreign persistent triggers on all hot settlement tables before it
 writes, and all such statements explicitly target the durable `main` schema.
 
-The full local suite passed 3,044 tests with 5 expected skips and 20 known
+The full local suite passed 3,047 tests with 5 expected skips and 20 known
 warnings. Detailed design and evidence are recorded in
 `docs/design/PR4C_FIFO_RUNTIME_SETTLEMENT.md` and
 `docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md`.

--- a/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
+++ b/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
@@ -674,7 +674,7 @@ event sequence. The locked settlement transaction also rejects temporary
 shadows and foreign persistent triggers on all hot settlement tables before it
 writes, and all such statements explicitly target the durable `main` schema.
 
-The full local suite passed 3,048 tests with 5 expected skips and 20 known
+The full local suite passed 3,049 tests with 5 expected skips and 20 known
 warnings. Detailed design and evidence are recorded in
 `docs/design/PR4C_FIFO_RUNTIME_SETTLEMENT.md` and
 `docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md`.

--- a/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
+++ b/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
@@ -674,7 +674,7 @@ event sequence. The locked settlement transaction also rejects temporary
 shadows and foreign persistent triggers on all hot settlement tables before it
 writes, and all such statements explicitly target the durable `main` schema.
 
-The full local suite passed 3,047 tests with 5 expected skips and 20 known
+The full local suite passed 3,048 tests with 5 expected skips and 20 known
 warnings. Detailed design and evidence are recorded in
 `docs/design/PR4C_FIFO_RUNTIME_SETTLEMENT.md` and
 `docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md`.

--- a/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
+++ b/docs/ROBOTRADER_REMEDIATION_PLAN_2026-07-20.md
@@ -669,6 +669,10 @@ SQLite transaction. Exact replay re-authenticates the stored event and link;
 missing epochs, conflicting evidence, projection divergence, and partial writes
 fail closed. Stopped-system recovery also verifies the full FIFO epoch and link
 from its existing query-only snapshot before releasing safety authority.
+Epoch realized P&L is accumulated across every instrument through the current
+event sequence. The locked settlement transaction also rejects temporary
+shadows and foreign persistent triggers on all hot settlement tables before it
+writes, and all such statements explicitly target the durable `main` schema.
 
 The full local suite passed 3,036 tests with 5 expected skips and 20 known
 warnings. Detailed design and evidence are recorded in

--- a/docs/design/PR4C_FIFO_RUNTIME_SETTLEMENT.md
+++ b/docs/design/PR4C_FIFO_RUNTIME_SETTLEMENT.md
@@ -77,6 +77,13 @@ Decimal subtraction.
 `paper_fifo_settlement_links` binds each terminal settlement to exactly one
 FIFO fill, sequence, execution ID, commission source, and state fingerprint.
 It is append-only and protected by uniqueness and composite foreign keys.
+Legacy schema-v1 `CANCELLED` and `REJECTED` payloads written before fill
+evidence fields were serialized remain fingerprint-authenticated and
+replayable. Their stored canonical payload is preserved for request and receipt
+authentication while a current-form semantic fingerprint permits idempotent
+online comparison. This compatibility path admits only zero-fill outcomes;
+filled payloads without the complete producer evidence remain invalid, and
+offline recovery still requires the absence of a FIFO settlement link.
 
 An exact retry authenticates the existing event payload, complete epoch, and
 link, then returns the original terminal receipt without adding a fill or

--- a/docs/design/PR4C_FIFO_RUNTIME_SETTLEMENT.md
+++ b/docs/design/PR4C_FIFO_RUNTIME_SETTLEMENT.md
@@ -57,9 +57,11 @@ SQLite does. The audit compares complete canonical table and explicit-index
 DDL, including constraints, uniqueness, foreign keys, defaults, and required
 indexes. SQL normalization preserves quoted literal contents. The exact
 multiuser-v1 compatibility definitions for `positions`, `trades`, and
-`account` are separately allowlisted so an already-supported upgraded ledger
-is not quarantined merely for predating the fresh-database DDL. Every
-settlement statement is explicitly qualified to the durable `main` schema.
+`account` are separately allowlisted for both its populated-table rename path
+and its partially initialized direct-create path, so an already-supported
+upgraded ledger is not quarantined merely for predating the fresh-database
+DDL. Every settlement statement is explicitly qualified to the durable `main`
+schema.
 The FIFO ledger separately performs the same in-transaction protection for all
 FIFO tables and triggers. Thus a temporary settlement-link table cannot divert
 lineage, a same-shaped table cannot substitute altered constraints, and an

--- a/docs/design/PR4C_FIFO_RUNTIME_SETTLEMENT.md
+++ b/docs/design/PR4C_FIFO_RUNTIME_SETTLEMENT.md
@@ -63,9 +63,12 @@ upgraded ledger is not quarantined merely for predating the fresh-database
 DDL. Every settlement statement is explicitly qualified to the durable `main`
 schema.
 The FIFO ledger separately performs the same in-transaction protection for all
-FIFO tables and triggers. Thus a temporary settlement-link table cannot divert
-lineage, a same-shaped table cannot substitute altered constraints, and an
-injected trade trigger cannot add an unreviewed compatibility row after
+FIFO tables and triggers. Its SQL normalization folds syntax outside quotes but
+preserves quoted literals exactly, so a case-changed commission constraint
+cannot authenticate as canonical and then reject the emitted uppercase
+currency after mutation begins. Thus a temporary settlement-link table cannot
+divert lineage, a same-shaped table cannot substitute altered constraints, and
+an injected trade trigger cannot add an unreviewed compatibility row after
 projection checks.
 
 Every fill-local and epoch-wide realized-P&L subtotal is accumulated in an

--- a/docs/design/PR4C_FIFO_RUNTIME_SETTLEMENT.md
+++ b/docs/design/PR4C_FIFO_RUNTIME_SETTLEMENT.md
@@ -70,7 +70,9 @@ projection checks.
 
 Every fill-local and epoch-wide realized-P&L subtotal is accumulated in an
 explicit 96-digit local Decimal context, independent of same-process ambient
-context changes.
+context changes. The transaction-side expected realized-P&L delta is likewise
+computed with the shared exact safety arithmetic helper rather than ambient
+Decimal subtraction.
 
 `paper_fifo_settlement_links` binds each terminal settlement to exactly one
 FIFO fill, sequence, execution ID, commission source, and state fingerprint.

--- a/docs/design/PR4C_FIFO_RUNTIME_SETTLEMENT.md
+++ b/docs/design/PR4C_FIFO_RUNTIME_SETTLEMENT.md
@@ -55,12 +55,20 @@ It rejects temporary shadows and any persistent hot-table trigger other than
 the exact append-only guards, matching trigger targets case-insensitively as
 SQLite does. The audit compares complete canonical table and explicit-index
 DDL, including constraints, uniqueness, foreign keys, defaults, and required
-indexes. Every settlement statement is explicitly qualified to the durable
-`main` schema. The FIFO ledger separately performs the same in-transaction
-protection for all FIFO tables and triggers. Thus a temporary settlement-link
-table cannot divert lineage, a same-shaped table cannot substitute altered
-constraints, and an injected trade trigger cannot add an unreviewed
-compatibility row after projection checks.
+indexes. SQL normalization preserves quoted literal contents. The exact
+multiuser-v1 compatibility definitions for `positions`, `trades`, and
+`account` are separately allowlisted so an already-supported upgraded ledger
+is not quarantined merely for predating the fresh-database DDL. Every
+settlement statement is explicitly qualified to the durable `main` schema.
+The FIFO ledger separately performs the same in-transaction protection for all
+FIFO tables and triggers. Thus a temporary settlement-link table cannot divert
+lineage, a same-shaped table cannot substitute altered constraints, and an
+injected trade trigger cannot add an unreviewed compatibility row after
+projection checks.
+
+Every fill-local and epoch-wide realized-P&L subtotal is accumulated in an
+explicit 96-digit local Decimal context, independent of same-process ambient
+context changes.
 
 `paper_fifo_settlement_links` binds each terminal settlement to exactly one
 FIFO fill, sequence, execution ID, commission source, and state fingerprint.

--- a/docs/design/PR4C_FIFO_RUNTIME_SETTLEMENT.md
+++ b/docs/design/PR4C_FIFO_RUNTIME_SETTLEMENT.md
@@ -52,11 +52,15 @@ snapshot is never treated as the account-wide total.
 After acquiring the immediate write lock and before appending a fill, the
 settlement path re-authenticates every non-FIFO table and trigger it can mutate.
 It rejects temporary shadows and any persistent hot-table trigger other than
-the exact append-only guards. Every settlement statement is explicitly
-qualified to the durable `main` schema. The FIFO ledger separately performs
-the same in-transaction protection for all FIFO tables and triggers. Thus a
-temporary settlement-link table cannot divert lineage and an injected trade
-trigger cannot add an unreviewed compatibility row after projection checks.
+the exact append-only guards, matching trigger targets case-insensitively as
+SQLite does. The audit compares complete canonical table and explicit-index
+DDL, including constraints, uniqueness, foreign keys, defaults, and required
+indexes. Every settlement statement is explicitly qualified to the durable
+`main` schema. The FIFO ledger separately performs the same in-transaction
+protection for all FIFO tables and triggers. Thus a temporary settlement-link
+table cannot divert lineage, a same-shaped table cannot substitute altered
+constraints, and an injected trade trigger cannot add an unreviewed
+compatibility row after projection checks.
 
 `paper_fifo_settlement_links` binds each terminal settlement to exactly one
 FIFO fill, sequence, execution ID, commission source, and state fingerprint.

--- a/docs/design/PR4C_FIFO_RUNTIME_SETTLEMENT.md
+++ b/docs/design/PR4C_FIFO_RUNTIME_SETTLEMENT.md
@@ -1,0 +1,78 @@
+# PR4C Runtime FIFO Settlement
+
+Date: 2026-07-30
+
+## Decision
+
+An authenticated local-paper fill is appended to the sealed FIFO accounting
+epoch in the same `BEGIN IMMEDIATE` transaction that writes the compatibility
+trade, position, account, exact-state, terminal-settlement, and immutable link
+rows. The transaction either commits all of those records or none of them.
+
+This slice does not create or infer an accounting epoch. A runtime allocation
+must have exactly one epoch established by the separately reviewed PR4B
+bootstrap. Missing or ambiguous epoch authority fails closed.
+
+## Evidence boundary
+
+The sealed local `PaperExecutor` is the only runtime producer connected by this
+slice. On a successful execution it emits:
+
+- an opaque deterministic execution identifier;
+- exact `Decimal` quantity and price;
+- an aware UTC occurrence time; and
+- an exact signed commission in USD minor units with a versioned producer
+  source.
+
+The current executor's explicit cost model reports zero commission. Zero is
+therefore producer evidence, not a database default. The FIFO bridge supports
+nonzero commissions and rebates, and its tests exercise both.
+
+No order intent, position delta, compatibility trade row, or broker quote can
+be converted into fill evidence. Positive outcomes without the producer-owned
+evidence are rejected before settlement.
+
+## Atomic write and replay
+
+`FifoLedger.record_fill_in_transaction` leaves commit and rollback ownership
+with the terminal-settlement transaction. The runtime bridge assigns the next
+gap-free epoch sequence while that transaction holds SQLite's immediate write
+lock, appends the fill and commission, derives FIFO lots/matches/snapshot, and
+recomputes the complete epoch integrity chain. Before any mutation, it also
+revalidates the durable FIFO tables and exact trigger bodies inside that same
+transaction, preserving PR4B's schema-substitution protection.
+
+The FIFO projection supplies the compatibility trade P&L, remaining quantity,
+remaining cost, average cost, and total realized P&L. Settlement refuses to
+commit if those values differ from the already-authorized exact terminal
+request.
+
+`paper_fifo_settlement_links` binds each terminal settlement to exactly one
+FIFO fill, sequence, execution ID, commission source, and state fingerprint.
+It is append-only and protected by uniqueness and composite foreign keys.
+
+An exact retry authenticates the existing event payload, complete epoch, and
+link, then returns the original terminal receipt without adding a fill or
+changing a projection. An identity collision with different evidence fails
+closed.
+
+## Crash recovery
+
+Stopped-system crash recovery now requires the linked FIFO event in addition
+to the existing terminal outbox and compatibility projections. It opens the
+ledger read-only, enables foreign-key validation, authenticates the complete
+FIFO schema and epoch, recomputes the immutable event and snapshot chain, and
+compares the link and exact projection with the terminal request. Missing,
+ambiguous, or tampered FIFO evidence leaves the safety reservation quarantined.
+
+## Current limitations
+
+- The active local-paper executor still produces one complete fill. Partial and
+  nonterminal outcomes remain quarantined; their order-lifecycle integration is
+  not enabled by this PR.
+- This slice does not authorize an IBKR write path or a live order.
+- It does not apply the offline bootstrap to an operational database.
+- It does not perform the backup/restore or broker-reconciliation drills needed
+  to complete PR4 and Gate A.
+
+The system remains paper-only and IBKR read-only. Gate A remains closed.

--- a/docs/design/PR4C_FIFO_RUNTIME_SETTLEMENT.md
+++ b/docs/design/PR4C_FIFO_RUNTIME_SETTLEMENT.md
@@ -45,7 +45,18 @@ transaction, preserving PR4B's schema-substitution protection.
 The FIFO projection supplies the compatibility trade P&L, remaining quantity,
 remaining cost, average cost, and total realized P&L. Settlement refuses to
 commit if those values differ from the already-authorized exact terminal
-request.
+request. Total realized P&L is the epoch baseline plus every lot match through
+the current event sequence across all instruments; an instrument-local
+snapshot is never treated as the account-wide total.
+
+After acquiring the immediate write lock and before appending a fill, the
+settlement path re-authenticates every non-FIFO table and trigger it can mutate.
+It rejects temporary shadows and any persistent hot-table trigger other than
+the exact append-only guards. Every settlement statement is explicitly
+qualified to the durable `main` schema. The FIFO ledger separately performs
+the same in-transaction protection for all FIFO tables and triggers. Thus a
+temporary settlement-link table cannot divert lineage and an injected trade
+trigger cannot add an unreviewed compatibility row after projection checks.
 
 `paper_fifo_settlement_links` binds each terminal settlement to exactly one
 FIFO fill, sequence, execution ID, commission source, and state fingerprint.

--- a/docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md
+++ b/docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md
@@ -17,9 +17,9 @@ Base: `main` at `4c7ea47`, including merged PR4B
 
 ## Local verification
 
-- Full repository suite: `3042 passed, 5 skipped, 20 warnings`.
+- Full repository suite: `3044 passed, 5 skipped, 20 warnings`.
 - Combined FIFO, migration, exact-bootstrap, settlement, failure-injection,
-  and recovery-status matrix: `215 passed`.
+  and recovery-status matrix: `217 passed`.
 - Existing-position and stop-event suite: `168 passed`.
 - Migration, exact bootstrap, and FIFO foundation suite: `120 passed`.
 - Terminal failure-injection and recovery-status suite: `66 passed`.
@@ -34,6 +34,9 @@ Base: `main` at `4c7ea47`, including merged PR4B
   `paper_fifo_settlement_links` shadow and a persistent `AFTER INSERT` trade
   injection trigger both fail before mutation, with no fill, commission,
   compatibility trade, settlement, or link partially committed.
+- The persistent-trigger regression uses SQLite's case-insensitive `Trades`
+  spelling, and complete-definition regressions reject both a same-column
+  replacement table with an added `CHECK` and a malformed hot-table index.
 - Settlement failure injection covers failures immediately after FIFO append,
   after compatibility trade insertion, and after immutable FIFO-link insertion;
   every case leaves zero fill, commission, trade, settlement, and link rows.

--- a/docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md
+++ b/docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md
@@ -2,7 +2,7 @@
 
 Date: 2026-07-30
 Branch: `codex/pr4c-fifo-settlement`
-Base: `main` including merged PR4B
+Base: `main` at `4c7ea47`, including merged PR4B
 
 ## Scope reviewed
 
@@ -17,7 +17,9 @@ Base: `main` including merged PR4B
 
 ## Local verification
 
-- Full repository suite: `3036 passed, 5 skipped, 20 warnings`.
+- Full repository suite: `3042 passed, 5 skipped, 20 warnings`.
+- Combined FIFO, migration, exact-bootstrap, settlement, failure-injection,
+  and recovery-status matrix: `215 passed`.
 - Existing-position and stop-event suite: `168 passed`.
 - Migration, exact bootstrap, and FIFO foundation suite: `120 passed`.
 - Terminal failure-injection and recovery-status suite: `66 passed`.

--- a/docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md
+++ b/docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md
@@ -17,9 +17,9 @@ Base: `main` at `4c7ea47`, including merged PR4B
 
 ## Local verification
 
-- Full repository suite: `3044 passed, 5 skipped, 20 warnings`.
+- Full repository suite: `3047 passed, 5 skipped, 20 warnings`.
 - Combined FIFO, migration, exact-bootstrap, settlement, failure-injection,
-  and recovery-status matrix: `217 passed`.
+  and recovery-status matrix: `220 passed`.
 - Existing-position and stop-event suite: `168 passed`.
 - Migration, exact bootstrap, and FIFO foundation suite: `120 passed`.
 - Terminal failure-injection and recovery-status suite: `66 passed`.
@@ -37,6 +37,11 @@ Base: `main` at `4c7ea47`, including merged PR4B
 - The persistent-trigger regression uses SQLite's case-insensitive `Trades`
   spelling, and complete-definition regressions reject both a same-column
   replacement table with an added `CHECK` and a malformed hot-table index.
+- Quoted SQL literals retain their exact case during DDL authentication;
+  lowercase `'usd'` is rejected. The reviewed multiuser-v1 compatibility DDL
+  is accepted as an exact alternate schema and completes an end-to-end
+  settlement. FIFO subtotal tests also lower the ambient Decimal precision and
+  prove the 96-digit local context preserves an exact cross-symbol result.
 - Settlement failure injection covers failures immediately after FIFO append,
   after compatibility trade insertion, and after immutable FIFO-link insertion;
   every case leaves zero fill, commission, trade, settlement, and link rows.

--- a/docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md
+++ b/docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md
@@ -1,0 +1,48 @@
+# PR4C Local Review Evidence
+
+Date: 2026-07-30
+Branch: `codex/pr4c-fifo-settlement`
+Stack base: PR4B exact head `318532e`
+
+## Scope reviewed
+
+- producer-owned local-paper fill and exact commission evidence;
+- transaction-owned FIFO append and exact replay;
+- atomic FIFO, compatibility projection, and terminal outbox settlement;
+- immutable settlement-to-FIFO lineage;
+- stopped-system query-only recovery authentication;
+- PR4B sealed-opening-manifest and trigger-body protections;
+- PR4B in-transaction durable schema and trigger revalidation;
+- paper/read-only containment and absence of runtime startup actions.
+
+## Local verification
+
+- Full repository suite: `3036 passed, 5 skipped, 20 warnings`.
+- Existing-position and stop-event suite: `168 passed`.
+- Migration, exact bootstrap, and FIFO foundation suite: `120 passed`.
+- Terminal failure-injection and recovery-status suite: `66 passed`.
+- Focused runtime FIFO tests cover multiple partial fill events, exact
+  commission allocation, a rebate, deterministic replay, conflicting replay,
+  missing-epoch refusal, and transaction rollback.
+- Settlement failure injection covers failures immediately after FIFO append,
+  after compatibility trade insertion, and after immutable FIFO-link insertion;
+  every case leaves zero fill, commission, trade, settlement, and link rows.
+- Recovery tests reject a tampered FIFO link and a missing FIFO-link schema.
+- Changed Python files pass Black, isort, and Flake8; compilation, dependency
+  consistency, and whitespace/diff checks pass.
+- The new FIFO runtime and terminal-request modules pass isolated mypy, and the
+  new accounting/execution/terminal modules pass targeted Bandit.
+
+The known full-suite warnings and expected skips predate this slice. No test
+opened a broker connection or used an authoritative trading database.
+Repository-wide Flake8 still reports nine pre-existing findings in the Claude
+emoji hook and two training scripts; repository-wide mypy remains baseline
+debt tracked outside PR4C. The broader changed-production Bandit scan reported
+only four pre-existing low-severity findings and no medium/high findings.
+
+## Safety conclusion
+
+The code slice connects only the sealed local-paper execution result to the
+exact FIFO ledger. It neither enables startup nor changes the live-order
+boundary. Operational bootstrap, backup/restore, current reconciliation, and
+Gate-A evidence remain outstanding.

--- a/docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md
+++ b/docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md
@@ -17,9 +17,9 @@ Base: `main` at `4c7ea47`, including merged PR4B
 
 ## Local verification
 
-- Full repository suite: `3049 passed, 5 skipped, 20 warnings`.
+- Full repository suite: `3054 passed, 5 skipped, 20 warnings`.
 - Combined FIFO, migration, exact-bootstrap, settlement, failure-injection,
-  and recovery-status matrix: `222 passed`.
+  and recovery-status matrix: `227 passed`.
 - Existing-position and stop-event suite: `168 passed`.
 - Migration, exact bootstrap, and FIFO foundation suite: `120 passed`.
 - Terminal failure-injection and recovery-status suite: `66 passed`.
@@ -46,6 +46,11 @@ Base: `main` at `4c7ea47`, including merged PR4B
   exact cross-symbol result. The transaction-side expected FIFO delta uses the
   exact safety arithmetic helper; under precision 6, an end-to-end settlement
   preserves the exact `12345.67` to `0.01` transition and `-12345.66` delta.
+- Fingerprint-authenticated legacy schema-v1 zero-fill payloads remain
+  replayable for `CANCELLED` and `REJECTED` outcomes online and through stopped
+  offline recovery. Their original canonical serialization remains bound to
+  the stored receipt, they claim no FIFO link, and missing or partial fill
+  evidence remains rejected for filled or malformed payloads.
 - Settlement failure injection covers failures immediately after FIFO append,
   after compatibility trade insertion, and after immutable FIFO-link insertion;
   every case leaves zero fill, commission, trade, settlement, and link rows.

--- a/docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md
+++ b/docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md
@@ -17,9 +17,9 @@ Base: `main` at `4c7ea47`, including merged PR4B
 
 ## Local verification
 
-- Full repository suite: `3047 passed, 5 skipped, 20 warnings`.
+- Full repository suite: `3048 passed, 5 skipped, 20 warnings`.
 - Combined FIFO, migration, exact-bootstrap, settlement, failure-injection,
-  and recovery-status matrix: `220 passed`.
+  and recovery-status matrix: `221 passed`.
 - Existing-position and stop-event suite: `168 passed`.
 - Migration, exact bootstrap, and FIFO foundation suite: `120 passed`.
 - Terminal failure-injection and recovery-status suite: `66 passed`.
@@ -39,9 +39,11 @@ Base: `main` at `4c7ea47`, including merged PR4B
   replacement table with an added `CHECK` and a malformed hot-table index.
 - Quoted SQL literals retain their exact case during DDL authentication;
   lowercase `'usd'` is rejected. The reviewed multiuser-v1 compatibility DDL
-  is accepted as an exact alternate schema and completes an end-to-end
-  settlement. FIFO subtotal tests also lower the ambient Decimal precision and
-  prove the 96-digit local context preserves an exact cross-symbol result.
+  from both populated-table rename migrations and partially initialized
+  direct-create migrations is accepted as an exact alternate schema and
+  completes an end-to-end settlement. FIFO subtotal tests also lower the
+  ambient Decimal precision and prove the 96-digit local context preserves an
+  exact cross-symbol result.
 - Settlement failure injection covers failures immediately after FIFO append,
   after compatibility trade insertion, and after immutable FIFO-link insertion;
   every case leaves zero fill, commission, trade, settlement, and link rows.

--- a/docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md
+++ b/docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md
@@ -17,9 +17,9 @@ Base: `main` at `4c7ea47`, including merged PR4B
 
 ## Local verification
 
-- Full repository suite: `3048 passed, 5 skipped, 20 warnings`.
+- Full repository suite: `3049 passed, 5 skipped, 20 warnings`.
 - Combined FIFO, migration, exact-bootstrap, settlement, failure-injection,
-  and recovery-status matrix: `221 passed`.
+  and recovery-status matrix: `222 passed`.
 - Existing-position and stop-event suite: `168 passed`.
 - Migration, exact bootstrap, and FIFO foundation suite: `120 passed`.
 - Terminal failure-injection and recovery-status suite: `66 passed`.
@@ -43,7 +43,9 @@ Base: `main` at `4c7ea47`, including merged PR4B
   direct-create migrations is accepted as an exact alternate schema and
   completes an end-to-end settlement. FIFO subtotal tests also lower the
   ambient Decimal precision and prove the 96-digit local context preserves an
-  exact cross-symbol result.
+  exact cross-symbol result. The transaction-side expected FIFO delta uses the
+  exact safety arithmetic helper; under precision 6, an end-to-end settlement
+  preserves the exact `12345.67` to `0.01` transition and `-12345.66` delta.
 - Settlement failure injection covers failures immediately after FIFO append,
   after compatibility trade insertion, and after immutable FIFO-link insertion;
   every case leaves zero fill, commission, trade, settlement, and link rows.

--- a/docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md
+++ b/docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md
@@ -2,7 +2,7 @@
 
 Date: 2026-07-30
 Branch: `codex/pr4c-fifo-settlement`
-Stack base: PR4B exact head `318532e`
+Base: `main` including merged PR4B
 
 ## Scope reviewed
 
@@ -23,7 +23,15 @@ Stack base: PR4B exact head `318532e`
 - Terminal failure-injection and recovery-status suite: `66 passed`.
 - Focused runtime FIFO tests cover multiple partial fill events, exact
   commission allocation, a rebate, deterministic replay, conflicting replay,
-  missing-epoch refusal, and transaction rollback.
+  missing-epoch refusal, transaction rollback, and account-wide realized P&L
+  accumulation across multiple symbols.
+- End-to-end settlement proves that a later AAPL reduction preserves earlier
+  MSFT realized P&L in the same epoch instead of replacing the account total
+  with the current instrument's cumulative snapshot.
+- Hot-schema regressions prove that a temporary
+  `paper_fifo_settlement_links` shadow and a persistent `AFTER INSERT` trade
+  injection trigger both fail before mutation, with no fill, commission,
+  compatibility trade, settlement, or link partially committed.
 - Settlement failure injection covers failures immediately after FIFO append,
   after compatibility trade insertion, and after immutable FIFO-link insertion;
   every case leaves zero fill, commission, trade, settlement, and link rows.

--- a/docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md
+++ b/docs/reviews/PR4C_LOCAL_REVIEW_EVIDENCE_2026-07-30.md
@@ -17,9 +17,9 @@ Base: `main` at `4c7ea47`, including merged PR4B
 
 ## Local verification
 
-- Full repository suite: `3054 passed, 5 skipped, 20 warnings`.
+- Full repository suite: `3055 passed, 5 skipped, 20 warnings`.
 - Combined FIFO, migration, exact-bootstrap, settlement, failure-injection,
-  and recovery-status matrix: `227 passed`.
+  and recovery-status matrix: `228 passed`.
 - Existing-position and stop-event suite: `168 passed`.
 - Migration, exact bootstrap, and FIFO foundation suite: `120 passed`.
 - Terminal failure-injection and recovery-status suite: `66 passed`.
@@ -37,8 +37,9 @@ Base: `main` at `4c7ea47`, including merged PR4B
 - The persistent-trigger regression uses SQLite's case-insensitive `Trades`
   spelling, and complete-definition regressions reject both a same-column
   replacement table with an added `CHECK` and a malformed hot-table index.
-- Quoted SQL literals retain their exact case during DDL authentication;
-  lowercase `'usd'` is rejected. The reviewed multiuser-v1 compatibility DDL
+- Quoted SQL literals retain their exact case during both hot-table and FIFO
+  DDL authentication; lowercase `'usd'` commission constraints are rejected
+  before a fill or commission write. The reviewed multiuser-v1 compatibility DDL
   from both populated-table rename migrations and partially initialized
   direct-create migrations is accepted as an exact alternate schema and
   completes an end-to-end settlement. FIFO subtotal tests also lower the

--- a/robo_trader/accounting/__init__.py
+++ b/robo_trader/accounting/__init__.py
@@ -1,9 +1,9 @@
-"""Dormant exact-accounting foundations.
+"""Exact FIFO accounting and its contained local-paper settlement bridge.
 
-Nothing in this package is connected to the trading runtime.  PR4A exposes a
-fixture-only schema migration and a deterministic FIFO projector. PR4B adds a
-separately guarded offline legacy-opening bridge; no runtime path imports this
-package to authorize startup or an order.
+PR4A provides the deterministic ledger, PR4B the separately guarded offline
+legacy-opening bridge, and PR4C the atomic projection of producer-authenticated
+local-paper terminal fills. Nothing here authorizes startup, an IBKR write, or
+a live order.
 """
 
 from .fifo import (
@@ -24,6 +24,16 @@ from .fifo_fixture_migration import (
     assert_fifo_accounting_schema,
     migrate_fifo_fixture_database,
 )
+from .fifo_runtime import (
+    LOCAL_PAPER_COMMISSION_SOURCE,
+    FifoRuntimeProjection,
+    FifoRuntimeSettlementError,
+    RuntimePaperFillEvidence,
+    append_runtime_fill_in_transaction,
+    append_runtime_fill_on_aiosqlite_worker,
+    reduction_side_to_fifo,
+    verify_runtime_fill_in_transaction,
+)
 
 __all__ = [
     "AccountingEpoch",
@@ -38,6 +48,14 @@ __all__ = [
     "FifoAccountingValidationError",
     "FifoLedger",
     "PositionSnapshot",
+    "LOCAL_PAPER_COMMISSION_SOURCE",
+    "FifoRuntimeProjection",
+    "FifoRuntimeSettlementError",
+    "RuntimePaperFillEvidence",
+    "append_runtime_fill_in_transaction",
+    "append_runtime_fill_on_aiosqlite_worker",
+    "reduction_side_to_fifo",
+    "verify_runtime_fill_in_transaction",
     "assert_fifo_accounting_schema",
     "migrate_fifo_fixture_database",
 ]

--- a/robo_trader/accounting/fifo.py
+++ b/robo_trader/accounting/fifo.py
@@ -484,6 +484,15 @@ class FifoLedger:
         }
 
     def record_fill(self, event: FillEvent) -> FillResult:
+        """Record one fill in a transaction owned by this ledger.
+
+        Runtime settlement must commit the immutable FIFO event and every
+        compatibility projection together.  It uses
+        :meth:`record_fill_in_transaction` while holding its own
+        ``BEGIN IMMEDIATE`` transaction; fixture callers retain this convenient
+        self-contained wrapper.
+        """
+
         _assert_no_temp_fifo_objects(self._connection)
         if type(event) is not FillEvent:
             raise TypeError("event must be FillEvent")
@@ -491,65 +500,83 @@ class FifoLedger:
             raise FifoAccountingError("fill recording requires an idle connection")
         try:
             self._connection.execute("BEGIN IMMEDIATE")
-            assert_fifo_accounting_schema(
-                self._connection,
-                allow_other_objects=self._allow_other_objects,
-            )
-            effective_at = self._require_epoch(event.epoch_id)
-            if event.occurred_at < effective_at:
-                raise FifoAccountingOrderingError("fill event time precedes epoch effective_at")
-            replay = self._existing_fill(event)
-            if replay is not None:
+            result = self.record_fill_in_transaction(event)
+            if result.replayed:
                 self._connection.rollback()
-                return replay
-            self._assert_next_event(event)
-            self._assert_instrument_identity(event)
-            self._connection.execute(
-                """
-                INSERT INTO fifo_fills(
-                    fill_id, epoch_id, event_sequence, execution_id, idempotency_key,
-                    con_id, symbol, side, quantity_text, price_text, occurred_at,
-                    recorded_at, payload_fingerprint
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    event.fill_id,
-                    event.epoch_id,
-                    event.event_sequence,
-                    event.execution_id,
-                    event.idempotency_key,
-                    event.con_id,
-                    event.symbol,
-                    event.side.value,
-                    _decimal_text(event.quantity),
-                    _decimal_text(event.price),
-                    _utc_text(event.occurred_at),
-                    _utc_text(event.recorded_at),
-                    event.fingerprint(),
-                ),
-            )
-            self._connection.execute(
-                """
-                INSERT INTO fifo_commissions(
-                    commission_id, epoch_id, fill_id, amount_minor, currency,
-                    minor_unit_exponent, recorded_at
-                ) VALUES (?, ?, ?, ?, 'USD', 2, ?)
-                """,
-                (
-                    event.commission_id,
-                    event.epoch_id,
-                    event.fill_id,
-                    event.commission_minor,
-                    _utc_text(event.recorded_at),
-                ),
-            )
-            result = self._project_fill(event)
+                return result
             self._connection.commit()
             return result
         except BaseException:
             if self._connection.in_transaction:
                 self._connection.rollback()
             raise
+
+    def record_fill_in_transaction(self, event: FillEvent) -> FillResult:
+        """Append one exact fill without committing the caller-owned transaction.
+
+        The caller must already hold a SQLite transaction.  This method never
+        commits or rolls back it, including for exact replay.  Any raised
+        exception therefore leaves transaction disposition to the caller and
+        lets FIFO state remain atomic with its compatibility projections.
+        """
+
+        _assert_no_temp_fifo_objects(self._connection)
+        if type(event) is not FillEvent:
+            raise TypeError("event must be FillEvent")
+        if not self._connection.in_transaction:
+            raise FifoAccountingError("runtime fill recording requires an active transaction")
+        assert_fifo_accounting_schema(
+            self._connection,
+            allow_other_objects=self._allow_other_objects,
+        )
+        effective_at = self._require_epoch(event.epoch_id)
+        if event.occurred_at < effective_at:
+            raise FifoAccountingOrderingError("fill event time precedes epoch effective_at")
+        replay = self._existing_fill(event)
+        if replay is not None:
+            return replay
+        self._assert_next_event(event)
+        self._assert_instrument_identity(event)
+        self._connection.execute(
+            """
+            INSERT INTO fifo_fills(
+                fill_id, epoch_id, event_sequence, execution_id, idempotency_key,
+                con_id, symbol, side, quantity_text, price_text, occurred_at,
+                recorded_at, payload_fingerprint
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                event.fill_id,
+                event.epoch_id,
+                event.event_sequence,
+                event.execution_id,
+                event.idempotency_key,
+                event.con_id,
+                event.symbol,
+                event.side.value,
+                _decimal_text(event.quantity),
+                _decimal_text(event.price),
+                _utc_text(event.occurred_at),
+                _utc_text(event.recorded_at),
+                event.fingerprint(),
+            ),
+        )
+        self._connection.execute(
+            """
+            INSERT INTO fifo_commissions(
+                commission_id, epoch_id, fill_id, amount_minor, currency,
+                minor_unit_exponent, recorded_at
+            ) VALUES (?, ?, ?, ?, 'USD', 2, ?)
+            """,
+            (
+                event.commission_id,
+                event.epoch_id,
+                event.fill_id,
+                event.commission_minor,
+                _utc_text(event.recorded_at),
+            ),
+        )
+        return self._project_fill(event)
 
     def verify_epoch_integrity(self, epoch_id: str) -> None:
         """Recompute immutable relationships and hash-chain evidence for an epoch."""

--- a/robo_trader/accounting/fifo_fixture_migration.py
+++ b/robo_trader/accounting/fifo_fixture_migration.py
@@ -503,9 +503,42 @@ _TRIGGER_SQL.update(
 
 
 def _normalize_sql(value: object) -> str:
-    if not isinstance(value, str):
+    if not isinstance(value, str) or not value.strip():
         return ""
-    return re.sub(r"\s+", " ", value.strip().lower())
+    normalized: list[str] = []
+    quote_end: Optional[str] = None
+    pending_space = False
+    index = 0
+    while index < len(value):
+        character = value[index]
+        if quote_end is not None:
+            normalized.append(character)
+            if character == quote_end:
+                if quote_end in {"'", '"', "`"} and index + 1 < len(value):
+                    if value[index + 1] == quote_end:
+                        normalized.append(value[index + 1])
+                        index += 2
+                        continue
+                quote_end = None
+            index += 1
+            continue
+        if character in {"'", '"', "`", "["}:
+            if pending_space and normalized:
+                normalized.append(" ")
+            pending_space = False
+            quote_end = "]" if character == "[" else character
+            normalized.append(character)
+        elif character.isspace():
+            pending_space = True
+        else:
+            if pending_space and normalized:
+                normalized.append(" ")
+            pending_space = False
+            normalized.append(character.lower())
+        index += 1
+    if quote_end is not None:
+        return ""
+    return "".join(normalized).strip()
 
 
 def _database_path(connection: sqlite3.Connection) -> Optional[Path]:

--- a/robo_trader/accounting/fifo_runtime.py
+++ b/robo_trader/accounting/fifo_runtime.py
@@ -179,9 +179,11 @@ def _projection_from_result(
         """,
         (epoch_id, fill_id),
     ).fetchall()
-    fill_realized = Decimal("0")
-    for row in realized_rows:
-        fill_realized += _parse_decimal(row[0], "runtime fill realized P&L")
+    with localcontext() as context:
+        context.prec = 96
+        fill_realized = Decimal("0")
+        for row in realized_rows:
+            fill_realized += _parse_decimal(row[0], "runtime fill realized P&L")
     epoch_realized_rows = connection.execute(
         """
         SELECT m.realized_pnl_text
@@ -193,9 +195,11 @@ def _projection_from_result(
         """,
         (epoch_id, event_sequence),
     ).fetchall()
-    epoch_realized = Decimal("0")
-    for row in epoch_realized_rows:
-        epoch_realized += _parse_decimal(row[0], "FIFO epoch realized P&L")
+    with localcontext() as context:
+        context.prec = 96
+        epoch_realized = Decimal("0")
+        for row in epoch_realized_rows:
+            epoch_realized += _parse_decimal(row[0], "FIFO epoch realized P&L")
     baseline_row = connection.execute(
         "SELECT realized_pnl_text FROM fifo_epoch_account_baselines WHERE epoch_id=?",
         (epoch_id,),

--- a/robo_trader/accounting/fifo_runtime.py
+++ b/robo_trader/accounting/fifo_runtime.py
@@ -1,0 +1,385 @@
+"""Transactional runtime bridge into the exact FIFO ledger.
+
+The bridge accepts only explicit local-paper fill evidence.  It assigns the
+next gap-free epoch sequence while the caller holds ``BEGIN IMMEDIATE``, writes
+the immutable FIFO event without committing, verifies the complete epoch, and
+returns exact values for compatibility projections.  It never creates an
+accounting epoch and never infers a fill from an order or position change.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal, localcontext
+from typing import Optional
+
+import aiosqlite
+
+from .fifo import (
+    FifoAccountingConflict,
+    FifoAccountingError,
+    FifoAccountingValidationError,
+    FifoLedger,
+    FillEvent,
+    FillResult,
+    FillSide,
+    _decimal_text,
+    _parse_decimal,
+    _stored_int,
+)
+
+LOCAL_PAPER_COMMISSION_SOURCE = "LOCAL_PAPER_EXECUTOR_EXACT_COMMISSION_V1"
+_SCOPE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
+_SYMBOL = re.compile(r"^[A-Z][A-Z0-9._-]{0,31}$")
+_HASH = re.compile(r"^[0-9a-f]{64}$")
+
+
+class FifoRuntimeSettlementError(FifoAccountingError):
+    """Runtime fill evidence cannot be projected without ambiguity."""
+
+
+def reduction_side_to_fifo(value: object) -> FillSide:
+    """Map the only two exposure-reducing order sides to FIFO directions."""
+
+    if value == "SELL":
+        return FillSide.SELL
+    if value == "BUY_TO_COVER":
+        return FillSide.BUY
+    raise FifoRuntimeSettlementError("runtime FIFO accepts only reduction order sides")
+
+
+def _strict_scope(value: object, field: str, pattern: re.Pattern[str] = _SCOPE) -> str:
+    if type(value) is not str or pattern.fullmatch(value) is None:
+        raise FifoRuntimeSettlementError(f"{field} is malformed")
+    return value
+
+
+def _strict_utc(value: object, field: str) -> datetime:
+    if type(value) is not datetime:
+        raise FifoRuntimeSettlementError(f"{field} must be a datetime")
+    offset = value.utcoffset()
+    if value.tzinfo is None or offset is None or offset.total_seconds() != 0:
+        raise FifoRuntimeSettlementError(f"{field} must be timezone-aware UTC")
+    return value.astimezone(timezone.utc)
+
+
+def _derived_id(prefix: str, *parts: object) -> str:
+    material = "\x1f".join(str(part) for part in parts)
+    return f"{prefix}-{hashlib.sha256(material.encode('utf-8')).hexdigest()[:32]}"
+
+
+def _runtime_epoch_id(
+    connection: sqlite3.Connection,
+    evidence: "RuntimePaperFillEvidence",
+) -> str:
+    epochs = connection.execute(
+        """
+        SELECT epoch_id FROM fifo_accounting_epochs
+        WHERE execution_domain_scope=? AND account_scope=? AND portfolio_id=?
+        """,
+        (
+            evidence.execution_domain_scope,
+            evidence.account_scope,
+            evidence.portfolio_id,
+        ),
+    ).fetchall()
+    if len(epochs) != 1:
+        raise FifoRuntimeSettlementError("runtime fill requires exactly one sealed FIFO epoch")
+    return str(epochs[0][0])
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimePaperFillEvidence:
+    """One producer-observed paper execution and its exact commission report."""
+
+    execution_domain_scope: str
+    account_scope: str
+    portfolio_id: str
+    con_id: int
+    symbol: str
+    side: FillSide
+    quantity: Decimal
+    price: Decimal
+    execution_id: str
+    idempotency_key: str
+    commission_minor: int
+    commission_currency: str
+    commission_source: str
+    occurred_at: datetime
+
+    def __post_init__(self) -> None:
+        _strict_scope(self.execution_domain_scope, "execution_domain_scope")
+        _strict_scope(self.account_scope, "account_scope")
+        _strict_scope(self.portfolio_id, "portfolio_id")
+        if type(self.con_id) is not int or self.con_id <= 0:
+            raise FifoRuntimeSettlementError("con_id must be a positive integer")
+        _strict_scope(self.symbol, "symbol", _SYMBOL)
+        if type(self.side) is not FillSide:
+            raise FifoRuntimeSettlementError("side must be FillSide")
+        FillEvent(
+            epoch_id="fepoch-" + ("0" * 32),
+            fill_id="ffill-" + ("0" * 32),
+            commission_id="fcomm-" + ("0" * 32),
+            event_sequence=1,
+            execution_id=self.execution_id,
+            idempotency_key=self.idempotency_key,
+            con_id=self.con_id,
+            symbol=self.symbol,
+            side=self.side,
+            quantity=self.quantity,
+            price=self.price,
+            commission_minor=self.commission_minor,
+            occurred_at=_strict_utc(self.occurred_at, "occurred_at"),
+            recorded_at=_strict_utc(self.occurred_at, "occurred_at"),
+        )
+        if self.commission_currency != "USD":
+            raise FifoRuntimeSettlementError("runtime FIFO supports only exact USD commissions")
+        if self.commission_source != LOCAL_PAPER_COMMISSION_SOURCE:
+            raise FifoRuntimeSettlementError("paper commission source is not authoritative")
+        if type(self.idempotency_key) is not str or _HASH.fullmatch(self.idempotency_key) is None:
+            raise FifoRuntimeSettlementError("idempotency_key must be a SHA-256 fingerprint")
+
+
+@dataclass(frozen=True, slots=True)
+class FifoRuntimeProjection:
+    """Exact post-fill values produced from immutable FIFO state."""
+
+    epoch_id: str
+    fill_id: str
+    event_sequence: int
+    signed_quantity: Decimal
+    open_cost: Optional[Decimal]
+    average_cost: Optional[Decimal]
+    fill_realized_pnl: Decimal
+    epoch_realized_pnl: Decimal
+    baseline_realized_pnl: Decimal
+    total_realized_pnl: Decimal
+    cumulative_commission_minor: int
+    state_fingerprint: str
+    replayed: bool
+
+
+def _projection_from_result(
+    connection: sqlite3.Connection,
+    *,
+    epoch_id: str,
+    fill_id: str,
+    event_sequence: int,
+    result: FillResult,
+) -> FifoRuntimeProjection:
+    snapshot = result.snapshot
+    realized_rows = connection.execute(
+        """
+        SELECT realized_pnl_text FROM fifo_lot_matches
+        WHERE epoch_id=? AND closing_fill_id=? ORDER BY match_ordinal
+        """,
+        (epoch_id, fill_id),
+    ).fetchall()
+    fill_realized = Decimal("0")
+    for row in realized_rows:
+        fill_realized += _parse_decimal(row[0], "runtime fill realized P&L")
+    baseline_row = connection.execute(
+        "SELECT realized_pnl_text FROM fifo_epoch_account_baselines WHERE epoch_id=?",
+        (epoch_id,),
+    ).fetchone()
+    baseline_realized = (
+        Decimal("0")
+        if baseline_row is None
+        else _parse_decimal(baseline_row[0], "FIFO epoch realized baseline")
+    )
+    average_cost: Optional[Decimal] = None
+    if snapshot.signed_quantity != 0:
+        if snapshot.open_cost is None:
+            raise FifoAccountingValidationError("nonzero FIFO position has no open cost")
+        with localcontext() as context:
+            context.prec = 96
+            average_cost = snapshot.open_cost / abs(snapshot.signed_quantity)
+        _decimal_text(average_cost)
+    elif snapshot.open_cost is not None:
+        raise FifoAccountingValidationError("flat FIFO position retained open cost")
+    with localcontext() as context:
+        context.prec = 96
+        total_realized = baseline_realized + snapshot.cumulative_realized_pnl
+    _decimal_text(total_realized)
+    return FifoRuntimeProjection(
+        epoch_id=epoch_id,
+        fill_id=fill_id,
+        event_sequence=event_sequence,
+        signed_quantity=snapshot.signed_quantity,
+        open_cost=snapshot.open_cost,
+        average_cost=average_cost,
+        fill_realized_pnl=fill_realized,
+        epoch_realized_pnl=snapshot.cumulative_realized_pnl,
+        baseline_realized_pnl=baseline_realized,
+        total_realized_pnl=total_realized,
+        cumulative_commission_minor=snapshot.cumulative_commission_minor,
+        state_fingerprint=snapshot.state_fingerprint,
+        replayed=result.replayed,
+    )
+
+
+def append_runtime_fill_in_transaction(
+    connection: sqlite3.Connection,
+    evidence: RuntimePaperFillEvidence,
+) -> FifoRuntimeProjection:
+    """Append or replay one fill inside the caller's active transaction."""
+
+    if type(connection) is not sqlite3.Connection:
+        raise TypeError("connection must be sqlite3.Connection")
+    if type(evidence) is not RuntimePaperFillEvidence:
+        raise TypeError("evidence must be RuntimePaperFillEvidence")
+    if not connection.in_transaction:
+        raise FifoRuntimeSettlementError("runtime FIFO append requires an active transaction")
+
+    epoch_id = _runtime_epoch_id(connection, evidence)
+    fill_id = _derived_id(
+        "ffill",
+        epoch_id,
+        evidence.execution_id,
+        evidence.idempotency_key,
+    )
+    commission_id = _derived_id("fcomm", epoch_id, fill_id)
+
+    identities = connection.execute(
+        """
+        SELECT fill_id,event_sequence FROM fifo_fills
+        WHERE epoch_id=? AND (execution_id=? OR idempotency_key=? OR fill_id=?)
+        """,
+        (epoch_id, evidence.execution_id, evidence.idempotency_key, fill_id),
+    ).fetchall()
+    identity_fill_ids = {str(row[0]) for row in identities}
+    if len(identity_fill_ids) > 1:
+        raise FifoAccountingConflict("runtime fill identities resolve to different events")
+    if identities:
+        if identity_fill_ids != {fill_id}:
+            raise FifoAccountingConflict("runtime fill identity is already bound elsewhere")
+        sequences = {_stored_int(row[1], "runtime fill event_sequence") for row in identities}
+        if len(sequences) != 1:
+            raise FifoAccountingConflict("runtime fill identities have inconsistent sequence")
+        event_sequence = sequences.pop()
+    else:
+        prior = connection.execute(
+            "SELECT MAX(event_sequence) FROM fifo_fills WHERE epoch_id=?",
+            (epoch_id,),
+        ).fetchone()
+        if prior is None or prior[0] is None:
+            event_sequence = 1
+        else:
+            event_sequence = _stored_int(prior[0], "prior event_sequence") + 1
+
+    event = FillEvent(
+        epoch_id=epoch_id,
+        fill_id=fill_id,
+        commission_id=commission_id,
+        event_sequence=event_sequence,
+        execution_id=evidence.execution_id,
+        idempotency_key=evidence.idempotency_key,
+        con_id=evidence.con_id,
+        symbol=evidence.symbol,
+        side=evidence.side,
+        quantity=evidence.quantity,
+        price=evidence.price,
+        commission_minor=evidence.commission_minor,
+        occurred_at=evidence.occurred_at,
+        # The producer observation is stable across crash replay.  Database
+        # commit time is recorded by the settlement outbox/link separately.
+        recorded_at=evidence.occurred_at,
+    )
+    ledger = FifoLedger(connection, allow_other_objects=True)
+    result = ledger.record_fill_in_transaction(event)
+    ledger.verify_epoch_integrity(epoch_id)
+
+    return _projection_from_result(
+        connection,
+        epoch_id=epoch_id,
+        fill_id=fill_id,
+        event_sequence=event_sequence,
+        result=result,
+    )
+
+
+def verify_runtime_fill_in_transaction(
+    connection: sqlite3.Connection,
+    evidence: RuntimePaperFillEvidence,
+) -> FifoRuntimeProjection:
+    """Authenticate one already-persisted runtime fill without writing."""
+
+    if type(connection) is not sqlite3.Connection:
+        raise TypeError("connection must be sqlite3.Connection")
+    if type(evidence) is not RuntimePaperFillEvidence:
+        raise TypeError("evidence must be RuntimePaperFillEvidence")
+    if not connection.in_transaction:
+        raise FifoRuntimeSettlementError("runtime FIFO verification requires an active transaction")
+    epoch_id = _runtime_epoch_id(connection, evidence)
+    fill_id = _derived_id(
+        "ffill",
+        epoch_id,
+        evidence.execution_id,
+        evidence.idempotency_key,
+    )
+    rows = connection.execute(
+        """
+        SELECT event_sequence FROM fifo_fills
+        WHERE epoch_id=? AND fill_id=? AND execution_id=? AND idempotency_key=?
+        """,
+        (epoch_id, fill_id, evidence.execution_id, evidence.idempotency_key),
+    ).fetchall()
+    if len(rows) != 1:
+        raise FifoRuntimeSettlementError("runtime FIFO fill is absent or ambiguous")
+    event_sequence = _stored_int(rows[0][0], "runtime fill event_sequence")
+    event = FillEvent(
+        epoch_id=epoch_id,
+        fill_id=fill_id,
+        commission_id=_derived_id("fcomm", epoch_id, fill_id),
+        event_sequence=event_sequence,
+        execution_id=evidence.execution_id,
+        idempotency_key=evidence.idempotency_key,
+        con_id=evidence.con_id,
+        symbol=evidence.symbol,
+        side=evidence.side,
+        quantity=evidence.quantity,
+        price=evidence.price,
+        commission_minor=evidence.commission_minor,
+        occurred_at=evidence.occurred_at,
+        recorded_at=evidence.occurred_at,
+    )
+    ledger = FifoLedger(connection, allow_other_objects=True)
+    result = ledger.record_fill_in_transaction(event)
+    if not result.replayed:
+        raise FifoRuntimeSettlementError("runtime FIFO verification attempted an append")
+    ledger.verify_epoch_integrity(epoch_id)
+    return _projection_from_result(
+        connection,
+        epoch_id=epoch_id,
+        fill_id=fill_id,
+        event_sequence=event_sequence,
+        result=result,
+    )
+
+
+async def append_runtime_fill_on_aiosqlite_worker(
+    connection: aiosqlite.Connection,
+    evidence: RuntimePaperFillEvidence,
+) -> FifoRuntimeProjection:
+    """Run the synchronous projector on aiosqlite's owning worker thread.
+
+    ``sqlite3.Connection`` objects may only be used by the thread that owns
+    them.  aiosqlite intentionally funnels operations through ``_execute``;
+    this narrow bridge keeps the complete FIFO append on that same worker and
+    inside the already-active outer transaction.
+    """
+
+    if type(connection) is not aiosqlite.Connection:
+        raise TypeError("connection must be aiosqlite.Connection")
+    if not connection.in_transaction:
+        raise FifoRuntimeSettlementError("runtime FIFO append requires an active transaction")
+
+    def project() -> FifoRuntimeProjection:
+        raw_connection = connection._conn  # type: ignore[attr-defined]
+        return append_runtime_fill_in_transaction(raw_connection, evidence)
+
+    return await connection._execute(project)  # type: ignore[attr-defined]

--- a/robo_trader/accounting/fifo_runtime.py
+++ b/robo_trader/accounting/fifo_runtime.py
@@ -182,6 +182,20 @@ def _projection_from_result(
     fill_realized = Decimal("0")
     for row in realized_rows:
         fill_realized += _parse_decimal(row[0], "runtime fill realized P&L")
+    epoch_realized_rows = connection.execute(
+        """
+        SELECT m.realized_pnl_text
+        FROM fifo_lot_matches AS m
+        JOIN fifo_fills AS f
+          ON f.epoch_id=m.epoch_id AND f.fill_id=m.closing_fill_id
+        WHERE m.epoch_id=? AND f.event_sequence<=?
+        ORDER BY f.event_sequence,m.match_ordinal
+        """,
+        (epoch_id, event_sequence),
+    ).fetchall()
+    epoch_realized = Decimal("0")
+    for row in epoch_realized_rows:
+        epoch_realized += _parse_decimal(row[0], "FIFO epoch realized P&L")
     baseline_row = connection.execute(
         "SELECT realized_pnl_text FROM fifo_epoch_account_baselines WHERE epoch_id=?",
         (epoch_id,),
@@ -203,7 +217,7 @@ def _projection_from_result(
         raise FifoAccountingValidationError("flat FIFO position retained open cost")
     with localcontext() as context:
         context.prec = 96
-        total_realized = baseline_realized + snapshot.cumulative_realized_pnl
+        total_realized = baseline_realized + epoch_realized
     _decimal_text(total_realized)
     return FifoRuntimeProjection(
         epoch_id=epoch_id,
@@ -213,7 +227,7 @@ def _projection_from_result(
         open_cost=snapshot.open_cost,
         average_cost=average_cost,
         fill_realized_pnl=fill_realized,
-        epoch_realized_pnl=snapshot.cumulative_realized_pnl,
+        epoch_realized_pnl=epoch_realized,
         baseline_realized_pnl=baseline_realized,
         total_realized_pnl=total_realized,
         cumulative_commission_minor=snapshot.cumulative_commission_minor,

--- a/robo_trader/database_async.py
+++ b/robo_trader/database_async.py
@@ -2624,7 +2624,7 @@ class AsyncTradingDatabase:
                     )
                 if replay_rows:
                     receipt = self._paper_settlement_receipt_from_row(replay_rows[0])
-                    if receipt.request.fingerprint() != request.fingerprint():
+                    if receipt.request.semantic_fingerprint() != request.semantic_fingerprint():
                         raise PaperTerminalSettlementConflict(
                             "paper settlement identity is bound to a different request"
                         )

--- a/robo_trader/database_async.py
+++ b/robo_trader/database_async.py
@@ -79,6 +79,7 @@ from robo_trader.paper_terminal_settlement import (
 )
 from robo_trader.safety.models import (
     MODEL_VERSION,
+    _exact_decimal_subtract,
     _strict_decimal,
     decimal_to_fixed,
     parse_fixed_decimal,
@@ -2869,8 +2870,10 @@ class AsyncTradingDatabase:
                             "exact FIFO settlement failed closed"
                         ) from exc
                     self._paper_settlement_fault("AFTER_FIFO_APPEND")
-                    expected_fifo_pnl = (
-                        request.expected_post_realized_pnl - request.expected_pre_realized_pnl
+                    expected_fifo_pnl = _exact_decimal_subtract(
+                        request.expected_post_realized_pnl,
+                        request.expected_pre_realized_pnl,
+                        "expected FIFO realized P&L",
                     )
                     if (
                         fifo_projection.replayed

--- a/robo_trader/database_async.py
+++ b/robo_trader/database_async.py
@@ -42,6 +42,7 @@ from robo_trader.accounting.fifo_runtime import (
 from robo_trader.database_migrations import (
     apply_exact_state_migrations,
     assert_exact_state_schema,
+    assert_paper_settlement_hot_schema,
 )
 from robo_trader.database_validator import DatabaseValidator, ValidationError
 from robo_trader.financial_state_bootstrap import (
@@ -2585,6 +2586,12 @@ class AsyncTradingDatabase:
                 raise PaperTerminalSettlementError("settlement database identity cannot be proven")
             try:
                 await conn.execute("BEGIN IMMEDIATE")
+                try:
+                    await assert_paper_settlement_hot_schema(conn)
+                except RuntimeError as exc:
+                    raise PaperTerminalSettlementError(
+                        "paper settlement hot schema cannot be authenticated"
+                    ) from exc
                 self._paper_settlement_fault("AFTER_BEGIN")
 
                 # Search every durable idempotency identity together. A
@@ -2596,7 +2603,7 @@ class AsyncTradingDatabase:
                            protective_quote_payload, trade_id, database_path, database_identity,
                            database_device, database_inode, committed_at,
                            receipt_fingerprint, schema_version
-                    FROM paper_reduction_settlements
+                    FROM main.paper_reduction_settlements
                     WHERE reservation_id = ? OR claim_id = ? OR (
                         execution_domain_scope = ? AND account_scope = ? AND order_ref = ?
                     )
@@ -2644,7 +2651,7 @@ class AsyncTradingDatabase:
                             SELECT request_fingerprint,epoch_id,fill_id,event_sequence,
                                    execution_id,commission_minor,commission_currency,
                                    commission_source,fifo_state_fingerprint
-                            FROM paper_fifo_settlement_links WHERE settlement_id=?
+                            FROM main.paper_fifo_settlement_links WHERE settlement_id=?
                             """,
                             (receipt.settlement_id,),
                         )
@@ -2665,7 +2672,7 @@ class AsyncTradingDatabase:
                             )
                     else:
                         link = await conn.execute(
-                            "SELECT 1 FROM paper_fifo_settlement_links WHERE settlement_id=?",
+                            "SELECT 1 FROM main.paper_fifo_settlement_links WHERE settlement_id=?",
                             (receipt.settlement_id,),
                         )
                         if await link.fetchone() is not None:
@@ -2676,7 +2683,7 @@ class AsyncTradingDatabase:
                     return receipt
 
                 cursor = await conn.execute(
-                    "SELECT id FROM portfolios WHERE id = ?",
+                    "SELECT id FROM main.portfolios WHERE id = ?",
                     (portfolio_id,),
                 )
                 if await cursor.fetchone() is None:
@@ -2687,7 +2694,7 @@ class AsyncTradingDatabase:
                 cursor = await conn.execute(
                     """
                     SELECT quantity, typeof(quantity), avg_cost, market_price
-                    FROM positions
+                    FROM main.positions
                     WHERE portfolio_id = ? AND symbol = ?
                     """,
                     (portfolio_id, symbol),
@@ -2712,7 +2719,7 @@ class AsyncTradingDatabase:
                 cursor = await conn.execute(
                     """
                     SELECT quantity, typeof(quantity)
-                    FROM positions WHERE symbol = ?
+                    FROM main.positions WHERE symbol = ?
                     """,
                     (symbol,),
                 )
@@ -2734,7 +2741,7 @@ class AsyncTradingDatabase:
                     """
                     SELECT cash_text, realized_pnl_text, daily_pnl_text,
                            daily_pnl_baseline_text, daily_pnl_date
-                    FROM paper_account_settlement_state
+                    FROM main.paper_account_settlement_state
                     WHERE portfolio_id = ?
                     """,
                     (portfolio_id,),
@@ -2772,7 +2779,7 @@ class AsyncTradingDatabase:
                         "current paper account differs from the requested pre-account state"
                     )
                 cursor = await conn.execute(
-                    "SELECT 1 FROM account WHERE portfolio_id = ?",
+                    "SELECT 1 FROM main.account WHERE portfolio_id = ?",
                     (portfolio_id,),
                 )
                 if await cursor.fetchone() is None:
@@ -2808,7 +2815,7 @@ class AsyncTradingDatabase:
                         """
                         SELECT cost_basis_text, mark_price_text,
                                source_settlement_id
-                        FROM paper_position_settlement_state
+                        FROM main.paper_position_settlement_state
                         WHERE portfolio_id = ? AND symbol = ?
                         """,
                         (portfolio_id, symbol),
@@ -2886,7 +2893,7 @@ class AsyncTradingDatabase:
                     exact_notional = request.fill_price * request.filled_quantity
                     cursor = await conn.execute(
                         """
-                        INSERT INTO trades (
+                        INSERT INTO main.trades (
                             portfolio_id, symbol, side, quantity, price, notional,
                             slippage, commission, pnl, timestamp
                         ) VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?, ?)
@@ -2911,7 +2918,7 @@ class AsyncTradingDatabase:
                     self._paper_settlement_fault("AFTER_TRADE_INSERT")
                     await conn.execute(
                         """
-                        UPDATE positions
+                        UPDATE main.positions
                         SET quantity = ?, avg_cost = ?, market_price = ?, timestamp = ?
                         WHERE portfolio_id = ? AND symbol = ?
                         """,
@@ -2932,7 +2939,7 @@ class AsyncTradingDatabase:
 
                     await conn.execute(
                         """
-                        UPDATE account
+                        UPDATE main.account
                         SET cash = ?, realized_pnl = ?, daily_pnl = ?,
                             unrealized_pnl = ?, timestamp = ?
                         WHERE portfolio_id = ?
@@ -2952,7 +2959,7 @@ class AsyncTradingDatabase:
                     )
                     await conn.execute(
                         """
-                        UPDATE paper_account_settlement_state
+                        UPDATE main.paper_account_settlement_state
                         SET cash_text = ?, realized_pnl_text = ?, daily_pnl_text = ?,
                             updated_at = ?,
                             source_settlement_id = NULL
@@ -2971,7 +2978,7 @@ class AsyncTradingDatabase:
                 cursor = await conn.execute(
                     """
                     SELECT quantity, typeof(quantity)
-                    FROM positions WHERE symbol = ?
+                    FROM main.positions WHERE symbol = ?
                     """,
                     (symbol,),
                 )
@@ -3002,7 +3009,7 @@ class AsyncTradingDatabase:
                 )
                 await conn.execute(
                     """
-                    INSERT INTO paper_reduction_settlements (
+                    INSERT INTO main.paper_reduction_settlements (
                         settlement_id, execution_domain_scope, account_scope,
                         portfolio_id, con_id, symbol, reservation_id, claim_id,
                         order_ref, protective_quote_payload, request_fingerprint,
@@ -3043,7 +3050,7 @@ class AsyncTradingDatabase:
                         )
                     await conn.execute(
                         """
-                        UPDATE paper_position_settlement_state
+                        UPDATE main.paper_position_settlement_state
                         SET cost_basis_text = ?, mark_price_text = ?, source_settlement_id = ?,
                             updated_at = ?
                         WHERE portfolio_id = ? AND symbol = ?
@@ -3063,7 +3070,7 @@ class AsyncTradingDatabase:
                     )
                     await conn.execute(
                         """
-                        INSERT INTO paper_fifo_settlement_links(
+                        INSERT INTO main.paper_fifo_settlement_links(
                             settlement_id,request_fingerprint,epoch_id,fill_id,
                             event_sequence,execution_id,commission_minor,
                             commission_currency,commission_source,
@@ -3088,7 +3095,7 @@ class AsyncTradingDatabase:
                 self._paper_settlement_fault("AFTER_SETTLEMENT_INSERT")
                 await conn.execute(
                     """
-                    UPDATE paper_account_settlement_state
+                    UPDATE main.paper_account_settlement_state
                     SET source_settlement_id = ?
                     WHERE portfolio_id = ?
                     """,

--- a/robo_trader/database_async.py
+++ b/robo_trader/database_async.py
@@ -27,10 +27,17 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 import aiosqlite
 
+from robo_trader.accounting.fifo import FifoAccountingError
 from robo_trader.accounting.fifo_bootstrap import (
     FifoBootstrapError,
     append_legacy_fifo_bootstrap_in_transaction,
     prepare_fifo_accounting_schema_in_transaction,
+)
+from robo_trader.accounting.fifo_runtime import (
+    FifoRuntimeProjection,
+    RuntimePaperFillEvidence,
+    append_runtime_fill_on_aiosqlite_worker,
+    reduction_side_to_fifo,
 )
 from robo_trader.database_migrations import (
     apply_exact_state_migrations,
@@ -93,6 +100,39 @@ DB_PATH = lexical_path_preserving_leaf(Path(os.getenv("RT_DB_PATH", "trading_dat
 
 # Default portfolio ID for backward compatibility
 DEFAULT_PORTFOLIO_ID = "default"
+
+
+def _fifo_evidence_from_terminal_request(
+    request: PaperTerminalSettlementRequest,
+) -> RuntimePaperFillEvidence:
+    """Require producer-owned fill fields before entering the FIFO ledger."""
+
+    if (
+        request.fill_price is None
+        or request.fill_execution_id is None
+        or request.fill_commission_minor is None
+        or request.fill_commission_currency is None
+        or request.fill_commission_source is None
+    ):
+        raise PaperTerminalSettlementError(
+            "filled paper settlement lacks exact producer execution evidence"
+        )
+    return RuntimePaperFillEvidence(
+        execution_domain_scope=request.execution_domain_scope,
+        account_scope=request.account_scope,
+        portfolio_id=request.portfolio_id,
+        con_id=request.con_id,
+        symbol=request.symbol,
+        side=reduction_side_to_fifo(request.side.value),
+        quantity=request.filled_quantity,
+        price=request.fill_price,
+        execution_id=request.fill_execution_id,
+        idempotency_key=request.fingerprint(),
+        commission_minor=request.fill_commission_minor,
+        commission_currency=request.fill_commission_currency,
+        commission_source=request.fill_commission_source,
+        occurred_at=request.outcome_at,
+    )
 
 
 class SafetyAllocationSnapshotError(ValidationError):
@@ -2589,6 +2629,49 @@ class AsyncTradingDatabase:
                         raise PaperTerminalSettlementError(
                             "persisted settlement database provenance changed"
                         )
+                    if request.filled_quantity > 0:
+                        try:
+                            replay_fifo_projection = await append_runtime_fill_on_aiosqlite_worker(
+                                conn,
+                                _fifo_evidence_from_terminal_request(request),
+                            )
+                        except FifoAccountingError as exc:
+                            raise PaperTerminalSettlementError(
+                                "persisted FIFO fill cannot be authenticated"
+                            ) from exc
+                        link = await conn.execute(
+                            """
+                            SELECT request_fingerprint,epoch_id,fill_id,event_sequence,
+                                   execution_id,commission_minor,commission_currency,
+                                   commission_source,fifo_state_fingerprint
+                            FROM paper_fifo_settlement_links WHERE settlement_id=?
+                            """,
+                            (receipt.settlement_id,),
+                        )
+                        expected_link = (
+                            request.fingerprint(),
+                            replay_fifo_projection.epoch_id,
+                            replay_fifo_projection.fill_id,
+                            replay_fifo_projection.event_sequence,
+                            request.fill_execution_id,
+                            request.fill_commission_minor,
+                            request.fill_commission_currency,
+                            request.fill_commission_source,
+                            replay_fifo_projection.state_fingerprint,
+                        )
+                        if await link.fetchone() != expected_link:
+                            raise PaperTerminalSettlementError(
+                                "persisted settlement FIFO lineage changed"
+                            )
+                    else:
+                        link = await conn.execute(
+                            "SELECT 1 FROM paper_fifo_settlement_links WHERE settlement_id=?",
+                            (receipt.settlement_id,),
+                        )
+                        if await link.fetchone() is not None:
+                            raise PaperTerminalSettlementError(
+                                "unfilled settlement unexpectedly claims a FIFO event"
+                            )
                     await conn.rollback()
                     return receipt
 
@@ -2698,9 +2781,18 @@ class AsyncTradingDatabase:
                     )
 
                 trade_id: Optional[int] = None
+                fifo_projection: Optional[FifoRuntimeProjection] = None
                 committed_at = datetime.now(timezone.utc)
                 if request.filled_quantity > 0:
-                    if position_row is None or avg_cost is None or request.fill_price is None:
+                    commission_minor = request.fill_commission_minor
+                    expected_cost_basis = request.expected_position_cost_basis
+                    if (
+                        position_row is None
+                        or avg_cost is None
+                        or request.fill_price is None
+                        or type(commission_minor) is not int
+                        or expected_cost_basis is None
+                    ):
                         raise PaperTerminalSettlementError(
                             "filled reduction has no authoritative local cost basis"
                         )
@@ -2735,7 +2827,7 @@ class AsyncTradingDatabase:
                         raise PaperTerminalSettlementError(
                             "exact paper position cost basis is malformed"
                         ) from exc
-                    if stored_cost_basis != request.expected_position_cost_basis:
+                    if stored_cost_basis != expected_cost_basis:
                         raise PaperTerminalSettlementConflict(
                             "paper position cost basis differs from settlement request"
                         )
@@ -2760,16 +2852,44 @@ class AsyncTradingDatabase:
                         raise PaperTerminalSettlementConflict(
                             "paper position mark source differs from settlement request"
                         )
-                    exact_pnl = (
+                    try:
+                        fifo_projection = await append_runtime_fill_on_aiosqlite_worker(
+                            conn,
+                            _fifo_evidence_from_terminal_request(request),
+                        )
+                    except FifoAccountingError as exc:
+                        raise PaperTerminalSettlementError(
+                            "exact FIFO settlement failed closed"
+                        ) from exc
+                    self._paper_settlement_fault("AFTER_FIFO_APPEND")
+                    expected_fifo_pnl = (
                         request.expected_post_realized_pnl - request.expected_pre_realized_pnl
                     )
+                    if (
+                        fifo_projection.replayed
+                        or fifo_projection.signed_quantity
+                        != request.expected_post_position_quantity
+                        or fifo_projection.fill_realized_pnl != expected_fifo_pnl
+                        or fifo_projection.total_realized_pnl != request.expected_post_realized_pnl
+                    ):
+                        raise PaperTerminalSettlementConflict(
+                            "FIFO projection differs from the requested exact settlement"
+                        )
+                    if request.expected_post_position_quantity != 0 and (
+                        fifo_projection.average_cost is None
+                        or fifo_projection.average_cost != expected_cost_basis
+                    ):
+                        raise PaperTerminalSettlementConflict(
+                            "FIFO remaining cost basis differs from exact position authority"
+                        )
+                    exact_pnl = fifo_projection.fill_realized_pnl
                     exact_notional = request.fill_price * request.filled_quantity
                     cursor = await conn.execute(
                         """
                         INSERT INTO trades (
                             portfolio_id, symbol, side, quantity, price, notional,
                             slippage, commission, pnl, timestamp
-                        ) VALUES (?, ?, ?, ?, ?, ?, 0, 0, ?, ?)
+                        ) VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?, ?)
                         """,
                         (
                             portfolio_id,
@@ -2778,6 +2898,7 @@ class AsyncTradingDatabase:
                             quantity_int,
                             price_float,
                             float(exact_notional),
+                            float(Decimal(commission_minor).scaleb(-2)),
                             float(exact_pnl),
                             utc_to_text(committed_at),
                         ),
@@ -2796,7 +2917,11 @@ class AsyncTradingDatabase:
                         """,
                         (
                             int(request.expected_post_position_quantity),
-                            avg_cost,
+                            (
+                                avg_cost
+                                if fifo_projection.average_cost is None
+                                else float(fifo_projection.average_cost)
+                            ),
                             protective_mark_float,
                             utc_to_text(committed_at),
                             portfolio_id,
@@ -2912,14 +3037,23 @@ class AsyncTradingDatabase:
                     ),
                 )
                 if request.filled_quantity > 0:
+                    if fifo_projection is None:
+                        raise PaperTerminalSettlementError(
+                            "filled settlement lost its FIFO projection before commit"
+                        )
                     await conn.execute(
                         """
                         UPDATE paper_position_settlement_state
-                        SET mark_price_text = ?, source_settlement_id = ?,
+                        SET cost_basis_text = ?, mark_price_text = ?, source_settlement_id = ?,
                             updated_at = ?
                         WHERE portfolio_id = ? AND symbol = ?
                         """,
                         (
+                            (
+                                decimal_to_fixed(expected_cost_basis)
+                                if fifo_projection.average_cost is None
+                                else decimal_to_fixed(fifo_projection.average_cost)
+                            ),
                             decimal_to_fixed(request.protective_mark_price),
                             settlement_id,
                             utc_to_text(committed_at),
@@ -2927,6 +3061,30 @@ class AsyncTradingDatabase:
                             symbol,
                         ),
                     )
+                    await conn.execute(
+                        """
+                        INSERT INTO paper_fifo_settlement_links(
+                            settlement_id,request_fingerprint,epoch_id,fill_id,
+                            event_sequence,execution_id,commission_minor,
+                            commission_currency,commission_source,
+                            fifo_state_fingerprint,committed_at
+                        ) VALUES (?,?,?,?,?,?,?,?,?,?,?)
+                        """,
+                        (
+                            settlement_id,
+                            request.fingerprint(),
+                            fifo_projection.epoch_id,
+                            fifo_projection.fill_id,
+                            fifo_projection.event_sequence,
+                            request.fill_execution_id,
+                            request.fill_commission_minor,
+                            request.fill_commission_currency,
+                            request.fill_commission_source,
+                            fifo_projection.state_fingerprint,
+                            utc_to_text(committed_at),
+                        ),
+                    )
+                    self._paper_settlement_fault("AFTER_FIFO_LINK_INSERT")
                 self._paper_settlement_fault("AFTER_SETTLEMENT_INSERT")
                 await conn.execute(
                     """

--- a/robo_trader/database_migrations.py
+++ b/robo_trader/database_migrations.py
@@ -13,7 +13,7 @@ from collections.abc import Awaitable, Callable
 import aiosqlite
 
 EXACT_STATE_COMPONENT = "paper_exact_state"
-EXACT_STATE_SCHEMA_VERSION = 2
+EXACT_STATE_SCHEMA_VERSION = 3
 
 
 async def _columns(connection: aiosqlite.Connection, table: str) -> set[str]:
@@ -142,9 +142,59 @@ async def _migration_v2(connection: aiosqlite.Connection) -> None:
     """)
 
 
+async def _migration_v3(connection: aiosqlite.Connection) -> None:
+    await connection.execute("""
+        CREATE TABLE IF NOT EXISTS paper_fifo_settlement_links (
+            settlement_id TEXT PRIMARY KEY,
+            request_fingerprint TEXT NOT NULL UNIQUE,
+            epoch_id TEXT NOT NULL,
+            fill_id TEXT NOT NULL UNIQUE,
+            event_sequence INTEGER NOT NULL CHECK (
+                typeof(event_sequence) = 'integer' AND event_sequence > 0
+            ),
+            execution_id TEXT NOT NULL,
+            commission_minor INTEGER NOT NULL CHECK (
+                typeof(commission_minor) = 'integer'
+                AND commission_minor BETWEEN -1000000000000 AND 1000000000000
+            ),
+            commission_currency TEXT NOT NULL CHECK (commission_currency = 'USD'),
+            commission_source TEXT NOT NULL CHECK (
+                commission_source = 'LOCAL_PAPER_EXECUTOR_EXACT_COMMISSION_V1'
+            ),
+            fifo_state_fingerprint TEXT NOT NULL CHECK (
+                length(fifo_state_fingerprint) = 64
+                AND fifo_state_fingerprint = lower(fifo_state_fingerprint)
+                AND fifo_state_fingerprint NOT GLOB '*[^0-9a-f]*'
+            ),
+            committed_at TEXT NOT NULL CHECK (committed_at LIKE '%Z'),
+            UNIQUE(epoch_id, event_sequence),
+            UNIQUE(epoch_id, execution_id),
+            FOREIGN KEY(settlement_id)
+                REFERENCES paper_reduction_settlements(settlement_id),
+            FOREIGN KEY(epoch_id, fill_id)
+                REFERENCES fifo_fills(epoch_id, fill_id)
+        )
+    """)
+    await connection.execute("""
+        CREATE TRIGGER IF NOT EXISTS paper_fifo_settlement_links_no_update
+        BEFORE UPDATE ON paper_fifo_settlement_links
+        BEGIN
+            SELECT RAISE(ABORT, 'paper FIFO settlement links are append-only');
+        END
+    """)
+    await connection.execute("""
+        CREATE TRIGGER IF NOT EXISTS paper_fifo_settlement_links_no_delete
+        BEFORE DELETE ON paper_fifo_settlement_links
+        BEGIN
+            SELECT RAISE(ABORT, 'paper FIFO settlement links are append-only');
+        END
+    """)
+
+
 _MIGRATIONS: tuple[tuple[int, Callable[[aiosqlite.Connection], Awaitable[None]]], ...] = (
     (1, _migration_v1),
     (2, _migration_v2),
+    (3, _migration_v3),
 )
 
 _EXPECTED_COLUMNS = {
@@ -191,6 +241,19 @@ _EXPECTED_COLUMNS = {
         "account_scope": ("TEXT", 0),
         "consumed_at": ("TEXT", 0),
     },
+    "paper_fifo_settlement_links": {
+        "settlement_id": ("TEXT", 1),
+        "request_fingerprint": ("TEXT", 0),
+        "epoch_id": ("TEXT", 0),
+        "fill_id": ("TEXT", 0),
+        "event_sequence": ("INTEGER", 0),
+        "execution_id": ("TEXT", 0),
+        "commission_minor": ("INTEGER", 0),
+        "commission_currency": ("TEXT", 0),
+        "commission_source": ("TEXT", 0),
+        "fifo_state_fingerprint": ("TEXT", 0),
+        "committed_at": ("TEXT", 0),
+    },
 }
 
 _EXPECTED_FOREIGN_KEYS = {
@@ -234,6 +297,18 @@ _EXPECTED_FOREIGN_KEYS = {
             "NO ACTION",
             "NONE",
         ),
+    },
+    "paper_fifo_settlement_links": {
+        (
+            "settlement_id",
+            "paper_reduction_settlements",
+            "settlement_id",
+            "NO ACTION",
+            "NO ACTION",
+            "NONE",
+        ),
+        ("epoch_id", "fifo_fills", "epoch_id", "NO ACTION", "NO ACTION", "NONE"),
+        ("fill_id", "fifo_fills", "fill_id", "NO ACTION", "NO ACTION", "NONE"),
     },
 }
 
@@ -297,6 +372,38 @@ _EXPECTED_TABLE_SQL = {
             FOREIGN KEY(bootstrap_id) REFERENCES paper_state_bootstraps(bootstrap_id)
         )
     """,
+    "paper_fifo_settlement_links": """
+        CREATE TABLE paper_fifo_settlement_links (
+            settlement_id TEXT PRIMARY KEY,
+            request_fingerprint TEXT NOT NULL UNIQUE,
+            epoch_id TEXT NOT NULL,
+            fill_id TEXT NOT NULL UNIQUE,
+            event_sequence INTEGER NOT NULL CHECK (
+                typeof(event_sequence) = 'integer' AND event_sequence > 0
+            ),
+            execution_id TEXT NOT NULL,
+            commission_minor INTEGER NOT NULL CHECK (
+                typeof(commission_minor) = 'integer'
+                AND commission_minor BETWEEN -1000000000000 AND 1000000000000
+            ),
+            commission_currency TEXT NOT NULL CHECK (commission_currency = 'USD'),
+            commission_source TEXT NOT NULL CHECK (
+                commission_source = 'LOCAL_PAPER_EXECUTOR_EXACT_COMMISSION_V1'
+            ),
+            fifo_state_fingerprint TEXT NOT NULL CHECK (
+                length(fifo_state_fingerprint) = 64
+                AND fifo_state_fingerprint = lower(fifo_state_fingerprint)
+                AND fifo_state_fingerprint NOT GLOB '*[^0-9a-f]*'
+            ),
+            committed_at TEXT NOT NULL CHECK (committed_at LIKE '%Z'),
+            UNIQUE(epoch_id, event_sequence),
+            UNIQUE(epoch_id, execution_id),
+            FOREIGN KEY(settlement_id)
+                REFERENCES paper_reduction_settlements(settlement_id),
+            FOREIGN KEY(epoch_id, fill_id)
+                REFERENCES fifo_fills(epoch_id, fill_id)
+        )
+    """,
 }
 
 _EXPECTED_TRIGGER_SQL = {
@@ -340,6 +447,20 @@ _EXPECTED_TRIGGER_SQL = {
         BEFORE DELETE ON exact_bootstrap_evidence_consumptions
         BEGIN
             SELECT RAISE(ABORT, 'bootstrap evidence consumptions are append-only');
+        END
+    """,
+    "paper_fifo_settlement_links_no_update": """
+        CREATE TRIGGER paper_fifo_settlement_links_no_update
+        BEFORE UPDATE ON paper_fifo_settlement_links
+        BEGIN
+            SELECT RAISE(ABORT, 'paper FIFO settlement links are append-only');
+        END
+    """,
+    "paper_fifo_settlement_links_no_delete": """
+        CREATE TRIGGER paper_fifo_settlement_links_no_delete
+        BEFORE DELETE ON paper_fifo_settlement_links
+        BEGIN
+            SELECT RAISE(ABORT, 'paper FIFO settlement links are append-only');
         END
     """,
 }
@@ -454,6 +575,7 @@ async def assert_exact_state_schema(connection: aiosqlite.Connection) -> None:
         "administrator_actions",
         "paper_state_bootstraps",
         "exact_bootstrap_evidence_consumptions",
+        "paper_fifo_settlement_links",
         "paper_account_settlement_state",
         "paper_position_settlement_state",
     }
@@ -480,13 +602,25 @@ async def assert_exact_state_schema(connection: aiosqlite.Connection) -> None:
         if lineage is None or lineage[0] != "TEXT":
             raise RuntimeError(f"exact-state {table} bootstrap lineage is malformed")
 
-    for table, expected in _EXPECTED_FOREIGN_KEYS.items():
-        if not expected.issubset(await _foreign_keys(connection, table)):
+    for table, expected_foreign_keys in _EXPECTED_FOREIGN_KEYS.items():
+        if not expected_foreign_keys.issubset(await _foreign_keys(connection, table)):
             raise RuntimeError(f"exact-state {table} foreign keys are malformed")
 
     unique_sets = await _unique_column_sets(connection, "paper_state_bootstraps")
     if not _EXPECTED_UNIQUE_COLUMN_SETS.issubset(unique_sets):
         raise RuntimeError("exact-state bootstrap uniqueness constraints are malformed")
+    fifo_link_unique_sets = await _unique_column_sets(
+        connection,
+        "paper_fifo_settlement_links",
+    )
+    expected_fifo_link_unique_sets = {
+        frozenset({"request_fingerprint"}),
+        frozenset({"fill_id"}),
+        frozenset({"epoch_id", "event_sequence"}),
+        frozenset({"epoch_id", "execution_id"}),
+    }
+    if not expected_fifo_link_unique_sets.issubset(fifo_link_unique_sets):
+        raise RuntimeError("exact-state FIFO settlement link uniqueness is malformed")
 
     table_sql_rows = await connection.execute(
         "SELECT name, sql FROM sqlite_master WHERE type = 'table'"
@@ -499,12 +633,13 @@ async def assert_exact_state_schema(connection: aiosqlite.Connection) -> None:
     trigger_rows = await connection.execute(
         """
         SELECT name, sql FROM sqlite_master
-        WHERE type = 'trigger' AND tbl_name IN (?, ?, ?)
+        WHERE type = 'trigger' AND tbl_name IN (?, ?, ?, ?)
         """,
         (
             "administrator_actions",
             "paper_state_bootstraps",
             "exact_bootstrap_evidence_consumptions",
+            "paper_fifo_settlement_links",
         ),
     )
     trigger_sql = {str(row[0]): _normalized_sql(row[1]) for row in await trigger_rows.fetchall()}

--- a/robo_trader/database_migrations.py
+++ b/robo_trader/database_migrations.py
@@ -17,7 +17,8 @@ EXACT_STATE_SCHEMA_VERSION = 3
 
 
 async def _columns(connection: aiosqlite.Connection, table: str) -> set[str]:
-    cursor = await connection.execute(f"PRAGMA table_info({table})")
+    quoted = '"' + table.replace('"', '""') + '"'
+    cursor = await connection.execute(f"PRAGMA main.table_info({quoted})")
     return {str(row[1]) for row in await cursor.fetchall()}
 
 
@@ -465,6 +466,189 @@ _EXPECTED_TRIGGER_SQL = {
     """,
 }
 
+_PAPER_SETTLEMENT_HOT_COLUMNS = {
+    "trades": {
+        "id",
+        "portfolio_id",
+        "symbol",
+        "side",
+        "quantity",
+        "price",
+        "notional",
+        "slippage",
+        "commission",
+        "pnl",
+        "timestamp",
+    },
+    "positions": {
+        "id",
+        "portfolio_id",
+        "symbol",
+        "quantity",
+        "avg_cost",
+        "market_price",
+        "timestamp",
+    },
+    "account": {
+        "portfolio_id",
+        "cash",
+        "equity",
+        "daily_pnl",
+        "realized_pnl",
+        "unrealized_pnl",
+        "timestamp",
+    },
+    "paper_reduction_settlements": {
+        "settlement_id",
+        "execution_domain_scope",
+        "account_scope",
+        "portfolio_id",
+        "con_id",
+        "symbol",
+        "reservation_id",
+        "claim_id",
+        "order_ref",
+        "protective_quote_payload",
+        "request_fingerprint",
+        "request_payload_json",
+        "terminal_status",
+        "trade_id",
+        "database_path",
+        "database_identity",
+        "database_device",
+        "database_inode",
+        "committed_at",
+        "receipt_fingerprint",
+        "schema_version",
+    },
+    "paper_account_settlement_state": {
+        "portfolio_id",
+        "cash_text",
+        "realized_pnl_text",
+        "daily_pnl_text",
+        "daily_pnl_baseline_text",
+        "daily_pnl_date",
+        "updated_at",
+        "source_settlement_id",
+        "origin_bootstrap_id",
+    },
+    "paper_position_settlement_state": {
+        "portfolio_id",
+        "symbol",
+        "cost_basis_text",
+        "mark_price_text",
+        "source_settlement_id",
+        "updated_at",
+        "origin_bootstrap_id",
+    },
+    "paper_fifo_settlement_links": set(_EXPECTED_COLUMNS["paper_fifo_settlement_links"]),
+}
+
+_PAPER_SETTLEMENT_HOT_COLUMN_TYPES = {
+    "trades": {
+        "id": ("INTEGER", 1),
+        "portfolio_id": ("TEXT", 0),
+        "symbol": ("TEXT", 0),
+        "side": ("TEXT", 0),
+        "quantity": ("INTEGER", 0),
+        "price": ("REAL", 0),
+        "notional": ("REAL", 0),
+        "slippage": ("REAL", 0),
+        "commission": ("REAL", 0),
+        "pnl": ("REAL", 0),
+        "timestamp": ("DATETIME", 0),
+    },
+    "positions": {
+        "id": ("INTEGER", 1),
+        "portfolio_id": ("TEXT", 0),
+        "symbol": ("TEXT", 0),
+        "quantity": ("INTEGER", 0),
+        "avg_cost": ("REAL", 0),
+        "market_price": ("REAL", 0),
+        "timestamp": ("DATETIME", 0),
+    },
+    "account": {
+        "portfolio_id": ("TEXT", 1),
+        "cash": ("REAL", 0),
+        "equity": ("REAL", 0),
+        "daily_pnl": ("REAL", 0),
+        "realized_pnl": ("REAL", 0),
+        "unrealized_pnl": ("REAL", 0),
+        "timestamp": ("DATETIME", 0),
+    },
+    "paper_reduction_settlements": {
+        "settlement_id": ("TEXT", 1),
+        "execution_domain_scope": ("TEXT", 0),
+        "account_scope": ("TEXT", 0),
+        "portfolio_id": ("TEXT", 0),
+        "con_id": ("INTEGER", 0),
+        "symbol": ("TEXT", 0),
+        "reservation_id": ("TEXT", 0),
+        "claim_id": ("TEXT", 0),
+        "order_ref": ("TEXT", 0),
+        "protective_quote_payload": ("TEXT", 0),
+        "request_fingerprint": ("TEXT", 0),
+        "request_payload_json": ("TEXT", 0),
+        "terminal_status": ("TEXT", 0),
+        "trade_id": ("INTEGER", 0),
+        "database_path": ("TEXT", 0),
+        "database_identity": ("TEXT", 0),
+        "database_device": ("INTEGER", 0),
+        "database_inode": ("INTEGER", 0),
+        "committed_at": ("TEXT", 0),
+        "receipt_fingerprint": ("TEXT", 0),
+        "schema_version": ("INTEGER", 0),
+    },
+    "paper_account_settlement_state": {
+        "portfolio_id": ("TEXT", 1),
+        "cash_text": ("TEXT", 0),
+        "realized_pnl_text": ("TEXT", 0),
+        "daily_pnl_text": ("TEXT", 0),
+        "daily_pnl_baseline_text": ("TEXT", 0),
+        "daily_pnl_date": ("TEXT", 0),
+        "updated_at": ("TEXT", 0),
+        "source_settlement_id": ("TEXT", 0),
+        "origin_bootstrap_id": ("TEXT", 0),
+    },
+    "paper_position_settlement_state": {
+        "portfolio_id": ("TEXT", 1),
+        "symbol": ("TEXT", 2),
+        "cost_basis_text": ("TEXT", 0),
+        "mark_price_text": ("TEXT", 0),
+        "source_settlement_id": ("TEXT", 0),
+        "updated_at": ("TEXT", 0),
+        "origin_bootstrap_id": ("TEXT", 0),
+    },
+    "paper_fifo_settlement_links": dict(_EXPECTED_COLUMNS["paper_fifo_settlement_links"]),
+}
+
+_PAPER_REDUCTION_SETTLEMENT_TRIGGER_SQL = {
+    "paper_reduction_settlements_no_update": """
+        CREATE TRIGGER paper_reduction_settlements_no_update
+        BEFORE UPDATE ON paper_reduction_settlements
+        BEGIN
+            SELECT RAISE(ABORT, 'paper reduction settlements are append-only');
+        END
+    """,
+    "paper_reduction_settlements_no_delete": """
+        CREATE TRIGGER paper_reduction_settlements_no_delete
+        BEFORE DELETE ON paper_reduction_settlements
+        BEGIN
+            SELECT RAISE(ABORT, 'paper reduction settlements are append-only');
+        END
+    """,
+}
+
+_PAPER_SETTLEMENT_HOT_TRIGGER_SQL = {
+    **_PAPER_REDUCTION_SETTLEMENT_TRIGGER_SQL,
+    "paper_fifo_settlement_links_no_update": _EXPECTED_TRIGGER_SQL[
+        "paper_fifo_settlement_links_no_update"
+    ],
+    "paper_fifo_settlement_links_no_delete": _EXPECTED_TRIGGER_SQL[
+        "paper_fifo_settlement_links_no_delete"
+    ],
+}
+
 
 def _normalized_sql(value: object) -> str:
     if not isinstance(value, str) or not value.strip():
@@ -476,7 +660,8 @@ async def _table_info(
     connection: aiosqlite.Connection,
     table: str,
 ) -> dict[str, tuple[str, int, int]]:
-    cursor = await connection.execute(f"PRAGMA table_info({table})")
+    quoted = '"' + table.replace('"', '""') + '"'
+    cursor = await connection.execute(f"PRAGMA main.table_info({quoted})")
     return {
         str(row[1]): (str(row[2]).upper(), int(row[3]), int(row[5]))
         for row in await cursor.fetchall()
@@ -487,7 +672,8 @@ async def _foreign_keys(
     connection: aiosqlite.Connection,
     table: str,
 ) -> set[tuple[str, str, str, str, str, str]]:
-    cursor = await connection.execute(f"PRAGMA foreign_key_list({table})")
+    quoted = '"' + table.replace('"', '""') + '"'
+    cursor = await connection.execute(f"PRAGMA main.foreign_key_list({quoted})")
     return {
         (
             str(row[3]),
@@ -505,13 +691,15 @@ async def _unique_column_sets(
     connection: aiosqlite.Connection,
     table: str,
 ) -> set[frozenset[str]]:
-    cursor = await connection.execute(f"PRAGMA index_list({table})")
+    quoted = '"' + table.replace('"', '""') + '"'
+    cursor = await connection.execute(f"PRAGMA main.index_list({quoted})")
     indexes = await cursor.fetchall()
     result: set[frozenset[str]] = set()
     for index in indexes:
         if int(index[2]) != 1:
             continue
-        detail = await connection.execute(f"PRAGMA index_info({index[1]})")
+        index_name = '"' + str(index[1]).replace('"', '""') + '"'
+        detail = await connection.execute(f"PRAGMA main.index_info({index_name})")
         result.add(frozenset(str(row[2]) for row in await detail.fetchall()))
     return result
 
@@ -562,7 +750,7 @@ async def assert_exact_state_schema(connection: aiosqlite.Connection) -> None:
         raise RuntimeError("exact-state schema requires foreign-key enforcement")
 
     migration_rows = await connection.execute(
-        "SELECT version FROM rt_schema_migrations WHERE component = ? ORDER BY version",
+        "SELECT version FROM main.rt_schema_migrations WHERE component = ? ORDER BY version",
         (EXACT_STATE_COMPONENT,),
     )
     if [int(row[0]) for row in await migration_rows.fetchall()] != list(
@@ -579,7 +767,7 @@ async def assert_exact_state_schema(connection: aiosqlite.Connection) -> None:
         "paper_account_settlement_state",
         "paper_position_settlement_state",
     }
-    cursor = await connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+    cursor = await connection.execute("SELECT name FROM main.sqlite_master WHERE type = 'table'")
     tables = {str(row[0]) for row in await cursor.fetchall()}
     if not required.issubset(tables):
         raise RuntimeError("exact-state schema is incomplete")
@@ -623,7 +811,7 @@ async def assert_exact_state_schema(connection: aiosqlite.Connection) -> None:
         raise RuntimeError("exact-state FIFO settlement link uniqueness is malformed")
 
     table_sql_rows = await connection.execute(
-        "SELECT name, sql FROM sqlite_master WHERE type = 'table'"
+        "SELECT name, sql FROM main.sqlite_master WHERE type = 'table'"
     )
     table_sql = {str(row[0]): _normalized_sql(row[1]) for row in await table_sql_rows.fetchall()}
     for table, expected_sql in _EXPECTED_TABLE_SQL.items():
@@ -632,7 +820,7 @@ async def assert_exact_state_schema(connection: aiosqlite.Connection) -> None:
 
     trigger_rows = await connection.execute(
         """
-        SELECT name, sql FROM sqlite_master
+        SELECT name, sql FROM main.sqlite_master
         WHERE type = 'trigger' AND tbl_name IN (?, ?, ?, ?)
         """,
         (
@@ -649,6 +837,60 @@ async def assert_exact_state_schema(connection: aiosqlite.Connection) -> None:
         if trigger_sql.get(name) != _normalized_sql(expected_sql):
             raise RuntimeError(f"exact-state trigger {name} is missing or malformed")
 
-    violations = await connection.execute("PRAGMA foreign_key_check")
+    violations = await connection.execute("PRAGMA main.foreign_key_check")
     if await violations.fetchone() is not None:
         raise RuntimeError("exact-state schema contains foreign-key violations")
+
+
+async def assert_paper_settlement_hot_schema(connection: aiosqlite.Connection) -> None:
+    """Revalidate every table and trigger touched by terminal settlement.
+
+    The caller holds ``BEGIN IMMEDIATE``.  Main-schema qualification prevents
+    temporary objects from redirecting a statement, while this audit rejects
+    both temp shadows and any persistent trigger capable of adding side
+    effects to the atomic settlement transaction.
+    """
+
+    if not connection.in_transaction:
+        raise RuntimeError("paper settlement schema audit requires an active transaction")
+    await assert_exact_state_schema(connection)
+
+    hot_tables = frozenset(_PAPER_SETTLEMENT_HOT_COLUMNS)
+    temporary = await connection.execute(
+        "SELECT type,name,tbl_name FROM temp.sqlite_master ORDER BY type,name"
+    )
+    for object_type, name, table_name in await temporary.fetchall():
+        if str(name).lower() in hot_tables or (
+            str(object_type).lower() == "trigger" and str(table_name).lower() in hot_tables
+        ):
+            raise RuntimeError("temporary objects cannot shadow paper settlement state")
+
+    main_tables = await connection.execute("SELECT name FROM main.sqlite_master WHERE type='table'")
+    present = {str(row[0]) for row in await main_tables.fetchall()}
+    if not hot_tables.issubset(present):
+        raise RuntimeError("paper settlement hot schema is incomplete")
+    for table, required_columns in _PAPER_SETTLEMENT_HOT_COLUMNS.items():
+        actual = await _table_info(connection, table)
+        if set(actual) != required_columns:
+            raise RuntimeError(f"paper settlement hot table {table} is malformed")
+        for column, (expected_type, expected_primary_key) in _PAPER_SETTLEMENT_HOT_COLUMN_TYPES[
+            table
+        ].items():
+            actual_type, _, actual_primary_key = actual[column]
+            if actual_type != expected_type or actual_primary_key != expected_primary_key:
+                raise RuntimeError(f"paper settlement hot table {table} is malformed")
+
+    triggers = await connection.execute(
+        """
+        SELECT name,sql FROM main.sqlite_master
+        WHERE type='trigger' AND tbl_name IN (?,?,?,?,?,?,?)
+        ORDER BY name
+        """,
+        tuple(sorted(hot_tables)),
+    )
+    trigger_sql = {str(name): _normalized_sql(sql) for name, sql in await triggers.fetchall()}
+    if set(trigger_sql) != set(_PAPER_SETTLEMENT_HOT_TRIGGER_SQL):
+        raise RuntimeError("paper settlement hot-table trigger set is malformed")
+    for name, expected_sql in _PAPER_SETTLEMENT_HOT_TRIGGER_SQL.items():
+        if trigger_sql.get(name) != _normalized_sql(expected_sql):
+            raise RuntimeError(f"paper settlement trigger {name} is malformed")

--- a/robo_trader/database_migrations.py
+++ b/robo_trader/database_migrations.py
@@ -649,6 +649,122 @@ _PAPER_SETTLEMENT_HOT_TRIGGER_SQL = {
     ],
 }
 
+_PAPER_SETTLEMENT_HOT_TABLE_SQL = {
+    "trades": """
+        CREATE TABLE trades (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            portfolio_id TEXT NOT NULL DEFAULT 'default',
+            symbol TEXT NOT NULL,
+            side TEXT NOT NULL,
+            quantity INTEGER NOT NULL,
+            price REAL NOT NULL,
+            notional REAL DEFAULT 0,
+            slippage REAL DEFAULT 0,
+            commission REAL DEFAULT 0,
+            pnl REAL DEFAULT NULL,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+    """,
+    "positions": """
+        CREATE TABLE positions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            portfolio_id TEXT NOT NULL DEFAULT 'default',
+            symbol TEXT NOT NULL CHECK (length(symbol) BETWEEN 1 AND 32),
+            quantity INTEGER NOT NULL,
+            avg_cost REAL NOT NULL,
+            market_price REAL,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(portfolio_id, symbol)
+        )
+    """,
+    "account": """
+        CREATE TABLE account (
+            portfolio_id TEXT PRIMARY KEY DEFAULT 'default',
+            cash REAL NOT NULL,
+            equity REAL NOT NULL,
+            daily_pnl REAL DEFAULT 0,
+            realized_pnl REAL DEFAULT 0,
+            unrealized_pnl REAL DEFAULT 0,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+    """,
+    "paper_reduction_settlements": """
+        CREATE TABLE paper_reduction_settlements (
+            settlement_id TEXT PRIMARY KEY,
+            execution_domain_scope TEXT NOT NULL,
+            account_scope TEXT NOT NULL,
+            portfolio_id TEXT NOT NULL,
+            con_id INTEGER NOT NULL CHECK (con_id > 0),
+            symbol TEXT NOT NULL,
+            reservation_id TEXT NOT NULL UNIQUE,
+            claim_id TEXT NOT NULL UNIQUE,
+            order_ref TEXT NOT NULL,
+            protective_quote_payload TEXT NOT NULL,
+            request_fingerprint TEXT NOT NULL,
+            request_payload_json TEXT NOT NULL,
+            terminal_status TEXT NOT NULL,
+            trade_id INTEGER,
+            database_path TEXT NOT NULL,
+            database_identity TEXT NOT NULL,
+            database_device INTEGER NOT NULL,
+            database_inode INTEGER NOT NULL,
+            committed_at TEXT NOT NULL,
+            receipt_fingerprint TEXT NOT NULL,
+            schema_version INTEGER NOT NULL,
+            UNIQUE(execution_domain_scope, account_scope, order_ref),
+            FOREIGN KEY(trade_id) REFERENCES trades(id)
+        )
+    """,
+    "paper_account_settlement_state": """
+        CREATE TABLE paper_account_settlement_state (
+            portfolio_id TEXT PRIMARY KEY,
+            cash_text TEXT NOT NULL,
+            realized_pnl_text TEXT NOT NULL,
+            daily_pnl_text TEXT NOT NULL,
+            daily_pnl_baseline_text TEXT NOT NULL,
+            daily_pnl_date TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            source_settlement_id TEXT,
+            origin_bootstrap_id TEXT REFERENCES paper_state_bootstraps(bootstrap_id),
+            FOREIGN KEY(source_settlement_id)
+                REFERENCES paper_reduction_settlements(settlement_id)
+        )
+    """,
+    "paper_position_settlement_state": """
+        CREATE TABLE paper_position_settlement_state (
+            portfolio_id TEXT NOT NULL,
+            symbol TEXT NOT NULL,
+            cost_basis_text TEXT NOT NULL,
+            mark_price_text TEXT,
+            source_settlement_id TEXT,
+            updated_at TEXT NOT NULL,
+            origin_bootstrap_id TEXT REFERENCES paper_state_bootstraps(bootstrap_id),
+            PRIMARY KEY (portfolio_id, symbol),
+            FOREIGN KEY(source_settlement_id)
+                REFERENCES paper_reduction_settlements(settlement_id)
+        )
+    """,
+    "paper_fifo_settlement_links": _EXPECTED_TABLE_SQL["paper_fifo_settlement_links"],
+}
+
+_PAPER_SETTLEMENT_HOT_INDEX_SQL = {
+    "idx_positions_portfolio": """
+        CREATE INDEX idx_positions_portfolio ON positions (portfolio_id)
+    """,
+    "idx_trades_portfolio": """
+        CREATE INDEX idx_trades_portfolio ON trades (portfolio_id)
+    """,
+    "idx_trades_portfolio_symbol": """
+        CREATE INDEX idx_trades_portfolio_symbol
+        ON trades (portfolio_id, symbol, timestamp DESC)
+    """,
+    "idx_paper_reduction_settlement_scope": """
+        CREATE INDEX idx_paper_reduction_settlement_scope
+        ON paper_reduction_settlements
+           (execution_domain_scope, account_scope, portfolio_id, symbol)
+    """,
+}
+
 
 def _normalized_sql(value: object) -> str:
     if not isinstance(value, str) or not value.strip():
@@ -880,10 +996,41 @@ async def assert_paper_settlement_hot_schema(connection: aiosqlite.Connection) -
             if actual_type != expected_type or actual_primary_key != expected_primary_key:
                 raise RuntimeError(f"paper settlement hot table {table} is malformed")
 
+    table_rows = await connection.execute(
+        """
+        SELECT name,sql FROM main.sqlite_master
+        WHERE type='table' AND lower(name) IN (?,?,?,?,?,?,?)
+        ORDER BY name
+        """,
+        tuple(sorted(hot_tables)),
+    )
+    table_sql = {str(name): _normalized_sql(sql) for name, sql in await table_rows.fetchall()}
+    if set(table_sql) != set(_PAPER_SETTLEMENT_HOT_TABLE_SQL):
+        raise RuntimeError("paper settlement hot-table definition set is malformed")
+    for name, expected_sql in _PAPER_SETTLEMENT_HOT_TABLE_SQL.items():
+        if table_sql.get(name) != _normalized_sql(expected_sql):
+            raise RuntimeError(f"paper settlement hot table {name} definition is malformed")
+
+    index_rows = await connection.execute(
+        """
+        SELECT name,sql FROM main.sqlite_master
+        WHERE type='index' AND name NOT LIKE 'sqlite_autoindex_%'
+          AND lower(tbl_name) IN (?,?,?,?,?,?,?)
+        ORDER BY name
+        """,
+        tuple(sorted(hot_tables)),
+    )
+    index_sql = {str(name): _normalized_sql(sql) for name, sql in await index_rows.fetchall()}
+    if set(index_sql) != set(_PAPER_SETTLEMENT_HOT_INDEX_SQL):
+        raise RuntimeError("paper settlement hot-table index set is malformed")
+    for name, expected_sql in _PAPER_SETTLEMENT_HOT_INDEX_SQL.items():
+        if index_sql.get(name) != _normalized_sql(expected_sql):
+            raise RuntimeError(f"paper settlement hot-table index {name} is malformed")
+
     triggers = await connection.execute(
         """
         SELECT name,sql FROM main.sqlite_master
-        WHERE type='trigger' AND tbl_name IN (?,?,?,?,?,?,?)
+        WHERE type='trigger' AND lower(tbl_name) IN (?,?,?,?,?,?,?)
         ORDER BY name
         """,
         tuple(sorted(hot_tables)),

--- a/robo_trader/database_migrations.py
+++ b/robo_trader/database_migrations.py
@@ -7,7 +7,6 @@ version would incorrectly make that migration appear complete.
 
 from __future__ import annotations
 
-import re
 from collections.abc import Awaitable, Callable
 
 import aiosqlite
@@ -747,6 +746,51 @@ _PAPER_SETTLEMENT_HOT_TABLE_SQL = {
     "paper_fifo_settlement_links": _EXPECTED_TABLE_SQL["paper_fifo_settlement_links"],
 }
 
+# MultiuserMigration v1 rebuilt these three compatibility tables before the
+# canonical initializer added stricter fresh-database DDL.  They remain an
+# explicitly supported, byte-for-byte reviewed operational schema variant;
+# accepting them does not relax any other table shape.
+_PAPER_SETTLEMENT_SUPPORTED_LEGACY_TABLE_SQL = {
+    "positions": """
+        CREATE TABLE "positions" (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            portfolio_id TEXT NOT NULL DEFAULT 'default',
+            symbol TEXT NOT NULL,
+            quantity INTEGER NOT NULL,
+            avg_cost REAL NOT NULL,
+            market_price REAL,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(portfolio_id, symbol)
+        )
+    """,
+    "trades": """
+        CREATE TABLE "trades" (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            portfolio_id TEXT NOT NULL DEFAULT 'default',
+            symbol TEXT NOT NULL,
+            side TEXT NOT NULL,
+            quantity INTEGER NOT NULL,
+            price REAL NOT NULL,
+            notional REAL DEFAULT 0,
+            slippage REAL DEFAULT 0,
+            commission REAL DEFAULT 0,
+            pnl REAL DEFAULT NULL,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+    """,
+    "account": """
+        CREATE TABLE "account" (
+            portfolio_id TEXT PRIMARY KEY,
+            cash REAL NOT NULL,
+            equity REAL NOT NULL,
+            daily_pnl REAL DEFAULT 0,
+            realized_pnl REAL DEFAULT 0,
+            unrealized_pnl REAL DEFAULT 0,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+    """,
+}
+
 _PAPER_SETTLEMENT_HOT_INDEX_SQL = {
     "idx_positions_portfolio": """
         CREATE INDEX idx_positions_portfolio ON positions (portfolio_id)
@@ -769,7 +813,40 @@ _PAPER_SETTLEMENT_HOT_INDEX_SQL = {
 def _normalized_sql(value: object) -> str:
     if not isinstance(value, str) or not value.strip():
         return ""
-    return re.sub(r"\s+", " ", value.strip().lower())
+    normalized: list[str] = []
+    quote_end: str | None = None
+    pending_space = False
+    index = 0
+    while index < len(value):
+        character = value[index]
+        if quote_end is not None:
+            normalized.append(character)
+            if character == quote_end:
+                if quote_end in {"'", '"', "`"} and index + 1 < len(value):
+                    if value[index + 1] == quote_end:
+                        normalized.append(value[index + 1])
+                        index += 2
+                        continue
+                quote_end = None
+            index += 1
+            continue
+        if character in {"'", '"', "`", "["}:
+            if pending_space and normalized:
+                normalized.append(" ")
+            pending_space = False
+            quote_end = "]" if character == "[" else character
+            normalized.append(character)
+        elif character.isspace():
+            pending_space = True
+        else:
+            if pending_space and normalized:
+                normalized.append(" ")
+            pending_space = False
+            normalized.append(character.lower())
+        index += 1
+    if quote_end is not None:
+        return ""
+    return "".join(normalized).strip()
 
 
 async def _table_info(
@@ -1008,7 +1085,11 @@ async def assert_paper_settlement_hot_schema(connection: aiosqlite.Connection) -
     if set(table_sql) != set(_PAPER_SETTLEMENT_HOT_TABLE_SQL):
         raise RuntimeError("paper settlement hot-table definition set is malformed")
     for name, expected_sql in _PAPER_SETTLEMENT_HOT_TABLE_SQL.items():
-        if table_sql.get(name) != _normalized_sql(expected_sql):
+        allowed_definitions = {_normalized_sql(expected_sql)}
+        supported_legacy_sql = _PAPER_SETTLEMENT_SUPPORTED_LEGACY_TABLE_SQL.get(name)
+        if supported_legacy_sql is not None:
+            allowed_definitions.add(_normalized_sql(supported_legacy_sql))
+        if table_sql.get(name) not in allowed_definitions:
             raise RuntimeError(f"paper settlement hot table {name} definition is malformed")
 
     index_rows = await connection.execute(

--- a/robo_trader/database_migrations.py
+++ b/robo_trader/database_migrations.py
@@ -791,6 +791,50 @@ _PAPER_SETTLEMENT_SUPPORTED_LEGACY_TABLE_SQL = {
     """,
 }
 
+# The same reviewed migration also has a direct-create path for a partially
+# initialized database.  SQLite records those table identifiers without the
+# quotes introduced by ALTER TABLE ... RENAME on the populated migration path.
+_PAPER_SETTLEMENT_SUPPORTED_DIRECT_CREATE_TABLE_SQL = {
+    "positions": """
+        CREATE TABLE positions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            portfolio_id TEXT NOT NULL DEFAULT 'default',
+            symbol TEXT NOT NULL,
+            quantity INTEGER NOT NULL,
+            avg_cost REAL NOT NULL,
+            market_price REAL,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(portfolio_id, symbol)
+        )
+    """,
+    "trades": """
+        CREATE TABLE trades (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            portfolio_id TEXT NOT NULL DEFAULT 'default',
+            symbol TEXT NOT NULL,
+            side TEXT NOT NULL,
+            quantity INTEGER NOT NULL,
+            price REAL NOT NULL,
+            notional REAL DEFAULT 0,
+            slippage REAL DEFAULT 0,
+            commission REAL DEFAULT 0,
+            pnl REAL DEFAULT NULL,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+    """,
+    "account": """
+        CREATE TABLE account (
+            portfolio_id TEXT PRIMARY KEY,
+            cash REAL NOT NULL,
+            equity REAL NOT NULL,
+            daily_pnl REAL DEFAULT 0,
+            realized_pnl REAL DEFAULT 0,
+            unrealized_pnl REAL DEFAULT 0,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+    """,
+}
+
 _PAPER_SETTLEMENT_HOT_INDEX_SQL = {
     "idx_positions_portfolio": """
         CREATE INDEX idx_positions_portfolio ON positions (portfolio_id)
@@ -1089,6 +1133,9 @@ async def assert_paper_settlement_hot_schema(connection: aiosqlite.Connection) -
         supported_legacy_sql = _PAPER_SETTLEMENT_SUPPORTED_LEGACY_TABLE_SQL.get(name)
         if supported_legacy_sql is not None:
             allowed_definitions.add(_normalized_sql(supported_legacy_sql))
+        direct_create_sql = _PAPER_SETTLEMENT_SUPPORTED_DIRECT_CREATE_TABLE_SQL.get(name)
+        if direct_create_sql is not None:
+            allowed_definitions.add(_normalized_sql(direct_create_sql))
         if table_sql.get(name) not in allowed_definitions:
             raise RuntimeError(f"paper settlement hot table {name} definition is malformed")
 

--- a/robo_trader/execution.py
+++ b/robo_trader/execution.py
@@ -36,6 +36,54 @@ class Order:
     take_profit: Optional[float | Decimal] = None
 
 
+@dataclass(frozen=True, slots=True)
+class LocalPaperExecutionEvidence:
+    """Exact evidence emitted only when the sealed paper sink fills an order."""
+
+    execution_id: str
+    filled_quantity: Decimal
+    exact_fill_price: Decimal
+    commission_minor: int
+    commission_currency: str
+    commission_source: str
+    occurred_at: dt.datetime
+
+    def __post_init__(self) -> None:
+        if (
+            type(self.execution_id) is not str
+            or not self.execution_id.startswith("lpfill-")
+            or len(self.execution_id) != 39
+            or any(character not in "0123456789abcdef" for character in self.execution_id[7:])
+        ):
+            raise ValueError("local paper execution_id is malformed")
+        if (
+            type(self.filled_quantity) is not Decimal
+            or not self.filled_quantity.is_finite()
+            or self.filled_quantity <= 0
+        ):
+            raise ValueError("local paper filled_quantity must be exact and positive")
+        if (
+            type(self.exact_fill_price) is not Decimal
+            or not self.exact_fill_price.is_finite()
+            or self.exact_fill_price <= 0
+        ):
+            raise ValueError("local paper fill price must be exact and positive")
+        if type(self.commission_minor) is not int:
+            raise ValueError("local paper commission must be exact integer minor units")
+        if self.commission_currency != "USD":
+            raise ValueError("local paper commission currency must be USD")
+        if self.commission_source != "LOCAL_PAPER_EXECUTOR_EXACT_COMMISSION_V1":
+            raise ValueError("local paper commission source is malformed")
+        offset = self.occurred_at.utcoffset() if type(self.occurred_at) is dt.datetime else None
+        if (
+            type(self.occurred_at) is not dt.datetime
+            or self.occurred_at.tzinfo is None
+            or offset is None
+            or offset.total_seconds() != 0
+        ):
+            raise ValueError("local paper execution time must be timezone-aware UTC")
+
+
 class ExecutionResult:
     def __init__(
         self,
@@ -44,6 +92,7 @@ class ExecutionResult:
         fill_price: Optional[float] = None,
         *,
         exact_fill_price: Optional[Decimal] = None,
+        local_paper_evidence: Optional[LocalPaperExecutionEvidence] = None,
     ) -> None:
         self.ok = ok
         self.message = message
@@ -52,6 +101,7 @@ class ExecutionResult:
         # their existing float-only contract and therefore cannot masquerade as
         # exact terminal paper evidence.
         self.exact_fill_price = exact_fill_price
+        self.local_paper_evidence = local_paper_evidence
 
 
 class AbstractExecutor:

--- a/robo_trader/paper_execution_capability.py
+++ b/robo_trader/paper_execution_capability.py
@@ -9,6 +9,7 @@ implementation integrity, never as isolation from hostile same-process code.
 from __future__ import annotations
 
 import datetime as dt
+import hashlib
 import math
 import threading
 import weakref
@@ -464,7 +465,12 @@ def _build_sealed_capability_runtime():
         if expected_fingerprint != fingerprint:
             raise PaperExecutionCapabilityError("paper fill capability order fingerprint changed")
 
-        from .execution import ExecutionResult, Order, PaperExecutor
+        from .execution import (
+            ExecutionResult,
+            LocalPaperExecutionEvidence,
+            Order,
+            PaperExecutor,
+        )
 
         if type(executor) is not PaperExecutor or type(order) is not Order:
             raise PaperExecutionCapabilityError(
@@ -520,8 +526,36 @@ def _build_sealed_capability_runtime():
             fill_decimal = Decimal(str(fill))
         if not math.isfinite(fill) or fill <= 0:
             return ExecutionResult(False, "Invalid paper execution fill")
+        occurred_at = dt.datetime.now(dt.timezone.utc)
+        if type(order.order_ref) is not str or not order.order_ref:
+            raise PaperExecutionCapabilityError(
+                "sealed paper execution requires a durable order reference"
+            )
+        execution_material = "\x1f".join(
+            (
+                order.order_ref,
+                order.symbol,
+                order.side,
+                str(order.quantity),
+            )
+        )
+        execution_id = (
+            "lpfill-" + hashlib.sha256(execution_material.encode("utf-8")).hexdigest()[:32]
+        )
+        evidence = LocalPaperExecutionEvidence(
+            execution_id=execution_id,
+            filled_quantity=Decimal(order.quantity),
+            exact_fill_price=fill_decimal,
+            # The current local-paper executor's explicit cost model has no
+            # commission.  Zero is producer evidence here, not a database
+            # default or a value inferred after execution.
+            commission_minor=0,
+            commission_currency="USD",
+            commission_source="LOCAL_PAPER_EXECUTOR_EXACT_COMMISSION_V1",
+            occurred_at=occurred_at,
+        )
         executor.fills[f"{order.symbol}-{len(executor.fills)+1}"] = (
-            dt.datetime.utcnow(),
+            occurred_at,
             order,
             fill,
         )
@@ -530,6 +564,7 @@ def _build_sealed_capability_runtime():
             "Paper fill",
             fill,
             exact_fill_price=fill_decimal,
+            local_paper_evidence=evidence,
         )
 
     def execute_sealed_paper_fill(executor, order, capability):

--- a/robo_trader/paper_reduction_gateway.py
+++ b/robo_trader/paper_reduction_gateway.py
@@ -1139,6 +1139,9 @@ class PaperReductionGateway:
             fill_price=outcome.exact_fill_price,
             protective_mark_price=final_quote.price,
             pre_position_quantity=pre_position,
+            commission_minor=(
+                0 if outcome.fill_evidence is None else outcome.fill_evidence.commission_minor
+            ),
         )
         settlement_request = PaperTerminalSettlementRequest(
             execution_domain_scope=authorization.claim.execution_domain_scope,
@@ -1177,6 +1180,18 @@ class PaperReductionGateway:
             terminal_status=terminal_status,
             fill_price=outcome.exact_fill_price,
             outcome_at=outcome.observed_at,
+            fill_execution_id=(
+                None if outcome.fill_evidence is None else outcome.fill_evidence.execution_id
+            ),
+            fill_commission_minor=(
+                None if outcome.fill_evidence is None else outcome.fill_evidence.commission_minor
+            ),
+            fill_commission_currency=(
+                None if outcome.fill_evidence is None else outcome.fill_evidence.commission_currency
+            ),
+            fill_commission_source=(
+                None if outcome.fill_evidence is None else outcome.fill_evidence.commission_source
+            ),
         )
         receipt = await self._database.commit_paper_reduction_outcome(
             settlement_request,

--- a/robo_trader/paper_reduction_submitter.py
+++ b/robo_trader/paper_reduction_submitter.py
@@ -14,7 +14,12 @@ from decimal import Decimal, InvalidOperation
 from enum import Enum
 from typing import Optional
 
-from .execution import ExecutionResult, Order, PaperExecutor
+from .execution import (
+    ExecutionResult,
+    LocalPaperExecutionEvidence,
+    Order,
+    PaperExecutor,
+)
 from .paper_execution_capability import (
     PaperReductionExecutionAuthority,
     _attach_gateway_reduction_submitter,
@@ -87,6 +92,7 @@ class LocalPaperTerminalOutcome:
     provenance: LocalPaperOutcomeProvenance
     terminal: bool
     message: str
+    fill_evidence: LocalPaperExecutionEvidence | None = None
 
     def __post_init__(self) -> None:
         if (
@@ -139,6 +145,7 @@ class LocalPaperTerminalOutcome:
                 raise PaperReductionSubmissionError(
                     "FILLED outcome requires an exact positive price"
                 )
+            self._validate_fill_evidence()
         elif self.status in {
             LocalPaperOrderStatus.REJECTED,
             LocalPaperOrderStatus.CANCELLED,
@@ -153,6 +160,10 @@ class LocalPaperTerminalOutcome:
             ):
                 raise PaperReductionSubmissionError(
                     "unfilled terminal outcome must not carry a fill"
+                )
+            if self.fill_evidence is not None:
+                raise PaperReductionSubmissionError(
+                    "unfilled terminal outcome must not carry execution evidence"
                 )
         elif self.status is LocalPaperOrderStatus.PARTIALLY_FILLED:
             if self.terminal is not False:
@@ -171,6 +182,7 @@ class LocalPaperTerminalOutcome:
                 raise PaperReductionSubmissionError(
                     "PARTIALLY_FILLED outcome requires an exact positive price"
                 )
+            self._validate_fill_evidence()
         elif self.status in {
             LocalPaperOrderStatus.SUBMITTED,
             LocalPaperOrderStatus.UNKNOWN,
@@ -187,6 +199,25 @@ class LocalPaperTerminalOutcome:
                 raise PaperReductionSubmissionError(
                     "submitted or unknown outcome cannot claim a fill"
                 )
+            if self.fill_evidence is not None:
+                raise PaperReductionSubmissionError(
+                    "submitted or unknown outcome cannot carry execution evidence"
+                )
+
+    def _validate_fill_evidence(self) -> None:
+        evidence = self.fill_evidence
+        if type(evidence) is not LocalPaperExecutionEvidence:
+            raise PaperReductionSubmissionError(
+                "positive paper outcome requires producer-owned fill evidence"
+            )
+        if (
+            evidence.filled_quantity != self.filled_quantity
+            or evidence.exact_fill_price != self.exact_fill_price
+            or evidence.occurred_at != self.observed_at
+        ):
+            raise PaperReductionSubmissionError(
+                "paper fill evidence does not match the observed outcome"
+            )
 
     @property
     def ok(self) -> bool:
@@ -419,17 +450,37 @@ def _terminal_outcome(
             raise PaperReductionSubmissionError(
                 "successful execution result requires a matching exact Decimal fill"
             )
+        evidence = result.local_paper_evidence
+        if type(evidence) is not LocalPaperExecutionEvidence:
+            raise PaperReductionSubmissionError(
+                "successful execution result requires exact local-paper fill evidence"
+            )
+        if (
+            evidence.filled_quantity != descriptor.quantity
+            or evidence.exact_fill_price != exact_fill_price
+        ):
+            raise PaperReductionSubmissionError(
+                "local-paper fill evidence does not match the submitted allocation"
+            )
     elif result.fill_price is not None:
         raise PaperReductionSubmissionError("rejected execution result must not carry a fill price")
     elif result.exact_fill_price is not None:
         raise PaperReductionSubmissionError(
             "rejected execution result must not carry an exact fill"
         )
+    elif result.local_paper_evidence is not None:
+        raise PaperReductionSubmissionError(
+            "rejected execution result must not carry paper fill evidence"
+        )
 
     requested = descriptor.quantity
     if type(requested) is not Decimal or not requested.is_finite() or requested <= 0:
         raise PaperReductionSubmissionError("descriptor quantity is malformed after submission")
-    observed_at = datetime.now(timezone.utc)
+    observed_at = (
+        result.local_paper_evidence.occurred_at
+        if result.ok and result.local_paper_evidence is not None
+        else datetime.now(timezone.utc)
+    )
     if result.ok:
         return LocalPaperTerminalOutcome(
             order_ref=descriptor.order_ref,
@@ -442,6 +493,7 @@ def _terminal_outcome(
             provenance=LocalPaperOutcomeProvenance.LOCAL_PAPER_EXECUTOR,
             terminal=True,
             message=result.message,
+            fill_evidence=result.local_paper_evidence,
         )
     return LocalPaperTerminalOutcome(
         order_ref=descriptor.order_ref,

--- a/robo_trader/paper_terminal_settlement.py
+++ b/robo_trader/paper_terminal_settlement.py
@@ -45,6 +45,7 @@ from robo_trader.safety.models import (
 _SCOPE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
 _SYMBOL_RE = re.compile(r"^[A-Z0-9][A-Z0-9._-]{0,31}$")
 _SETTLEMENT_ID_RE = re.compile(r"^pset-[0-9a-f]{32}$")
+_LOCAL_PAPER_EXECUTION_ID_RE = re.compile(r"^lpfill-[0-9a-f]{32}$")
 
 
 class PaperTerminalSettlementError(RuntimeError):
@@ -91,11 +92,8 @@ def _parse_protective_quote_timestamp(value: object) -> datetime:
         raise ValueError("protective quote timestamp must be text")
     normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
     parsed = datetime.fromisoformat(normalized)
-    if (
-        parsed.tzinfo is None
-        or parsed.utcoffset() is None
-        or parsed.utcoffset().total_seconds() != 0
-    ):
+    offset = parsed.utcoffset()
+    if parsed.tzinfo is None or offset is None or offset.total_seconds() != 0:
         raise ValueError("protective quote timestamp must be UTC")
     return parsed.astimezone(timezone.utc)
 
@@ -152,6 +150,7 @@ class PaperAccountSettlementState:
         fill_price: Optional[Decimal],
         protective_mark_price: Decimal,
         pre_position_quantity: Decimal,
+        commission_minor: int = 0,
     ) -> Tuple[Decimal, Decimal, Decimal]:
         """Return exact cash/P&L after a reduction, without float arithmetic.
 
@@ -170,9 +169,14 @@ class PaperAccountSettlementState:
         )
         if filled < 0:
             raise ValidationError("filled_quantity must be nonnegative")
+        if type(commission_minor) is not int or abs(commission_minor) > 1_000_000_000_000:
+            raise ValidationError("commission_minor is outside the exact allowed range")
+        commission = Decimal(commission_minor).scaleb(-2)
         if filled.is_zero():
             if fill_price is not None:
                 raise ValidationError("unfilled settlement cannot have a fill price")
+            if commission_minor != 0:
+                raise ValidationError("unfilled settlement cannot have a commission")
             return self.cash, self.realized_pnl, self.daily_pnl
         if (
             fill_price is None
@@ -196,7 +200,11 @@ class PaperAccountSettlementState:
         fill = _strict_decimal(fill_price, "fill_price", positive=True)
         notional = _exact_decimal_multiply(fill, filled, "fill notional")
         if side is OrderSide.SELL:
-            post_cash = _exact_decimal_add(self.cash, notional, "post cash")
+            post_cash = _exact_decimal_subtract(
+                _exact_decimal_add(self.cash, notional, "post cash before commission"),
+                commission,
+                "post cash",
+            )
             per_share_pnl = _exact_decimal_subtract(
                 fill,
                 self.position_cost_basis,
@@ -213,7 +221,11 @@ class PaperAccountSettlementState:
                 "long mark change per share",
             )
         elif side is OrderSide.BUY_TO_COVER:
-            post_cash = _exact_decimal_subtract(self.cash, notional, "post cash")
+            post_cash = _exact_decimal_subtract(
+                _exact_decimal_subtract(self.cash, notional, "post cash before commission"),
+                commission,
+                "post cash",
+            )
             per_share_pnl = _exact_decimal_subtract(
                 self.position_cost_basis,
                 fill,
@@ -236,9 +248,14 @@ class PaperAccountSettlementState:
             filled,
             "realized P&L delta",
         )
+        pnl_after_commission = _exact_decimal_subtract(
+            pnl_delta,
+            commission,
+            "realized P&L delta after commission",
+        )
         realized_pnl = _exact_decimal_add(
             self.realized_pnl,
-            pnl_delta,
+            pnl_after_commission,
             "post realized P&L",
         )
         removed_unrealized = _exact_decimal_multiply(
@@ -258,7 +275,7 @@ class PaperAccountSettlementState:
                     mark_revaluation,
                     "daily P&L after mark revaluation",
                 ),
-                pnl_delta,
+                pnl_after_commission,
                 "daily P&L after realized fill",
             ),
             removed_unrealized,
@@ -305,6 +322,10 @@ class PaperTerminalSettlementRequest:
     terminal_status: TerminalOrderStatus
     fill_price: Optional[Decimal]
     outcome_at: datetime
+    fill_execution_id: Optional[str] = None
+    fill_commission_minor: Optional[int] = None
+    fill_commission_currency: Optional[str] = None
+    fill_commission_source: Optional[str] = None
     schema_version: int = MODEL_VERSION
 
     def __post_init__(self) -> None:
@@ -445,6 +466,9 @@ class PaperTerminalSettlementRequest:
             fill_price=self.fill_price,
             protective_mark_price=quote_price,
             pre_position_quantity=pre_position,
+            commission_minor=(
+                0 if self.fill_commission_minor is None else self.fill_commission_minor
+            ),
         )
         _strict_decimal(self.expected_post_cash, "expected_post_cash")
         _strict_decimal(
@@ -471,6 +495,20 @@ class PaperTerminalSettlementRequest:
             if self.fill_price is None:
                 raise ValidationError("FILLED settlement requires an exact fill price")
             _strict_decimal(self.fill_price, "fill_price", positive=True)
+            if (
+                type(self.fill_execution_id) is not str
+                or _LOCAL_PAPER_EXECUTION_ID_RE.fullmatch(self.fill_execution_id) is None
+            ):
+                raise ValidationError("fill_execution_id is malformed")
+            if (
+                type(self.fill_commission_minor) is not int
+                or abs(self.fill_commission_minor) > 1_000_000_000_000
+            ):
+                raise ValidationError("FILLED settlement requires exact commission minor units")
+            if self.fill_commission_currency != "USD":
+                raise ValidationError("FILLED settlement commission currency must be USD")
+            if self.fill_commission_source != "LOCAL_PAPER_EXECUTOR_EXACT_COMMISSION_V1":
+                raise ValidationError("FILLED settlement commission source is not authoritative")
         elif self.terminal_status in {
             TerminalOrderStatus.CANCELLED,
             TerminalOrderStatus.REJECTED,
@@ -481,6 +519,16 @@ class PaperTerminalSettlementRequest:
                 raise ValidationError("unfilled terminal settlement has inconsistent quantities")
             if self.fill_price is not None:
                 raise ValidationError("unfilled terminal settlement cannot contain a fill price")
+            if any(
+                value is not None
+                for value in (
+                    self.fill_execution_id,
+                    self.fill_commission_minor,
+                    self.fill_commission_currency,
+                    self.fill_commission_source,
+                )
+            ):
+                raise ValidationError("unfilled terminal settlement cannot contain fill evidence")
         else:  # pragma: no cover - enum exhaustiveness guard
             raise ValidationError("unsupported paper terminal status")
         object.__setattr__(self, "outcome_at", _strict_utc(self.outcome_at, "outcome_at"))
@@ -511,6 +559,10 @@ class PaperTerminalSettlementRequest:
                     self.expected_pre_position_source_settlement_id
                 ),
                 "fill_price": self.fill_price,
+                "fill_execution_id": self.fill_execution_id,
+                "fill_commission_minor": self.fill_commission_minor,
+                "fill_commission_currency": self.fill_commission_currency,
+                "fill_commission_source": self.fill_commission_source,
                 "filled_quantity": self.filled_quantity,
                 "order_ref": self.order_ref,
                 "outcome_at": self.outcome_at,
@@ -647,6 +699,10 @@ class PaperTerminalSettlementRequest:
                     else parse_fixed_decimal(payload["fill_price"], "fill_price")
                 ),
                 outcome_at=parse_utc_text(payload["outcome_at"], "outcome_at"),
+                fill_execution_id=payload["fill_execution_id"],
+                fill_commission_minor=payload["fill_commission_minor"],
+                fill_commission_currency=payload["fill_commission_currency"],
+                fill_commission_source=payload["fill_commission_source"],
                 schema_version=payload["schema_version"],
             )
         except (KeyError, TypeError, ValueError, ValidationError) as exc:

--- a/robo_trader/paper_terminal_settlement.py
+++ b/robo_trader/paper_terminal_settlement.py
@@ -43,6 +43,14 @@ from robo_trader.safety.models import (
 )
 
 _SCOPE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
+_FILL_EVIDENCE_PAYLOAD_FIELDS = frozenset(
+    {
+        "fill_execution_id",
+        "fill_commission_minor",
+        "fill_commission_currency",
+        "fill_commission_source",
+    }
+)
 _SYMBOL_RE = re.compile(r"^[A-Z0-9][A-Z0-9._-]{0,31}$")
 _SETTLEMENT_ID_RE = re.compile(r"^pset-[0-9a-f]{32}$")
 _LOCAL_PAPER_EXECUTION_ID_RE = re.compile(r"^lpfill-[0-9a-f]{32}$")
@@ -327,6 +335,12 @@ class PaperTerminalSettlementRequest:
     fill_commission_currency: Optional[str] = None
     fill_commission_source: Optional[str] = None
     schema_version: int = MODEL_VERSION
+    _persisted_canonical_payload: Optional[str] = field(
+        default=None,
+        init=False,
+        repr=False,
+        compare=False,
+    )
 
     def __post_init__(self) -> None:
         if type(self.schema_version) is not int or self.schema_version != MODEL_VERSION:
@@ -533,7 +547,7 @@ class PaperTerminalSettlementRequest:
             raise ValidationError("unsupported paper terminal status")
         object.__setattr__(self, "outcome_at", _strict_utc(self.outcome_at, "outcome_at"))
 
-    def canonical_payload(self) -> str:
+    def _current_canonical_payload(self) -> str:
         return canonical_json(
             {
                 "account_scope": self.account_scope,
@@ -580,8 +594,18 @@ class PaperTerminalSettlementRequest:
             }
         )
 
+    def canonical_payload(self) -> str:
+        if self._persisted_canonical_payload is not None:
+            return self._persisted_canonical_payload
+        return self._current_canonical_payload()
+
     def fingerprint(self) -> str:
         return sha256_text(self.canonical_payload())
+
+    def semantic_fingerprint(self) -> str:
+        """Fingerprint the current field set, independent of legacy serialization."""
+
+        return sha256_text(self._current_canonical_payload())
 
     @property
     def protective_mark_price(self) -> Decimal:
@@ -608,8 +632,21 @@ class PaperTerminalSettlementRequest:
             raise PaperTerminalSettlementError("stored settlement request is malformed") from exc
         if not isinstance(payload, dict) or canonical_json(payload) != payload_json:
             raise PaperTerminalSettlementError("stored settlement request is not canonical")
+        present_fill_fields = _FILL_EVIDENCE_PAYLOAD_FIELDS.intersection(payload)
+        legacy_zero_fill = not present_fill_fields
+        if present_fill_fields and present_fill_fields != _FILL_EVIDENCE_PAYLOAD_FIELDS:
+            raise PaperTerminalSettlementError(
+                "stored settlement request has partial fill evidence fields"
+            )
+        if legacy_zero_fill and payload.get("terminal_status") not in {
+            TerminalOrderStatus.CANCELLED.value,
+            TerminalOrderStatus.REJECTED.value,
+        }:
+            raise PaperTerminalSettlementError(
+                "legacy settlement request is not an admitted zero-fill outcome"
+            )
         try:
-            return cls(
+            request = cls(
                 execution_domain_scope=payload["execution_domain_scope"],
                 account_scope=payload["account_scope"],
                 portfolio_id=payload["portfolio_id"],
@@ -699,14 +736,17 @@ class PaperTerminalSettlementRequest:
                     else parse_fixed_decimal(payload["fill_price"], "fill_price")
                 ),
                 outcome_at=parse_utc_text(payload["outcome_at"], "outcome_at"),
-                fill_execution_id=payload["fill_execution_id"],
-                fill_commission_minor=payload["fill_commission_minor"],
-                fill_commission_currency=payload["fill_commission_currency"],
-                fill_commission_source=payload["fill_commission_source"],
+                fill_execution_id=payload.get("fill_execution_id"),
+                fill_commission_minor=payload.get("fill_commission_minor"),
+                fill_commission_currency=payload.get("fill_commission_currency"),
+                fill_commission_source=payload.get("fill_commission_source"),
                 schema_version=payload["schema_version"],
             )
         except (KeyError, TypeError, ValueError, ValidationError) as exc:
             raise PaperTerminalSettlementError("stored settlement request is invalid") from exc
+        if legacy_zero_fill:
+            object.__setattr__(request, "_persisted_canonical_payload", payload_json)
+        return request
 
 
 _RECEIPT_PRODUCER_MARKER = object()

--- a/scripts/manage_paper_safety_journal.py
+++ b/scripts/manage_paper_safety_journal.py
@@ -32,6 +32,11 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+from robo_trader.accounting.fifo_runtime import (  # noqa: E402
+    RuntimePaperFillEvidence,
+    reduction_side_to_fifo,
+    verify_runtime_fill_in_transaction,
+)
 from robo_trader.config import (  # noqa: E402
     RuntimeContract,
     _derive_safety_account_scope,
@@ -119,6 +124,18 @@ _SETTLEMENT_PROJECTION_SCHEMA = {
         "source_settlement_id",
         "symbol",
         "updated_at",
+    },
+    "paper_fifo_settlement_links": {
+        "commission_currency",
+        "commission_minor",
+        "commission_source",
+        "epoch_id",
+        "event_sequence",
+        "execution_id",
+        "fifo_state_fingerprint",
+        "fill_id",
+        "request_fingerprint",
+        "settlement_id",
     },
 }
 
@@ -586,7 +603,12 @@ def _linked_settlement_projection_matches(
         return False
 
     if request.filled_quantity > 0:
-        if type(trade_id) is not int or trade_id <= 0 or request.fill_price is None:
+        if (
+            type(trade_id) is not int
+            or trade_id <= 0
+            or request.fill_price is None
+            or request.fill_commission_minor is None
+        ):
             return False
         trade_rows = connection.execute(
             """
@@ -612,6 +634,7 @@ def _linked_settlement_projection_matches(
             trade_timestamp,
         ) = trade_rows[0]
         exact_notional = request.fill_price * request.filled_quantity
+        exact_commission = Decimal(request.fill_commission_minor) / Decimal("100")
         exact_pnl = request.expected_post_realized_pnl - request.expected_pre_realized_pnl
         trade_matches = (
             trade_portfolio == request.portfolio_id
@@ -623,7 +646,7 @@ def _linked_settlement_projection_matches(
             and _float_projection_matches(trade_price, request.fill_price)
             and _float_projection_matches(trade_notional, exact_notional)
             and _float_projection_matches(trade_slippage, Decimal(0))
-            and _float_projection_matches(trade_commission, Decimal(0))
+            and _float_projection_matches(trade_commission, exact_commission)
             and _float_projection_matches(trade_pnl, exact_pnl)
             and trade_timestamp == committed_at
         )
@@ -634,7 +657,7 @@ def _linked_settlement_projection_matches(
             """
             SELECT COUNT(*) FROM trades
             WHERE portfolio_id = ? AND symbol = ? AND side = ? AND quantity = ?
-              AND price = ? AND notional = ? AND slippage = 0 AND commission = 0
+              AND price = ? AND notional = ? AND slippage = 0 AND commission = ?
               AND pnl = ? AND timestamp = ?
             """,
             (
@@ -644,6 +667,7 @@ def _linked_settlement_projection_matches(
                 int(request.filled_quantity),
                 float(request.fill_price),
                 float(exact_notional),
+                float(exact_commission),
                 float(exact_pnl),
                 committed_at,
             ),
@@ -860,6 +884,88 @@ def _linked_settlement_projection_matches(
     return _legacy_timestamp_not_after(account_rows[0][4], exact_committed_at)
 
 
+def _fifo_settlement_projection_matches(
+    connection: sqlite3.Connection,
+    *,
+    settlement_id: object,
+    request_fingerprint: object,
+    request: PaperTerminalSettlementRequest,
+) -> bool:
+    """Authenticate the immutable FIFO event linked to one settlement."""
+
+    if type(settlement_id) is not str or type(request_fingerprint) is not str:
+        return False
+    rows = connection.execute(
+        """
+        SELECT epoch_id,fill_id,event_sequence,execution_id,commission_minor,
+               commission_currency,commission_source,fifo_state_fingerprint
+        FROM paper_fifo_settlement_links WHERE settlement_id=?
+        """,
+        (settlement_id,),
+    ).fetchall()
+    if request.filled_quantity == 0:
+        return not rows
+    if (
+        len(rows) != 1
+        or request.fill_price is None
+        or request.fill_execution_id is None
+        or request.fill_commission_minor is None
+        or request.fill_commission_currency is None
+        or request.fill_commission_source is None
+    ):
+        return False
+    (
+        epoch_id,
+        fill_id,
+        event_sequence,
+        execution_id,
+        commission_minor,
+        commission_currency,
+        commission_source,
+        state_fingerprint,
+    ) = rows[0]
+    try:
+        evidence = RuntimePaperFillEvidence(
+            execution_domain_scope=request.execution_domain_scope,
+            account_scope=request.account_scope,
+            portfolio_id=request.portfolio_id,
+            con_id=request.con_id,
+            symbol=request.symbol,
+            side=reduction_side_to_fifo(request.side.value),
+            quantity=request.filled_quantity,
+            price=request.fill_price,
+            execution_id=request.fill_execution_id,
+            idempotency_key=request_fingerprint,
+            commission_minor=request.fill_commission_minor,
+            commission_currency=request.fill_commission_currency,
+            commission_source=request.fill_commission_source,
+            occurred_at=request.outcome_at,
+        )
+        projection = verify_runtime_fill_in_transaction(connection, evidence)
+    except (sqlite3.Error, RuntimeError, TypeError, ValueError):
+        return False
+    return (
+        epoch_id == projection.epoch_id
+        and fill_id == projection.fill_id
+        and event_sequence == projection.event_sequence
+        and execution_id == request.fill_execution_id
+        and commission_minor == request.fill_commission_minor
+        and commission_currency == request.fill_commission_currency
+        and commission_source == request.fill_commission_source
+        and state_fingerprint == projection.state_fingerprint
+        and projection.replayed
+        and projection.signed_quantity == request.expected_post_position_quantity
+        and (
+            projection.average_cost == request.expected_position_cost_basis
+            if projection.signed_quantity != 0
+            else projection.average_cost is None and projection.open_cost is None
+        )
+        and projection.fill_realized_pnl
+        == request.expected_post_realized_pnl - request.expected_pre_realized_pnl
+        and projection.total_realized_pnl == request.expected_post_realized_pnl
+    )
+
+
 def _local_settlement_correlations(
     contract: RuntimeContract,
     reservations: tuple[ReplayReservation, ...],
@@ -880,6 +986,9 @@ def _local_settlement_correlations(
             uri=True,
             isolation_level=None,
         )
+        connection.execute("PRAGMA foreign_keys = ON")
+        if connection.execute("PRAGMA foreign_keys").fetchone() != (1,):
+            raise RuntimeError("paper allocation ledger foreign keys cannot be enforced")
         connection.execute("PRAGMA query_only = ON")
         if connection.execute("PRAGMA query_only").fetchone() != (1,):
             raise RuntimeError("paper allocation ledger query-only mode cannot be proven")
@@ -1031,6 +1140,12 @@ def _local_settlement_correlations(
                     trade_id=trade_id,
                     committed_at=committed_at,
                     protective_quote_payload=protective_quote_payload,
+                    request=request,
+                )
+                and _fifo_settlement_projection_matches(
+                    connection,
+                    settlement_id=settlement_id,
+                    request_fingerprint=request_fingerprint,
                     request=request,
                 )
             )

--- a/tests/accounting/test_fifo_runtime_settlement.py
+++ b/tests/accounting/test_fifo_runtime_settlement.py
@@ -11,7 +11,12 @@ import pytest
 
 from robo_trader.accounting import AccountingEpoch, FifoAccountingConflict, FifoLedger
 from robo_trader.accounting.fifo import FillSide
-from robo_trader.accounting.fifo_fixture_migration import migrate_fifo_fixture_database
+from robo_trader.accounting.fifo_fixture_migration import (
+    _TABLE_SQL,
+    _TRIGGER_SQL,
+    FifoFixtureMigrationError,
+    migrate_fifo_fixture_database,
+)
 from robo_trader.accounting.fifo_runtime import (
     LOCAL_PAPER_COMMISSION_SOURCE,
     FifoRuntimeSettlementError,
@@ -229,6 +234,36 @@ def test_epoch_realized_pnl_is_independent_of_ambient_decimal_precision() -> Non
         assert projection.fill_realized_pnl == Decimal("-12345.66")
         assert projection.epoch_realized_pnl == Decimal("0.01")
         assert projection.total_realized_pnl == Decimal("0.01")
+    finally:
+        connection.close()
+
+
+def test_runtime_fill_rejects_case_changed_fifo_constraint_before_writing() -> None:
+    connection, effective = _connection()
+    try:
+        connection.execute("DROP TABLE fifo_commissions")
+        connection.execute(_TABLE_SQL["fifo_commissions"].replace("'USD'", "'usd'"))
+        for name, statement in _TRIGGER_SQL.items():
+            if name.startswith("fifo_commissions_no_"):
+                connection.execute(statement)
+
+        connection.execute("BEGIN IMMEDIATE")
+        with pytest.raises(FifoFixtureMigrationError, match="fifo_commissions is malformed"):
+            append_runtime_fill_in_transaction(
+                connection,
+                _evidence(
+                    1,
+                    side=FillSide.BUY,
+                    quantity="1",
+                    price="100",
+                    commission_minor=0,
+                    occurred_at=effective,
+                ),
+            )
+        connection.rollback()
+
+        assert connection.execute("SELECT COUNT(*) FROM fifo_fills").fetchone() == (0,)
+        assert connection.execute("SELECT COUNT(*) FROM fifo_commissions").fetchone() == (0,)
     finally:
         connection.close()
 

--- a/tests/accounting/test_fifo_runtime_settlement.py
+++ b/tests/accounting/test_fifo_runtime_settlement.py
@@ -1,0 +1,227 @@
+"""PR4C atomic runtime FIFO settlement and recovery evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+from robo_trader.accounting import AccountingEpoch, FifoAccountingConflict, FifoLedger
+from robo_trader.accounting.fifo import FillSide
+from robo_trader.accounting.fifo_fixture_migration import migrate_fifo_fixture_database
+from robo_trader.accounting.fifo_runtime import (
+    LOCAL_PAPER_COMMISSION_SOURCE,
+    FifoRuntimeSettlementError,
+    RuntimePaperFillEvidence,
+    append_runtime_fill_in_transaction,
+    reduction_side_to_fifo,
+    verify_runtime_fill_in_transaction,
+)
+
+
+def _connection() -> tuple[sqlite3.Connection, datetime]:
+    connection = sqlite3.connect(":memory:", isolation_level=None)
+    connection.execute("PRAGMA foreign_keys=ON")
+    migrate_fifo_fixture_database(connection, expected_path=None)
+    effective = datetime(2026, 7, 30, 12, tzinfo=timezone.utc)
+    FifoLedger(connection).create_epoch(
+        AccountingEpoch(
+            epoch_id="fepoch-" + ("1" * 32),
+            execution_domain_scope="paper-simulator-v1",
+            account_scope="acct_v1_" + ("2" * 64),
+            portfolio_id="portfolio-a",
+            source_fingerprint="3" * 64,
+            effective_at=effective,
+            created_at=effective,
+        )
+    )
+    return connection, effective
+
+
+def _evidence(
+    sequence: int,
+    *,
+    side: FillSide,
+    quantity: str,
+    price: str,
+    commission_minor: int,
+    occurred_at: datetime,
+) -> RuntimePaperFillEvidence:
+    identity = hashlib.sha256(f"runtime-fill-{sequence}".encode()).hexdigest()
+    return RuntimePaperFillEvidence(
+        execution_domain_scope="paper-simulator-v1",
+        account_scope="acct_v1_" + ("2" * 64),
+        portfolio_id="portfolio-a",
+        con_id=265598,
+        symbol="AAPL",
+        side=side,
+        quantity=Decimal(quantity),
+        price=Decimal(price),
+        execution_id=f"lpfill-{identity[:32]}",
+        idempotency_key=identity,
+        commission_minor=commission_minor,
+        commission_currency="USD",
+        commission_source=LOCAL_PAPER_COMMISSION_SOURCE,
+        occurred_at=occurred_at,
+    )
+
+
+def test_partial_fills_and_commissions_project_exact_fifo() -> None:
+    connection, effective = _connection()
+    try:
+        events = (
+            _evidence(
+                1,
+                side=FillSide.BUY,
+                quantity="10",
+                price="100",
+                commission_minor=101,
+                occurred_at=effective,
+            ),
+            _evidence(
+                2,
+                side=FillSide.SELL,
+                quantity="4",
+                price="110",
+                commission_minor=51,
+                occurred_at=effective + timedelta(seconds=1),
+            ),
+            _evidence(
+                3,
+                side=FillSide.SELL,
+                quantity="6",
+                price="120",
+                commission_minor=-25,
+                occurred_at=effective + timedelta(seconds=2),
+            ),
+        )
+        projections = []
+        for event in events:
+            connection.execute("BEGIN IMMEDIATE")
+            projections.append(append_runtime_fill_in_transaction(connection, event))
+            connection.commit()
+
+        first, partial, final = projections
+        assert first.signed_quantity == Decimal("10")
+        assert first.average_cost == Decimal("100")
+        assert partial.signed_quantity == Decimal("6")
+        assert partial.fill_realized_pnl == Decimal("39.09")
+        assert final.signed_quantity == Decimal("0")
+        assert final.average_cost is None
+        assert final.fill_realized_pnl == Decimal("119.64")
+        assert final.total_realized_pnl == Decimal("158.73")
+        assert final.cumulative_commission_minor == 127
+        assert connection.execute("PRAGMA foreign_key_check").fetchone() is None
+    finally:
+        connection.close()
+
+
+def test_exact_replay_is_read_only_and_conflict_fails_closed() -> None:
+    connection, effective = _connection()
+    evidence = _evidence(
+        1,
+        side=FillSide.BUY,
+        quantity="2",
+        price="10",
+        commission_minor=3,
+        occurred_at=effective,
+    )
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        first = append_runtime_fill_in_transaction(connection, evidence)
+        connection.commit()
+        before = connection.total_changes
+
+        connection.execute("BEGIN IMMEDIATE")
+        replay = append_runtime_fill_in_transaction(connection, evidence)
+        connection.rollback()
+        assert replay.replayed is True
+        assert replay.state_fingerprint == first.state_fingerprint
+        assert connection.total_changes == before
+
+        connection.execute("BEGIN")
+        verified = verify_runtime_fill_in_transaction(connection, evidence)
+        connection.rollback()
+        assert verified.replayed is True
+        assert verified.state_fingerprint == first.state_fingerprint
+        assert connection.total_changes == before
+
+        conflicting = RuntimePaperFillEvidence(
+            **{
+                **{
+                    field: getattr(evidence, field)
+                    for field in evidence.__dataclass_fields__
+                },
+                "price": Decimal("11"),
+            }
+        )
+        connection.execute("BEGIN IMMEDIATE")
+        with pytest.raises(FifoAccountingConflict, match="different data"):
+            append_runtime_fill_in_transaction(connection, conflicting)
+        connection.rollback()
+        assert connection.execute("SELECT COUNT(*) FROM fifo_fills").fetchone() == (1,)
+    finally:
+        connection.close()
+
+
+def test_reduction_side_mapping_handles_short_cover_without_guessing() -> None:
+    assert reduction_side_to_fifo("SELL") is FillSide.SELL
+    assert reduction_side_to_fifo("BUY_TO_COVER") is FillSide.BUY
+    with pytest.raises(FifoRuntimeSettlementError, match="only reduction"):
+        reduction_side_to_fifo("BUY")
+
+
+def test_failure_injection_rolls_back_fifo_and_compatibility_projection() -> None:
+    connection, effective = _connection()
+    connection.execute(
+        "CREATE TABLE compatibility_position(symbol TEXT PRIMARY KEY, quantity_text TEXT NOT NULL)"
+    )
+    connection.execute("INSERT INTO compatibility_position VALUES ('AAPL','0')")
+    evidence = _evidence(
+        1,
+        side=FillSide.BUY,
+        quantity="5",
+        price="10",
+        commission_minor=0,
+        occurred_at=effective,
+    )
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        append_runtime_fill_in_transaction(connection, evidence)
+        connection.execute(
+            "UPDATE compatibility_position SET quantity_text='5' WHERE symbol='AAPL'"
+        )
+        connection.rollback()
+
+        assert connection.execute("SELECT COUNT(*) FROM fifo_fills").fetchone() == (0,)
+        assert connection.execute(
+            "SELECT quantity_text FROM compatibility_position WHERE symbol='AAPL'"
+        ).fetchone() == ("0",)
+    finally:
+        connection.close()
+
+
+def test_missing_epoch_never_invents_a_fill() -> None:
+    connection = sqlite3.connect(":memory:", isolation_level=None)
+    connection.execute("PRAGMA foreign_keys=ON")
+    migrate_fifo_fixture_database(connection, expected_path=None)
+    effective = datetime(2026, 7, 30, 12, tzinfo=timezone.utc)
+    evidence = _evidence(
+        1,
+        side=FillSide.BUY,
+        quantity="1",
+        price="10",
+        commission_minor=0,
+        occurred_at=effective,
+    )
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        with pytest.raises(FifoRuntimeSettlementError, match="exactly one sealed FIFO epoch"):
+            append_runtime_fill_in_transaction(connection, evidence)
+        connection.rollback()
+        assert connection.execute("SELECT COUNT(*) FROM fifo_fills").fetchone() == (0,)
+    finally:
+        connection.close()

--- a/tests/accounting/test_fifo_runtime_settlement.py
+++ b/tests/accounting/test_fifo_runtime_settlement.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import sqlite3
 from datetime import datetime, timedelta, timezone
-from decimal import Decimal
+from decimal import Decimal, localcontext
 
 import pytest
 
@@ -174,6 +174,61 @@ def test_epoch_realized_pnl_accumulates_across_symbols() -> None:
         assert second_close.fill_realized_pnl == Decimal("20")
         assert second_close.epoch_realized_pnl == Decimal("30")
         assert second_close.total_realized_pnl == Decimal("30")
+    finally:
+        connection.close()
+
+
+def test_epoch_realized_pnl_is_independent_of_ambient_decimal_precision() -> None:
+    connection, effective = _connection()
+    try:
+        events = (
+            _evidence(
+                1,
+                side=FillSide.BUY,
+                quantity="1",
+                price="10000",
+                commission_minor=0,
+                occurred_at=effective,
+            ),
+            _evidence(
+                2,
+                side=FillSide.SELL,
+                quantity="1",
+                price="22345.67",
+                commission_minor=0,
+                occurred_at=effective + timedelta(seconds=1),
+            ),
+            _evidence(
+                3,
+                side=FillSide.BUY,
+                quantity="1",
+                price="20000",
+                commission_minor=0,
+                occurred_at=effective + timedelta(seconds=2),
+                con_id=272093,
+                symbol="MSFT",
+            ),
+            _evidence(
+                4,
+                side=FillSide.SELL,
+                quantity="1",
+                price="7654.34",
+                commission_minor=0,
+                occurred_at=effective + timedelta(seconds=3),
+                con_id=272093,
+                symbol="MSFT",
+            ),
+        )
+        with localcontext() as context:
+            context.prec = 6
+            for event in events:
+                connection.execute("BEGIN IMMEDIATE")
+                projection = append_runtime_fill_in_transaction(connection, event)
+                connection.commit()
+
+        assert projection.fill_realized_pnl == Decimal("-12345.66")
+        assert projection.epoch_realized_pnl == Decimal("0.01")
+        assert projection.total_realized_pnl == Decimal("0.01")
     finally:
         connection.close()
 

--- a/tests/accounting/test_fifo_runtime_settlement.py
+++ b/tests/accounting/test_fifo_runtime_settlement.py
@@ -49,14 +49,16 @@ def _evidence(
     price: str,
     commission_minor: int,
     occurred_at: datetime,
+    con_id: int = 265598,
+    symbol: str = "AAPL",
 ) -> RuntimePaperFillEvidence:
     identity = hashlib.sha256(f"runtime-fill-{sequence}".encode()).hexdigest()
     return RuntimePaperFillEvidence(
         execution_domain_scope="paper-simulator-v1",
         account_scope="acct_v1_" + ("2" * 64),
         portfolio_id="portfolio-a",
-        con_id=265598,
-        symbol="AAPL",
+        con_id=con_id,
+        symbol=symbol,
         side=side,
         quantity=Decimal(quantity),
         price=Decimal(price),
@@ -119,6 +121,63 @@ def test_partial_fills_and_commissions_project_exact_fifo() -> None:
         connection.close()
 
 
+def test_epoch_realized_pnl_accumulates_across_symbols() -> None:
+    connection, effective = _connection()
+    try:
+        events = (
+            _evidence(
+                1,
+                side=FillSide.BUY,
+                quantity="1",
+                price="100",
+                commission_minor=0,
+                occurred_at=effective,
+            ),
+            _evidence(
+                2,
+                side=FillSide.SELL,
+                quantity="1",
+                price="110",
+                commission_minor=0,
+                occurred_at=effective + timedelta(seconds=1),
+            ),
+            _evidence(
+                3,
+                side=FillSide.BUY,
+                quantity="1",
+                price="100",
+                commission_minor=0,
+                occurred_at=effective + timedelta(seconds=2),
+                con_id=272093,
+                symbol="MSFT",
+            ),
+            _evidence(
+                4,
+                side=FillSide.SELL,
+                quantity="1",
+                price="120",
+                commission_minor=0,
+                occurred_at=effective + timedelta(seconds=3),
+                con_id=272093,
+                symbol="MSFT",
+            ),
+        )
+        projections = []
+        for event in events:
+            connection.execute("BEGIN IMMEDIATE")
+            projections.append(append_runtime_fill_in_transaction(connection, event))
+            connection.commit()
+
+        first_close, second_close = projections[1], projections[3]
+        assert first_close.fill_realized_pnl == Decimal("10")
+        assert first_close.epoch_realized_pnl == Decimal("10")
+        assert second_close.fill_realized_pnl == Decimal("20")
+        assert second_close.epoch_realized_pnl == Decimal("30")
+        assert second_close.total_realized_pnl == Decimal("30")
+    finally:
+        connection.close()
+
+
 def test_exact_replay_is_read_only_and_conflict_fails_closed() -> None:
     connection, effective = _connection()
     evidence = _evidence(
@@ -151,10 +210,7 @@ def test_exact_replay_is_read_only_and_conflict_fails_closed() -> None:
 
         conflicting = RuntimePaperFillEvidence(
             **{
-                **{
-                    field: getattr(evidence, field)
-                    for field in evidence.__dataclass_fields__
-                },
+                **{field: getattr(evidence, field) for field in evidence.__dataclass_fields__},
                 "price": Decimal("11"),
             }
         )

--- a/tests/fifo_runtime_test_support.py
+++ b/tests/fifo_runtime_test_support.py
@@ -1,0 +1,189 @@
+"""Synthetic, non-authoritative FIFO epochs for isolated runtime tests only."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+
+from robo_trader.accounting.fifo_bootstrap import prepare_fifo_accounting_schema_in_transaction
+from robo_trader.accounting.fifo_fixture_migration import _legacy_opening_manifest_hash
+from robo_trader.database_async import AsyncTradingDatabase
+from robo_trader.safety.models import utc_to_text
+
+
+def _identifier(prefix: str, *parts: object) -> str:
+    material = "\x1f".join(str(part) for part in parts)
+    return f"{prefix}-{hashlib.sha256(material.encode('utf-8')).hexdigest()[:32]}"
+
+
+async def install_synthetic_fifo_epoch(
+    database: AsyncTradingDatabase,
+    *,
+    execution_domain_scope: str,
+    account_scope: str,
+    portfolio_id: str,
+    con_id: int,
+    symbol: str,
+) -> str:
+    """Install one explicit opening balance in a pytest-isolated database.
+
+    This helper is intentionally under ``tests/``.  It never reads a user
+    database and cannot be imported by the runtime package.
+    """
+
+    effective_at = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    effective_text = utc_to_text(effective_at)
+    source_fingerprint = hashlib.sha256(
+        f"synthetic-test-epoch:{execution_domain_scope}:{account_scope}:{portfolio_id}".encode()
+    ).hexdigest()
+    epoch_id = _identifier("fepoch", source_fingerprint)
+    async with database.get_connection() as connection:
+        await connection.execute("BEGIN IMMEDIATE")
+        try:
+            await prepare_fifo_accounting_schema_in_transaction(
+                connection,
+                applied_at=effective_text,
+            )
+            account = await (
+                await connection.execute(
+                    """
+                    SELECT cash_text,realized_pnl_text,daily_pnl_text,
+                           daily_pnl_baseline_text,daily_pnl_date
+                    FROM paper_account_settlement_state WHERE portfolio_id=?
+                    """,
+                    (portfolio_id,),
+                )
+            ).fetchone()
+            position = await (
+                await connection.execute(
+                    """
+                    SELECT quantity,cost_basis_text,mark_price_text
+                    FROM positions JOIN paper_position_settlement_state USING(portfolio_id,symbol)
+                    WHERE portfolio_id=? AND symbol=?
+                    """,
+                    (portfolio_id, symbol),
+                )
+            ).fetchone()
+            if account is None:
+                raise AssertionError("synthetic FIFO epoch requires seeded exact account state")
+            empty_epoch = position is None or position[0] == 0
+            await connection.execute(
+                """
+                INSERT INTO fifo_accounting_epochs(
+                    epoch_id,schema_version,execution_domain_scope,account_scope,
+                    portfolio_id,origin_kind,source_fingerprint,effective_at,created_at
+                ) VALUES (?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    epoch_id,
+                    1,
+                    execution_domain_scope,
+                    account_scope,
+                    portfolio_id,
+                    "EMPTY_LEDGER" if empty_epoch else "LEGACY_AGGREGATE_OPENING_BALANCE",
+                    source_fingerprint,
+                    effective_text,
+                    effective_text,
+                ),
+            )
+            await connection.execute(
+                """
+                INSERT INTO fifo_epoch_account_baselines(
+                    epoch_id,cash_text,realized_pnl_text,daily_pnl_text,
+                    daily_pnl_baseline_text,daily_pnl_date,recorded_at
+                ) VALUES (?,?,?,?,?,?,?)
+                """,
+                (epoch_id, *account, effective_text),
+            )
+            if empty_epoch:
+                await connection.commit()
+                return epoch_id
+            quantity = int(position[0])
+            opening_balance_id = _identifier("fobal", epoch_id, con_id, symbol)
+            lot_id = _identifier("flot", epoch_id, opening_balance_id)
+            direction = "LONG" if quantity > 0 else "SHORT"
+            manifest_row = (
+                opening_balance_id,
+                lot_id,
+                con_id,
+                symbol,
+                direction,
+                str(abs(quantity)),
+                str(position[1]),
+                str(position[2]),
+                effective_text,
+                "7" * 64,
+                0,
+                0,
+                effective_text,
+            )
+            await connection.execute(
+                """
+                INSERT INTO fifo_legacy_bootstrap_lineage(
+                    epoch_id,bootstrap_id,candidate_fingerprint,
+                    opening_manifest_count,opening_manifest_hash,
+                    reconciliation_snapshot_id,reconciliation_report_hash,
+                    broker_snapshot_hash,legacy_snapshot_hash,operator_action_id,recorded_at
+                ) VALUES (?,?,?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    epoch_id,
+                    _identifier("pboot", epoch_id),
+                    source_fingerprint,
+                    1,
+                    _legacy_opening_manifest_hash([manifest_row]),
+                    "synthetic-reconciliation",
+                    "4" * 64,
+                    "5" * 64,
+                    "6" * 64,
+                    _identifier("padmin", epoch_id),
+                    effective_text,
+                ),
+            )
+            await connection.execute(
+                """
+                INSERT INTO fifo_opening_balances(
+                    opening_balance_id,epoch_id,con_id,symbol,direction,
+                    opened_quantity_text,cost_basis_text,mark_price_text,
+                    mark_observed_at,mark_evidence_fingerprint,recorded_at
+                ) VALUES (?,?,?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    opening_balance_id,
+                    epoch_id,
+                    con_id,
+                    symbol,
+                    direction,
+                    str(abs(quantity)),
+                    str(position[1]),
+                    str(position[2]),
+                    effective_text,
+                    "7" * 64,
+                    effective_text,
+                ),
+            )
+            await connection.execute(
+                """
+                INSERT INTO fifo_lot_openings(
+                    lot_id,epoch_id,opening_fill_id,opening_balance_id,lot_ordinal,
+                    con_id,symbol,direction,opened_quantity_text,open_price_text,
+                    opening_commission_minor,opened_sequence,opened_at
+                ) VALUES (?,?,NULL,?,0,?,?,?,?,?,0,0,?)
+                """,
+                (
+                    lot_id,
+                    epoch_id,
+                    opening_balance_id,
+                    con_id,
+                    symbol,
+                    direction,
+                    str(abs(quantity)),
+                    str(position[1]),
+                    effective_text,
+                ),
+            )
+            await connection.commit()
+        except BaseException:
+            await connection.rollback()
+            raise
+    return epoch_id

--- a/tests/security/test_trading_core.py
+++ b/tests/security/test_trading_core.py
@@ -19,7 +19,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from robo_trader.execution import ExecutionResult, Order, PaperExecutor
+from robo_trader.execution import (
+    ExecutionResult,
+    LocalPaperExecutionEvidence,
+    Order,
+    PaperExecutor,
+)
 from robo_trader.paper_reduction_submitter import (
     LocalPaperOrderStatus,
     LocalPaperOutcomeProvenance,
@@ -66,6 +71,16 @@ def _filled_terminal_outcome(
     """Return exact local-paper terminal evidence for monitor-only tests."""
 
     quantity = Decimal(order.quantity)
+    observed_at = datetime.now(timezone.utc)
+    fill_evidence = LocalPaperExecutionEvidence(
+        execution_id="lpfill-" + hashlib.sha256(order.order_ref.encode("utf-8")).hexdigest()[:32],
+        filled_quantity=quantity,
+        exact_fill_price=fill_price,
+        commission_minor=0,
+        commission_currency="USD",
+        commission_source="LOCAL_PAPER_EXECUTOR_EXACT_COMMISSION_V1",
+        occurred_at=observed_at,
+    )
     return LocalPaperTerminalOutcome(
         order_ref=order.order_ref,
         status=LocalPaperOrderStatus.FILLED,
@@ -73,10 +88,11 @@ def _filled_terminal_outcome(
         filled_quantity=quantity,
         remaining_quantity=Decimal("0"),
         exact_fill_price=fill_price,
-        observed_at=datetime.now(timezone.utc),
+        observed_at=observed_at,
         provenance=LocalPaperOutcomeProvenance.LOCAL_PAPER_EXECUTOR,
         terminal=True,
         message="exact local paper fill",
+        fill_evidence=fill_evidence,
     )
 
 
@@ -1138,6 +1154,10 @@ def _paper_settlement_request(
         terminal_status=TerminalOrderStatus.FILLED,
         fill_price=fill_price,
         outcome_at=datetime(2026, 7, 25, 14, 30, tzinfo=timezone.utc),
+        fill_execution_id="lpfill-" + ("8" * 32),
+        fill_commission_minor=0,
+        fill_commission_currency="USD",
+        fill_commission_source="LOCAL_PAPER_EXECUTOR_EXACT_COMMISSION_V1",
     )
 
 

--- a/tests/test_exact_state_bootstrap.py
+++ b/tests/test_exact_state_bootstrap.py
@@ -687,7 +687,7 @@ async def test_offline_atomic_bootstrap_migrates_raw_legacy_schema_in_one_commit
     with sqlite3.connect(path) as connection:
         assert connection.execute(
             "SELECT COUNT(*) FROM rt_schema_migrations " "WHERE component='paper_exact_state'"
-        ).fetchone() == (2,)
+        ).fetchone() == (3,)
         assert connection.execute("SELECT COUNT(*) FROM paper_state_bootstraps").fetchone() == (1,)
         assert connection.execute(
             "SELECT COUNT(*) FROM exact_bootstrap_evidence_consumptions"

--- a/tests/test_pr1a_existing_position_protection.py
+++ b/tests/test_pr1a_existing_position_protection.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import inspect
 import json
 import subprocess
@@ -18,7 +19,7 @@ import pytest
 
 from robo_trader.config import RuntimeContract
 from robo_trader.database_validator import ValidationError
-from robo_trader.execution import ExecutionResult
+from robo_trader.execution import ExecutionResult, LocalPaperExecutionEvidence
 from robo_trader.paper_reduction_submitter import (
     LocalPaperOrderStatus,
     LocalPaperOutcomeProvenance,
@@ -93,6 +94,7 @@ def _filled_terminal_outcome(
     fill_price: Decimal = Decimal("97.5"),
 ) -> LocalPaperTerminalOutcome:
     quantity = Decimal(order.quantity)
+    observed_at = datetime.now(timezone.utc)
     return LocalPaperTerminalOutcome(
         order_ref=order.order_ref,
         status=LocalPaperOrderStatus.FILLED,
@@ -100,10 +102,20 @@ def _filled_terminal_outcome(
         filled_quantity=quantity,
         remaining_quantity=Decimal("0"),
         exact_fill_price=fill_price,
-        observed_at=datetime.now(timezone.utc),
+        observed_at=observed_at,
         provenance=LocalPaperOutcomeProvenance.LOCAL_PAPER_EXECUTOR,
         terminal=True,
         message="exact local paper fill",
+        fill_evidence=LocalPaperExecutionEvidence(
+            execution_id="lpfill-"
+            + hashlib.sha256(order.order_ref.encode("utf-8")).hexdigest()[:32],
+            filled_quantity=quantity,
+            exact_fill_price=fill_price,
+            commission_minor=0,
+            commission_currency="USD",
+            commission_source="LOCAL_PAPER_EXECUTOR_EXACT_COMMISSION_V1",
+            occurred_at=observed_at,
+        ),
     )
 
 

--- a/tests/test_pr1a_stop_event_time.py
+++ b/tests/test_pr1a_stop_event_time.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from robo_trader.execution import LocalPaperExecutionEvidence
 from robo_trader.paper_reduction_submitter import (
     LocalPaperOrderStatus,
     LocalPaperOutcomeProvenance,
@@ -29,17 +31,29 @@ def _monitor() -> StopLossMonitor:
 
 def _filled_terminal_outcome(order, fill_price: float) -> LocalPaperTerminalOutcome:
     quantity = Decimal(order.quantity)
+    exact_fill_price = Decimal(str(fill_price))
+    observed_at = datetime.now(timezone.utc)
     return LocalPaperTerminalOutcome(
         order_ref=order.order_ref,
         status=LocalPaperOrderStatus.FILLED,
         requested_quantity=quantity,
         filled_quantity=quantity,
         remaining_quantity=Decimal("0"),
-        exact_fill_price=Decimal(str(fill_price)),
-        observed_at=datetime.now(timezone.utc),
+        exact_fill_price=exact_fill_price,
+        observed_at=observed_at,
         provenance=LocalPaperOutcomeProvenance.LOCAL_PAPER_EXECUTOR,
         terminal=True,
         message="exact local paper fill",
+        fill_evidence=LocalPaperExecutionEvidence(
+            execution_id="lpfill-"
+            + hashlib.sha256(order.order_ref.encode("utf-8")).hexdigest()[:32],
+            filled_quantity=quantity,
+            exact_fill_price=exact_fill_price,
+            commission_minor=0,
+            commission_currency="USD",
+            commission_source="LOCAL_PAPER_EXECUTOR_EXACT_COMMISSION_V1",
+            occurred_at=observed_at,
+        ),
     )
 
 

--- a/tests/test_pr2b2_paper_reduction_gateway.py
+++ b/tests/test_pr2b2_paper_reduction_gateway.py
@@ -61,6 +61,7 @@ from robo_trader.safety_runtime_evidence import (
     assemble_local_paper_safety_evidence,
 )
 from robo_trader.stop_loss_monitor import StopLossMonitor
+from tests.fifo_runtime_test_support import install_synthetic_fifo_epoch
 
 ACCOUNT = "DU1234567"
 SCOPE_KEY = "0123456789abcdef" * 4
@@ -151,6 +152,14 @@ async def _seed_allocations(
             Decimal("100000"),
             realized_pnl=Decimal("0"),
             portfolio_id=portfolio_id,
+        )
+        await install_synthetic_fifo_epoch(
+            database,
+            execution_domain_scope="paper-simulator-v1",
+            account_scope=ACCOUNT_SCOPE,
+            portfolio_id=portfolio_id,
+            con_id=CON_ID,
+            symbol=SYMBOL,
         )
 
 

--- a/tests/test_pr2b3_gateway_failure_injection.py
+++ b/tests/test_pr2b3_gateway_failure_injection.py
@@ -15,7 +15,7 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 import pytest_asyncio
 
-from robo_trader.execution import PaperExecutor
+from robo_trader.execution import LocalPaperExecutionEvidence, PaperExecutor
 from robo_trader.paper_reduction_gateway import (
     PaperReductionGateway,
     PaperReductionGatewayError,
@@ -80,6 +80,22 @@ async def _ledger_counts(harness: GatewayHarness) -> tuple[int, int]:
     return trade_count, settlement_count
 
 
+async def _fifo_settlement_counts(harness: GatewayHarness) -> tuple[int, int, int]:
+    async with harness.database.get_connection() as connection:
+        fill_count = (
+            await (await connection.execute("SELECT COUNT(*) FROM fifo_fills")).fetchone()
+        )[0]
+        commission_count = (
+            await (await connection.execute("SELECT COUNT(*) FROM fifo_commissions")).fetchone()
+        )[0]
+        link_count = (
+            await (
+                await connection.execute("SELECT COUNT(*) FROM paper_fifo_settlement_links")
+            ).fetchone()
+        )[0]
+    return fill_count, commission_count, link_count
+
+
 async def _bind_projection(
     harness: GatewayHarness,
     executor: PaperExecutor,
@@ -124,6 +140,20 @@ def _unsafe_outcome(
     status: LocalPaperOrderStatus,
 ) -> LocalPaperTerminalOutcome:
     partial = status is LocalPaperOrderStatus.PARTIALLY_FILLED
+    observed_at = datetime.now(timezone.utc)
+    fill_evidence = (
+        LocalPaperExecutionEvidence(
+            execution_id="lpfill-" + ("9" * 32),
+            filled_quantity=Decimal("1"),
+            exact_fill_price=Decimal("123.45"),
+            commission_minor=0,
+            commission_currency="USD",
+            commission_source="LOCAL_PAPER_EXECUTOR_EXACT_COMMISSION_V1",
+            occurred_at=observed_at,
+        )
+        if partial
+        else None
+    )
     return LocalPaperTerminalOutcome(
         order_ref=order_ref,
         status=status,
@@ -131,10 +161,11 @@ def _unsafe_outcome(
         filled_quantity=Decimal("1") if partial else Decimal("0"),
         remaining_quantity=Decimal("1") if partial else Decimal("2"),
         exact_fill_price=Decimal("123.45") if partial else None,
-        observed_at=datetime.now(timezone.utc),
+        observed_at=observed_at,
         provenance=LocalPaperOutcomeProvenance.LOCAL_PAPER_EXECUTOR,
         terminal=False,
         message=f"injected {status.value.lower()} outcome",
+        fill_evidence=fill_evidence,
     )
 
 
@@ -580,9 +611,14 @@ async def test_database_failure_after_fill_quarantines_without_executor_retry(
 
 
 @pytest.mark.asyncio
-async def test_after_trade_insert_fault_rolls_back_and_blocks_restart(
+@pytest.mark.parametrize(
+    "fault_step",
+    ["AFTER_FIFO_APPEND", "AFTER_TRADE_INSERT", "AFTER_FIFO_LINK_INSERT"],
+)
+async def test_atomic_settlement_fault_rolls_back_fifo_and_blocks_restart(
     failure_harness: GatewayHarness,
     monkeypatch: pytest.MonkeyPatch,
+    fault_step: str,
 ) -> None:
     harness = failure_harness
     executor = PaperExecutor()
@@ -590,14 +626,14 @@ async def test_after_trade_insert_fault_rolls_back_and_blocks_restart(
     _install_broker_boundary(harness, monkeypatch)
 
     def fault(step: str) -> None:
-        if step == "AFTER_TRADE_INSERT":
-            raise RuntimeError("injected AFTER_TRADE_INSERT failure")
+        if step == fault_step:
+            raise RuntimeError(f"injected {fault_step} failure")
 
     harness.database._paper_settlement_fault_hook = fault
     try:
-        with pytest.raises(RuntimeError, match="AFTER_TRADE_INSERT"):
+        with pytest.raises(RuntimeError, match=fault_step):
             await harness.gateway.submit_reduction(
-                order=_order(order_ref="fault-after-trade-insert"),
+                order=_order(order_ref=f"fault-{fault_step.lower()}"),
                 portfolio_id="portfolio-a",
             )
     finally:
@@ -605,6 +641,7 @@ async def test_after_trade_insert_fault_rolls_back_and_blocks_restart(
 
     assert len(executor.fills) == 1
     assert await _ledger_counts(harness) == (0, 0)
+    assert await _fifo_settlement_counts(harness) == (0, 0, 0)
     allocation = await harness.database.get_safety_allocation_snapshot(
         SYMBOL,
         runtime_contract=harness.context.runtime_contract,

--- a/tests/test_pr2b3_paper_safety_status.py
+++ b/tests/test_pr2b3_paper_safety_status.py
@@ -15,6 +15,19 @@ from pathlib import Path
 import pytest
 
 import scripts.manage_paper_safety_journal as journal_script
+from robo_trader.accounting.fifo import FillSide
+from robo_trader.accounting.fifo_fixture_migration import (
+    _TABLE_SQL,
+    _TRIGGER_SQL,
+    FIFO_ACCOUNTING_COMPONENT,
+    FIFO_ACCOUNTING_MIGRATIONS,
+    _legacy_opening_manifest_hash,
+)
+from robo_trader.accounting.fifo_runtime import (
+    LOCAL_PAPER_COMMISSION_SOURCE,
+    RuntimePaperFillEvidence,
+    append_runtime_fill_in_transaction,
+)
 from robo_trader.config import _derive_safety_account_scope
 from robo_trader.database_async import AsyncTradingDatabase
 from robo_trader.paper_terminal_settlement import (
@@ -175,6 +188,7 @@ def _seed_unresolved_claim(
 
 def _create_settlement_schema(path: Path) -> None:
     with sqlite3.connect(path) as connection:
+        connection.execute("PRAGMA foreign_keys=ON")
         connection.executescript("""
             CREATE TABLE trades (
                 id INTEGER PRIMARY KEY,
@@ -252,6 +266,49 @@ def _create_settlement_schema(path: Path) -> None:
                 schema_version INTEGER NOT NULL
             )
             """)
+        for statement in _TABLE_SQL.values():
+            connection.execute(statement)
+        connection.executemany(
+            """
+            INSERT INTO fifo_schema_migrations(component,version,description,applied_at)
+            VALUES (?,?,?,'2020-01-01T00:00:00.000000Z')
+            """,
+            tuple(
+                (FIFO_ACCOUNTING_COMPONENT, version, description)
+                for version, description in FIFO_ACCOUNTING_MIGRATIONS
+            ),
+        )
+        for statement in _TRIGGER_SQL.values():
+            connection.execute(statement)
+        connection.executescript("""
+            CREATE TABLE paper_fifo_settlement_links (
+                settlement_id TEXT PRIMARY KEY,
+                request_fingerprint TEXT NOT NULL UNIQUE,
+                epoch_id TEXT NOT NULL,
+                fill_id TEXT NOT NULL UNIQUE,
+                event_sequence INTEGER NOT NULL,
+                execution_id TEXT NOT NULL,
+                commission_minor INTEGER NOT NULL,
+                commission_currency TEXT NOT NULL,
+                commission_source TEXT NOT NULL,
+                fifo_state_fingerprint TEXT NOT NULL,
+                committed_at TEXT NOT NULL,
+                UNIQUE(epoch_id,event_sequence),
+                UNIQUE(epoch_id,execution_id),
+                FOREIGN KEY(settlement_id) REFERENCES paper_reduction_settlements(settlement_id),
+                FOREIGN KEY(epoch_id,fill_id) REFERENCES fifo_fills(epoch_id,fill_id)
+            );
+            CREATE TRIGGER paper_fifo_settlement_links_no_update
+            BEFORE UPDATE ON paper_fifo_settlement_links
+            BEGIN
+                SELECT RAISE(ABORT, 'paper FIFO settlement links are append-only');
+            END;
+            CREATE TRIGGER paper_fifo_settlement_links_no_delete
+            BEFORE DELETE ON paper_fifo_settlement_links
+            BEGIN
+                SELECT RAISE(ABORT, 'paper FIFO settlement links are append-only');
+            END;
+            """)
 
 
 def _insert_exact_settlement(
@@ -315,6 +372,10 @@ def _insert_exact_settlement(
         terminal_status=TerminalOrderStatus.FILLED,
         fill_price=Decimal("101.25"),
         outcome_at=datetime.now(timezone.utc) - timedelta(seconds=10),
+        fill_execution_id="lpfill-" + ("8" * 32),
+        fill_commission_minor=0,
+        fill_commission_currency="USD",
+        fill_commission_source=LOCAL_PAPER_COMMISSION_SOURCE,
     )
     database_metadata = ledger_path.stat()
     settlement_id = "pset-" + ("2" * 32)
@@ -342,6 +403,120 @@ def _insert_exact_settlement(
     )
     receipt_fingerprint = hashlib.sha256(receipt_payload.encode("utf-8")).hexdigest()
     with sqlite3.connect(ledger_path) as connection:
+        connection.execute("PRAGMA foreign_keys=ON")
+        epoch_id = "fepoch-" + ("1" * 32)
+        effective_at = "2020-01-01T00:00:00.000000Z"
+        opening_balance_id = "fobal-" + ("3" * 32)
+        connection.execute(
+            """
+            INSERT INTO fifo_accounting_epochs VALUES (
+                ?,1,?,?,?,'LEGACY_AGGREGATE_OPENING_BALANCE',?,?,?
+            )
+            """,
+            (
+                epoch_id,
+                request.execution_domain_scope,
+                request.account_scope,
+                request.portfolio_id,
+                "4" * 64,
+                effective_at,
+                effective_at,
+            ),
+        )
+        connection.execute(
+            "INSERT INTO fifo_epoch_account_baselines VALUES (?,?,?,?,?,?,?)",
+            (
+                epoch_id,
+                "10000",
+                "0",
+                "0",
+                "0",
+                request.expected_daily_pnl_date,
+                effective_at,
+            ),
+        )
+        manifest_row = (
+            opening_balance_id,
+            "flot-" + ("a" * 32),
+            request.con_id,
+            request.symbol,
+            "LONG",
+            "5",
+            "100",
+            "100",
+            effective_at,
+            "9" * 64,
+            0,
+            0,
+            effective_at,
+        )
+        connection.execute(
+            "INSERT INTO fifo_legacy_bootstrap_lineage VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                epoch_id,
+                "pboot-" + ("5" * 32),
+                "4" * 64,
+                1,
+                _legacy_opening_manifest_hash([manifest_row]),
+                "status-reconciliation",
+                "6" * 64,
+                "7" * 64,
+                "8" * 64,
+                "status-administrator-action",
+                effective_at,
+            ),
+        )
+        connection.execute(
+            "INSERT INTO fifo_opening_balances VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                opening_balance_id,
+                epoch_id,
+                request.con_id,
+                request.symbol,
+                "LONG",
+                "5",
+                "100",
+                "100",
+                effective_at,
+                "9" * 64,
+                effective_at,
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO fifo_lot_openings VALUES (
+                ?,?,NULL,?,0,?,?,?,'5','100',0,0,?
+            )
+            """,
+            (
+                "flot-" + ("a" * 32),
+                epoch_id,
+                opening_balance_id,
+                request.con_id,
+                request.symbol,
+                "LONG",
+                effective_at,
+            ),
+        )
+        fifo_projection = append_runtime_fill_in_transaction(
+            connection,
+            RuntimePaperFillEvidence(
+                execution_domain_scope=request.execution_domain_scope,
+                account_scope=request.account_scope,
+                portfolio_id=request.portfolio_id,
+                con_id=request.con_id,
+                symbol=request.symbol,
+                side=FillSide.SELL,
+                quantity=request.filled_quantity,
+                price=request.fill_price,
+                execution_id=request.fill_execution_id,
+                idempotency_key=request.fingerprint(),
+                commission_minor=request.fill_commission_minor,
+                commission_currency=request.fill_commission_currency,
+                commission_source=request.fill_commission_source,
+                occurred_at=request.outcome_at,
+            ),
+        )
         connection.execute(
             """
             INSERT INTO trades (
@@ -473,6 +648,24 @@ def _insert_exact_settlement(
                 request.expected_daily_pnl_date,
                 committed_at,
                 settlement_id,
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO paper_fifo_settlement_links VALUES (?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                settlement_id,
+                request.fingerprint(),
+                fifo_projection.epoch_id,
+                fifo_projection.fill_id,
+                fifo_projection.event_sequence,
+                request.fill_execution_id,
+                request.fill_commission_minor,
+                request.fill_commission_currency,
+                request.fill_commission_source,
+                fifo_projection.state_fingerprint,
+                committed_at,
             ),
         )
     return request
@@ -736,6 +929,8 @@ def test_status_rejects_nonmatching_local_settlement_receipt(tmp_path: Path) -> 
         "TAMPERED_ACCOUNT_SOURCE",
         "TAMPERED_LEGACY_ACCOUNT",
         "AMBIGUOUS_TRADE",
+        "TAMPERED_FIFO_LINK",
+        "MISSING_FIFO_LINK_SCHEMA",
         "MISSING_MARK_SCHEMA",
         "MISSING_ACCOUNT_BASELINE_SCHEMA",
         "OUTBOX_ONLY",
@@ -813,6 +1008,14 @@ def test_status_and_recovery_reject_partial_or_forged_atomic_projection(
                          slippage, commission, pnl, timestamp
                   FROM trades WHERE id = 7
                 """)
+        elif corruption == "TAMPERED_FIFO_LINK":
+            connection.execute("DROP TRIGGER paper_fifo_settlement_links_no_update")
+            connection.execute(
+                "UPDATE paper_fifo_settlement_links SET fifo_state_fingerprint = ?",
+                ("0" * 64,),
+            )
+        elif corruption == "MISSING_FIFO_LINK_SCHEMA":
+            connection.execute("DROP TABLE paper_fifo_settlement_links")
         elif corruption == "MISSING_MARK_SCHEMA":
             connection.execute(
                 "ALTER TABLE paper_position_settlement_state DROP COLUMN mark_price_text"
@@ -838,7 +1041,13 @@ def test_status_and_recovery_reject_partial_or_forged_atomic_projection(
     item = journal_script.paper_safety_status(environ)["unresolved_reservations"][0]
     expected_status = (
         "SCHEMA_MISSING"
-        if corruption in {"OUTBOX_ONLY", "MISSING_MARK_SCHEMA", "MISSING_ACCOUNT_BASELINE_SCHEMA"}
+        if corruption
+        in {
+            "OUTBOX_ONLY",
+            "MISSING_MARK_SCHEMA",
+            "MISSING_ACCOUNT_BASELINE_SCHEMA",
+            "MISSING_FIFO_LINK_SCHEMA",
+        }
         else "MISMATCH"
     )
     assert item["local_settlement_status"] == expected_status

--- a/tests/test_pr2b3_paper_safety_status.py
+++ b/tests/test_pr2b3_paper_safety_status.py
@@ -834,6 +834,62 @@ def _resign_settlement_receipt(connection: sqlite3.Connection) -> None:
     )
 
 
+def _rewrite_zero_fill_settlement_as_legacy_v1(ledger_path: Path) -> str:
+    with sqlite3.connect(ledger_path) as connection:
+        row = connection.execute("""
+            SELECT settlement_id,request_payload_json,trade_id,database_path,
+                   database_identity,database_device,database_inode,committed_at,
+                   schema_version
+            FROM paper_reduction_settlements
+            """).fetchone()
+        assert row is not None
+        payload = json.loads(row[1])
+        for field_name in (
+            "fill_execution_id",
+            "fill_commission_minor",
+            "fill_commission_currency",
+            "fill_commission_source",
+        ):
+            payload.pop(field_name)
+        legacy_payload = canonical_json(payload)
+        request_fingerprint = hashlib.sha256(legacy_payload.encode("utf-8")).hexdigest()
+        receipt_payload = canonical_json(
+            {
+                "committed_at": row[7],
+                "database_device": row[5],
+                "database_identity": row[4],
+                "database_inode": row[6],
+                "database_path": row[3],
+                "request_fingerprint": request_fingerprint,
+                "schema_version": row[8],
+                "settlement_id": row[0],
+                "trade_id": row[2],
+            }
+        )
+        connection.execute("DROP TRIGGER paper_reduction_settlements_no_update")
+        connection.execute(
+            """
+            UPDATE paper_reduction_settlements
+            SET request_fingerprint=?,request_payload_json=?,receipt_fingerprint=?
+            """,
+            (
+                request_fingerprint,
+                legacy_payload,
+                hashlib.sha256(receipt_payload.encode("utf-8")).hexdigest(),
+            ),
+        )
+        connection.execute("""
+            CREATE TRIGGER paper_reduction_settlements_no_update
+            BEFORE UPDATE ON paper_reduction_settlements
+            BEGIN
+                SELECT RAISE(ABORT, 'paper reduction settlements are append-only');
+            END
+            """)
+        connection.commit()
+        connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    return request_fingerprint
+
+
 def test_status_json_is_redacted_exact_and_strictly_read_only(
     tmp_path: Path,
     monkeypatch,
@@ -1163,6 +1219,40 @@ async def test_zero_fill_commit_release_failure_recovers_offline_exactly_once(
     assert _sqlite_durable_snapshot(ledger_path) == before_ledger
     assert request.terminal_status is terminal_status
     assert receipt.request.fingerprint() == request.fingerprint()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "terminal_status",
+    [TerminalOrderStatus.CANCELLED, TerminalOrderStatus.REJECTED],
+)
+async def test_legacy_v1_zero_fill_payload_recovers_offline_exactly_once(
+    tmp_path: Path,
+    monkeypatch,
+    terminal_status: TerminalOrderStatus,
+) -> None:
+    environ, reservation, request, _ = await _commit_zero_fill_case(
+        tmp_path,
+        terminal_status,
+    )
+    ledger_path = Path(environ["RT_DB_PATH"])
+    journal_path = Path(environ["SAFETY_JOURNAL_PATH"])
+    legacy_fingerprint = _rewrite_zero_fill_settlement_as_legacy_v1(ledger_path)
+    before_ledger = _sqlite_durable_snapshot(ledger_path)
+
+    item = journal_script.paper_safety_status(environ)["unresolved_reservations"][0]
+    assert item["local_settlement_status"] == "MATCH"
+    _enable_stopped_offline_recovery(monkeypatch)
+    recovered = journal_script.recover_exact_local_paper_settlement(
+        environ,
+        confirmation=journal_script.RECOVER_CONFIRMATION,
+    )
+
+    assert len(legacy_fingerprint) == 64
+    assert recovered.terminal_sequence > 0
+    assert SafetyJournal(journal_path).replay().active_reservations == ()
+    assert _sqlite_durable_snapshot(ledger_path) == before_ledger
+    assert request.filled_quantity == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_pr2b3_terminal_settlement_persistence.py
+++ b/tests/test_pr2b3_terminal_settlement_persistence.py
@@ -43,7 +43,11 @@ from robo_trader.safety import (
     StateTransitionError,
     TerminalOrderStatus,
 )
-from robo_trader.safety.models import ValidationError, _strict_database_identity
+from robo_trader.safety.models import (
+    ValidationError,
+    _strict_database_identity,
+    canonical_json,
+)
 from tests.fifo_runtime_test_support import install_synthetic_fifo_epoch
 from tests.safety.conftest import make_case
 from tests.test_multiuser import create_legacy_schema
@@ -223,6 +227,94 @@ def _request(*, outcome_at: datetime) -> PaperTerminalSettlementRequest:
     )
 
 
+def _zero_fill_request(
+    *,
+    outcome_at: datetime,
+    terminal_status: TerminalOrderStatus,
+) -> PaperTerminalSettlementRequest:
+    return replace(
+        _request(outcome_at=outcome_at),
+        filled_quantity=Decimal("0"),
+        remaining_quantity=Decimal("2"),
+        expected_post_position_quantity=Decimal("5"),
+        expected_post_aggregate_quantity=Decimal("10"),
+        expected_post_cash=Decimal("100000"),
+        expected_post_realized_pnl=Decimal("0"),
+        expected_post_daily_pnl=Decimal("0"),
+        terminal_status=terminal_status,
+        fill_price=None,
+        fill_execution_id=None,
+        fill_commission_minor=None,
+        fill_commission_currency=None,
+        fill_commission_source=None,
+    )
+
+
+async def _rewrite_as_legacy_zero_fill_payload(
+    database: AsyncTradingDatabase,
+    settlement_id: str,
+) -> str:
+    async with database.get_connection() as connection:
+        row = await (
+            await connection.execute(
+                """
+                SELECT request_payload_json,trade_id,database_path,database_identity,
+                       database_device,database_inode,committed_at,schema_version
+                FROM main.paper_reduction_settlements WHERE settlement_id=?
+                """,
+                (settlement_id,),
+            )
+        ).fetchone()
+        assert row is not None
+        payload = json.loads(row[0])
+        for field_name in (
+            "fill_execution_id",
+            "fill_commission_minor",
+            "fill_commission_currency",
+            "fill_commission_source",
+        ):
+            payload.pop(field_name)
+        legacy_payload = canonical_json(payload)
+        request_fingerprint = hashlib.sha256(legacy_payload.encode("utf-8")).hexdigest()
+        receipt_payload = canonical_json(
+            {
+                "committed_at": row[6],
+                "database_device": row[4],
+                "database_identity": row[3],
+                "database_inode": row[5],
+                "database_path": row[2],
+                "request_fingerprint": request_fingerprint,
+                "schema_version": row[7],
+                "settlement_id": settlement_id,
+                "trade_id": row[1],
+            }
+        )
+        receipt_fingerprint = hashlib.sha256(receipt_payload.encode("utf-8")).hexdigest()
+        await connection.execute("DROP TRIGGER main.paper_reduction_settlements_no_update")
+        await connection.execute(
+            """
+            UPDATE main.paper_reduction_settlements
+            SET request_fingerprint=?,request_payload_json=?,receipt_fingerprint=?
+            WHERE settlement_id=?
+            """,
+            (
+                request_fingerprint,
+                legacy_payload,
+                receipt_fingerprint,
+                settlement_id,
+            ),
+        )
+        await connection.execute("""
+            CREATE TRIGGER main.paper_reduction_settlements_no_update
+            BEFORE UPDATE ON paper_reduction_settlements
+            BEGIN
+                SELECT RAISE(ABORT, 'paper reduction settlements are append-only');
+            END
+            """)
+        await connection.commit()
+    return request_fingerprint
+
+
 def _runtime_evidence(
     *,
     sequence: int,
@@ -270,6 +362,32 @@ async def _assert_no_partial_settlement(database: AsyncTradingDatabase) -> None:
     assert counts == (0, 0, 0, 0, 0)
     assert position == (5,)
     assert account == ("100000", "0", "0", None)
+
+
+def test_legacy_v1_payload_admission_is_zero_fill_only() -> None:
+    filled_payload = json.loads(_request(outcome_at=datetime.now(timezone.utc)).canonical_payload())
+    for field_name in (
+        "fill_execution_id",
+        "fill_commission_minor",
+        "fill_commission_currency",
+        "fill_commission_source",
+    ):
+        filled_payload.pop(field_name)
+    with pytest.raises(
+        PaperTerminalSettlementError,
+        match="not an admitted zero-fill outcome",
+    ):
+        PaperTerminalSettlementRequest.from_canonical_payload(canonical_json(filled_payload))
+
+    zero_fill_payload = json.loads(
+        _zero_fill_request(
+            outcome_at=datetime.now(timezone.utc),
+            terminal_status=TerminalOrderStatus.CANCELLED,
+        ).canonical_payload()
+    )
+    zero_fill_payload.pop("fill_execution_id")
+    with pytest.raises(PaperTerminalSettlementError, match="partial fill evidence"):
+        PaperTerminalSettlementRequest.from_canonical_payload(canonical_json(zero_fill_payload))
 
 
 def test_protective_quote_timestamp_accepts_canonical_z_utc_text() -> None:
@@ -687,6 +805,56 @@ async def test_expected_fifo_delta_is_independent_of_ambient_decimal_precision(
         assert fifo_delta == ("-12345.66",)
     finally:
         await database.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "terminal_status",
+    [TerminalOrderStatus.CANCELLED, TerminalOrderStatus.REJECTED],
+)
+async def test_legacy_v1_zero_fill_payload_replays_without_fifo_lineage(
+    tmp_path: Path,
+    terminal_status: TerminalOrderStatus,
+):
+    contract = _runtime_contract(tmp_path)
+    database = AsyncTradingDatabase(Path(contract.database_path), pool_size=1)
+    await database.initialize()
+    await _seed(database)
+    request = _zero_fill_request(
+        outcome_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+        terminal_status=terminal_status,
+    )
+    receipt = await database.commit_paper_reduction_outcome(
+        request,
+        runtime_contract=contract,
+    )
+    legacy_fingerprint = await _rewrite_as_legacy_zero_fill_payload(
+        database,
+        receipt.settlement_id,
+    )
+    await database.close()
+
+    restarted = AsyncTradingDatabase(Path(contract.database_path), pool_size=1)
+    await restarted.initialize()
+    try:
+        replay = await restarted.commit_paper_reduction_outcome(
+            request,
+            runtime_contract=contract,
+        )
+
+        assert replay.settlement_id == receipt.settlement_id
+        assert replay.request.fingerprint() == legacy_fingerprint
+        assert replay.request.semantic_fingerprint() == request.semantic_fingerprint()
+        async with restarted.get_connection() as connection:
+            counts = await (await connection.execute("""
+                    SELECT
+                        (SELECT COUNT(*) FROM main.trades),
+                        (SELECT COUNT(*) FROM main.paper_reduction_settlements),
+                        (SELECT COUNT(*) FROM main.paper_fifo_settlement_links)
+                    """)).fetchone()
+        assert counts == (0, 1, 0)
+    finally:
+        await restarted.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_pr2b3_terminal_settlement_persistence.py
+++ b/tests/test_pr2b3_terminal_settlement_persistence.py
@@ -24,6 +24,7 @@ from robo_trader.accounting.fifo_runtime import (
 from robo_trader.config import RuntimeContract
 from robo_trader.database_async import AsyncTradingDatabase
 from robo_trader.database_validator import ValidationError as DatabaseValidationError
+from robo_trader.multiuser.migration import MultiuserMigration
 from robo_trader.paper_terminal_settlement import (
     PaperAccountSettlementState,
     PaperTerminalSettlementConflict,
@@ -45,6 +46,7 @@ from robo_trader.safety import (
 from robo_trader.safety.models import ValidationError, _strict_database_identity
 from tests.fifo_runtime_test_support import install_synthetic_fifo_epoch
 from tests.safety.conftest import make_case
+from tests.test_multiuser import create_legacy_schema
 
 ACCOUNT_SCOPE = "acct_v1_0123456789abcdef0123456789abcdef" "fedcba9876543210fedcba9876543210"
 
@@ -749,6 +751,72 @@ async def test_malformed_hot_table_index_fails_before_mutation(tmp_path: Path):
             )
 
         await _assert_no_partial_settlement(database)
+    finally:
+        await database.close()
+
+
+@pytest.mark.asyncio
+async def test_quoted_literal_case_change_fails_before_mutation(tmp_path: Path):
+    contract = _runtime_contract(tmp_path)
+    database = AsyncTradingDatabase(Path(contract.database_path), pool_size=1)
+    await database.initialize()
+    try:
+        await _seed(database)
+        async with database.get_connection() as connection:
+            schema_version = await (
+                await connection.execute("PRAGMA main.schema_version")
+            ).fetchone()
+            await connection.execute("PRAGMA writable_schema=ON")
+            await connection.execute(
+                """
+                UPDATE main.sqlite_master
+                SET sql=replace(sql,?,?)
+                WHERE type='table' AND name='paper_fifo_settlement_links'
+                """,
+                ("commission_currency = 'USD'", "commission_currency = 'usd'"),
+            )
+            await connection.execute("PRAGMA writable_schema=OFF")
+            await connection.execute(f"PRAGMA main.schema_version={schema_version[0] + 1}")
+            await connection.commit()
+
+        with pytest.raises(PaperTerminalSettlementError, match="hot schema"):
+            await database.commit_paper_reduction_outcome(
+                _request(outcome_at=datetime.now(timezone.utc) - timedelta(seconds=1)),
+                runtime_contract=contract,
+            )
+
+        await _assert_no_partial_settlement(database)
+    finally:
+        await database.close()
+
+
+@pytest.mark.asyncio
+async def test_supported_multiuser_v1_hot_schema_can_settle(tmp_path: Path):
+    contract = _runtime_contract(tmp_path)
+    database_path = Path(contract.database_path)
+    await create_legacy_schema(database_path)
+    assert await MultiuserMigration(database_path).migrate() is True
+
+    database = AsyncTradingDatabase(database_path, pool_size=1)
+    await database.initialize()
+    try:
+        async with database.get_connection() as connection:
+            await connection.execute("""
+                UPDATE main.positions SET quantity=0
+                WHERE portfolio_id='default' AND symbol='AAPL'
+                """)
+            await connection.commit()
+        await _seed(database)
+
+        receipt = await database.commit_paper_reduction_outcome(
+            _request(outcome_at=datetime.now(timezone.utc) - timedelta(seconds=1)),
+            runtime_contract=contract,
+        )
+
+        assert receipt.trade_id is not None
+        position = await database.get_position("AAPL", portfolio_id="portfolio-a")
+        assert position is not None
+        assert position["quantity"] == 3
     finally:
         await database.close()
 

--- a/tests/test_pr2b3_terminal_settlement_persistence.py
+++ b/tests/test_pr2b3_terminal_settlement_persistence.py
@@ -15,6 +15,12 @@ from types import SimpleNamespace
 
 import pytest
 
+from robo_trader.accounting.fifo import FillSide
+from robo_trader.accounting.fifo_runtime import (
+    LOCAL_PAPER_COMMISSION_SOURCE,
+    RuntimePaperFillEvidence,
+    append_runtime_fill_on_aiosqlite_worker,
+)
 from robo_trader.config import RuntimeContract
 from robo_trader.database_async import AsyncTradingDatabase
 from robo_trader.database_validator import ValidationError as DatabaseValidationError
@@ -205,6 +211,55 @@ def _request(*, outcome_at: datetime) -> PaperTerminalSettlementRequest:
         fill_commission_currency="USD",
         fill_commission_source="LOCAL_PAPER_EXECUTOR_EXACT_COMMISSION_V1",
     )
+
+
+def _runtime_evidence(
+    *,
+    sequence: int,
+    side: FillSide,
+    occurred_at: datetime,
+) -> RuntimePaperFillEvidence:
+    identity = hashlib.sha256(f"prior-msft-fill-{sequence}".encode()).hexdigest()
+    return RuntimePaperFillEvidence(
+        execution_domain_scope=PAPER_EXECUTION_DOMAIN_SCOPE,
+        account_scope=ACCOUNT_SCOPE,
+        portfolio_id="portfolio-a",
+        con_id=272093,
+        symbol="MSFT",
+        side=side,
+        quantity=Decimal("1"),
+        price=Decimal("100") if side is FillSide.BUY else Decimal("110"),
+        execution_id=f"lpfill-{identity[:32]}",
+        idempotency_key=identity,
+        commission_minor=0,
+        commission_currency="USD",
+        commission_source=LOCAL_PAPER_COMMISSION_SOURCE,
+        occurred_at=occurred_at,
+    )
+
+
+async def _assert_no_partial_settlement(database: AsyncTradingDatabase) -> None:
+    async with database.get_connection() as connection:
+        counts = await (await connection.execute("""
+                SELECT
+                    (SELECT COUNT(*) FROM main.fifo_fills),
+                    (SELECT COUNT(*) FROM main.fifo_commissions),
+                    (SELECT COUNT(*) FROM main.trades),
+                    (SELECT COUNT(*) FROM main.paper_reduction_settlements),
+                    (SELECT COUNT(*) FROM main.paper_fifo_settlement_links)
+                """)).fetchone()
+        position = await (await connection.execute("""
+                SELECT quantity FROM main.positions
+                WHERE portfolio_id='portfolio-a' AND symbol='AAPL'
+                """)).fetchone()
+        account = await (await connection.execute("""
+                SELECT cash_text,realized_pnl_text,daily_pnl_text,source_settlement_id
+                FROM main.paper_account_settlement_state
+                WHERE portfolio_id='portfolio-a'
+                """)).fetchone()
+    assert counts == (0, 0, 0, 0, 0)
+    assert position == (5,)
+    assert account == ("100000", "0", "0", None)
 
 
 def test_protective_quote_timestamp_accepts_canonical_z_utc_text() -> None:
@@ -485,6 +540,143 @@ async def test_atomic_settlement_exact_replay_has_no_duplicate_mutation(tmp_path
                 replace(request, order_ref="different-close-reference"),
                 runtime_contract=contract,
             )
+    finally:
+        await database.close()
+
+
+@pytest.mark.asyncio
+async def test_cross_symbol_realized_pnl_settles_against_epoch_total(tmp_path: Path):
+    contract = _runtime_contract(tmp_path)
+    database = AsyncTradingDatabase(Path(contract.database_path), pool_size=1)
+    await database.initialize()
+    try:
+        await _seed(database)
+        now = datetime.now(timezone.utc)
+        for evidence in (
+            _runtime_evidence(
+                sequence=1,
+                side=FillSide.BUY,
+                occurred_at=now - timedelta(seconds=4),
+            ),
+            _runtime_evidence(
+                sequence=2,
+                side=FillSide.SELL,
+                occurred_at=now - timedelta(seconds=3),
+            ),
+        ):
+            async with database.get_connection() as connection:
+                await connection.execute("BEGIN IMMEDIATE")
+                await append_runtime_fill_on_aiosqlite_worker(connection, evidence)
+                await connection.commit()
+
+        await database.update_account(
+            cash=Decimal("100010"),
+            equity=Decimal("100010"),
+            daily_pnl=Decimal("10"),
+            realized_pnl=Decimal("10"),
+            unrealized_pnl=Decimal("0"),
+            daily_pnl_baseline=Decimal("0"),
+            portfolio_id="portfolio-a",
+        )
+        request = replace(
+            _request(outcome_at=now - timedelta(seconds=1)),
+            expected_pre_cash=Decimal("100010"),
+            expected_post_cash=Decimal("100212.50"),
+            expected_pre_realized_pnl=Decimal("10"),
+            expected_post_realized_pnl=Decimal("12.50"),
+            expected_pre_daily_pnl=Decimal("10"),
+            expected_post_daily_pnl=Decimal("12.50"),
+        )
+
+        receipt = await database.commit_paper_reduction_outcome(
+            request,
+            runtime_contract=contract,
+        )
+
+        account = await database.get_account_info(portfolio_id="portfolio-a")
+        assert account["realized_pnl_exact"] == Decimal("12.5")
+        assert account["daily_pnl_exact"] == Decimal("12.5")
+        async with database.get_connection() as connection:
+            link = await (
+                await connection.execute(
+                    """
+                    SELECT epoch_id,event_sequence
+                    FROM main.paper_fifo_settlement_links
+                    WHERE settlement_id=?
+                    """,
+                    (receipt.settlement_id,),
+                )
+            ).fetchone()
+            realized_rows = await (
+                await connection.execute(
+                    """
+                    SELECT m.realized_pnl_text
+                    FROM main.fifo_lot_matches AS m
+                    JOIN main.fifo_fills AS f
+                      ON f.epoch_id=m.epoch_id AND f.fill_id=m.closing_fill_id
+                    WHERE m.epoch_id=? AND f.event_sequence<=?
+                    """,
+                    link,
+                )
+            ).fetchall()
+        assert sum((Decimal(row[0]) for row in realized_rows), Decimal("0")) == Decimal("12.5")
+    finally:
+        await database.close()
+
+
+@pytest.mark.asyncio
+async def test_temp_fifo_link_shadow_fails_closed_before_any_mutation(tmp_path: Path):
+    contract = _runtime_contract(tmp_path)
+    database = AsyncTradingDatabase(Path(contract.database_path), pool_size=1)
+    await database.initialize()
+    try:
+        await _seed(database)
+        async with database.get_connection() as connection:
+            await connection.execute(
+                "CREATE TEMP TABLE paper_fifo_settlement_links(settlement_id TEXT)"
+            )
+
+        with pytest.raises(PaperTerminalSettlementError, match="hot schema"):
+            await database.commit_paper_reduction_outcome(
+                _request(outcome_at=datetime.now(timezone.utc) - timedelta(seconds=1)),
+                runtime_contract=contract,
+            )
+
+        await _assert_no_partial_settlement(database)
+    finally:
+        await database.close()
+
+
+@pytest.mark.asyncio
+async def test_persistent_trade_trigger_fails_closed_before_any_mutation(tmp_path: Path):
+    contract = _runtime_contract(tmp_path)
+    database = AsyncTradingDatabase(Path(contract.database_path), pool_size=1)
+    await database.initialize()
+    try:
+        await _seed(database)
+        async with database.get_connection() as connection:
+            await connection.execute("""
+                CREATE TRIGGER inject_second_trade_after_settlement
+                AFTER INSERT ON main.trades
+                BEGIN
+                    INSERT INTO trades(
+                        portfolio_id,symbol,side,quantity,price,notional,
+                        slippage,commission,pnl,timestamp
+                    ) VALUES(
+                        NEW.portfolio_id,'MSFT','SELL',1,1,1,0,0,0,
+                        '2026-07-30T12:00:00Z'
+                    );
+                END
+                """)
+            await connection.commit()
+
+        with pytest.raises(PaperTerminalSettlementError, match="hot schema"):
+            await database.commit_paper_reduction_outcome(
+                _request(outcome_at=datetime.now(timezone.utc) - timedelta(seconds=1)),
+                runtime_contract=contract,
+            )
+
+        await _assert_no_partial_settlement(database)
     finally:
         await database.close()
 

--- a/tests/test_pr2b3_terminal_settlement_persistence.py
+++ b/tests/test_pr2b3_terminal_settlement_persistence.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
-from decimal import Decimal
+from decimal import Decimal, localcontext
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -113,7 +113,13 @@ def _runtime_contract(tmp_path: Path) -> RuntimeContract:
     )
 
 
-async def _seed(database: AsyncTradingDatabase) -> None:
+async def _seed(
+    database: AsyncTradingDatabase,
+    *,
+    position_cost: Decimal = Decimal("100"),
+    realized_pnl: Decimal = Decimal("0"),
+    daily_pnl: Decimal = Decimal("0"),
+) -> None:
     async with database.get_connection() as connection:
         await connection.executemany(
             "INSERT INTO portfolios (id, name) VALUES (?, ?)",
@@ -124,20 +130,22 @@ async def _seed(database: AsyncTradingDatabase) -> None:
         await database.update_position(
             "AAPL",
             5,
-            Decimal("100"),
+            position_cost,
             Decimal("100"),
             portfolio_id=portfolio_id,
         )
     await database.update_account(
         Decimal("100000"),
         Decimal("100000"),
-        realized_pnl=Decimal("0"),
+        daily_pnl=daily_pnl,
+        realized_pnl=realized_pnl,
         portfolio_id="portfolio-a",
     )
     await database.update_account(
         Decimal("100000"),
         Decimal("100000"),
-        realized_pnl=Decimal("0"),
+        daily_pnl=daily_pnl,
+        realized_pnl=realized_pnl,
         portfolio_id="portfolio-b",
     )
     for portfolio_id in ("portfolio-a", "portfolio-b"):
@@ -622,6 +630,61 @@ async def test_cross_symbol_realized_pnl_settles_against_epoch_total(tmp_path: P
                 )
             ).fetchall()
         assert sum((Decimal(row[0]) for row in realized_rows), Decimal("0")) == Decimal("12.5")
+    finally:
+        await database.close()
+
+
+@pytest.mark.asyncio
+async def test_expected_fifo_delta_is_independent_of_ambient_decimal_precision(
+    tmp_path: Path,
+):
+    contract = _runtime_contract(tmp_path)
+    database = AsyncTradingDatabase(Path(contract.database_path), pool_size=1)
+    await database.initialize()
+    try:
+        await _seed(
+            database,
+            position_cost=Decimal("10000"),
+            realized_pnl=Decimal("12345.67"),
+            daily_pnl=Decimal("12345.67"),
+        )
+        request = replace(
+            _request(outcome_at=datetime.now(timezone.utc) - timedelta(seconds=1)),
+            expected_post_cash=Decimal("107654.34"),
+            expected_pre_realized_pnl=Decimal("12345.67"),
+            expected_post_realized_pnl=Decimal("0.01"),
+            expected_pre_daily_pnl=Decimal("12345.67"),
+            expected_post_daily_pnl=Decimal("19800.01"),
+            expected_position_cost_basis=Decimal("10000"),
+            fill_price=Decimal("3827.17"),
+        )
+
+        with localcontext() as context:
+            context.prec = 6
+            receipt = await database.commit_paper_reduction_outcome(
+                request,
+                runtime_contract=contract,
+            )
+
+        assert receipt.pre_realized_pnl == Decimal("12345.67")
+        assert receipt.post_realized_pnl == Decimal("0.01")
+        account = await database.get_account_info(portfolio_id="portfolio-a")
+        assert account["realized_pnl_exact"] == Decimal("0.01")
+        async with database.get_connection() as connection:
+            fifo_delta = await (
+                await connection.execute(
+                    """
+                    SELECT match.realized_pnl_text
+                    FROM main.paper_fifo_settlement_links AS link
+                    JOIN main.fifo_lot_matches AS match
+                      ON match.epoch_id=link.epoch_id
+                     AND match.closing_fill_id=link.fill_id
+                    WHERE link.settlement_id=?
+                    """,
+                    (receipt.settlement_id,),
+                )
+            ).fetchone()
+        assert fifo_delta == ("-12345.66",)
     finally:
         await database.close()
 

--- a/tests/test_pr2b3_terminal_settlement_persistence.py
+++ b/tests/test_pr2b3_terminal_settlement_persistence.py
@@ -37,6 +37,7 @@ from robo_trader.safety import (
     TerminalOrderStatus,
 )
 from robo_trader.safety.models import ValidationError, _strict_database_identity
+from tests.fifo_runtime_test_support import install_synthetic_fifo_epoch
 from tests.safety.conftest import make_case
 
 ACCOUNT_SCOPE = "acct_v1_0123456789abcdef0123456789abcdef" "fedcba9876543210fedcba9876543210"
@@ -131,6 +132,15 @@ async def _seed(database: AsyncTradingDatabase) -> None:
         realized_pnl=Decimal("0"),
         portfolio_id="portfolio-b",
     )
+    for portfolio_id in ("portfolio-a", "portfolio-b"):
+        await install_synthetic_fifo_epoch(
+            database,
+            execution_domain_scope=PAPER_EXECUTION_DOMAIN_SCOPE,
+            account_scope=ACCOUNT_SCOPE,
+            portfolio_id=portfolio_id,
+            con_id=265598,
+            symbol="AAPL",
+        )
 
 
 def _quote_payload() -> str:
@@ -190,6 +200,10 @@ def _request(*, outcome_at: datetime) -> PaperTerminalSettlementRequest:
         terminal_status=TerminalOrderStatus.FILLED,
         fill_price=Decimal("101.25"),
         outcome_at=outcome_at,
+        fill_execution_id="lpfill-" + ("8" * 32),
+        fill_commission_minor=0,
+        fill_commission_currency="USD",
+        fill_commission_source="LOCAL_PAPER_EXECUTOR_EXACT_COMMISSION_V1",
     )
 
 

--- a/tests/test_pr2b3_terminal_settlement_persistence.py
+++ b/tests/test_pr2b3_terminal_settlement_persistence.py
@@ -822,6 +822,32 @@ async def test_supported_multiuser_v1_hot_schema_can_settle(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_supported_multiuser_v1_direct_create_schema_can_settle(tmp_path: Path):
+    contract = _runtime_contract(tmp_path)
+    database_path = Path(contract.database_path)
+    with sqlite3.connect(database_path):
+        pass
+    assert await MultiuserMigration(database_path).migrate() is True
+
+    database = AsyncTradingDatabase(database_path, pool_size=1)
+    await database.initialize()
+    try:
+        await _seed(database)
+
+        receipt = await database.commit_paper_reduction_outcome(
+            _request(outcome_at=datetime.now(timezone.utc) - timedelta(seconds=1)),
+            runtime_contract=contract,
+        )
+
+        assert receipt.trade_id is not None
+        position = await database.get_position("AAPL", portfolio_id="portfolio-a")
+        assert position is not None
+        assert position["quantity"] == 3
+    finally:
+        await database.close()
+
+
+@pytest.mark.asyncio
 async def test_fault_after_trade_insert_rolls_back_every_effect(tmp_path: Path):
     contract = _runtime_contract(tmp_path)
     database = AsyncTradingDatabase(Path(contract.database_path), pool_size=1)

--- a/tests/test_pr2b3_terminal_settlement_persistence.py
+++ b/tests/test_pr2b3_terminal_settlement_persistence.py
@@ -648,7 +648,7 @@ async def test_temp_fifo_link_shadow_fails_closed_before_any_mutation(tmp_path: 
 
 
 @pytest.mark.asyncio
-async def test_persistent_trade_trigger_fails_closed_before_any_mutation(tmp_path: Path):
+async def test_mixed_case_persistent_trade_trigger_fails_before_any_mutation(tmp_path: Path):
     contract = _runtime_contract(tmp_path)
     database = AsyncTradingDatabase(Path(contract.database_path), pool_size=1)
     await database.initialize()
@@ -657,7 +657,7 @@ async def test_persistent_trade_trigger_fails_closed_before_any_mutation(tmp_pat
         async with database.get_connection() as connection:
             await connection.execute("""
                 CREATE TRIGGER inject_second_trade_after_settlement
-                AFTER INSERT ON main.trades
+                AFTER INSERT ON main.Trades
                 BEGIN
                     INSERT INTO trades(
                         portfolio_id,symbol,side,quantity,price,notional,
@@ -667,6 +667,78 @@ async def test_persistent_trade_trigger_fails_closed_before_any_mutation(tmp_pat
                         '2026-07-30T12:00:00Z'
                     );
                 END
+                """)
+            await connection.commit()
+
+        with pytest.raises(PaperTerminalSettlementError, match="hot schema"):
+            await database.commit_paper_reduction_outcome(
+                _request(outcome_at=datetime.now(timezone.utc) - timedelta(seconds=1)),
+                runtime_contract=contract,
+            )
+
+        await _assert_no_partial_settlement(database)
+    finally:
+        await database.close()
+
+
+@pytest.mark.asyncio
+async def test_same_shape_trade_table_with_extra_check_fails_before_mutation(tmp_path: Path):
+    contract = _runtime_contract(tmp_path)
+    database = AsyncTradingDatabase(Path(contract.database_path), pool_size=1)
+    await database.initialize()
+    try:
+        await _seed(database)
+        async with database.get_connection() as connection:
+            await connection.execute("PRAGMA foreign_keys=OFF")
+            await connection.execute("DROP TABLE main.trades")
+            await connection.execute("""
+                CREATE TABLE main.trades (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    portfolio_id TEXT NOT NULL DEFAULT 'default',
+                    symbol TEXT NOT NULL,
+                    side TEXT NOT NULL,
+                    quantity INTEGER NOT NULL,
+                    price REAL NOT NULL,
+                    notional REAL DEFAULT 0,
+                    slippage REAL DEFAULT 0,
+                    commission REAL DEFAULT 0,
+                    pnl REAL DEFAULT NULL,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    CHECK (symbol <> 'AAPL')
+                )
+                """)
+            await connection.execute("""
+                CREATE INDEX idx_trades_portfolio ON trades (portfolio_id)
+                """)
+            await connection.execute("""
+                CREATE INDEX idx_trades_portfolio_symbol
+                ON trades (portfolio_id, symbol, timestamp DESC)
+                """)
+            await connection.commit()
+            await connection.execute("PRAGMA foreign_keys=ON")
+
+        with pytest.raises(PaperTerminalSettlementError, match="hot schema"):
+            await database.commit_paper_reduction_outcome(
+                _request(outcome_at=datetime.now(timezone.utc) - timedelta(seconds=1)),
+                runtime_contract=contract,
+            )
+
+        await _assert_no_partial_settlement(database)
+    finally:
+        await database.close()
+
+
+@pytest.mark.asyncio
+async def test_malformed_hot_table_index_fails_before_mutation(tmp_path: Path):
+    contract = _runtime_contract(tmp_path)
+    database = AsyncTradingDatabase(Path(contract.database_path), pool_size=1)
+    await database.initialize()
+    try:
+        await _seed(database)
+        async with database.get_connection() as connection:
+            await connection.execute("DROP INDEX main.idx_trades_portfolio_symbol")
+            await connection.execute("""
+                CREATE INDEX idx_trades_portfolio_symbol ON trades (symbol)
                 """)
             await connection.commit()
 


### PR DESCRIPTION
## Summary
- require producer-owned local-paper execution IDs, exact Decimal fill evidence, and signed USD commission minor units
- append FIFO fill/commission/lots/matches/snapshot atomically with trade, position, account, terminal outbox, and immutable settlement link
- make exact replay and stopped-system recovery re-authenticate the complete FIFO epoch and link
- preserve PR4B sealed opening manifests, exact trigger bodies, and in-transaction schema revalidation

## Verification
- full suite: 3036 passed, 5 skipped, 20 known warnings
- final focused FIFO/gateway/settlement/recovery suite: 133 passed
- changed files: Black, isort, Flake8, compileall, diff check, pip check
- isolated new-module mypy and targeted Bandit: pass

## Dependency and safety boundary
This PR is intentionally stacked on PR #123 at exact head 318532e. Retarget it to main only after PR #123 merges. It does not apply an operational bootstrap, start the trader, enable IBKR writes, or close Gate A. The active local simulator still emits complete fills only; partial/nonterminal outcomes remain quarantined.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the atomic paper settlement transaction and realized-P&L authority through FIFO; regressions could corrupt ledger projections or replay semantics despite paper-only scope and fail-closed guards.
> 
> **Overview**
> **PR4C** wires producer-authenticated local-paper fills into the exact FIFO ledger inside the existing `BEGIN IMMEDIATE` paper reduction settlement path. Filled outcomes now require execution ID, exact price/qty, and signed USD commission minor units from `LocalPaperExecutionEvidence`; unfilled terminals still cannot carry fill fields.
> 
> On commit, settlement **re-authenticates hot tables/triggers** (`assert_paper_settlement_hot_schema`), appends the FIFO event via `record_fill_in_transaction` / `fifo_runtime`, checks projections against the authorized terminal request (including **account-wide** realized P&L), then writes compatibility `trades`/`positions`/`account` rows, the settlement outbox, and a new append-only **`paper_fifo_settlement_links`** row (exact-state schema **v3**). Replay and stopped-system recovery must match the linked FIFO epoch and fingerprint; legacy zero-fill `CANCELLED`/`REJECTED` payloads replay via **semantic** fingerprint while preserving stored canonical JSON.
> 
> Supporting changes: `FifoLedger.record_fill_in_transaction` for caller-owned transactions, quote-preserving SQL normalization for DDL auth, commission-aware `post_values`, journal recovery verifies FIFO links, and docs/plan checkpoints—**no startup, bootstrap application, or Gate A closure**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 850afa0e6623763881984763f73607a94f259795. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->